### PR TITLE
feat(chat-api): P1 transcript readers + surface registry

### DIFF
--- a/src/pollypm/web_api/chat/__init__.py
+++ b/src/pollypm/web_api/chat/__init__.py
@@ -3,9 +3,10 @@
 P1 ships the read-side primitives the chat endpoints (P2) compose:
 
 - :mod:`envelope` — the uniform :class:`MessageEnvelope` dataclass and
-  the eight type discriminators (``text``, ``tool_use``, ``tool_result``,
-  ``thinking``, ``ask_user``, ``file``, ``subagent_spawn``,
-  ``subagent_result``, ``system_event``) per spec §3.
+  the type discriminators (``text``, ``tool_use``, ``tool_result``,
+  ``ask_user``, ``file``, ``subagent_spawn``, ``subagent_result``,
+  ``system_event``) per spec §3. ``thinking`` is deferred — the
+  ingestor doesn't preserve provider thinking blocks yet.
 - :mod:`registry` — enumerates every live chat surface (operator,
   architect, advisor, worker) into :class:`ChatSurface` dataclasses,
   resolving the tmux window + transcript path for each.

--- a/src/pollypm/web_api/chat/__init__.py
+++ b/src/pollypm/web_api/chat/__init__.py
@@ -1,0 +1,63 @@
+"""Chat-surface data layer for the PollyPM Web API.
+
+P1 ships the read-side primitives the chat endpoints (P2) compose:
+
+- :mod:`envelope` — the uniform :class:`MessageEnvelope` dataclass and
+  the eight type discriminators (``text``, ``tool_use``, ``tool_result``,
+  ``thinking``, ``ask_user``, ``file``, ``subagent_spawn``,
+  ``subagent_result``, ``system_event``) per spec §3.
+- :mod:`registry` — enumerates every live chat surface (operator,
+  architect, advisor, worker) into :class:`ChatSurface` dataclasses,
+  resolving the tmux window + transcript path for each.
+- :mod:`transcripts` — parses the normalized ``events.jsonl`` archive
+  emitted by :mod:`pollypm.transcript_ingest` into envelopes.
+- :mod:`tmux_capture` — fallback reader using ``tmux capture-pane`` when
+  the archive is absent or stale (>60s).
+
+No HTTP routes here — P2 (#TBD) wires these primitives into FastAPI.
+Per the chat-endpoints spec (``~/Desktop/pollypm-chat-endpoints-spec.md``)
+§6, the layered split keeps the parser unit-testable and lets the
+router be a thin adapter.
+"""
+
+from __future__ import annotations
+
+from pollypm.web_api.chat.envelope import (
+    MessageEnvelope,
+    MessageRole,
+    MessageType,
+)
+from pollypm.web_api.chat.registry import (
+    ChatSurface,
+    SurfaceType,
+    enumerate_chat_surfaces,
+    enumerate_config_surfaces,
+    enumerate_worker_surfaces,
+)
+from pollypm.web_api.chat.tmux_capture import (
+    capture_envelopes,
+    synthesize_capture_id,
+)
+from pollypm.web_api.chat.transcripts import (
+    STALE_THRESHOLD_SECONDS,
+    is_archive_stale,
+    parse_events_jsonl,
+    resolve_transcript_path,
+)
+
+__all__ = [
+    "STALE_THRESHOLD_SECONDS",
+    "ChatSurface",
+    "MessageEnvelope",
+    "MessageRole",
+    "MessageType",
+    "SurfaceType",
+    "capture_envelopes",
+    "enumerate_chat_surfaces",
+    "enumerate_config_surfaces",
+    "enumerate_worker_surfaces",
+    "is_archive_stale",
+    "parse_events_jsonl",
+    "resolve_transcript_path",
+    "synthesize_capture_id",
+]

--- a/src/pollypm/web_api/chat/envelope.py
+++ b/src/pollypm/web_api/chat/envelope.py
@@ -1,0 +1,100 @@
+"""Uniform :class:`MessageEnvelope` shape for chat endpoints.
+
+Every message returned by ``GET /api/v1/chat/{session_name}/messages``
+is one of these envelopes — even tool calls and subagent spawns. The
+shape mirrors spec §3 verbatim so the JSON serialization (handled by
+:mod:`pollypm.web_api.chat` consumers / the P2 router) is a direct
+``dataclasses.asdict`` away.
+
+Eight discriminators are defined in :class:`MessageType`. Each
+envelope's ``metadata`` payload is type-specific; callers branch on
+``envelope.type`` to interpret it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class MessageRole(StrEnum):
+    """Speaker role per spec §3."""
+
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+    SYSTEM = "system"
+
+
+class MessageType(StrEnum):
+    """Envelope discriminator per spec §3."""
+
+    TEXT = "text"
+    TOOL_USE = "tool_use"
+    TOOL_RESULT = "tool_result"
+    THINKING = "thinking"
+    ASK_USER = "ask_user"
+    FILE = "file"
+    SUBAGENT_SPAWN = "subagent_spawn"
+    SUBAGENT_RESULT = "subagent_result"
+    SYSTEM_EVENT = "system_event"
+
+
+@dataclass(slots=True)
+class MessageEnvelope:
+    """One chat message, normalized.
+
+    Fields:
+
+    ``id`` — stable id derived from the source event's file offset
+    (archive path) or capture-line hash (tmux fallback). Sortable by
+    timestamp when paired with ``ts``. Format: ``msg_<hex>`` for
+    archived events, ``cap_<hex>`` for tmux-captured lines, or the raw
+    ``tool_use_id`` / ``subagent_id`` when a more specific id exists.
+
+    ``ts`` — ISO-8601 UTC with ``Z`` suffix, matching the ingestor
+    output. Tmux-capture envelopes inherit the capture wall-clock.
+
+    ``role`` — one of :class:`MessageRole`.
+
+    ``actor`` — display name (``"Polly"``, ``"Archie"``, persona name,
+    ``"system"``, etc.). The registry layer fills this in based on
+    surface type when the event itself doesn't carry it.
+
+    ``type`` — one of :class:`MessageType`; chooses the metadata shape.
+
+    ``text`` — always populated with a display-ready string. For
+    tool calls this is a one-liner like ``"[Bash] git status"``; for
+    ``tool_result`` it's the textual content; for ``ask_user`` it's
+    the question text. Front-ends can render this directly.
+
+    ``metadata`` — type-specific payload. See spec §3.1-§3.8 for the
+    per-type schemas.
+    """
+
+    id: str
+    ts: str
+    role: MessageRole
+    actor: str
+    type: MessageType
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict suitable for JSON encoding.
+
+        Enum fields are coerced to their string values so
+        ``json.dumps`` works without a custom encoder.
+        """
+        payload = asdict(self)
+        payload["role"] = str(self.role)
+        payload["type"] = str(self.type)
+        return payload
+
+
+__all__ = [
+    "MessageEnvelope",
+    "MessageRole",
+    "MessageType",
+]

--- a/src/pollypm/web_api/chat/envelope.py
+++ b/src/pollypm/web_api/chat/envelope.py
@@ -28,12 +28,19 @@ class MessageRole(StrEnum):
 
 
 class MessageType(StrEnum):
-    """Envelope discriminator per spec §3."""
+    """Envelope discriminator per spec §3.
+
+    NOTE: ``thinking`` is intentionally absent. The transcript ingestor
+    does not currently preserve provider thinking blocks, so adding the
+    discriminator before the upstream support exists would let callers
+    branch on a type that's never emitted. Tracking the follow-up arc
+    (preserve thinking in TranscriptIngestor + add the envelope type)
+    as a separate GitHub issue.
+    """
 
     TEXT = "text"
     TOOL_USE = "tool_use"
     TOOL_RESULT = "tool_result"
-    THINKING = "thinking"
     ASK_USER = "ask_user"
     FILE = "file"
     SUBAGENT_SPAWN = "subagent_spawn"

--- a/src/pollypm/web_api/chat/registry.py
+++ b/src/pollypm/web_api/chat/registry.py
@@ -1,0 +1,445 @@
+"""Enumerate every chat surface PollyPM currently exposes.
+
+Four surface types, all addressed by a unique ``session_name`` per
+spec §1:
+
+- **Operator** (``role="operator-pm"`` or ``name="operator"``) — the
+  user-facing Polly persona. One per workspace.
+- **Architect** (``role="architect"``) — per-project planner persona.
+- **Advisor** (``role="advisor"``) — per-project strategic advisor.
+- **Worker** (per-task, ``session_name = task-{project}-{N}``) — one
+  per active task. Enumerated from the work-service ``WorkerSession``
+  records, not from ``config.sessions`` (workers spawn on demand).
+
+This module produces :class:`ChatSurface` dataclasses; the P2 router
+serializes them into the spec §2.1 JSON shape. The registry is pure
+read-only: never spawns sessions, never edits config, never touches
+the database.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pollypm.models import PollyPMConfig, SessionConfig
+from pollypm.work.session_manager import task_window_name
+from pollypm.web_api.chat.transcripts import resolve_transcript_path
+
+logger = logging.getLogger(__name__)
+
+
+# ``SessionConfig.role`` values that the operator persona uses. We
+# accept the legacy ``operator-pm`` role marker AND the convention of
+# naming the session ``"operator"`` (older configs predate the
+# explicit role taxonomy). Either match qualifies.
+_OPERATOR_ROLES = frozenset({"operator-pm", "operator"})
+_OPERATOR_NAMES = frozenset({"operator", "polly"})
+_ARCHITECT_ROLES = frozenset({"architect"})
+_ADVISOR_ROLES = frozenset({"advisor"})
+
+
+class SurfaceType(StrEnum):
+    """The four chat surface types per spec §1."""
+
+    OPERATOR = "operator"
+    ARCHITECT = "architect"
+    ADVISOR = "advisor"
+    WORKER = "worker"
+
+
+@dataclass(slots=True)
+class TmuxWindowState:
+    """Snapshot of the tmux window backing a surface.
+
+    ``present`` is ``False`` when the configured window doesn't exist
+    in tmux (e.g. session never started, or was killed). The GET
+    endpoint still works against the on-disk transcript per spec §4.9;
+    the POST endpoint returns ``503 window_missing``.
+    """
+
+    tmux_session: str
+    window_name: str
+    present: bool = False
+    pane_id: str | None = None
+    pane_dead: bool = False
+
+
+@dataclass(slots=True)
+class ChatSurface:
+    """One chat surface descriptor.
+
+    Fields:
+
+    ``session_name`` — the canonical surface address (spec §1). For
+    config sessions it's the ``config.sessions`` key; for workers it's
+    :func:`task_window_name`.
+
+    ``surface_type`` — :class:`SurfaceType`.
+
+    ``persona`` — display name (e.g. ``"Polly"``, ``"Archie"``, the
+    architect's persona) or ``None`` for workers.
+
+    ``project`` — project key or ``None`` for the operator (the
+    operator is workspace-wide, not project-bound).
+
+    ``task_id`` — only set for worker surfaces.
+
+    ``window`` — :class:`TmuxWindowState` describing the tmux backing.
+
+    ``transcript_path`` — absolute path to the ``events.jsonl``
+    archive, or ``None`` when no transcript has been ingested yet
+    (brand-new surface; spec §4.8 says GET returns ``messages: []``).
+
+    ``cwd`` — working directory the agent runs in. Used by the
+    transcript resolver to pick the right archive when multiple
+    provider-session UUIDs live in the same project root.
+
+    ``provider`` — ``"claude"`` / ``"codex"`` / etc. Drives the
+    capture-fallback decision per spec §4.12.
+
+    ``auth_token_present`` — mirrors :attr:`SessionConfig.auth_token`
+    so the spec §2.1 response can render the ``auth_token_present``
+    field without leaking the token itself.
+
+    ``worktree_path`` — only set for worker surfaces; the per-task
+    worktree where the worker runs.
+    """
+
+    session_name: str
+    surface_type: SurfaceType
+    persona: str | None
+    project: str | None
+    window: TmuxWindowState
+    transcript_path: Path | None = None
+    task_id: int | None = None
+    cwd: Path | None = None
+    provider: str = ""
+    auth_token_present: bool = False
+    worktree_path: Path | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for the spec §2.1 JSON response.
+
+        Mirrors the shape in the spec verbatim; the P2 router can
+        return this directly as the ``sessions[]`` entry.
+        """
+        return {
+            "session_name": self.session_name,
+            "surface_type": str(self.surface_type),
+            "persona": self.persona,
+            "project": self.project,
+            "task_id": self.task_id,
+            "window": {
+                "tmux_session": self.window.tmux_session,
+                "window_name": self.window.window_name,
+                "present": self.window.present,
+                "pane_id": self.window.pane_id,
+                "pane_dead": self.window.pane_dead,
+            },
+            "transcript": {
+                "source": "jsonl" if self.transcript_path else None,
+                "path": str(self.transcript_path) if self.transcript_path else None,
+            },
+            "cwd": str(self.cwd) if self.cwd else None,
+            "provider": self.provider,
+            "auth_token_present": self.auth_token_present,
+            "worktree_path": (
+                str(self.worktree_path) if self.worktree_path else None
+            ),
+        }
+
+
+def enumerate_chat_surfaces(
+    config: PollyPMConfig,
+    *,
+    work_service: Any | None = None,
+    tmux_client: Any | None = None,
+) -> list[ChatSurface]:
+    """Return every chat surface (operator/architect/advisor/worker).
+
+    ``work_service`` is the :class:`pollypm.work.service.WorkService`
+    used to enumerate active worker sessions. When ``None``, worker
+    surfaces are skipped (useful for tests that only care about
+    configured surfaces).
+
+    ``tmux_client`` is used to populate :attr:`TmuxWindowState.present`
+    and ``pane_id``. When ``None`` we don't probe tmux — the response
+    still returns the configured ``window_name`` and the caller can
+    treat ``present`` as "unknown" (defaults to ``False``).
+
+    The returned list is ordered: operator first, then architects,
+    then advisors, then workers (sorted by ``project`` then ``task_id``).
+    Stable ordering keeps the JSON response deterministic for tests
+    and lets clients render a stable sidebar.
+    """
+    tmux_state_cache = _build_tmux_state_cache(config, tmux_client)
+    surfaces: list[ChatSurface] = []
+    surfaces.extend(enumerate_config_surfaces(
+        config, tmux_state_cache=tmux_state_cache,
+    ))
+    if work_service is not None:
+        surfaces.extend(enumerate_worker_surfaces(
+            config, work_service, tmux_state_cache=tmux_state_cache,
+        ))
+    surfaces.sort(key=_surface_sort_key)
+    return surfaces
+
+
+def enumerate_config_surfaces(
+    config: PollyPMConfig,
+    *,
+    tmux_state_cache: dict[str, TmuxWindowState] | None = None,
+) -> list[ChatSurface]:
+    """Enumerate operator/architect/advisor surfaces from ``config.sessions``.
+
+    Workers are NOT included (they live in the work-service, not the
+    config). Disabled sessions are also skipped — they aren't running
+    so they can't be chatted with.
+    """
+    surfaces: list[ChatSurface] = []
+    for session_name, session in (config.sessions or {}).items():
+        if not session.enabled:
+            continue
+        surface_type = _classify_session(session)
+        if surface_type is None:
+            continue
+        project_key = _project_key_for_session(config, session, surface_type)
+        project_root = _project_root_for_key(config, project_key)
+        persona = _persona_for_session(config, session, surface_type)
+        cwd = session.cwd if isinstance(session.cwd, Path) else Path(session.cwd or ".")
+        transcript_path = resolve_transcript_path(
+            project_root,
+            cwd=str(cwd),
+            session_hint=session_name,
+        )
+        window_name = session.window_name or session_name
+        if tmux_state_cache and window_name in tmux_state_cache:
+            window_state = tmux_state_cache[window_name]
+        else:
+            window_state = TmuxWindowState(
+                tmux_session=config.project.tmux_session,
+                window_name=window_name,
+                present=False,
+            )
+        surfaces.append(ChatSurface(
+            session_name=session_name,
+            surface_type=surface_type,
+            persona=persona,
+            project=project_key if surface_type != SurfaceType.OPERATOR else None,
+            window=window_state,
+            transcript_path=transcript_path,
+            cwd=cwd,
+            provider=str(session.provider),
+            auth_token_present=bool(session.auth_token),
+        ))
+    return surfaces
+
+
+def enumerate_worker_surfaces(
+    config: PollyPMConfig,
+    work_service: Any,
+    *,
+    tmux_state_cache: dict[str, TmuxWindowState] | None = None,
+) -> list[ChatSurface]:
+    """Enumerate per-task worker surfaces from the work-service.
+
+    Reads active :class:`WorkerSessionRecord`s and computes the
+    canonical ``task-{project}-{N}`` session_name for each.
+    """
+    list_fn = getattr(work_service, "list_worker_sessions", None)
+    if not callable(list_fn):
+        logger.debug(
+            "chat.registry: work_service has no list_worker_sessions; "
+            "skipping worker surfaces",
+        )
+        return []
+    try:
+        records = list_fn(active_only=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "chat.registry: list_worker_sessions failed: %s", exc,
+        )
+        return []
+    surfaces: list[ChatSurface] = []
+    for record in records or []:
+        project = getattr(record, "task_project", "") or ""
+        task_number = getattr(record, "task_number", 0)
+        if not project or not task_number:
+            continue
+        session_name = task_window_name(project, task_number)
+        project_root = _project_root_for_key(config, project)
+        worktree_path = (
+            Path(record.worktree_path) if record.worktree_path else None
+        )
+        cwd_for_lookup = str(worktree_path) if worktree_path else None
+        transcript_path = resolve_transcript_path(
+            project_root,
+            cwd=cwd_for_lookup,
+            session_hint=session_name,
+        )
+        provider_value = getattr(record, "provider", "") or ""
+        window_name = session_name
+        if tmux_state_cache and window_name in tmux_state_cache:
+            window_state = tmux_state_cache[window_name]
+        else:
+            window_state = TmuxWindowState(
+                tmux_session=config.project.tmux_session,
+                window_name=window_name,
+                present=False,
+                pane_id=getattr(record, "pane_id", None),
+            )
+        surfaces.append(ChatSurface(
+            session_name=session_name,
+            surface_type=SurfaceType.WORKER,
+            persona=None,
+            project=project,
+            window=window_state,
+            transcript_path=transcript_path,
+            task_id=int(task_number),
+            cwd=worktree_path,
+            provider=provider_value,
+            auth_token_present=False,
+            worktree_path=worktree_path,
+        ))
+    return surfaces
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _classify_session(session: SessionConfig) -> SurfaceType | None:
+    """Pick the surface type for a ``SessionConfig`` or return ``None``.
+
+    Returns ``None`` for roles that aren't chat-surface-shaped
+    (heartbeat-supervisor, reviewer, triage, etc.).
+    """
+    role = (session.role or "").lower().strip()
+    name = (session.name or "").lower().strip()
+    if role in _OPERATOR_ROLES or name in _OPERATOR_NAMES:
+        return SurfaceType.OPERATOR
+    if role in _ARCHITECT_ROLES or name.startswith("architect"):
+        return SurfaceType.ARCHITECT
+    if role in _ADVISOR_ROLES or name.startswith("advisor"):
+        return SurfaceType.ADVISOR
+    return None
+
+
+def _project_key_for_session(
+    config: PollyPMConfig,
+    session: SessionConfig,
+    surface_type: SurfaceType,
+) -> str:
+    """Pick the project key the session is bound to.
+
+    Operators are workspace-wide so we return the workspace's default
+    project (``config.project.name``). Architects/advisors are
+    explicitly per-project via ``SessionConfig.project``.
+    """
+    if surface_type == SurfaceType.OPERATOR:
+        return session.project or config.project.name
+    return session.project or config.project.name
+
+
+def _persona_for_session(
+    config: PollyPMConfig,
+    session: SessionConfig,
+    surface_type: SurfaceType,
+) -> str | None:
+    """Compute the display persona for a surface.
+
+    For operators we hard-code ``"Polly"`` (the global PM persona).
+    For architects and advisors we read the project's
+    :attr:`KnownProject.persona_name` so per-project personas show up
+    in the response.
+    """
+    if surface_type == SurfaceType.OPERATOR:
+        return "Polly"
+    project_key = session.project or config.project.name
+    project = (config.projects or {}).get(project_key)
+    if project and getattr(project, "persona_name", None):
+        return project.persona_name
+    # Fall back to the role-derived display name so the response is
+    # never None for configured persona surfaces.
+    if surface_type == SurfaceType.ARCHITECT:
+        return "Archie"
+    if surface_type == SurfaceType.ADVISOR:
+        return "Advisor"
+    return None
+
+
+def _project_root_for_key(config: PollyPMConfig, project_key: str) -> Path:
+    project = (config.projects or {}).get(project_key)
+    if project is not None:
+        return project.path
+    return config.project.root_dir
+
+
+def _build_tmux_state_cache(
+    config: PollyPMConfig,
+    tmux_client: Any | None,
+) -> dict[str, TmuxWindowState]:
+    """Probe tmux once and index ``TmuxWindowState`` by window name.
+
+    Calling ``list_windows`` once is cheaper than calling
+    ``has_session`` per surface, and lets us populate ``pane_id`` /
+    ``pane_dead`` in the same pass. Returns an empty dict when
+    ``tmux_client`` is ``None`` or the probe fails.
+    """
+    cache: dict[str, TmuxWindowState] = {}
+    if tmux_client is None:
+        return cache
+    list_windows = getattr(tmux_client, "list_windows", None)
+    if not callable(list_windows):
+        return cache
+    target = config.project.tmux_session
+    try:
+        windows = list_windows(target)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "chat.registry: tmux list_windows(%s) failed: %s",
+            target, exc,
+        )
+        return cache
+    for window in windows or []:
+        window_name = getattr(window, "name", "") or ""
+        if not window_name:
+            continue
+        cache[window_name] = TmuxWindowState(
+            tmux_session=getattr(window, "session", target),
+            window_name=window_name,
+            present=True,
+            pane_id=getattr(window, "pane_id", None),
+            pane_dead=bool(getattr(window, "pane_dead", False)),
+        )
+    return cache
+
+
+def _surface_sort_key(surface: ChatSurface) -> tuple[int, str, int]:
+    """Stable ordering — operator first, then alphabetical project."""
+    type_order = {
+        SurfaceType.OPERATOR: 0,
+        SurfaceType.ARCHITECT: 1,
+        SurfaceType.ADVISOR: 2,
+        SurfaceType.WORKER: 3,
+    }
+    return (
+        type_order.get(surface.surface_type, 99),
+        surface.project or "",
+        surface.task_id or 0,
+    )
+
+
+__all__ = [
+    "ChatSurface",
+    "SurfaceType",
+    "TmuxWindowState",
+    "enumerate_chat_surfaces",
+    "enumerate_config_surfaces",
+    "enumerate_worker_surfaces",
+]

--- a/src/pollypm/web_api/chat/registry.py
+++ b/src/pollypm/web_api/chat/registry.py
@@ -26,8 +26,12 @@ from pathlib import Path
 from typing import Any
 
 from pollypm.models import PollyPMConfig, SessionConfig
+from pollypm.projects import project_transcripts_dir
 from pollypm.work.session_manager import task_window_name
-from pollypm.web_api.chat.transcripts import resolve_transcript_path
+from pollypm.web_api.chat.transcripts import (
+    build_session_index,
+    lookup_transcript_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -177,28 +181,64 @@ def enumerate_chat_surfaces(
     and lets clients render a stable sidebar.
     """
     tmux_state_cache = _build_tmux_state_cache(config, tmux_client)
+    # Build the session-index ONCE per request — keyed by project root.
+    # Codex review blocker #2: previously each surface re-scanned the
+    # transcripts root inside ``resolve_transcript_path``. We now scan
+    # each project's root at most once via :func:`_build_session_index`
+    # and look up per surface (#2044).
+    session_index_cache: dict[Path, list] = {}
     surfaces: list[ChatSurface] = []
     surfaces.extend(enumerate_config_surfaces(
-        config, tmux_state_cache=tmux_state_cache,
+        config,
+        tmux_state_cache=tmux_state_cache,
+        session_index_cache=session_index_cache,
     ))
     if work_service is not None:
         surfaces.extend(enumerate_worker_surfaces(
-            config, work_service, tmux_state_cache=tmux_state_cache,
+            config, work_service,
+            tmux_state_cache=tmux_state_cache,
+            session_index_cache=session_index_cache,
         ))
     surfaces.sort(key=_surface_sort_key)
     return surfaces
+
+
+def _build_session_index(
+    project_root: Path,
+    cache: dict[Path, list] | None = None,
+) -> list:
+    """Return (and memoize) the session index for ``project_root``.
+
+    Keyed by the resolved transcripts root so multiple surfaces in the
+    same project share one scan, even when called via the two distinct
+    enumerate-*-surfaces helpers in the same request. The cache is
+    request-scoped (passed in by :func:`enumerate_chat_surfaces`); no
+    module-level state.
+    """
+    transcripts_root = project_transcripts_dir(project_root)
+    if cache is not None and transcripts_root in cache:
+        return cache[transcripts_root]
+    index = build_session_index(transcripts_root)
+    if cache is not None:
+        cache[transcripts_root] = index
+    return index
 
 
 def enumerate_config_surfaces(
     config: PollyPMConfig,
     *,
     tmux_state_cache: dict[str, TmuxWindowState] | None = None,
+    session_index_cache: dict[Path, list] | None = None,
 ) -> list[ChatSurface]:
     """Enumerate operator/architect/advisor surfaces from ``config.sessions``.
 
     Workers are NOT included (they live in the work-service, not the
     config). Disabled sessions are also skipped — they aren't running
     so they can't be chatted with.
+
+    ``session_index_cache`` memoizes the per-project session-index scan
+    so the same project's transcripts root is read at most once per
+    request even when multiple surfaces share it.
     """
     surfaces: list[ChatSurface] = []
     for session_name, session in (config.sessions or {}).items():
@@ -211,10 +251,12 @@ def enumerate_config_surfaces(
         project_root = _project_root_for_key(config, project_key)
         persona = _persona_for_session(config, session, surface_type)
         cwd = session.cwd if isinstance(session.cwd, Path) else Path(session.cwd or ".")
-        transcript_path = resolve_transcript_path(
-            project_root,
+        index = _build_session_index(project_root, session_index_cache)
+        transcript_path = lookup_transcript_path(
+            index,
             cwd=str(cwd),
-            session_hint=session_name,
+            account_name=session.account,
+            provider=str(session.provider),
         )
         window_name = session.window_name or session_name
         if tmux_state_cache and window_name in tmux_state_cache:
@@ -244,11 +286,16 @@ def enumerate_worker_surfaces(
     work_service: Any,
     *,
     tmux_state_cache: dict[str, TmuxWindowState] | None = None,
+    session_index_cache: dict[Path, list] | None = None,
 ) -> list[ChatSurface]:
     """Enumerate per-task worker surfaces from the work-service.
 
     Reads active :class:`WorkerSessionRecord`s and computes the
     canonical ``task-{project}-{N}`` session_name for each.
+
+    ``session_index_cache`` memoizes the per-project session-index scan
+    so multiple workers (and any config surface) under the same project
+    share one filesystem walk.
     """
     list_fn = getattr(work_service, "list_worker_sessions", None)
     if not callable(list_fn):
@@ -276,12 +323,14 @@ def enumerate_worker_surfaces(
             Path(record.worktree_path) if record.worktree_path else None
         )
         cwd_for_lookup = str(worktree_path) if worktree_path else None
-        transcript_path = resolve_transcript_path(
-            project_root,
-            cwd=cwd_for_lookup,
-            session_hint=session_name,
-        )
         provider_value = getattr(record, "provider", "") or ""
+        index = _build_session_index(project_root, session_index_cache)
+        transcript_path = lookup_transcript_path(
+            index,
+            cwd=cwd_for_lookup,
+            account_name=None,  # WorkerSessionRecord doesn't carry account
+            provider=provider_value or None,
+        )
         window_name = session_name
         if tmux_state_cache and window_name in tmux_state_cache:
             window_state = tmux_state_cache[window_name]

--- a/src/pollypm/web_api/chat/tmux_capture.py
+++ b/src/pollypm/web_api/chat/tmux_capture.py
@@ -1,0 +1,148 @@
+"""Fallback transcript reader using ``tmux capture-pane``.
+
+Per spec §4.7 and §4.12 the GET endpoint falls back to a live pane
+capture when the normalized archive is missing or stale (>60s) AND the
+tmux pane is alive. The Codex CLI doesn't write the Claude JSONL shape
+either, so Codex surfaces always land here.
+
+Each captured line becomes one :class:`MessageEnvelope` with
+``type=text`` and ``metadata.from_capture=true``. Envelope ids are
+synthesized as ``cap_<hex>`` from a blake2b digest of
+``f"{session_name}:{line_index}:{content}"`` so the same line read
+twice yields the same id (stable, sortable within a capture).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from pollypm.web_api.chat.envelope import (
+    MessageEnvelope,
+    MessageRole,
+    MessageType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Default capture depth — spec §4.7 calls out ``tmux capture-pane -p -S -3000``.
+# The pane scrollback ceiling lives in tmux config; -3000 lines is plenty
+# for the typical agent session without flooding the response.
+DEFAULT_CAPTURE_LINES = 3000
+
+
+# ANSI escape sequence stripper. Tmux capture preserves color codes by
+# default; strip them so the API returns clean text. Same regex shape
+# as :mod:`pollypm.recovery.worker_turn_end`.
+_ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_C0_CTRL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
+
+def synthesize_capture_id(session_name: str, line_index: int, content: str) -> str:
+    """Deterministic id for one captured pane line.
+
+    Hash includes the session name + line offset + content so the same
+    line captured twice yields the same id (stable) and two different
+    lines on the same offset still differ (collision-resistant).
+    """
+    key = f"{session_name}:{line_index}:{content}".encode("utf-8")
+    digest = hashlib.blake2b(key, digest_size=8).hexdigest()
+    return f"cap_{digest}"
+
+
+def capture_envelopes(
+    tmux_client: Any,
+    *,
+    session_name: str,
+    target: str,
+    actor_fallback: str = "agent",
+    lines: int = DEFAULT_CAPTURE_LINES,
+    timestamp: str | None = None,
+    role: MessageRole = MessageRole.ASSISTANT,
+) -> list[MessageEnvelope]:
+    """Capture a tmux pane and translate each line into an envelope.
+
+    ``tmux_client`` — a :class:`pollypm.tmux.client.TmuxClient` (or
+    test double exposing ``capture_pane(target, lines=...)``).
+
+    ``session_name`` — the surface's session_name; used only for
+    envelope id stability and the ``metadata.session_name`` field.
+
+    ``target`` — tmux target string the client expects (e.g.
+    ``"storage-closet:pm-operator"``). Built by the registry layer
+    from the surface's tmux session + window.
+
+    ``actor_fallback`` — actor name to stamp on every envelope.
+
+    ``lines`` — capture depth (-S argument to tmux capture-pane).
+
+    ``timestamp`` — ISO-8601 string for every envelope; defaults to
+    capture wall-clock. (Pane captures don't carry per-line timestamps
+    — the whole capture happened at the same instant from our PoV.)
+
+    Returns ``[]`` on any tmux failure; the caller decides whether to
+    surface an error or fall through to "no transcript available".
+    """
+    if tmux_client is None:
+        return []
+    capture_fn = getattr(tmux_client, "capture_pane", None)
+    if not callable(capture_fn):
+        return []
+    try:
+        raw = capture_fn(target, lines=lines)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "chat.tmux_capture: capture_pane failed for %s (target=%s): %s",
+            session_name, target, exc,
+        )
+        return []
+    if not isinstance(raw, str) or not raw:
+        return []
+    cleaned = _strip_control_codes(raw)
+    ts = timestamp or _utc_now()
+    envelopes: list[MessageEnvelope] = []
+    for line_index, line in enumerate(cleaned.splitlines()):
+        # Skip leading/trailing pure-whitespace lines but preserve internal
+        # blank lines so the structure of a Claude-Code box is recognisable.
+        if not line.strip() and not envelopes:
+            continue
+        envelope_id = synthesize_capture_id(session_name, line_index, line)
+        envelopes.append(MessageEnvelope(
+            id=envelope_id,
+            ts=ts,
+            role=role,
+            actor=actor_fallback,
+            type=MessageType.TEXT,
+            text=line,
+            metadata={
+                "from_capture": True,
+                "session_name": session_name,
+                "line_index": line_index,
+            },
+        ))
+    # Drop any trailing blank lines that we appended along the way —
+    # they're just visual padding at the bottom of the pane.
+    while envelopes and not envelopes[-1].text.strip():
+        envelopes.pop()
+    return envelopes
+
+
+def _strip_control_codes(text: str) -> str:
+    text = _ANSI_CSI_RE.sub("", text)
+    text = _C0_CTRL_RE.sub("", text)
+    return text
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+__all__ = [
+    "DEFAULT_CAPTURE_LINES",
+    "capture_envelopes",
+    "synthesize_capture_id",
+]

--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -1,0 +1,798 @@
+"""Parse the normalized ``events.jsonl`` archive into MessageEnvelopes.
+
+The upstream :class:`pollypm.transcript_ingest.TranscriptIngestor` polls
+provider JSONLs (Claude Code, Codex) and rewrites them into a project-
+scoped, normalized event stream at::
+
+    <project>/.pollypm/transcripts/<session_id>/events.jsonl
+
+Each line is one ``_event_base`` dict (see ``transcript_ingest.py``):
+
+    {
+      "timestamp": "2026-05-21T20:48:11Z",
+      "event_type": "user_turn" | "assistant_turn" | "tool_call"
+                  | "tool_result" | "error" | "token_usage"
+                  | "session_state" | "turn_end",
+      "session_id": "<provider-internal uuid>",
+      "account_name": "claude_main",
+      "provider": "claude" | "codex",
+      "project_key": "samblog",
+      "source_path": "...",
+      "source_offset": 12345,
+      "cwd": "/path/to/project",
+      "model_name": "claude-opus-4-7",
+      "payload": {...}    # provider-shape preserved verbatim
+    }
+
+This module translates each event into a :class:`MessageEnvelope`, with
+the following non-trivial mappings:
+
+- ``token_usage`` and ``session_state`` are dropped (not chat messages).
+- ``tool_call`` for the Claude ``Task`` tool becomes a
+  ``subagent_spawn`` envelope (subagent_id = tool_use_id).
+- The matching ``tool_result`` for a Task call becomes
+  ``subagent_result``.
+- Claude ``AskUserQuestion`` tool calls become ``ask_user`` envelopes.
+- Claude ``SendUserFile`` tool calls become ``file`` envelopes.
+- ``thinking`` blocks (when surfaced by the provider) only flow when
+  ``include_thinking=True``.
+- Compaction / session-start markers become ``system_event``.
+
+The parser is pure: takes a file path + flags, returns a list of
+envelopes. The P2 router layers pagination / filtering on top.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from pollypm.projects import project_transcripts_dir
+from pollypm.web_api.chat.envelope import (
+    MessageEnvelope,
+    MessageRole,
+    MessageType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Spec §4.7 — when the archive hasn't been written in ``N`` seconds AND
+# the tmux pane is live, fall back to ``tmux capture-pane``. Default 60s
+# per the spec; exposed as a module-level constant so callers can tune
+# (the future SSE / polling endpoints may want a different threshold).
+STALE_THRESHOLD_SECONDS = 60.0
+
+
+# Claude's special tool names that get bespoke envelope discriminators.
+# Anything else falls through to the generic ``tool_use`` rendering.
+_TASK_TOOL_NAMES = frozenset({"Task", "Agent"})
+_ASK_USER_TOOL_NAMES = frozenset({"AskUserQuestion"})
+_FILE_TOOL_NAMES = frozenset({"SendUserFile"})
+
+
+# Codex payload-type discriminators that need their own translation.
+# Most Codex events flow through the generic mapping; these are the
+# exceptions where the spec wants a richer envelope.
+_CODEX_PAYLOAD_KINDS = {
+    "tool_call": MessageType.TOOL_USE,
+    "tool_result": MessageType.TOOL_RESULT,
+}
+
+
+def resolve_transcript_path(
+    project_root: Path,
+    cwd: str | None = None,
+    *,
+    session_hint: str | None = None,
+) -> Path | None:
+    """Find the most recent ``events.jsonl`` for a surface.
+
+    The ingestor names subdirectories by the provider-internal session
+    UUID (Claude ``sessionId`` / Codex ``session_meta.id``), not by the
+    tmux session name. We resolve the right subdir by walking the
+    project's transcripts root and preferring:
+
+    1. A subdir whose tail event's ``cwd`` matches ``cwd``, OR
+    2. The most-recently-modified ``events.jsonl`` under the root.
+
+    Returns ``None`` when no events file exists yet (e.g. brand-new
+    session that hasn't streamed its first turn). Per spec §4.8 this is
+    not an error — callers surface ``messages: []`` to the client.
+    """
+    root = project_transcripts_dir(project_root)
+    if not root.exists():
+        return None
+    candidates: list[tuple[float, Path, str | None]] = []
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        if child.name in {"tasks", ".ingestion-state.lock"}:
+            # ``tasks/`` holds per-task raw-provider-JSONL archives
+            # written by SessionManager._archive_jsonl; not normalized.
+            continue
+        if session_hint and child.name == session_hint:
+            events_path = child / "events.jsonl"
+            if events_path.exists():
+                return events_path
+        events_path = child / "events.jsonl"
+        if not events_path.exists():
+            continue
+        try:
+            mtime = events_path.stat().st_mtime
+        except OSError:
+            continue
+        candidates.append((mtime, events_path, _tail_cwd(events_path)))
+    if not candidates:
+        return None
+    if cwd:
+        normalized = str(Path(cwd).resolve())
+        matching = [
+            (mtime, path)
+            for mtime, path, tail_cwd in candidates
+            if tail_cwd and str(Path(tail_cwd).resolve()) == normalized
+        ]
+        if matching:
+            matching.sort(reverse=True)
+            return matching[0][1]
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def _tail_cwd(events_path: Path) -> str | None:
+    """Best-effort: return the ``cwd`` from the last well-formed event.
+
+    Used by :func:`resolve_transcript_path` to pick the right subdir
+    when multiple Claude sessions have streamed into the same project.
+    Reads only the tail of the file (~16 KB) so we don't choke on
+    multi-MB transcripts.
+    """
+    try:
+        size = events_path.stat().st_size
+    except OSError:
+        return None
+    if size == 0:
+        return None
+    read_size = min(size, 16 * 1024)
+    try:
+        with events_path.open("rb") as handle:
+            handle.seek(size - read_size)
+            tail = handle.read().decode("utf-8", errors="ignore")
+    except OSError:
+        return None
+    last_cwd: str | None = None
+    for line in tail.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            cwd = obj.get("cwd")
+            if isinstance(cwd, str) and cwd:
+                last_cwd = cwd
+    return last_cwd
+
+
+def is_archive_stale(
+    events_path: Path | None,
+    *,
+    threshold_seconds: float = STALE_THRESHOLD_SECONDS,
+    now: float | None = None,
+) -> bool:
+    """True when the archive is missing or older than the threshold.
+
+    Drives the spec §4.7 jsonl→capture fallback decision: when the
+    ingestor hasn't appended in over ``threshold_seconds``, the live
+    pane is the authoritative source. ``now`` is injectable for tests.
+    """
+    if events_path is None or not events_path.exists():
+        return True
+    try:
+        mtime = events_path.stat().st_mtime
+    except OSError:
+        return True
+    current = now if now is not None else time.time()
+    return (current - mtime) > threshold_seconds
+
+
+def parse_events_jsonl(
+    events_path: Path,
+    *,
+    include_thinking: bool = False,
+    actor_fallback: str = "agent",
+) -> list[MessageEnvelope]:
+    """Parse an ``events.jsonl`` archive into envelopes.
+
+    ``include_thinking`` — when ``False`` (default), ``thinking``
+    blocks are dropped per spec §3.4.
+
+    ``actor_fallback`` — used when the event doesn't carry a clear
+    actor name. The registry layer passes the surface's persona name
+    here so worker transcripts say ``"worker"`` and operator transcripts
+    say ``"Polly"``.
+
+    Malformed lines are skipped with a debug log; the parser never
+    raises on bad JSON because partially-flushed archives are normal
+    (the ingestor appends line-by-line, the API may read mid-flush).
+    """
+    envelopes: list[MessageEnvelope] = []
+    if not events_path.exists():
+        return envelopes
+    source_key = hashlib.blake2b(
+        str(events_path).encode("utf-8"), digest_size=4,
+    ).hexdigest()
+    try:
+        with events_path.open("r", encoding="utf-8", errors="ignore") as handle:
+            while True:
+                start_offset = handle.tell()
+                line = handle.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.debug(
+                        "chat.transcripts: skipping malformed line in %s @ %d",
+                        events_path, start_offset,
+                    )
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                converted = _event_to_envelopes(
+                    event,
+                    offset=start_offset,
+                    source_key=source_key,
+                    include_thinking=include_thinking,
+                    actor_fallback=actor_fallback,
+                )
+                envelopes.extend(converted)
+    except OSError as exc:
+        logger.warning(
+            "chat.transcripts: read failed for %s: %s",
+            events_path, exc,
+        )
+        return envelopes
+    return envelopes
+
+
+def _event_to_envelopes(
+    event: dict[str, Any],
+    *,
+    offset: int,
+    source_key: str,
+    include_thinking: bool,
+    actor_fallback: str,
+) -> list[MessageEnvelope]:
+    """Translate one ingestor event into 0+ envelopes.
+
+    Most events emit exactly one envelope; the multi-emit case is
+    reserved for future Codex shapes that bundle several user/assistant
+    turns in a single ``event_msg`` line.
+    """
+    event_type = event.get("event_type")
+    timestamp = str(event.get("timestamp") or "")
+    payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+    provider = str(event.get("provider") or "")
+    msg_id = _envelope_id(source_key, offset, payload, event_type)
+
+    if event_type == "user_turn":
+        return [_envelope_user_turn(event, payload, msg_id, timestamp)]
+    if event_type == "assistant_turn":
+        return [_envelope_assistant_turn(
+            event, payload, msg_id, timestamp, actor_fallback,
+        )]
+    if event_type == "tool_call":
+        return _envelope_tool_call(
+            event, payload, msg_id, timestamp, provider, actor_fallback,
+        )
+    if event_type == "tool_result":
+        return _envelope_tool_result(
+            event, payload, msg_id, timestamp, provider,
+        )
+    if event_type == "error":
+        return [_envelope_error(event, payload, msg_id, timestamp)]
+    if event_type == "turn_end":
+        return [_envelope_turn_end(event, payload, msg_id, timestamp)]
+    # ``token_usage`` and ``session_state`` are not chat messages per
+    # the spec — skip silently. The token data lives on the analytics
+    # rail and the session_state marker is handled by the registry.
+    return []
+
+
+def _envelope_id(
+    source_key: str,
+    offset: int,
+    payload: dict[str, Any],
+    event_type: Any,
+) -> str:
+    """Derive a stable, unique envelope id.
+
+    Prefer the provider's own ``tool_use_id`` when present (so a
+    follow-up ``tool_result`` can link to the spawn deterministically
+    even when the offsets differ). Fall back to ``msg_<sourcekey>_<offset>``
+    which is unique within a file.
+    """
+    tool_use_id = payload.get("id") if isinstance(payload, dict) else None
+    if isinstance(tool_use_id, str) and tool_use_id:
+        if event_type == "tool_call":
+            return f"msg_{tool_use_id}"
+    return f"msg_{source_key}_{offset:08x}"
+
+
+def _extract_text_from_blocks(value: Any) -> str:
+    """Mirror :func:`transcript_ingest._extract_text` for our parsing.
+
+    Claude content can be a string, a list of ``{type, text}`` blocks,
+    or a dict. The ingestor flattens it into one string for
+    ``user_turn`` / ``assistant_turn`` events, but ``tool_result``
+    events keep the raw content list — we have to unwrap it here.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+            elif isinstance(item, str) and item:
+                parts.append(item)
+        return "\n".join(parts).strip()
+    if isinstance(value, dict):
+        text = value.get("text")
+        if isinstance(text, str):
+            return text
+    return ""
+
+
+def _envelope_user_turn(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+) -> MessageEnvelope:
+    text = str(payload.get("text") or "")
+    return MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.USER,
+        actor="user",
+        type=MessageType.TEXT,
+        text=text,
+        metadata={"provider": event.get("provider", "")},
+    )
+
+
+def _envelope_assistant_turn(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+    actor_fallback: str,
+) -> MessageEnvelope:
+    text = str(payload.get("text") or "")
+    return MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.ASSISTANT,
+        actor=actor_fallback,
+        type=MessageType.TEXT,
+        text=text,
+        metadata={
+            "provider": event.get("provider", ""),
+            "model": event.get("model_name") or "",
+        },
+    )
+
+
+def _envelope_tool_call(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+    provider: str,
+    actor_fallback: str,
+) -> list[MessageEnvelope]:
+    """Branch the ``tool_call`` event by tool name into the right shape.
+
+    Claude tool calls carry ``{type:"tool_use", id, name, input}``.
+    Codex tool calls have a different shape (handled inline below).
+    """
+    if provider == "claude":
+        tool_name = str(payload.get("name") or "")
+        tool_input = payload.get("input") if isinstance(payload.get("input"), dict) else {}
+        tool_use_id = str(payload.get("id") or msg_id)
+        if tool_name in _TASK_TOOL_NAMES:
+            return [_envelope_subagent_spawn(
+                event, payload, msg_id, timestamp,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                tool_use_id=tool_use_id,
+                actor_fallback=actor_fallback,
+            )]
+        if tool_name in _ASK_USER_TOOL_NAMES:
+            return [_envelope_ask_user(
+                event, payload, msg_id, timestamp,
+                tool_input=tool_input,
+                tool_use_id=tool_use_id,
+                actor_fallback=actor_fallback,
+            )]
+        if tool_name in _FILE_TOOL_NAMES:
+            return [_envelope_file(
+                event, payload, msg_id, timestamp,
+                tool_input=tool_input,
+                tool_use_id=tool_use_id,
+                actor_fallback=actor_fallback,
+            )]
+        text = _format_tool_use_summary(tool_name, tool_input)
+        return [MessageEnvelope(
+            id=msg_id,
+            ts=timestamp,
+            role=MessageRole.ASSISTANT,
+            actor=actor_fallback,
+            type=MessageType.TOOL_USE,
+            text=text,
+            metadata={
+                "tool_use_id": tool_use_id,
+                "tool_name": tool_name,
+                "tool_input": tool_input,
+            },
+        )]
+    # Codex path — payload is the raw event_msg payload. Best-effort:
+    # render the tool name + a short input summary, defer the deeper
+    # parsing (Codex tool shapes are still in flux) to a P3 follow-up.
+    tool_name = str(
+        payload.get("name") or payload.get("tool") or payload.get("type") or "tool"
+    )
+    return [MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.ASSISTANT,
+        actor=actor_fallback,
+        type=MessageType.TOOL_USE,
+        text=f"[{tool_name}]",
+        metadata={
+            "tool_use_id": msg_id,
+            "tool_name": tool_name,
+            "tool_input": payload,
+        },
+    )]
+
+
+def _envelope_tool_result(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+    provider: str,
+) -> list[MessageEnvelope]:
+    """Tool result envelope; link to spawn via ``tool_use_id``."""
+    if provider == "claude":
+        tool_use_id = str(payload.get("tool_use_id") or "")
+        content = payload.get("content") or []
+        is_error = bool(payload.get("is_error", False))
+        text = _extract_text_from_blocks(content)
+        # If this is a Task tool result, emit ``subagent_result``.
+        # The spawn-side envelope ALSO carries the tool_use_id under
+        # ``metadata.subagent_id`` so the P2 router can pair them.
+        if _looks_like_subagent_result(content):
+            return [_envelope_subagent_result(
+                event, payload, msg_id, timestamp,
+                tool_use_id=tool_use_id,
+                content=content,
+                text=text,
+            )]
+        return [MessageEnvelope(
+            id=msg_id,
+            ts=timestamp,
+            role=MessageRole.TOOL,
+            actor="tool",
+            type=MessageType.TOOL_RESULT,
+            text=text,
+            metadata={
+                "tool_use_id": tool_use_id,
+                "is_error": is_error,
+                "content": content,
+            },
+        )]
+    # Codex: leave the structured payload intact, render a short text.
+    summary = _extract_text_from_blocks(
+        payload.get("output") or payload.get("text") or payload.get("content"),
+    )
+    return [MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.TOOL,
+        actor="tool",
+        type=MessageType.TOOL_RESULT,
+        text=summary,
+        metadata={"tool_use_id": "", "is_error": False, "content": payload},
+    )]
+
+
+def _envelope_subagent_spawn(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+    *,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    tool_use_id: str,
+    actor_fallback: str,
+) -> MessageEnvelope:
+    description = str(tool_input.get("description") or "")
+    summary = description or "subagent"
+    return MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.ASSISTANT,
+        actor=actor_fallback,
+        type=MessageType.SUBAGENT_SPAWN,
+        text=f"[subagent] {summary}",
+        metadata={
+            "subagent_id": tool_use_id,
+            "subagent_type": str(tool_input.get("subagent_type") or "general-purpose"),
+            "description": description,
+            "prompt": str(tool_input.get("prompt") or ""),
+            "isolation": str(tool_input.get("isolation") or ""),
+            "run_in_background": bool(tool_input.get("run_in_background", False)),
+            "tool_use_id": tool_use_id,
+            "tool_name": tool_name,
+        },
+    )
+
+
+def _envelope_subagent_result(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+    *,
+    tool_use_id: str,
+    content: Any,
+    text: str,
+) -> MessageEnvelope:
+    """Render a Task tool's result as a subagent_result envelope.
+
+    P1 surfaces the text summary + the ``tool_use_id`` (which the
+    spawn-side envelope ALSO carries as ``subagent_id``) so the P2
+    router can pair spawn ↔ result. We do NOT inline the subagent's
+    own transcript here — that requires the ingestor to preserve
+    ``task-notification`` block ``output-file`` references (the JSONL
+    path of the subagent's own session). See follow-up issue noted in
+    the P1 PR description.
+    """
+    notification = _extract_task_notification(content)
+    metadata: dict[str, Any] = {
+        "subagent_id": tool_use_id,
+        "tool_use_id": tool_use_id,
+        "summary": text[:200] if text else "",
+        "result_body_truncated": False,
+        "content": content,
+    }
+    if notification:
+        metadata.update({
+            "task_id": str(notification.get("task-id") or ""),
+            "output_file": str(notification.get("output-file") or ""),
+            "duration_ms": int(notification.get("duration-ms") or 0),
+            "total_tokens": int(notification.get("total-tokens") or 0),
+            "worktree_path": str(notification.get("worktree-path") or ""),
+        })
+    return MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.TOOL,
+        actor="tool",
+        type=MessageType.SUBAGENT_RESULT,
+        text=text or "(subagent completed)",
+        metadata=metadata,
+    )
+
+
+def _envelope_ask_user(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+    *,
+    tool_input: dict[str, Any],
+    tool_use_id: str,
+    actor_fallback: str,
+) -> MessageEnvelope:
+    questions_raw = tool_input.get("questions")
+    if not isinstance(questions_raw, list):
+        questions_raw = []
+    primary_text = ""
+    if questions_raw:
+        first = questions_raw[0]
+        if isinstance(first, dict):
+            primary_text = str(first.get("question") or "")
+    return MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.ASSISTANT,
+        actor=actor_fallback,
+        type=MessageType.ASK_USER,
+        text=primary_text or "[ask_user]",
+        metadata={
+            "tool_use_id": tool_use_id,
+            "questions": questions_raw,
+            "answered": False,
+            "answers": None,
+        },
+    )
+
+
+def _envelope_file(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+    *,
+    tool_input: dict[str, Any],
+    tool_use_id: str,
+    actor_fallback: str,
+) -> MessageEnvelope:
+    files_raw = tool_input.get("files")
+    if isinstance(files_raw, str):
+        files = [files_raw]
+    elif isinstance(files_raw, list):
+        files = [str(item) for item in files_raw if isinstance(item, (str, Path))]
+    else:
+        files = []
+    caption = str(tool_input.get("caption") or "")
+    status = str(tool_input.get("status") or "")
+    display = ", ".join(files) if files else "(no files)"
+    return MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.ASSISTANT,
+        actor=actor_fallback,
+        type=MessageType.FILE,
+        text=f"[file] {display}",
+        metadata={
+            "tool_use_id": tool_use_id,
+            "files": files,
+            "caption": caption,
+            "status": status,
+        },
+    )
+
+
+def _envelope_error(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+) -> MessageEnvelope:
+    error_blob = payload.get("error") if isinstance(payload, dict) else payload
+    text = ""
+    if isinstance(error_blob, dict):
+        text = str(
+            error_blob.get("message")
+            or error_blob.get("text")
+            or json.dumps(error_blob, default=str)[:200],
+        )
+    else:
+        text = str(error_blob or "(error)")
+    return MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.SYSTEM,
+        actor="system",
+        type=MessageType.SYSTEM_EVENT,
+        text=text,
+        metadata={"subtype": "error", "error": error_blob},
+    )
+
+
+def _envelope_turn_end(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    msg_id: str,
+    timestamp: str,
+) -> MessageEnvelope:
+    """Codex-only — Claude doesn't emit a turn-end marker.
+
+    Surfaced as a system_event so clients can render turn boundaries
+    when they want them; default UIs should hide it.
+    """
+    return MessageEnvelope(
+        id=msg_id,
+        ts=timestamp,
+        role=MessageRole.SYSTEM,
+        actor="system",
+        type=MessageType.SYSTEM_EVENT,
+        text="(turn end)",
+        metadata={"subtype": "turn_end", "raw": payload},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_tool_use_summary(tool_name: str, tool_input: dict[str, Any]) -> str:
+    """One-liner display string for a tool_use envelope.
+
+    Per spec §3.2 the API formats things like ``[Bash] git status`` so
+    front-ends can render tool calls without parsing the input dict.
+    """
+    if not tool_name:
+        return "[tool]"
+    if tool_name == "Bash":
+        cmd = str(tool_input.get("command") or "").strip()
+        # Bash commands can be multi-line; clamp to a single line.
+        first_line = cmd.splitlines()[0] if cmd else ""
+        clamp = first_line[:120]
+        return f"[Bash] {clamp}" if clamp else "[Bash]"
+    if tool_name in {"Read", "Edit", "Write", "Glob", "Grep"}:
+        path = (
+            tool_input.get("file_path")
+            or tool_input.get("path")
+            or tool_input.get("pattern")
+            or ""
+        )
+        return f"[{tool_name}] {path}".rstrip()
+    if tool_name == "WebFetch":
+        return f"[WebFetch] {tool_input.get('url') or ''}".rstrip()
+    if tool_name == "WebSearch":
+        return f"[WebSearch] {tool_input.get('query') or ''}".rstrip()
+    description = tool_input.get("description") or tool_input.get("query") or ""
+    return f"[{tool_name}] {description}".rstrip() if description else f"[{tool_name}]"
+
+
+def _looks_like_subagent_result(content: Any) -> bool:
+    """Detect whether a ``tool_result`` content list is from Task/Agent.
+
+    Claude returns Task results as a list with a ``task-notification``
+    block carrying ``task-id`` + ``output-file`` keys (along with the
+    summary text). This is the strongest signal that the parent
+    tool_use was a subagent spawn.
+    """
+    if not isinstance(content, list):
+        return False
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "task-notification":
+            return True
+        # Some Claude versions wrap in a structured dict with this key.
+        if "task-id" in item and "output-file" in item:
+            return True
+    return False
+
+
+def _extract_task_notification(content: Any) -> dict[str, Any] | None:
+    """Pull the first ``task-notification`` block out of a result content."""
+    if not isinstance(content, list):
+        return None
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "task-notification":
+            return item
+        if "task-id" in item and "output-file" in item:
+            return item
+    return None
+
+
+__all__ = [
+    "STALE_THRESHOLD_SECONDS",
+    "is_archive_stale",
+    "parse_events_jsonl",
+    "resolve_transcript_path",
+]

--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -34,9 +34,11 @@ the following non-trivial mappings:
   ``subagent_result``.
 - Claude ``AskUserQuestion`` tool calls become ``ask_user`` envelopes.
 - Claude ``SendUserFile`` tool calls become ``file`` envelopes.
-- ``thinking`` blocks (when surfaced by the provider) only flow when
-  ``include_thinking=True``.
 - Compaction / session-start markers become ``system_event``.
+
+The ingestor does NOT currently preserve provider ``thinking`` blocks,
+so the P1 envelope contract does not surface them. Tracking that work
+as a follow-up arc (see GitHub issue linked in the P1 PR description).
 
 The parser is pure: takes a file path + flags, returns a list of
 envelopes. The P2 router layers pagination / filtering on top.
@@ -48,6 +50,7 @@ import hashlib
 import json
 import logging
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -84,41 +87,51 @@ _CODEX_PAYLOAD_KINDS = {
 }
 
 
-def resolve_transcript_path(
-    project_root: Path,
-    cwd: str | None = None,
-    *,
-    session_hint: str | None = None,
-) -> Path | None:
-    """Find the most recent ``events.jsonl`` for a surface.
+# A "session-index" entry: one record per ingested ``events.jsonl``
+# under a project's transcripts root. The registry builds the index
+# ONCE per request (via :func:`build_session_index`) and then matches
+# each surface by its fingerprint (cwd + account + provider) via
+# :func:`lookup_transcript_path` — no per-surface filesystem fan-out.
+#
+# Codex review blocker (#2044): the prior implementation fell back to
+# "freshest mtime under the project" when cwd matching had ties, which
+# could cross-attach the operator's transcript to the architect (or
+# vice-versa) whenever two surfaces shared a cwd. The fingerprint-based
+# index returns ``None`` for ambiguous surfaces instead of guessing.
+@dataclass(frozen=True, slots=True)
+class _SessionIndexEntry:
+    path: Path
+    session_id: str
+    cwd: str
+    account_name: str
+    provider: str
+    mtime: float
 
-    The ingestor names subdirectories by the provider-internal session
-    UUID (Claude ``sessionId`` / Codex ``session_meta.id``), not by the
-    tmux session name. We resolve the right subdir by walking the
-    project's transcripts root and preferring:
 
-    1. A subdir whose tail event's ``cwd`` matches ``cwd``, OR
-    2. The most-recently-modified ``events.jsonl`` under the root.
+def build_session_index(transcripts_root: Path) -> list[_SessionIndexEntry]:
+    """Walk a project's transcripts root and index every ``events.jsonl``.
 
-    Returns ``None`` when no events file exists yet (e.g. brand-new
-    session that hasn't streamed its first turn). Per spec §4.8 this is
-    not an error — callers surface ``messages: []`` to the client.
+    Reads the first well-formed event from each ``<session_id>/events.jsonl``
+    to extract ``(session_id, cwd, account_name, provider)`` — the
+    fingerprint we match a :class:`pollypm.models.SessionConfig` against.
+
+    Skips the ``tasks/`` subdirectory (raw-provider JSONLs archived by
+    :meth:`SessionManager._archive_jsonl`) and any malformed/empty files.
+
+    Cheaper than the prior tail-read because the first event of any
+    normalized ``events.jsonl`` already carries the full ``_event_base``
+    metadata (see :func:`pollypm.transcript_ingest._event_base`).
     """
-    root = project_transcripts_dir(project_root)
-    if not root.exists():
-        return None
-    candidates: list[tuple[float, Path, str | None]] = []
-    for child in root.iterdir():
+    if not transcripts_root.exists():
+        return []
+    entries: list[_SessionIndexEntry] = []
+    for child in transcripts_root.iterdir():
         if not child.is_dir():
             continue
         if child.name in {"tasks", ".ingestion-state.lock"}:
             # ``tasks/`` holds per-task raw-provider-JSONL archives
             # written by SessionManager._archive_jsonl; not normalized.
             continue
-        if session_hint and child.name == session_hint:
-            events_path = child / "events.jsonl"
-            if events_path.exists():
-                return events_path
         events_path = child / "events.jsonl"
         if not events_path.exists():
             continue
@@ -126,58 +139,133 @@ def resolve_transcript_path(
             mtime = events_path.stat().st_mtime
         except OSError:
             continue
-        candidates.append((mtime, events_path, _tail_cwd(events_path)))
-    if not candidates:
-        return None
-    if cwd:
-        normalized = str(Path(cwd).resolve())
-        matching = [
-            (mtime, path)
-            for mtime, path, tail_cwd in candidates
-            if tail_cwd and str(Path(tail_cwd).resolve()) == normalized
-        ]
-        if matching:
-            matching.sort(reverse=True)
-            return matching[0][1]
-    candidates.sort(key=lambda item: item[0], reverse=True)
-    return candidates[0][1]
+        fingerprint = _read_first_event_fingerprint(events_path)
+        if fingerprint is None:
+            # Empty / malformed — skip so we never serve an
+            # unidentifiable transcript to the wrong surface.
+            continue
+        session_id, cwd, account_name, provider = fingerprint
+        # Prefer the directory name as the canonical session_id (the
+        # ingestor names dirs by session_id), but fall back to the event's
+        # session_id if the dir name diverges.
+        entries.append(_SessionIndexEntry(
+            path=events_path,
+            session_id=child.name or session_id,
+            cwd=cwd,
+            account_name=account_name,
+            provider=provider,
+            mtime=mtime,
+        ))
+    return entries
 
 
-def _tail_cwd(events_path: Path) -> str | None:
-    """Best-effort: return the ``cwd`` from the last well-formed event.
+def lookup_transcript_path(
+    index: list[_SessionIndexEntry],
+    *,
+    cwd: str | None,
+    account_name: str | None = None,
+    provider: str | None = None,
+) -> Path | None:
+    """Resolve a single surface's events.jsonl path from the index.
 
-    Used by :func:`resolve_transcript_path` to pick the right subdir
-    when multiple Claude sessions have streamed into the same project.
-    Reads only the tail of the file (~16 KB) so we don't choke on
-    multi-MB transcripts.
+    Matching is fingerprint-based, NOT "freshest under the project":
+
+    1. ``cwd`` must match the surface's cwd (resolved). Required.
+    2. When ``account_name`` is given, entries with a different
+       ``account_name`` are filtered out.
+    3. When ``provider`` is given, entries with a different
+       ``provider`` are filtered out.
+    4. If multiple entries remain (e.g. a restarted session left two
+       events.jsonl with the same fingerprint), the most-recent mtime
+       wins — same fingerprint means same surface identity, so this
+       can never cross-attach to a different surface.
+    5. No matches → ``None`` (spec §4.8 — surface ``messages: []``).
+       Cross-surface fallback is explicitly forbidden.
     """
+    if not index or not cwd:
+        return None
     try:
-        size = events_path.stat().st_size
-    except OSError:
-        return None
-    if size == 0:
-        return None
-    read_size = min(size, 16 * 1024)
-    try:
-        with events_path.open("rb") as handle:
-            handle.seek(size - read_size)
-            tail = handle.read().decode("utf-8", errors="ignore")
-    except OSError:
-        return None
-    last_cwd: str | None = None
-    for line in tail.splitlines():
-        line = line.strip()
-        if not line:
+        normalized = str(Path(cwd).resolve())
+    except (OSError, RuntimeError):
+        normalized = str(cwd)
+    matches: list[_SessionIndexEntry] = []
+    for entry in index:
+        if not entry.cwd:
             continue
         try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
+            entry_cwd = str(Path(entry.cwd).resolve())
+        except (OSError, RuntimeError):
+            entry_cwd = entry.cwd
+        if entry_cwd != normalized:
             continue
-        if isinstance(obj, dict):
-            cwd = obj.get("cwd")
-            if isinstance(cwd, str) and cwd:
-                last_cwd = cwd
-    return last_cwd
+        if account_name and entry.account_name and entry.account_name != account_name:
+            continue
+        if provider and entry.provider and entry.provider != provider:
+            continue
+        matches.append(entry)
+    if not matches:
+        return None
+    matches.sort(key=lambda item: item.mtime, reverse=True)
+    return matches[0].path
+
+
+def resolve_transcript_path(
+    project_root: Path,
+    cwd: str | None = None,
+    *,
+    account_name: str | None = None,
+    provider: str | None = None,
+) -> Path | None:
+    """One-shot fingerprint resolver for a single surface.
+
+    Builds the index for ``project_root`` then looks up by fingerprint.
+    Callers iterating multiple surfaces should use
+    :func:`build_session_index` + :func:`lookup_transcript_path` to
+    amortize the scan; this helper exists for one-off resolution and to
+    keep the public surface ergonomic.
+
+    Returns ``None`` when no transcript matches the fingerprint — never
+    falls back to another surface's archive.
+    """
+    root = project_transcripts_dir(project_root)
+    index = build_session_index(root)
+    return lookup_transcript_path(
+        index, cwd=cwd, account_name=account_name, provider=provider,
+    )
+
+
+def _read_first_event_fingerprint(
+    events_path: Path,
+) -> tuple[str, str, str, str] | None:
+    """Return ``(session_id, cwd, account_name, provider)`` from line 1.
+
+    The ingestor writes ``_event_base`` dicts that always carry these
+    four fields, so we only need to read one well-formed line. Returns
+    ``None`` when the file is empty or contains nothing decodable.
+    """
+    try:
+        with events_path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for _ in range(8):  # Tolerate a handful of leading blanks.
+                line = handle.readline()
+                if not line:
+                    return None
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                session_id = str(obj.get("session_id") or "")
+                cwd = str(obj.get("cwd") or "")
+                account_name = str(obj.get("account_name") or "")
+                provider = str(obj.get("provider") or "")
+                return (session_id, cwd, account_name, provider)
+    except OSError:
+        return None
+    return None
 
 
 def is_archive_stale(
@@ -205,13 +293,9 @@ def is_archive_stale(
 def parse_events_jsonl(
     events_path: Path,
     *,
-    include_thinking: bool = False,
     actor_fallback: str = "agent",
 ) -> list[MessageEnvelope]:
     """Parse an ``events.jsonl`` archive into envelopes.
-
-    ``include_thinking`` — when ``False`` (default), ``thinking``
-    blocks are dropped per spec §3.4.
 
     ``actor_fallback`` — used when the event doesn't carry a clear
     actor name. The registry layer passes the surface's persona name
@@ -221,6 +305,10 @@ def parse_events_jsonl(
     Malformed lines are skipped with a debug log; the parser never
     raises on bad JSON because partially-flushed archives are normal
     (the ingestor appends line-by-line, the API may read mid-flush).
+
+    NOTE: provider ``thinking`` blocks are not surfaced — the
+    transcript ingestor does not currently preserve them. Tracking the
+    follow-up work as a separate arc (linked from the P1 PR).
     """
     envelopes: list[MessageEnvelope] = []
     if not events_path.exists():
@@ -252,7 +340,6 @@ def parse_events_jsonl(
                     event,
                     offset=start_offset,
                     source_key=source_key,
-                    include_thinking=include_thinking,
                     actor_fallback=actor_fallback,
                 )
                 envelopes.extend(converted)
@@ -270,7 +357,6 @@ def _event_to_envelopes(
     *,
     offset: int,
     source_key: str,
-    include_thinking: bool,
     actor_fallback: str,
 ) -> list[MessageEnvelope]:
     """Translate one ingestor event into 0+ envelopes.
@@ -792,7 +878,9 @@ def _extract_task_notification(content: Any) -> dict[str, Any] | None:
 
 __all__ = [
     "STALE_THRESHOLD_SECONDS",
+    "build_session_index",
     "is_archive_stale",
+    "lookup_transcript_path",
     "parse_events_jsonl",
     "resolve_transcript_path",
 ]

--- a/tests/test_chat_registry.py
+++ b/tests/test_chat_registry.py
@@ -1,0 +1,654 @@
+"""Unit tests for the chat-API surface registry (P1 spec §1).
+
+Synthesizes a :class:`PollyPMConfig` with all four surface types and a
+mock work-service emitting :class:`WorkerSessionRecord` rows. Asserts
+:func:`enumerate_chat_surfaces` returns one :class:`ChatSurface` per
+expected surface, with the correct persona, project, tmux window, and
+transcript-path resolution.
+
+Also covers:
+
+- Disabled sessions are filtered out
+- Non-chat roles (heartbeat-supervisor, reviewer) are filtered out
+- Persona fallback (Polly / Archie / Advisor) when project lacks a persona
+- TmuxClient probing populates window.present + pane_id
+- Worker session_name follows ``task-{project}-{N}`` convention
+- ``ChatSurface.to_dict`` produces the spec §2.1 shape
+- Stable surface ordering (operator → architect → advisor → worker)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+    SessionConfig,
+)
+from pollypm.tmux.client import TmuxWindow
+from pollypm.web_api.chat import (
+    ChatSurface,
+    SurfaceType,
+    enumerate_chat_surfaces,
+    enumerate_config_surfaces,
+    enumerate_worker_surfaces,
+)
+from pollypm.web_api.chat.registry import (
+    TmuxWindowState,
+    _classify_session,
+    _surface_sort_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _build_config(
+    tmp_path: Path,
+    *,
+    sessions: dict[str, SessionConfig] | None = None,
+    projects: dict[str, KnownProject] | None = None,
+) -> PollyPMConfig:
+    project_root = tmp_path / "repo"
+    project_root.mkdir(exist_ok=True)
+    sessions = sessions or {}
+    projects = projects or {
+        "samblog": KnownProject(
+            key="samblog",
+            path=project_root,
+            name="Sam Blog",
+            persona_name="Archie",
+            kind=ProjectKind.GIT,
+        ),
+    }
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="pollypm",
+            root_dir=project_root,
+            base_dir=project_root / ".pollypm",
+            logs_dir=project_root / ".pollypm/logs",
+            snapshots_dir=project_root / ".pollypm/snapshots",
+            state_db=project_root / ".pollypm/state.db",
+            tmux_session="storage-closet",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_main"),
+        accounts={
+            "claude_main": AccountConfig(
+                name="claude_main",
+                provider=ProviderKind.CLAUDE,
+                home=project_root / ".pollypm/homes/claude_main",
+            ),
+        },
+        sessions=sessions,
+        projects=projects,
+    )
+
+
+def _session(name: str, role: str, **kwargs) -> SessionConfig:
+    defaults = {
+        "name": name,
+        "role": role,
+        "provider": ProviderKind.CLAUDE,
+        "account": "claude_main",
+        "cwd": Path("/tmp/work"),
+    }
+    defaults.update(kwargs)
+    return SessionConfig(**defaults)
+
+
+@dataclass
+class _StubWorkerRecord:
+    task_project: str
+    task_number: int
+    agent_name: str = "worker"
+    pane_id: str | None = "%42"
+    worktree_path: str | None = None
+    branch_name: str | None = None
+    started_at: str = "2026-05-21T20:00:00Z"
+    ended_at: str | None = None
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    archive_path: str | None = None
+    provider: str | None = "claude"
+    provider_home: str | None = None
+
+
+class _StubWorkService:
+    """Minimal work-service stand-in returning canned WorkerSession rows."""
+
+    def __init__(self, records: list[_StubWorkerRecord]) -> None:
+        self._records = records
+        self.calls: list[dict[str, Any]] = []
+
+    def list_worker_sessions(
+        self, *, active_only: bool = True,
+    ) -> list[_StubWorkerRecord]:
+        self.calls.append({"active_only": active_only})
+        return list(self._records)
+
+
+class _StubTmuxClient:
+    """TmuxClient stand-in that returns canned ``list_windows`` results."""
+
+    def __init__(self, windows: list[TmuxWindow]) -> None:
+        self._windows = windows
+        self.list_calls: list[str] = []
+
+    def list_windows(self, target: str) -> list[TmuxWindow]:
+        self.list_calls.append(target)
+        return list(self._windows)
+
+
+# ---------------------------------------------------------------------------
+# All four surface types end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_enumerate_returns_all_four_surface_types(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session("operator", role="operator-pm", project=""),
+        "architect_samblog": _session(
+            "architect_samblog", role="architect", project="samblog",
+            window_name="architect-samblog",
+        ),
+        "advisor_samblog": _session(
+            "advisor_samblog", role="advisor", project="samblog",
+            window_name="advisor-samblog",
+        ),
+    })
+    worker_records = [
+        _StubWorkerRecord(task_project="samblog", task_number=47),
+    ]
+    surfaces = enumerate_chat_surfaces(
+        config, work_service=_StubWorkService(worker_records),
+    )
+    types = [s.surface_type for s in surfaces]
+    assert SurfaceType.OPERATOR in types
+    assert SurfaceType.ARCHITECT in types
+    assert SurfaceType.ADVISOR in types
+    assert SurfaceType.WORKER in types
+    # Stable ordering: operator first, worker last.
+    assert types[0] == SurfaceType.OPERATOR
+    assert types[-1] == SurfaceType.WORKER
+
+
+def test_operator_surface_has_polly_persona_and_no_project(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session("operator", role="operator-pm"),
+    })
+    surfaces = enumerate_chat_surfaces(config)
+    assert len(surfaces) == 1
+    assert surfaces[0].persona == "Polly"
+    assert surfaces[0].project is None
+    assert surfaces[0].surface_type == SurfaceType.OPERATOR
+
+
+def test_architect_surface_carries_project_persona(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "architect_samblog": _session(
+            "architect_samblog", role="architect", project="samblog",
+        ),
+    })
+    surfaces = enumerate_chat_surfaces(config)
+    assert surfaces[0].project == "samblog"
+    assert surfaces[0].persona == "Archie"
+    assert surfaces[0].surface_type == SurfaceType.ARCHITECT
+
+
+def test_architect_surface_falls_back_to_archie_when_no_persona(tmp_path: Path) -> None:
+    config = _build_config(
+        tmp_path,
+        sessions={
+            "architect_other": _session(
+                "architect_other", role="architect", project="other",
+            ),
+        },
+        projects={
+            "other": KnownProject(
+                key="other", path=tmp_path / "repo", persona_name=None,
+            ),
+        },
+    )
+    surfaces = enumerate_chat_surfaces(config)
+    assert surfaces[0].persona == "Archie"
+
+
+def test_advisor_surface_falls_back_to_advisor_when_no_persona(tmp_path: Path) -> None:
+    config = _build_config(
+        tmp_path,
+        sessions={
+            "advisor_other": _session(
+                "advisor_other", role="advisor", project="other",
+            ),
+        },
+        projects={
+            "other": KnownProject(
+                key="other", path=tmp_path / "repo", persona_name=None,
+            ),
+        },
+    )
+    surfaces = enumerate_chat_surfaces(config)
+    assert surfaces[0].persona == "Advisor"
+
+
+# ---------------------------------------------------------------------------
+# Filtering: disabled / non-chat roles
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_sessions_are_skipped(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session("operator", role="operator-pm"),
+        "architect_off": _session(
+            "architect_off", role="architect", project="samblog",
+            enabled=False,
+        ),
+    })
+    surfaces = enumerate_chat_surfaces(config)
+    names = [s.session_name for s in surfaces]
+    assert "operator" in names
+    assert "architect_off" not in names
+
+
+def test_non_chat_roles_are_skipped(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "heartbeat": _session("heartbeat", role="heartbeat-supervisor"),
+        "reviewer-samblog-1": _session(
+            "reviewer-samblog-1", role="reviewer", project="samblog",
+        ),
+        "operator": _session("operator", role="operator-pm"),
+    })
+    surfaces = enumerate_chat_surfaces(config)
+    names = [s.session_name for s in surfaces]
+    assert names == ["operator"]
+
+
+# ---------------------------------------------------------------------------
+# Classification edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_classify_recognizes_operator_by_name() -> None:
+    # A session named ``operator`` with no role still classifies.
+    session = SessionConfig(
+        name="operator",
+        role="",
+        provider=ProviderKind.CLAUDE,
+        account="claude_main",
+        cwd=Path("."),
+    )
+    assert _classify_session(session) == SurfaceType.OPERATOR
+
+
+def test_classify_recognizes_architect_by_name_prefix() -> None:
+    session = SessionConfig(
+        name="architect_samblog",
+        role="",
+        provider=ProviderKind.CLAUDE,
+        account="claude_main",
+        cwd=Path("."),
+    )
+    assert _classify_session(session) == SurfaceType.ARCHITECT
+
+
+def test_classify_recognizes_advisor_by_name_prefix() -> None:
+    session = SessionConfig(
+        name="advisor_samblog",
+        role="",
+        provider=ProviderKind.CLAUDE,
+        account="claude_main",
+        cwd=Path("."),
+    )
+    assert _classify_session(session) == SurfaceType.ADVISOR
+
+
+def test_classify_returns_none_for_unknown_role() -> None:
+    session = SessionConfig(
+        name="random",
+        role="custom-role",
+        provider=ProviderKind.CLAUDE,
+        account="claude_main",
+        cwd=Path("."),
+    )
+    assert _classify_session(session) is None
+
+
+def test_classify_handles_case_insensitive_roles() -> None:
+    session = SessionConfig(
+        name="x",
+        role="ARCHITECT",
+        provider=ProviderKind.CLAUDE,
+        account="claude_main",
+        cwd=Path("."),
+    )
+    assert _classify_session(session) == SurfaceType.ARCHITECT
+
+
+# ---------------------------------------------------------------------------
+# Workers
+# ---------------------------------------------------------------------------
+
+
+def test_worker_session_name_uses_task_window_convention(tmp_path: Path) -> None:
+    config = _build_config(tmp_path)
+    work_service = _StubWorkService([
+        _StubWorkerRecord(task_project="samblog", task_number=47),
+        _StubWorkerRecord(task_project="other", task_number=3),
+    ])
+    surfaces = enumerate_worker_surfaces(config, work_service)
+    names = sorted(s.session_name for s in surfaces)
+    assert names == ["task-other-3", "task-samblog-47"]
+
+
+def test_worker_surface_includes_task_id_and_project(tmp_path: Path) -> None:
+    config = _build_config(tmp_path)
+    work_service = _StubWorkService([
+        _StubWorkerRecord(
+            task_project="samblog",
+            task_number=47,
+            worktree_path="/Users/x/wt-47",
+            provider="claude",
+        ),
+    ])
+    surfaces = enumerate_worker_surfaces(config, work_service)
+    assert len(surfaces) == 1
+    surface = surfaces[0]
+    assert surface.task_id == 47
+    assert surface.project == "samblog"
+    assert surface.worktree_path == Path("/Users/x/wt-47")
+    assert surface.provider == "claude"
+    assert surface.persona is None  # workers have no persona
+
+
+def test_worker_surfaces_empty_when_work_service_has_no_records(tmp_path: Path) -> None:
+    config = _build_config(tmp_path)
+    work_service = _StubWorkService([])
+    assert enumerate_worker_surfaces(config, work_service) == []
+
+
+def test_enumerate_skips_workers_when_no_work_service(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session("operator", role="operator-pm"),
+    })
+    surfaces = enumerate_chat_surfaces(config, work_service=None)
+    assert all(s.surface_type != SurfaceType.WORKER for s in surfaces)
+
+
+def test_worker_enumeration_skips_records_with_missing_project_or_task(
+    tmp_path: Path,
+) -> None:
+    config = _build_config(tmp_path)
+    work_service = _StubWorkService([
+        _StubWorkerRecord(task_project="", task_number=1),
+        _StubWorkerRecord(task_project="samblog", task_number=0),
+        _StubWorkerRecord(task_project="samblog", task_number=2),
+    ])
+    surfaces = enumerate_worker_surfaces(config, work_service)
+    assert [s.session_name for s in surfaces] == ["task-samblog-2"]
+
+
+def test_worker_enumeration_tolerates_service_exception(tmp_path: Path) -> None:
+    config = _build_config(tmp_path)
+
+    class _BrokenService:
+        def list_worker_sessions(self, **_kw):
+            raise RuntimeError("backend offline")
+
+    assert enumerate_worker_surfaces(config, _BrokenService()) == []
+
+
+def test_worker_enumeration_skips_when_protocol_unsupported(tmp_path: Path) -> None:
+    config = _build_config(tmp_path)
+    assert enumerate_worker_surfaces(config, object()) == []
+
+
+# ---------------------------------------------------------------------------
+# Tmux probing
+# ---------------------------------------------------------------------------
+
+
+def test_tmux_client_populates_window_present_and_pane_id(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session(
+            "operator", role="operator-pm", window_name="pm-operator",
+        ),
+    })
+    tmux = _StubTmuxClient([
+        TmuxWindow(
+            session="storage-closet",
+            index=1,
+            name="pm-operator",
+            active=True,
+            pane_id="%17",
+            pane_current_command="claude",
+            pane_current_path="/x",
+            pane_dead=False,
+        ),
+    ])
+    surfaces = enumerate_chat_surfaces(config, tmux_client=tmux)
+    assert surfaces[0].window.present is True
+    assert surfaces[0].window.pane_id == "%17"
+    assert surfaces[0].window.tmux_session == "storage-closet"
+    assert tmux.list_calls == ["storage-closet"]
+
+
+def test_window_present_false_when_tmux_returns_no_window(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session(
+            "operator", role="operator-pm", window_name="pm-operator",
+        ),
+    })
+    tmux = _StubTmuxClient(windows=[])
+    surfaces = enumerate_chat_surfaces(config, tmux_client=tmux)
+    assert surfaces[0].window.present is False
+    assert surfaces[0].window.window_name == "pm-operator"
+
+
+def test_window_present_false_when_no_tmux_client(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session(
+            "operator", role="operator-pm", window_name="pm-operator",
+        ),
+    })
+    surfaces = enumerate_chat_surfaces(config)
+    assert surfaces[0].window.present is False
+
+
+def test_tmux_probe_failure_falls_back_to_unknown_state(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session("operator", role="operator-pm"),
+    })
+
+    class _BrokenTmux:
+        def list_windows(self, _target):
+            raise OSError("tmux exploded")
+
+    surfaces = enumerate_chat_surfaces(config, tmux_client=_BrokenTmux())
+    assert surfaces[0].window.present is False
+
+
+def test_pane_dead_propagates_from_tmux(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session(
+            "operator", role="operator-pm", window_name="pm-operator",
+        ),
+    })
+    tmux = _StubTmuxClient([
+        TmuxWindow(
+            session="storage-closet",
+            index=1,
+            name="pm-operator",
+            active=False,
+            pane_id="%99",
+            pane_current_command="dead",
+            pane_current_path="/x",
+            pane_dead=True,
+        ),
+    ])
+    surfaces = enumerate_chat_surfaces(config, tmux_client=tmux)
+    assert surfaces[0].window.pane_dead is True
+
+
+# ---------------------------------------------------------------------------
+# Transcript-path resolution wiring
+# ---------------------------------------------------------------------------
+
+
+def test_surface_transcript_path_resolves_from_events_jsonl(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session(
+            "operator", role="operator-pm",
+            cwd=tmp_path / "repo",
+        ),
+    })
+    # Lay an events.jsonl in the project's transcripts dir.
+    transcripts = config.project.root_dir / ".pollypm" / "transcripts" / "uuid-1"
+    transcripts.mkdir(parents=True)
+    event = {
+        "timestamp": "2026-05-21T20:48:11Z",
+        "event_type": "user_turn",
+        "session_id": "uuid-1",
+        "account_name": "claude_main",
+        "provider": "claude",
+        "project_key": "pollypm",
+        "source_path": "/tmp/raw",
+        "source_offset": 0,
+        "cwd": str(tmp_path / "repo"),
+        "payload": {"text": "x"},
+    }
+    (transcripts / "events.jsonl").write_text(json.dumps(event) + "\n")
+    surfaces = enumerate_chat_surfaces(config)
+    assert surfaces[0].transcript_path == transcripts / "events.jsonl"
+
+
+def test_surface_transcript_path_none_when_archive_missing(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session("operator", role="operator-pm"),
+    })
+    surfaces = enumerate_chat_surfaces(config)
+    assert surfaces[0].transcript_path is None
+
+
+# ---------------------------------------------------------------------------
+# auth_token_present surfacing
+# ---------------------------------------------------------------------------
+
+
+def test_auth_token_present_reflects_session_field(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session(
+            "operator", role="operator-pm", auth_token="0123abcd",
+        ),
+        "architect_samblog": _session(
+            "architect_samblog", role="architect", project="samblog",
+        ),
+    })
+    surfaces = enumerate_chat_surfaces(config)
+    by_name = {s.session_name: s for s in surfaces}
+    assert by_name["operator"].auth_token_present is True
+    assert by_name["architect_samblog"].auth_token_present is False
+
+
+# ---------------------------------------------------------------------------
+# to_dict serialization
+# ---------------------------------------------------------------------------
+
+
+def test_chat_surface_to_dict_matches_spec_shape(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "architect_samblog": _session(
+            "architect_samblog", role="architect", project="samblog",
+            window_name="architect-samblog",
+        ),
+    })
+    surfaces = enumerate_chat_surfaces(config)
+    payload = surfaces[0].to_dict()
+    assert payload["session_name"] == "architect_samblog"
+    assert payload["surface_type"] == "architect"
+    assert payload["persona"] == "Archie"
+    assert payload["project"] == "samblog"
+    assert payload["task_id"] is None
+    assert payload["window"]["window_name"] == "architect-samblog"
+    assert payload["window"]["present"] is False
+    assert payload["transcript"]["source"] is None
+    assert payload["transcript"]["path"] is None
+    assert payload["auth_token_present"] is False
+    assert payload["provider"] == "claude"
+
+
+def test_worker_surface_to_dict_includes_task_id_and_worktree(tmp_path: Path) -> None:
+    config = _build_config(tmp_path)
+    surfaces = enumerate_worker_surfaces(config, _StubWorkService([
+        _StubWorkerRecord(
+            task_project="samblog",
+            task_number=99,
+            worktree_path="/Users/x/wt",
+            provider="claude",
+        ),
+    ]))
+    payload = surfaces[0].to_dict()
+    assert payload["task_id"] == 99
+    assert payload["worktree_path"] == "/Users/x/wt"
+    assert payload["surface_type"] == "worker"
+
+
+# ---------------------------------------------------------------------------
+# Sort key
+# ---------------------------------------------------------------------------
+
+
+def test_surface_sort_key_orders_by_type_then_project_then_task(
+    tmp_path: Path,
+) -> None:
+    op = ChatSurface(
+        session_name="operator",
+        surface_type=SurfaceType.OPERATOR,
+        persona="Polly",
+        project=None,
+        window=TmuxWindowState(tmux_session="x", window_name="y"),
+    )
+    arch = ChatSurface(
+        session_name="architect_a",
+        surface_type=SurfaceType.ARCHITECT,
+        persona="A",
+        project="a",
+        window=TmuxWindowState(tmux_session="x", window_name="y"),
+    )
+    worker_1 = ChatSurface(
+        session_name="task-a-1",
+        surface_type=SurfaceType.WORKER,
+        persona=None,
+        project="a",
+        task_id=1,
+        window=TmuxWindowState(tmux_session="x", window_name="y"),
+    )
+    worker_2 = ChatSurface(
+        session_name="task-a-2",
+        surface_type=SurfaceType.WORKER,
+        persona=None,
+        project="a",
+        task_id=2,
+        window=TmuxWindowState(tmux_session="x", window_name="y"),
+    )
+    ordered = sorted([worker_2, worker_1, arch, op], key=_surface_sort_key)
+    assert ordered == [op, arch, worker_1, worker_2]
+
+
+def test_only_config_surfaces_helper_does_not_call_work_service(tmp_path: Path) -> None:
+    config = _build_config(tmp_path, sessions={
+        "operator": _session("operator", role="operator-pm"),
+    })
+    # No work_service arg at all — should still produce config surfaces.
+    surfaces = enumerate_config_surfaces(config)
+    assert len(surfaces) == 1

--- a/tests/test_chat_registry.py
+++ b/tests/test_chat_registry.py
@@ -540,6 +540,107 @@ def test_surface_transcript_path_none_when_archive_missing(tmp_path: Path) -> No
     assert surfaces[0].transcript_path is None
 
 
+def test_two_surfaces_sharing_cwd_resolve_to_correct_transcripts(
+    tmp_path: Path,
+) -> None:
+    """Codex review #2044 — blocker 1 regression test.
+
+    Operator + architect both run with ``cwd = project_root``. Without
+    the account-based fingerprint disambiguator, the prior freshest-mtime
+    fallback would cross-attach: both surfaces would resolve to whichever
+    transcript was written last. With the fingerprint lookup, each
+    surface resolves to its OWN transcript exactly.
+    """
+    project_root = tmp_path / "repo"
+    project_root.mkdir(exist_ok=True)
+    accounts = {
+        "claude_main": AccountConfig(
+            name="claude_main",
+            provider=ProviderKind.CLAUDE,
+            home=project_root / ".pollypm/homes/claude_main",
+        ),
+        "claude_alt": AccountConfig(
+            name="claude_alt",
+            provider=ProviderKind.CLAUDE,
+            home=project_root / ".pollypm/homes/claude_alt",
+        ),
+    }
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            name="pollypm",
+            root_dir=project_root,
+            base_dir=project_root / ".pollypm",
+            logs_dir=project_root / ".pollypm/logs",
+            snapshots_dir=project_root / ".pollypm/snapshots",
+            state_db=project_root / ".pollypm/state.db",
+            tmux_session="storage-closet",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_main"),
+        accounts=accounts,
+        sessions={
+            "operator": _session(
+                "operator", role="operator-pm",
+                account="claude_main", cwd=project_root,
+            ),
+            "architect_pollypm": _session(
+                "architect_pollypm", role="architect", project="pollypm",
+                account="claude_alt", cwd=project_root,
+            ),
+        },
+        projects={
+            "pollypm": KnownProject(
+                key="pollypm", path=project_root, persona_name="Archie",
+                kind=ProjectKind.GIT,
+            ),
+        },
+    )
+    transcripts = project_root / ".pollypm" / "transcripts"
+    # Plant operator transcript first (older mtime).
+    op_dir = transcripts / "session-op-uuid"
+    op_dir.mkdir(parents=True)
+    op_event = {
+        "timestamp": "2026-05-21T20:00:00Z",
+        "event_type": "user_turn",
+        "session_id": "session-op-uuid",
+        "account_name": "claude_main",
+        "provider": "claude",
+        "project_key": "pollypm",
+        "source_path": "/tmp/raw-op",
+        "source_offset": 0,
+        "cwd": str(project_root),
+        "payload": {"text": "from operator"},
+    }
+    (op_dir / "events.jsonl").write_text(json.dumps(op_event) + "\n")
+    import time as _time
+    _time.sleep(0.05)
+    # Architect's transcript is the freshest — if the old "freshest mtime"
+    # fallback were still in place, the operator surface would
+    # cross-attach to this one.
+    arch_dir = transcripts / "session-arch-uuid"
+    arch_dir.mkdir(parents=True)
+    arch_event = {
+        "timestamp": "2026-05-21T21:00:00Z",
+        "event_type": "user_turn",
+        "session_id": "session-arch-uuid",
+        "account_name": "claude_alt",
+        "provider": "claude",
+        "project_key": "pollypm",
+        "source_path": "/tmp/raw-arch",
+        "source_offset": 0,
+        "cwd": str(project_root),
+        "payload": {"text": "from architect"},
+    }
+    (arch_dir / "events.jsonl").write_text(json.dumps(arch_event) + "\n")
+
+    surfaces = enumerate_chat_surfaces(config)
+    by_name = {s.session_name: s for s in surfaces}
+    assert by_name["operator"].transcript_path == op_dir / "events.jsonl"
+    assert by_name["architect_pollypm"].transcript_path == arch_dir / "events.jsonl"
+    # Symmetric assertion: neither surface attached to the other's
+    # transcript, even though both shared the same cwd.
+    assert by_name["operator"].transcript_path != by_name["architect_pollypm"].transcript_path
+
+
 # ---------------------------------------------------------------------------
 # auth_token_present surfacing
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_tmux_capture.py
+++ b/tests/test_chat_tmux_capture.py
@@ -1,0 +1,261 @@
+"""Unit tests for the chat-API tmux capture fallback (P1 spec §4.7).
+
+Tests :func:`capture_envelopes` with a stub ``TmuxClient`` to assert:
+
+- Each captured line becomes one envelope with ``type=text``
+- ``metadata.from_capture`` is True
+- ``metadata.session_name`` propagates
+- Envelope ids are synthesized as ``cap_<hex>``
+- Same line at same offset yields same id (stability)
+- ANSI escape codes are stripped
+- Leading/trailing blank lines are dropped
+- Empty captures return an empty list
+- Captures with no ``capture_pane`` method fail safe
+- Captures that throw exceptions fail safe
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pollypm.web_api.chat import (
+    MessageRole,
+    MessageType,
+    capture_envelopes,
+    synthesize_capture_id,
+)
+from pollypm.web_api.chat.tmux_capture import (
+    DEFAULT_CAPTURE_LINES,
+    _strip_control_codes,
+)
+
+
+class _StubTmuxClient:
+    """Records capture_pane calls and returns canned output."""
+
+    def __init__(self, output: str = "") -> None:
+        self.output = output
+        self.calls: list[dict[str, Any]] = []
+
+    def capture_pane(self, target: str, lines: int = 200) -> str:
+        self.calls.append({"target": target, "lines": lines})
+        return self.output
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_capture_envelopes_one_per_line() -> None:
+    tmux = _StubTmuxClient(output="line one\nline two\nline three\n")
+    envelopes = capture_envelopes(
+        tmux,
+        session_name="operator",
+        target="storage-closet:pm-operator",
+    )
+    assert len(envelopes) == 3
+    texts = [e.text for e in envelopes]
+    assert texts == ["line one", "line two", "line three"]
+
+
+def test_capture_envelope_marked_text_type_and_from_capture() -> None:
+    tmux = _StubTmuxClient(output="hello world\n")
+    envelopes = capture_envelopes(
+        tmux, session_name="operator", target="x",
+    )
+    env = envelopes[0]
+    assert env.type == MessageType.TEXT
+    assert env.role == MessageRole.ASSISTANT
+    assert env.metadata["from_capture"] is True
+    assert env.metadata["session_name"] == "operator"
+    assert env.metadata["line_index"] == 0
+
+
+def test_capture_envelope_id_uses_cap_prefix() -> None:
+    tmux = _StubTmuxClient(output="x\n")
+    env = capture_envelopes(tmux, session_name="s", target="t")[0]
+    assert env.id.startswith("cap_")
+
+
+def test_capture_envelope_actor_uses_fallback() -> None:
+    tmux = _StubTmuxClient(output="hi\n")
+    env = capture_envelopes(
+        tmux, session_name="s", target="t", actor_fallback="Polly",
+    )[0]
+    assert env.actor == "Polly"
+
+
+def test_capture_envelope_role_is_configurable() -> None:
+    tmux = _StubTmuxClient(output="hi\n")
+    env = capture_envelopes(
+        tmux, session_name="s", target="t", role=MessageRole.USER,
+    )[0]
+    assert env.role == MessageRole.USER
+
+
+def test_capture_envelope_timestamp_is_iso_z() -> None:
+    tmux = _StubTmuxClient(output="hi\n")
+    env = capture_envelopes(tmux, session_name="s", target="t")[0]
+    assert env.ts.endswith("Z")
+    # Year 2026 sanity bound — the real wall-clock should be after this.
+    assert env.ts.startswith("20")
+
+
+def test_capture_envelope_timestamp_override() -> None:
+    tmux = _StubTmuxClient(output="hi\n")
+    env = capture_envelopes(
+        tmux, session_name="s", target="t",
+        timestamp="2020-01-01T00:00:00Z",
+    )[0]
+    assert env.ts == "2020-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Stability / id determinism
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_capture_id_is_stable() -> None:
+    id1 = synthesize_capture_id("operator", 0, "hello")
+    id2 = synthesize_capture_id("operator", 0, "hello")
+    assert id1 == id2
+
+
+def test_synthesize_capture_id_differs_for_different_content() -> None:
+    id1 = synthesize_capture_id("operator", 0, "hello")
+    id2 = synthesize_capture_id("operator", 0, "goodbye")
+    assert id1 != id2
+
+
+def test_synthesize_capture_id_differs_for_different_offset() -> None:
+    id1 = synthesize_capture_id("operator", 0, "hello")
+    id2 = synthesize_capture_id("operator", 1, "hello")
+    assert id1 != id2
+
+
+def test_synthesize_capture_id_differs_for_different_session() -> None:
+    id1 = synthesize_capture_id("operator", 0, "hello")
+    id2 = synthesize_capture_id("architect", 0, "hello")
+    assert id1 != id2
+
+
+# ---------------------------------------------------------------------------
+# ANSI stripping / cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_capture_strips_ansi_color_codes() -> None:
+    output = "\x1b[31mred text\x1b[0m\n"
+    tmux = _StubTmuxClient(output=output)
+    envelopes = capture_envelopes(tmux, session_name="s", target="t")
+    assert envelopes[0].text == "red text"
+
+
+def test_capture_strips_c0_control_bytes_but_keeps_newlines_tabs() -> None:
+    output = "hello\x00\x07\tworld\n"
+    tmux = _StubTmuxClient(output=output)
+    envelopes = capture_envelopes(tmux, session_name="s", target="t")
+    assert "\x00" not in envelopes[0].text
+    assert "\x07" not in envelopes[0].text
+    assert "\t" in envelopes[0].text
+
+
+def test_strip_control_codes_handles_complex_ansi() -> None:
+    out = _strip_control_codes("\x1b[1;31mfoo\x1b[0m\x1b[2J\x1b[H")
+    assert out == "foo"
+
+
+def test_capture_drops_leading_blank_lines() -> None:
+    tmux = _StubTmuxClient(output="\n\n\nfirst content\nsecond\n")
+    envelopes = capture_envelopes(tmux, session_name="s", target="t")
+    assert envelopes[0].text == "first content"
+    assert envelopes[1].text == "second"
+
+
+def test_capture_drops_trailing_blank_lines() -> None:
+    tmux = _StubTmuxClient(output="first\nsecond\n\n\n\n")
+    envelopes = capture_envelopes(tmux, session_name="s", target="t")
+    assert envelopes[-1].text == "second"
+
+
+def test_capture_preserves_internal_blank_lines() -> None:
+    tmux = _StubTmuxClient(output="first\n\nthird\n")
+    envelopes = capture_envelopes(tmux, session_name="s", target="t")
+    texts = [e.text for e in envelopes]
+    assert texts == ["first", "", "third"]
+
+
+# ---------------------------------------------------------------------------
+# Empty / failure cases
+# ---------------------------------------------------------------------------
+
+
+def test_capture_empty_output_returns_empty_list() -> None:
+    tmux = _StubTmuxClient(output="")
+    assert capture_envelopes(tmux, session_name="s", target="t") == []
+
+
+def test_capture_with_none_client_returns_empty_list() -> None:
+    assert capture_envelopes(None, session_name="s", target="t") == []
+
+
+def test_capture_with_client_missing_capture_pane_returns_empty_list() -> None:
+    class NoCapture:
+        pass
+
+    assert capture_envelopes(NoCapture(), session_name="s", target="t") == []
+
+
+def test_capture_with_client_raising_returns_empty_list() -> None:
+    class Boom:
+        def capture_pane(self, target: str, lines: int = 200) -> str:
+            raise RuntimeError("tmux dead")
+
+    assert capture_envelopes(Boom(), session_name="s", target="t") == []
+
+
+def test_capture_with_non_string_return_returns_empty_list() -> None:
+    class WeirdReturn:
+        def capture_pane(self, target: str, lines: int = 200) -> Any:
+            return None
+
+    assert capture_envelopes(WeirdReturn(), session_name="s", target="t") == []
+
+
+# ---------------------------------------------------------------------------
+# Capture depth argument
+# ---------------------------------------------------------------------------
+
+
+def test_capture_default_lines_matches_spec() -> None:
+    # Spec §4.7: ``tmux capture-pane -p -S -3000``.
+    assert DEFAULT_CAPTURE_LINES == 3000
+
+
+def test_capture_passes_lines_arg_through_to_client() -> None:
+    tmux = _StubTmuxClient(output="x\n")
+    capture_envelopes(tmux, session_name="s", target="t", lines=500)
+    assert tmux.calls == [{"target": "t", "lines": 500}]
+
+
+def test_capture_passes_target_through_to_client() -> None:
+    tmux = _StubTmuxClient(output="x\n")
+    capture_envelopes(
+        tmux, session_name="s", target="storage-closet:pm-operator",
+    )
+    assert tmux.calls[0]["target"] == "storage-closet:pm-operator"
+
+
+# ---------------------------------------------------------------------------
+# line_index monotonicity
+# ---------------------------------------------------------------------------
+
+
+def test_line_index_is_monotonic_per_envelope() -> None:
+    tmux = _StubTmuxClient(output="a\nb\nc\n")
+    envelopes = capture_envelopes(tmux, session_name="s", target="t")
+    indices = [e.metadata["line_index"] for e in envelopes]
+    assert indices == sorted(indices)
+    # Strict monotonic (no dupes).
+    assert len(set(indices)) == len(indices)

--- a/tests/test_chat_transcripts.py
+++ b/tests/test_chat_transcripts.py
@@ -1,0 +1,812 @@
+"""Unit tests for the chat-API transcript parser (P1 spec §3).
+
+Exercises every MessageEnvelope discriminator the parser produces:
+
+- ``text`` for user_turn / assistant_turn
+- ``tool_use`` for generic Claude tool calls (Bash, Read, Edit, Write,
+  Glob, Grep, WebFetch, WebSearch, custom)
+- ``tool_result`` for matching results
+- ``subagent_spawn`` / ``subagent_result`` for Task tool pairs
+- ``ask_user`` for AskUserQuestion
+- ``file`` for SendUserFile
+- ``system_event`` for error / turn_end
+
+Also covers:
+
+- Codex-shape event handling (assistant_message, tool_call, tool_result)
+- Stale-archive detection (spec §4.7)
+- ``include_thinking`` flag
+- Malformed JSON line skip
+- ``resolve_transcript_path`` cwd matching + most-recent fallback
+- Subagent linking via task-notification block
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from pollypm.web_api.chat import (
+    MessageRole,
+    MessageType,
+    STALE_THRESHOLD_SECONDS,
+    is_archive_stale,
+    parse_events_jsonl,
+    resolve_transcript_path,
+)
+from pollypm.web_api.chat.transcripts import (
+    _extract_text_from_blocks,
+    _format_tool_use_summary,
+    _looks_like_subagent_result,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+    )
+
+
+def _claude_event(event_type: str, **payload_kwargs) -> dict:
+    """Build a Claude-shaped ingestor event for tests."""
+    return {
+        "timestamp": "2026-05-21T20:48:11Z",
+        "event_type": event_type,
+        "session_id": "session-abc",
+        "account_name": "claude_main",
+        "provider": "claude",
+        "project_key": "demo",
+        "source_path": "/tmp/raw.jsonl",
+        "source_offset": 0,
+        "cwd": "/tmp/repo",
+        "model_name": "claude-opus-4-7",
+        "payload": payload_kwargs,
+    }
+
+
+def _codex_event(event_type: str, **payload_kwargs) -> dict:
+    return {
+        "timestamp": "2026-05-21T21:00:00Z",
+        "event_type": event_type,
+        "session_id": "codex-xyz",
+        "account_name": "codex_main",
+        "provider": "codex",
+        "project_key": "demo",
+        "source_path": "/tmp/rollout.jsonl",
+        "source_offset": 0,
+        "cwd": "/tmp/repo",
+        "model_name": "gpt-5",
+        "payload": payload_kwargs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Basic text turns
+# ---------------------------------------------------------------------------
+
+
+def test_parses_claude_user_turn_as_text_envelope(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event("user_turn", text="Hello agent")])
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env.type == MessageType.TEXT
+    assert env.role == MessageRole.USER
+    assert env.text == "Hello agent"
+    assert env.actor == "user"
+    assert env.metadata["provider"] == "claude"
+
+
+def test_parses_claude_assistant_turn_with_actor_fallback(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event("assistant_turn", text="Done.")])
+    envelopes = parse_events_jsonl(events_path, actor_fallback="Polly")
+    assert len(envelopes) == 1
+    assert envelopes[0].actor == "Polly"
+    assert envelopes[0].role == MessageRole.ASSISTANT
+    assert envelopes[0].metadata["model"] == "claude-opus-4-7"
+
+
+def test_skips_user_turn_with_empty_text(tmp_path: Path) -> None:
+    # Spec: ingestor only emits user_turn when text is truthy, but we
+    # still test the parser is tolerant of an empty-string payload.
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event("user_turn", text="")])
+    envelopes = parse_events_jsonl(events_path)
+    # Parser still emits — empty text is allowed; the renderer decides.
+    assert len(envelopes) == 1
+    assert envelopes[0].text == ""
+
+
+def test_token_usage_events_are_dropped(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [
+        _claude_event("user_turn", text="Hi"),
+        _claude_event("token_usage", usage={"total_tokens": 42}),
+    ])
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 1
+    assert envelopes[0].type == MessageType.TEXT
+
+
+def test_session_state_events_are_dropped(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [
+        _codex_event("session_state", state="started"),
+        _codex_event("user_turn", text="Hello"),
+    ])
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 1
+    assert envelopes[0].type == MessageType.TEXT
+    assert envelopes[0].text == "Hello"
+
+
+# ---------------------------------------------------------------------------
+# Tool use / tool result pairing
+# ---------------------------------------------------------------------------
+
+
+def test_bash_tool_call_formats_with_command_summary(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_111",
+        name="Bash",
+        input={"command": "git status", "description": "Show working tree"},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env.type == MessageType.TOOL_USE
+    assert env.text == "[Bash] git status"
+    assert env.metadata["tool_use_id"] == "toolu_111"
+    assert env.metadata["tool_name"] == "Bash"
+    assert env.metadata["tool_input"]["command"] == "git status"
+
+
+def test_bash_multiline_command_truncates_to_first_line(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_222",
+        name="Bash",
+        input={"command": "git add foo\ngit commit -m 'x'", "description": "two lines"},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].text == "[Bash] git add foo"
+
+
+def test_read_tool_call_summarizes_file_path(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_333",
+        name="Read",
+        input={"file_path": "/etc/hosts"},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].text == "[Read] /etc/hosts"
+
+
+def test_write_edit_glob_grep_tool_summary_includes_target() -> None:
+    cases = [
+        ("Write", {"file_path": "/tmp/x"}, "[Write] /tmp/x"),
+        ("Edit", {"file_path": "/tmp/y"}, "[Edit] /tmp/y"),
+        ("Glob", {"pattern": "**/*.py"}, "[Glob] **/*.py"),
+        ("Grep", {"pattern": "TODO"}, "[Grep] TODO"),
+    ]
+    for tool_name, tool_input, expected in cases:
+        assert _format_tool_use_summary(tool_name, tool_input) == expected
+
+
+def test_webfetch_summary_includes_url() -> None:
+    summary = _format_tool_use_summary("WebFetch", {"url": "https://x.example"})
+    assert summary == "[WebFetch] https://x.example"
+
+
+def test_websearch_summary_includes_query() -> None:
+    summary = _format_tool_use_summary("WebSearch", {"query": "rust async"})
+    assert summary == "[WebSearch] rust async"
+
+
+def test_unknown_tool_summary_uses_description_or_name() -> None:
+    assert _format_tool_use_summary("CustomTool", {"description": "fetch X"}) == "[CustomTool] fetch X"
+    assert _format_tool_use_summary("CustomTool", {}) == "[CustomTool]"
+
+
+def test_empty_tool_name_returns_generic_marker() -> None:
+    assert _format_tool_use_summary("", {}) == "[tool]"
+
+
+def test_tool_result_links_back_via_tool_use_id(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [
+        _claude_event(
+            "tool_call",
+            type="tool_use",
+            id="toolu_999",
+            name="Bash",
+            input={"command": "ls"},
+        ),
+        _claude_event(
+            "tool_result",
+            type="tool_result",
+            tool_use_id="toolu_999",
+            content=[{"type": "text", "text": "foo\nbar"}],
+            is_error=False,
+        ),
+    ])
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 2
+    use_env, result_env = envelopes
+    assert use_env.metadata["tool_use_id"] == "toolu_999"
+    assert result_env.metadata["tool_use_id"] == "toolu_999"
+    assert result_env.text == "foo\nbar"
+    assert result_env.metadata["is_error"] is False
+    assert result_env.role == MessageRole.TOOL
+
+
+def test_tool_result_preserves_raw_content_blocks(tmp_path: Path) -> None:
+    blocks = [
+        {"type": "text", "text": "summary"},
+        {"type": "image", "source": {"data": "..."}},
+    ]
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_result",
+        type="tool_result",
+        tool_use_id="t",
+        content=blocks,
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].metadata["content"] == blocks
+
+
+def test_tool_result_marks_errors(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_result",
+        type="tool_result",
+        tool_use_id="toolu_e",
+        content=[{"type": "text", "text": "exit 1"}],
+        is_error=True,
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].metadata["is_error"] is True
+
+
+# ---------------------------------------------------------------------------
+# Subagent spawn / result pairing
+# ---------------------------------------------------------------------------
+
+
+def test_task_tool_call_emits_subagent_spawn_envelope(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_sub1",
+        name="Task",
+        input={
+            "description": "Fix #1234 sweep dedupe",
+            "prompt": "Read the issue and fix the dedupe...",
+            "subagent_type": "general-purpose",
+            "isolation": "worktree",
+            "run_in_background": True,
+        },
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env.type == MessageType.SUBAGENT_SPAWN
+    assert env.text == "[subagent] Fix #1234 sweep dedupe"
+    assert env.metadata["subagent_id"] == "toolu_sub1"
+    assert env.metadata["subagent_type"] == "general-purpose"
+    assert env.metadata["isolation"] == "worktree"
+    assert env.metadata["run_in_background"] is True
+    assert "Read the issue" in env.metadata["prompt"]
+
+
+def test_agent_tool_name_also_treated_as_subagent(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_sub_alt",
+        name="Agent",
+        input={"description": "alt"},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].type == MessageType.SUBAGENT_SPAWN
+
+
+def test_task_tool_result_with_task_notification_emits_subagent_result(
+    tmp_path: Path,
+) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [
+        _claude_event(
+            "tool_call",
+            type="tool_use",
+            id="toolu_sub2",
+            name="Task",
+            input={"description": "Run something"},
+        ),
+        _claude_event(
+            "tool_result",
+            type="tool_result",
+            tool_use_id="toolu_sub2",
+            content=[
+                {"type": "text", "text": "PR #1235 pushed."},
+                {
+                    "type": "task-notification",
+                    "task-id": "task-99",
+                    "output-file": "/tmp/transcripts/task-99/events.jsonl",
+                    "duration-ms": 12345,
+                    "total-tokens": 4500,
+                    "worktree-path": "/Users/x/wt",
+                },
+            ],
+        ),
+    ])
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 2
+    spawn_env, result_env = envelopes
+    assert spawn_env.type == MessageType.SUBAGENT_SPAWN
+    assert result_env.type == MessageType.SUBAGENT_RESULT
+    # Subagent linking: same id on both envelopes.
+    assert spawn_env.metadata["subagent_id"] == result_env.metadata["subagent_id"]
+    assert result_env.metadata["task_id"] == "task-99"
+    assert result_env.metadata["output_file"].endswith("events.jsonl")
+    assert result_env.metadata["duration_ms"] == 12345
+    assert result_env.metadata["total_tokens"] == 4500
+    assert result_env.metadata["worktree_path"] == "/Users/x/wt"
+
+
+def test_looks_like_subagent_result_detects_task_notification_block() -> None:
+    assert _looks_like_subagent_result([
+        {"type": "task-notification", "task-id": "t-1", "output-file": "/x"},
+    ]) is True
+    assert _looks_like_subagent_result([
+        {"task-id": "t-1", "output-file": "/x"},  # missing explicit type
+    ]) is True
+    assert _looks_like_subagent_result([{"type": "text", "text": "x"}]) is False
+    assert _looks_like_subagent_result("not a list") is False
+
+
+# ---------------------------------------------------------------------------
+# AskUserQuestion
+# ---------------------------------------------------------------------------
+
+
+def test_ask_user_question_emits_ask_user_envelope(tmp_path: Path) -> None:
+    questions = [{
+        "question": "Which library should we use?",
+        "header": "Library",
+        "multiSelect": False,
+        "options": [
+            {"label": "date-fns", "description": "Modular"},
+            {"label": "dayjs", "description": "Lightweight"},
+        ],
+    }]
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_ask",
+        name="AskUserQuestion",
+        input={"questions": questions},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    env = envelopes[0]
+    assert env.type == MessageType.ASK_USER
+    assert env.text == "Which library should we use?"
+    assert env.metadata["tool_use_id"] == "toolu_ask"
+    assert env.metadata["answered"] is False
+    assert env.metadata["answers"] is None
+    assert env.metadata["questions"][0]["options"][0]["label"] == "date-fns"
+
+
+def test_ask_user_with_missing_questions_uses_fallback_text(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_ask_empty",
+        name="AskUserQuestion",
+        input={"questions": "not a list"},  # malformed
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].text == "[ask_user]"
+    assert envelopes[0].metadata["questions"] == []
+
+
+# ---------------------------------------------------------------------------
+# SendUserFile
+# ---------------------------------------------------------------------------
+
+
+def test_send_user_file_with_multiple_files(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_file",
+        name="SendUserFile",
+        input={
+            "files": ["~/Desktop/a.pdf", "~/Desktop/b.pdf"],
+            "caption": "Reports",
+            "status": "proactive",
+        },
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    env = envelopes[0]
+    assert env.type == MessageType.FILE
+    assert "a.pdf" in env.text and "b.pdf" in env.text
+    assert env.metadata["files"] == ["~/Desktop/a.pdf", "~/Desktop/b.pdf"]
+    assert env.metadata["caption"] == "Reports"
+    assert env.metadata["status"] == "proactive"
+
+
+def test_send_user_file_accepts_single_string(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_file2",
+        name="SendUserFile",
+        input={"files": "~/Desktop/only.pdf"},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].metadata["files"] == ["~/Desktop/only.pdf"]
+
+
+def test_send_user_file_with_no_files_renders_placeholder(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_file3",
+        name="SendUserFile",
+        input={"files": []},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].text == "[file] (no files)"
+
+
+# ---------------------------------------------------------------------------
+# System events: error, turn_end
+# ---------------------------------------------------------------------------
+
+
+def test_error_event_becomes_system_event(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "error",
+        error={"message": "boom", "kind": "fatal"},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    env = envelopes[0]
+    assert env.type == MessageType.SYSTEM_EVENT
+    assert env.metadata["subtype"] == "error"
+    assert env.text == "boom"
+
+
+def test_error_event_handles_string_error(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event("error", error="oops")])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].text == "oops"
+
+
+def test_turn_end_event_is_system_event(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_codex_event("turn_end", reason="done")])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].type == MessageType.SYSTEM_EVENT
+    assert envelopes[0].metadata["subtype"] == "turn_end"
+
+
+# ---------------------------------------------------------------------------
+# Codex shapes
+# ---------------------------------------------------------------------------
+
+
+def test_codex_user_turn_parses_to_text(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_codex_event("user_turn", text="hi codex")])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].text == "hi codex"
+    assert envelopes[0].metadata["provider"] == "codex"
+
+
+def test_codex_assistant_turn_parses_to_text(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_codex_event(
+        "assistant_turn", text="codex reply",
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].role == MessageRole.ASSISTANT
+    assert envelopes[0].text == "codex reply"
+
+
+def test_codex_tool_call_renders_with_generic_name(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_codex_event(
+        "tool_call",
+        type="local_shell",
+        command="ls -la",
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].type == MessageType.TOOL_USE
+    assert "[local_shell]" in envelopes[0].text
+
+
+def test_codex_tool_result_extracts_output_text(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_codex_event(
+        "tool_result",
+        type="local_shell_result",
+        output="file1\nfile2",
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].type == MessageType.TOOL_RESULT
+    assert envelopes[0].text == "file1\nfile2"
+
+
+# ---------------------------------------------------------------------------
+# Helper: _extract_text_from_blocks
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_from_string() -> None:
+    assert _extract_text_from_blocks("hello") == "hello"
+
+
+def test_extract_text_from_list_of_blocks() -> None:
+    blocks = [
+        {"type": "text", "text": "part 1"},
+        {"type": "text", "text": "part 2"},
+    ]
+    assert _extract_text_from_blocks(blocks) == "part 1\npart 2"
+
+
+def test_extract_text_from_dict() -> None:
+    assert _extract_text_from_blocks({"text": "wrapped"}) == "wrapped"
+
+
+def test_extract_text_returns_empty_for_other_types() -> None:
+    assert _extract_text_from_blocks(None) == ""
+    assert _extract_text_from_blocks(42) == ""
+
+
+def test_extract_text_skips_non_text_blocks() -> None:
+    blocks = [
+        {"type": "image", "source": "..."},
+        {"type": "text", "text": "kept"},
+    ]
+    assert _extract_text_from_blocks(blocks) == "kept"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: malformed lines, missing file, empty file
+# ---------------------------------------------------------------------------
+
+
+def test_parse_skips_malformed_json_lines(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text(
+        json.dumps(_claude_event("user_turn", text="ok")) + "\n"
+        + "not json at all\n"
+        + json.dumps(_claude_event("assistant_turn", text="reply")) + "\n",
+    )
+    envelopes = parse_events_jsonl(events_path)
+    assert [e.text for e in envelopes] == ["ok", "reply"]
+
+
+def test_parse_skips_blank_lines(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text(
+        "\n\n"
+        + json.dumps(_claude_event("user_turn", text="hi")) + "\n"
+        + "\n",
+    )
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 1
+
+
+def test_parse_skips_non_object_lines(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text(
+        "[1, 2, 3]\n"
+        + json.dumps(_claude_event("user_turn", text="ok")) + "\n",
+    )
+    envelopes = parse_events_jsonl(events_path)
+    assert len(envelopes) == 1
+
+
+def test_parse_missing_file_returns_empty_list(tmp_path: Path) -> None:
+    envelopes = parse_events_jsonl(tmp_path / "nope.jsonl")
+    assert envelopes == []
+
+
+def test_parse_empty_file_returns_empty_list(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text("")
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes == []
+
+
+# ---------------------------------------------------------------------------
+# Stale detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_archive_stale_true_for_missing_file(tmp_path: Path) -> None:
+    assert is_archive_stale(tmp_path / "missing.jsonl") is True
+    assert is_archive_stale(None) is True
+
+
+def test_is_archive_stale_true_for_old_file(tmp_path: Path) -> None:
+    path = tmp_path / "old.jsonl"
+    path.write_text("x")
+    # Simulate an old file by injecting ``now`` 120s in the future.
+    assert is_archive_stale(
+        path, threshold_seconds=60, now=time.time() + 120,
+    ) is True
+
+
+def test_is_archive_stale_false_for_fresh_file(tmp_path: Path) -> None:
+    path = tmp_path / "fresh.jsonl"
+    path.write_text("x")
+    assert is_archive_stale(path, threshold_seconds=60) is False
+
+
+def test_stale_threshold_default_matches_spec() -> None:
+    # Spec §4.7 says ">60s" — module constant should match so the
+    # router can document the spec value without drift.
+    assert STALE_THRESHOLD_SECONDS == 60.0
+
+
+# ---------------------------------------------------------------------------
+# resolve_transcript_path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_transcript_picks_most_recent_when_no_cwd_match(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    older = transcripts / "session-old"
+    newer = transcripts / "session-new"
+    older.mkdir(parents=True)
+    newer.mkdir(parents=True)
+    (older / "events.jsonl").write_text(
+        json.dumps(_claude_event("user_turn", text="x")) + "\n",
+    )
+    time.sleep(0.05)  # Filesystem mtime resolution.
+    (newer / "events.jsonl").write_text(
+        json.dumps(_claude_event("user_turn", text="y")) + "\n",
+    )
+    resolved = resolve_transcript_path(project_root)
+    assert resolved is not None
+    assert resolved.parent.name == "session-new"
+
+
+def test_resolve_transcript_prefers_cwd_match(tmp_path: Path) -> None:
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    matching = transcripts / "session-match"
+    unrelated = transcripts / "session-unrelated"
+    matching.mkdir(parents=True)
+    unrelated.mkdir(parents=True)
+    cwd_match = str(tmp_path / "match-cwd")
+    cwd_other = str(tmp_path / "other-cwd")
+    Path(cwd_match).mkdir()
+    Path(cwd_other).mkdir()
+    # Put the matching dir with the OLDER mtime to confirm cwd wins.
+    matching_event = _claude_event("user_turn", text="hi")
+    matching_event["cwd"] = cwd_match
+    (matching / "events.jsonl").write_text(json.dumps(matching_event) + "\n")
+    time.sleep(0.05)
+    other_event = _claude_event("user_turn", text="hi")
+    other_event["cwd"] = cwd_other
+    (unrelated / "events.jsonl").write_text(json.dumps(other_event) + "\n")
+    resolved = resolve_transcript_path(project_root, cwd=cwd_match)
+    assert resolved is not None
+    assert resolved.parent.name == "session-match"
+
+
+def test_resolve_transcript_returns_none_when_root_missing(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "no-transcripts"
+    project_root.mkdir()
+    assert resolve_transcript_path(project_root) is None
+
+
+def test_resolve_transcript_returns_none_when_no_event_files(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    (transcripts / "empty-session").mkdir(parents=True)
+    assert resolve_transcript_path(project_root) is None
+
+
+def test_resolve_transcript_skips_tasks_subdir(tmp_path: Path) -> None:
+    # ``tasks/`` holds raw provider JSONLs archived by SessionManager;
+    # it's never the normalized ``events.jsonl`` shape.
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    tasks_dir = transcripts / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / "events.jsonl").write_text(
+        json.dumps(_claude_event("user_turn", text="x")) + "\n",
+    )
+    assert resolve_transcript_path(project_root) is None
+
+
+def test_resolve_transcript_session_hint_wins(tmp_path: Path) -> None:
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    hint_dir = transcripts / "my-session-hint"
+    other_dir = transcripts / "other"
+    hint_dir.mkdir(parents=True)
+    other_dir.mkdir(parents=True)
+    (hint_dir / "events.jsonl").write_text(
+        json.dumps(_claude_event("user_turn", text="x")) + "\n",
+    )
+    time.sleep(0.05)
+    (other_dir / "events.jsonl").write_text(
+        json.dumps(_claude_event("user_turn", text="y")) + "\n",
+    )
+    # Without hint, ``other`` is most recent → wins.
+    assert resolve_transcript_path(project_root).parent.name == "other"
+    # With hint, ``my-session-hint`` wins even though older.
+    resolved = resolve_transcript_path(
+        project_root, session_hint="my-session-hint",
+    )
+    assert resolved.parent.name == "my-session-hint"
+
+
+# ---------------------------------------------------------------------------
+# Envelope id stability
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_ids_are_unique_within_file(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [
+        _claude_event("user_turn", text="one"),
+        _claude_event("user_turn", text="two"),
+        _claude_event("user_turn", text="three"),
+    ])
+    envelopes = parse_events_jsonl(events_path)
+    ids = [e.id for e in envelopes]
+    assert len(set(ids)) == len(ids)
+
+
+def test_tool_call_envelope_id_uses_tool_use_id(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event(
+        "tool_call",
+        type="tool_use",
+        id="toolu_stable_123",
+        name="Bash",
+        input={"command": "echo"},
+    )])
+    envelopes = parse_events_jsonl(events_path)
+    assert envelopes[0].id == "msg_toolu_stable_123"

--- a/tests/test_chat_transcripts.py
+++ b/tests/test_chat_transcripts.py
@@ -15,10 +15,11 @@ Also covers:
 
 - Codex-shape event handling (assistant_message, tool_call, tool_result)
 - Stale-archive detection (spec §4.7)
-- ``include_thinking`` flag
 - Malformed JSON line skip
 - ``resolve_transcript_path`` cwd matching + most-recent fallback
 - Subagent linking via task-notification block
+- Session-index fingerprint matching (cwd + account + provider) with
+  explicit ``None`` on unresolved surfaces (Codex review #2044)
 """
 
 from __future__ import annotations
@@ -39,6 +40,8 @@ from pollypm.web_api.chat.transcripts import (
     _extract_text_from_blocks,
     _format_tool_use_summary,
     _looks_like_subagent_result,
+    build_session_index,
+    lookup_transcript_path,
 )
 
 
@@ -684,25 +687,32 @@ def test_stale_threshold_default_matches_spec() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_transcript_picks_most_recent_when_no_cwd_match(
+def test_resolve_transcript_returns_none_when_no_cwd_match(
     tmp_path: Path,
 ) -> None:
+    # Codex review #2044 — explicit unresolved instead of falling back
+    # to "freshest events.jsonl under the project root". Without a cwd
+    # match we MUST return None so the API never cross-attaches a
+    # different surface's transcript.
     project_root = tmp_path / "proj"
     transcripts = project_root / ".pollypm" / "transcripts"
     older = transcripts / "session-old"
     newer = transcripts / "session-new"
     older.mkdir(parents=True)
     newer.mkdir(parents=True)
-    (older / "events.jsonl").write_text(
-        json.dumps(_claude_event("user_turn", text="x")) + "\n",
-    )
+    old_event = _claude_event("user_turn", text="x")
+    old_event["cwd"] = str(tmp_path / "elsewhere-a")
+    (older / "events.jsonl").write_text(json.dumps(old_event) + "\n")
     time.sleep(0.05)  # Filesystem mtime resolution.
-    (newer / "events.jsonl").write_text(
-        json.dumps(_claude_event("user_turn", text="y")) + "\n",
-    )
-    resolved = resolve_transcript_path(project_root)
-    assert resolved is not None
-    assert resolved.parent.name == "session-new"
+    new_event = _claude_event("user_turn", text="y")
+    new_event["cwd"] = str(tmp_path / "elsewhere-b")
+    (newer / "events.jsonl").write_text(json.dumps(new_event) + "\n")
+    # No cwd supplied → cannot fingerprint → None.
+    assert resolve_transcript_path(project_root) is None
+    # cwd supplied but no match → still None (no freshest fallback).
+    assert resolve_transcript_path(
+        project_root, cwd=str(tmp_path / "nowhere"),
+    ) is None
 
 
 def test_resolve_transcript_prefers_cwd_match(tmp_path: Path) -> None:
@@ -753,33 +763,84 @@ def test_resolve_transcript_skips_tasks_subdir(tmp_path: Path) -> None:
     transcripts = project_root / ".pollypm" / "transcripts"
     tasks_dir = transcripts / "tasks"
     tasks_dir.mkdir(parents=True)
-    (tasks_dir / "events.jsonl").write_text(
-        json.dumps(_claude_event("user_turn", text="x")) + "\n",
-    )
-    assert resolve_transcript_path(project_root) is None
+    tasks_event = _claude_event("user_turn", text="x")
+    tasks_event["cwd"] = str(tmp_path / "anywhere")
+    (tasks_dir / "events.jsonl").write_text(json.dumps(tasks_event) + "\n")
+    # Even with a matching cwd, the tasks/ subdir must be ignored.
+    assert resolve_transcript_path(
+        project_root, cwd=str(tmp_path / "anywhere"),
+    ) is None
 
 
-def test_resolve_transcript_session_hint_wins(tmp_path: Path) -> None:
+def test_resolve_transcript_filters_by_account_name(tmp_path: Path) -> None:
+    # Two surfaces sharing the same cwd MUST be disambiguated by their
+    # account_name fingerprint. Without this filter the older sibling
+    # would cross-attach to the newer surface's transcript.
     project_root = tmp_path / "proj"
     transcripts = project_root / ".pollypm" / "transcripts"
-    hint_dir = transcripts / "my-session-hint"
-    other_dir = transcripts / "other"
-    hint_dir.mkdir(parents=True)
-    other_dir.mkdir(parents=True)
-    (hint_dir / "events.jsonl").write_text(
-        json.dumps(_claude_event("user_turn", text="x")) + "\n",
+    shared_cwd = str(tmp_path / "shared")
+    Path(shared_cwd).mkdir()
+    main_event = _claude_event("user_turn", text="ops")
+    main_event["account_name"] = "claude_main"
+    main_event["cwd"] = shared_cwd
+    (transcripts / "session-main").mkdir(parents=True)
+    (transcripts / "session-main" / "events.jsonl").write_text(
+        json.dumps(main_event) + "\n",
     )
     time.sleep(0.05)
-    (other_dir / "events.jsonl").write_text(
-        json.dumps(_claude_event("user_turn", text="y")) + "\n",
+    alt_event = _claude_event("user_turn", text="arch")
+    alt_event["account_name"] = "claude_alt"
+    alt_event["cwd"] = shared_cwd
+    (transcripts / "session-alt").mkdir(parents=True)
+    (transcripts / "session-alt" / "events.jsonl").write_text(
+        json.dumps(alt_event) + "\n",
     )
-    # Without hint, ``other`` is most recent → wins.
-    assert resolve_transcript_path(project_root).parent.name == "other"
-    # With hint, ``my-session-hint`` wins even though older.
-    resolved = resolve_transcript_path(
-        project_root, session_hint="my-session-hint",
+    main_resolved = resolve_transcript_path(
+        project_root, cwd=shared_cwd, account_name="claude_main",
     )
-    assert resolved.parent.name == "my-session-hint"
+    assert main_resolved is not None
+    assert main_resolved.parent.name == "session-main"
+    alt_resolved = resolve_transcript_path(
+        project_root, cwd=shared_cwd, account_name="claude_alt",
+    )
+    assert alt_resolved is not None
+    assert alt_resolved.parent.name == "session-alt"
+
+
+def test_build_session_index_skips_unreadable_events(tmp_path: Path) -> None:
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    transcripts.mkdir(parents=True)
+    # Empty events.jsonl — no fingerprint, must be skipped.
+    (transcripts / "session-empty").mkdir()
+    (transcripts / "session-empty" / "events.jsonl").write_text("")
+    # Malformed first line — must be skipped.
+    (transcripts / "session-bad").mkdir()
+    (transcripts / "session-bad" / "events.jsonl").write_text("garbage\n")
+    # Well-formed line — kept.
+    (transcripts / "session-ok").mkdir()
+    good = _claude_event("user_turn", text="ok")
+    good["cwd"] = str(tmp_path / "cwd-ok")
+    (transcripts / "session-ok" / "events.jsonl").write_text(
+        json.dumps(good) + "\n",
+    )
+    index = build_session_index(transcripts)
+    assert {entry.session_id for entry in index} == {"session-ok"}
+
+
+def test_lookup_returns_none_without_cwd(tmp_path: Path) -> None:
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    transcripts.mkdir(parents=True)
+    (transcripts / "session-a").mkdir()
+    event = _claude_event("user_turn", text="hi")
+    event["cwd"] = str(tmp_path / "x")
+    (transcripts / "session-a" / "events.jsonl").write_text(
+        json.dumps(event) + "\n",
+    )
+    index = build_session_index(transcripts)
+    assert lookup_transcript_path(index, cwd=None) is None
+    assert lookup_transcript_path(index, cwd="") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements **P1** of the chat-endpoints spec (`~/Desktop/pollypm-chat-endpoints-spec.md` §6) — the data layer that powers the HTTP chat endpoints that ship in P2. **No HTTP routes** in this PR.

New package `src/pollypm/web_api/chat/`:

- **`envelope.py`** — `MessageEnvelope` dataclass with 8 type discriminators (`text`, `tool_use`, `tool_result`, `thinking`, `ask_user`, `file`, `subagent_spawn`, `subagent_result`, `system_event`) per spec §3.
- **`transcripts.py`** — parses the normalized `events.jsonl` archive emitted by `TranscriptIngestor` into envelopes. Drops `token_usage` / `session_state` (not chat messages). Detects subagent pairs via Task `tool_use` + `task-notification` result blocks. Resolves the right archive subdir by `cwd` match → most-recent mtime fallback.
- **`tmux_capture.py`** — fallback reader using `tmux capture-pane -p -S -3000` when the archive is missing or >60s stale (spec §4.7). Synthesizes deterministic `cap_<hex>` envelope ids from `blake2b(session_name : line_index : content)`. Strips ANSI escapes.
- **`registry.py`** — enumerates all four chat surface types (operator/architect/advisor/worker) into `ChatSurface` dataclasses with `session_name`, `surface_type`, `persona`, `project`, `task_id`, tmux window state, and resolved transcript path. Worker enumeration reads `WorkerSession` rows from work-service. Tmux probing is one `list_windows` call cached per request.

## Subagent linking decision

Implemented **detection** (spawn + result envelopes paired via `tool_use_id` as `subagent_id`, with `task-notification` block fields surfaced in result metadata). **Deferred** the recursive inline `subagent_transcript[]` payload that the spec's `?include_subagents=true` flag requires — that needs `TranscriptIngestor` to preserve a clean `output-file` reference per Task `tool_result`, which it currently keeps inside the raw payload but not as a first-class field. P1 spec calls out: "decide if subagent linking is feasible in P1 or needs an ingestor enhancement (file a follow-up issue if so, don't try to land both in P1)." Filing a follow-up issue rather than touching the ingestor in this PR.

## Spec gaps noticed while implementing

1. The spec assumes `<project>/.pollypm/transcripts/<session_name>/events.jsonl` exists with `session_name` matching the tmux session name. In practice the ingestor names subdirs by the provider-internal session UUID (Claude `sessionId` / Codex `session_meta.id`), not the tmux session_name. `resolve_transcript_path` works around this by preferring `cwd` match then most-recent mtime.
2. Codex tool-call payload shape isn't pinned in the spec; the parser renders a generic `[<tool_name>]` summary and preserves the raw payload in metadata. Deeper Codex tool parsing can land in P3 alongside the send-side Codex work.
3. AskUserQuestion `selections_no_question` / `selections_invalid` errors (spec §2.3) belong on the POST endpoint in P3 — not the read path.

## Tests shipped

**111 cases**, all green (well above the ≥40 case goal):

- `tests/test_chat_transcripts.py` — 54 cases. All 8 envelope types, Claude + Codex shapes, stale detection, cwd-match resolution, malformed-line tolerance, envelope id stability.
- `tests/test_chat_registry.py` — 31 cases. All 4 surface types, persona fallback, tmux probing, disabled / non-chat filtering, deterministic sort order, `to_dict` serialization.
- `tests/test_chat_tmux_capture.py` — 26 cases. ANSI stripping, deterministic id synthesis, empty / error handling, capture-depth wiring.

Run: `uv run --with pytest python -m pytest tests/test_chat_*.py --noconftest` → `111 passed in 1.40s`.

## Constraints honoured

- No ingestor changes (spec gap flagged for follow-up issue)
- No HTTP routes (P2)
- No `StateStore` imports
- No new pg paths
- v1 RC stability — pure read-side, only adds new files

## Test plan

- [x] Unit tests for every MessageEnvelope discriminator
- [x] Unit tests for surface enumeration across all 4 types
- [x] Unit tests for tmux capture fallback
- [x] Manual: package imports cleanly (`from pollypm.web_api.chat import ...`)
- [ ] Integration: wired into FastAPI in P2 (next PR)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)