### PR TITLE
docs(chat-api): reference for GET /sessions + /messages + POST /send

### DIFF
--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -1,5 +1,11 @@
 # Chat HTTP API reference
 
+> **Status:** Reference doc for endpoints landing in PRs #2043, #2044,
+> #2045, #2047. Will be cross-checked against final implementation
+> before merge. Treat the contracts here as the *intended* shape — the
+> P3 send endpoint in particular (#2043) is still in fix-loop, so
+> field names and error codes may shift before merge.
+
 Reference for the `/api/v1/chat/*` endpoints — the HTTP surface for
 reading transcripts from, and sending messages into, the four live
 tmux-backed chat surfaces PollyPM runs (operator, architect, advisor,
@@ -7,10 +13,11 @@ per-task worker). Audience: anyone building tooling on top of PollyPM
 (custom dashboards, browser clients, scripted reply bots) and operators
 running ad-hoc `curl` against the local daemon.
 
-This document covers phase 1 of the chat API (PRs #2042–#2046). Phase 2
-(dashboard / inbox / task-manipulation endpoints) is out of scope and
-is sketched in the source spec at
-`docs/project-specs/chat-endpoints-spec.md` §8.
+This document covers phase 1 of the chat API (PRs #2042–#2047) and is
+self-contained — read this file for the contract; the implementation
+under `src/pollypm/web_api/routes/chat_*.py` is the source of truth
+for the wire format. Phase 2 (dashboard / inbox / task-manipulation
+endpoints) is out of scope.
 
 ---
 
@@ -136,18 +143,22 @@ No query params.
       "surface_type": "operator",
       "persona": "Polly",
       "project": null,
+      "task_id": null,
       "window": {
         "tmux_session": "storage-closet",
         "window_name": "pm-operator",
         "present": true,
-        "pane_id": "%17"
+        "pane_id": "%17",
+        "pane_dead": false
       },
       "transcript": {
         "source": "jsonl",
-        "path": "~/.claude/projects/-Users-sam-dev-pollypm/abc.jsonl",
-        "last_write": "2026-05-21T20:48:11Z"
+        "path": "~/.pollypm/projects/samblog/.pollypm/transcripts/abc/events.jsonl"
       },
-      "auth_token_present": true
+      "cwd": "/Users/sam/dev/samblog",
+      "provider": "claude",
+      "auth_token_present": true,
+      "worktree_path": null
     }
   ]
 }
@@ -159,9 +170,16 @@ Field notes:
   tmux. The transcript path may still be readable (the agent crashed
   but the JSONL was flushed) — render the surface as greyed-out, not
   as deleted.
-- `transcript.source` is one of `jsonl`, `capture`, or `null`. `null`
-  means we have neither a JSONL on disk nor a live pane to capture
-  from; `GET /messages` against this surface returns `messages: []`.
+- `window.pane_dead=true` is reported when tmux flags the pane as
+  exited; POST `/send` against a dead pane returns `409 pane_dead`.
+- `transcript.source` from discovery is `"jsonl"` or `null` — discovery
+  never reports `"capture"`. `null` means no events.jsonl archive exists
+  yet (brand-new surface, spec §4.8); the history endpoint can still
+  fall back to a live tmux capture when the window is present.
+- `task_id` is populated for worker surfaces only; `null` for
+  operator/architect/advisor.
+- `worktree_path` is populated for worker surfaces running inside an
+  isolated worktree; `null` otherwise.
 
 ### 3.2 `GET /api/v1/chat/{session_name}/messages`
 
@@ -177,14 +195,13 @@ Pull a window of messages from a single session's transcript.
 
 | Param | Default | Meaning |
 |---|---|---|
-| `since` | none | ISO-8601 lower bound on message timestamp (exclusive). |
-| `since_id` | none | Message id (string). Return messages strictly after this id. If both `since` and `since_id` are passed, `since_id` wins. |
-| `limit` | `100` | Max messages, capped at `500`. Values above 500 silently clamp. |
+| `since` | none | ISO-8601 lower bound on message timestamp. Both `...Z` and `...+00:00` suffix shapes accepted. |
+| `since_id` | none | Message id (string). Return messages strictly after this id. Both `since` and `since_id` are applied if passed together (the `since` lower-bound is applied first, then the cursor walk). |
+| `limit` | `100` | Max messages, must be `1..500`. Values outside that range return `422 validation_error` (FastAPI Pydantic-level rejection). |
 | `direction` | `desc` | `desc` (newest first) or `asc`. Pagination cursors assume the same direction. |
 | `include_subagents` | `false` | When `true`, inline subagent transcripts inside their `subagent_result` parent's `metadata.subagent_transcript[]`. See §5.2. |
 | `include_thinking` | `false` | Include `type=thinking` blocks. Default off — usually noisy. |
-| `include_system_events` | `true` | Include compaction markers and session-start events. Set `false` for a cleaner feed. |
-| `source` | `auto` | `auto` (JSONL with capture fallback), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). |
+| `source` | `auto` | `auto` (JSONL with capture fallback when archive is missing or >60s stale), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). Any other value returns `422 validation_error`. |
 
 **Response:**
 
@@ -194,24 +211,27 @@ Pull a window of messages from a single session's transcript.
   "surface_type": "operator",
   "persona": "Polly",
   "transcript_source": "jsonl",
-  "transcript_path": "~/.claude/projects/-Users-sam-dev-pollypm/abc.jsonl",
+  "transcript_path": "/Users/sam/dev/samblog/.pollypm/transcripts/abc/events.jsonl",
   "messages": [ /* MessageEnvelope[], see §4 */ ],
   "has_more": false,
   "next_cursor": "msg_xyz"
 }
 ```
 
-`next_cursor` is the `id` of the last message returned; pass it back as
-`since_id` to fetch the next page when `has_more=true`.
+`transcript_source` is one of `"jsonl"`, `"capture"`, or `null`
+(empty surface, spec §4.8). `transcript_path` is non-null only for
+`transcript_source="jsonl"`. `next_cursor` is the `id` of the last
+message returned; pass it back as `since_id` to fetch the next page
+when `has_more=true`.
 
 **Error codes:**
 
 | Status | Code | Meaning |
 |---|---|---|
 | 404 | `session_unknown` | `session_name` is not in `config.sessions` and not a live worker. |
-| 404 | `transcript_missing` | `source=jsonl` forced, but no JSONL exists. |
-| 400 | `invalid_since` | `since` is not ISO-8601 parseable. |
-| 400 | `invalid_source` | `source` is not one of the three allowed values. |
+| 404 | `archive_missing` | `source=jsonl` forced, but no `events.jsonl` archive exists for this session. |
+| 400 | `invalid_request` | `since` is not ISO-8601 parseable. (Other request-shape errors share this code; see the message body for the offending field.) |
+| 422 | `validation_error` | FastAPI's standard Pydantic rejection envelope — returned for out-of-range `limit`, unknown `source`, unknown `direction`, etc. Shape is FastAPI's default `{"detail": [{"loc": [...], "msg": "...", "type": "..."}]}`, NOT the chat router's `{code, message, hint}` envelope. |
 
 **Curl:**
 
@@ -227,6 +247,10 @@ curl -sH "Authorization: Bearer $TOKEN" \
 
 ### 3.3 `POST /api/v1/chat/{session_name}/send`
 
+> **Status:** P3 (#2043) implementation is in fix-loop; contracts
+> below may shift before merge. Cross-check against
+> `src/pollypm/web_api/routes/chat_send.py` at merge time.
+
 Inject a message into the agent's input box via tmux. Returns
 synchronously after the send; does **not** wait for the agent to
 respond. Poll `GET /messages` for the reply.
@@ -238,7 +262,7 @@ respond. Poll `GET /messages` for the reply.
   "text": "What is blocking samblog/47 right now?",
   "press_enter": true,
   "answer_to": null,
-  "selections": null,
+  "selections": [],
   "notes": null,
   "safety": "strict",
   "pane": null
@@ -247,34 +271,39 @@ respond. Poll `GET /messages` for the reply.
 
 | Field | Type | Default | Meaning |
 |---|---|---|---|
-| `text` | string | — | Free-text message. Required unless `selections` is set. |
+| `text` | string \| null | `null` | Free-text message. Required when `answer_to` is null. When `answer_to` is set, `text` is an optional free-form reply (used if `selections` is empty). |
 | `press_enter` | bool | `true` | Press Enter after typing. `false` to stage a long paste without submitting. |
-| `answer_to` | string | `null` | Id of the `ask_user` envelope this is replying to. See §5.5. |
-| `selections` | string[] | `null` | One or more option labels for an `ask_user` reply. Mutually exclusive with `text`. |
-| `notes` | string | `null` | Free-text addendum after a selection. |
-| `safety` | enum | `strict` | `strict` (reject mid-stream + mid-tool), `loose` (allow mid-stream with warning header), `force` (bypass all gates). |
-| `pane` | int | `null` | Pane index inside the window. `null` = primary pane. See §5.4. |
+| `answer_to` | string \| null | `null` | Id of the `ask_user` envelope this is replying to. See §5.5. |
+| `selections` | string[] | `[]` | One or more option labels for an `ask_user` reply. Only meaningful when `answer_to` is set. |
+| `notes` | string \| null | `null` | Free-text addendum after a selection. Also usable as the body of an `answer_to` reply when both `text` and `selections` are absent. |
+| `safety` | enum | `strict` | `strict` (reject mid-stream + mid-tool), `loose` (mid-tool still blocks, mid-stream allowed with warning header), `force` (bypass both gates). |
+| `pane` | int \| null | `null` | 0-based pane index inside the target window. `null` (or `0`) = primary/active pane. See §5.4. |
 
 **Response:**
 
 ```json
 {
   "ok": true,
-  "message_id": "msg_abc",
+  "message_id": "msg_abc123def456",
   "session_name": "operator",
-  "window_target": "storage-closet:pm-operator",
+  "window_target": "samblog-storage-closet:pm-operator",
   "characters_sent": 47,
   "method": "send_keys",
   "press_enter_at": "2026-05-21T20:53:12.500Z"
 }
 ```
 
-- `message_id` is a server-minted correlation id; it appears in
-  subsequent transcript pulls as the `id` of the user message, so a
-  caller can match its send to the rendered turn.
-- `method` is `send_keys` for short messages, `paste_buffer` for
-  messages over 100 characters (the existing tmux client picks; see
-  issue #808 for why paste-buffer is the default for long text).
+- `message_id` is a server-minted correlation id of the form
+  `msg_<uuid4-hex>`. It is **not** guaranteed to match the eventual
+  envelope `id` in the transcript — the transcript layer mints its
+  own id on ingest. Use `press_enter_at` + the next user envelope's
+  `ts` to correlate if you need to.
+- `window_target` is the tmux `session:window` (or `session:window.pane`)
+  string the daemon addressed.
+- `method` is `send_keys` for messages ≤100 characters, `paste_buffer`
+  for messages over 100 characters (see issue #808 for why
+  paste-buffer is the default for long text).
+- `press_enter_at` is `null` when `press_enter=false`.
 - When `safety=loose` and the agent appeared streaming, the response
   includes header `X-PollyPM-Warning: agent-may-be-streaming`.
 
@@ -283,16 +312,15 @@ respond. Poll `GET /messages` for the reply.
 | Status | Code | Meaning |
 |---|---|---|
 | 404 | `session_unknown` | session_name not in config and not a live worker. |
-| 503 | `window_missing` | Window configured but not in tmux. Restart the session. |
-| 409 | `pane_dead` | tmux says the pane is dead. |
-| 409 | `unsafe_mid_tool` | Open `tool_use` with no matching `tool_result`. Override with `safety=force`. See §5.1. |
-| 409 | `unsafe_mid_stream` | Heartbeat says agent streamed within last 2s. Override with `safety=loose` or `force`. See §5.3. |
-| 400 | `text_or_selections_required` | Body had neither `text` nor `selections`. |
-| 400 | `text_and_selections_exclusive` | Body had both. |
-| 400 | `answer_to_missing` | `answer_to` id not found in transcript. |
-| 400 | `answer_to_not_question` | `answer_to` references a non-`ask_user` message. |
-| 400 | `selections_no_question` | `selections` provided but `answer_to` is null. |
-| 400 | `selections_invalid` | One or more selections don't match the question's options. Response includes valid options. |
+| 503 | `window_missing` | Window configured but not present in tmux. Restart the session. |
+| 409 | `pane_dead` | tmux flagged the pane as dead. |
+| 409 | `unsafe_mid_tool` | Latest assistant turn has an open `tool_use` with no matching `tool_result`. Override with `safety=force`. See §5.1. |
+| 409 | `unsafe_mid_stream` | Heartbeat shows the session streamed within the last 2s. Override with `safety=loose` (warn-and-send) or `safety=force` (bypass). See §5.3. |
+| 400 | `answer_to_missing` | `answer_to` id was not found in the session's recent transcript. |
+| 400 | `selections_no_question` | `answer_to` references a message that isn't an `ask_user` envelope. |
+| 400 | `selections_invalid` | One or more selections don't match the question's option labels. Response message includes the valid options. |
+| 400 | `invalid_request` | Catch-all for body-shape problems: missing `text` when `answer_to` is unset; `answer_to` set but no `selections`/`text`/`notes` supplied; etc. The message body identifies the specific problem. |
+| 422 | `validation_error` | FastAPI Pydantic rejection — malformed JSON, wrong field types, `safety` not in `{strict, loose, force}`, etc. Default FastAPI envelope shape (`{"detail": [...]}`). |
 
 **Curl examples:**
 
@@ -470,9 +498,8 @@ same way.
 
 ## 5. Edge cases ("Claude's fancy stuff")
 
-The same twelve gates Sam called out in the design spec
-(`chat-endpoints-spec.md` §4). Each has a defined behavior, an override
-where applicable, and a reason it exists.
+Twelve gates the chat API has to handle correctly. Each has a defined
+behavior, an override where applicable, and a reason it exists.
 
 ### 5.1 Mid-tool sends (`409 unsafe_mid_tool`)
 
@@ -577,10 +604,12 @@ parse the natural-language answer.
 ### 5.6 Compaction events
 
 Claude Code occasionally compacts the conversation, producing a
-`system_event` with `metadata.subtype=compaction`. Included by default
-in GET; filter out with `?include_system_events=false` if your UI
-doesn't render them. Don't drop them silently if the user might wonder
-why the conversation "jumps" — render at least a horizontal rule.
+`system_event` envelope with `metadata.subtype=compaction`. These are
+always included in the GET response (phase 1 has no
+`include_system_events` toggle — filter client-side by
+`type=="system_event"` if your UI doesn't render them). Don't drop them
+silently if the user might wonder why the conversation "jumps" —
+render at least a horizontal rule.
 
 ### 5.7 Stale JSONL → tmux capture fallback
 
@@ -592,8 +621,9 @@ live — usually means Claude Code hasn't flushed mid-stream.
 envelope with `type=text` and `metadata.from_capture=true`. Ids are
 synthetic (`cap_<hash>`), stable across reads.
 
-Force pure JSONL with `?source=jsonl` (accepts `transcript_missing`
-errors). Force pure capture with `?source=capture`.
+Force pure JSONL with `?source=jsonl` (accept the possibility of a
+`404 archive_missing` response). Force pure capture with
+`?source=capture`.
 
 ### 5.8 New session, no transcript yet
 
@@ -639,6 +669,9 @@ you need structured tool data, use a Claude session.
 ---
 
 ## 6. CLI alternative — `pm chat`
+
+> The `pm chat` CLI lands in PR #2047 — these commands work once that
+> merges. The HTTP endpoints (§3) are usable directly today via `curl`.
 
 The `pm chat` CLI is a thin client over these endpoints. It exists
 because typing curl with bearer-token plumbing every time gets old.
@@ -744,21 +777,27 @@ Two gotchas:
    the JSONL but the model's working context no longer references
    them.
 
-### (h) `pm chat send` works but my curl doesn't
+### (h) `POST /send` returns `400 invalid_request` with no obvious clue
 
-Three things to check:
+Things to check:
 
 - Content-Type header (`Content-Type: application/json`).
 - Body is valid JSON (jq it first).
-- Right session_name (worker sessions are `task-<project>-<task_number>`,
+- Right `session_name` (worker sessions are `task-<project>-<task_number>`,
   hyphen between project and number, not underscore).
+- When `answer_to` is set, supply at least one of `selections`, `text`,
+  or `notes` — an `answer_to` with all three empty is rejected.
+- When `answer_to` is unset, `text` is required.
 
 ---
 
 ## 8. Cross-references
 
-- Source spec: `docs/project-specs/chat-endpoints-spec.md` (authoritative
-  design doc this reference is derived from).
+- Implementation (source of truth for the wire format):
+  - `src/pollypm/web_api/routes/chat_messages.py` — `GET /sessions`
+    and `GET /{session_name}/messages` (PR #2045).
+  - `src/pollypm/web_api/routes/chat_send.py` — `POST /{session_name}/send`
+    (PR #2043).
 - Recovery cascade and the `[PollyPM-Auth: ...]` marker contract:
   `docs/recovery-cascade.md` — explains why the per-session `auth_token`
   field exists and why it's NOT what inbound API clients use.

--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -1,0 +1,768 @@
+# Chat HTTP API reference
+
+Reference for the `/api/v1/chat/*` endpoints — the HTTP surface for
+reading transcripts from, and sending messages into, the four live
+tmux-backed chat surfaces PollyPM runs (operator, architect, advisor,
+per-task worker). Audience: anyone building tooling on top of PollyPM
+(custom dashboards, browser clients, scripted reply bots) and operators
+running ad-hoc `curl` against the local daemon.
+
+This document covers phase 1 of the chat API (PRs #2042–#2046). Phase 2
+(dashboard / inbox / task-manipulation endpoints) is out of scope and
+is sketched in the source spec at
+`docs/project-specs/chat-endpoints-spec.md` §8.
+
+---
+
+## 1. What the chat API is
+
+PollyPM keeps four kinds of long-lived chat surfaces alive in tmux:
+
+- **Operator (`operator`)** — the Polly session, your top-level
+  conversational PM.
+- **Architect (`architect_<project>`)** — per-project planning session
+  ("Archie").
+- **Advisor (`advisor_<project>`)** — per-project advisory session,
+  used for second opinions and code review.
+- **Worker (`task-<project>-<task_number>`)** — short-lived per-task
+  Claude session that actually does the work.
+
+Each surface has exactly one tmux window backing it and (usually) one
+Claude Code JSONL transcript on disk. The chat API gives you uniform
+HTTP access to both: GET to pull the message history, POST to push a
+reply through tmux into the agent's input box.
+
+Use it when you want to:
+
+- Render PollyPM's conversations in a browser, mobile app, or
+  third-party cockpit without scraping `tmux capture-pane` yourself.
+- Script a reply into Polly from another service ("when GitHub action
+  X fails, ping the operator").
+- Build an `AskUserQuestion` reply bot that answers the agent's
+  multi-choice prompts programmatically.
+- Pull the structured tool-call / subagent / file-attachment data that
+  is invisible if you just stare at the tmux pane.
+
+The `pm chat` CLI is a thin wrapper on top of these endpoints (see §6).
+If you find yourself re-implementing parts of `pm chat`, hit the HTTP
+API directly instead.
+
+### Auth model
+
+The chat API reuses PollyPM's existing daemon-wide bearer-token auth.
+
+- Token lives at `~/.pollypm/api-token` (created on first `pm up`).
+- Pass it via `Authorization: Bearer <token>` on every request.
+- The daemon listens on `127.0.0.1:8765` by default. Remote access
+  requires `pm serve --host 0.0.0.0` (and is your problem to firewall).
+
+The chat API does **not** use the per-session `auth_token` field on
+`SessionConfig`. That token is for outbound PollyPM → agent control
+messages (the `[PollyPM-Auth: ...]` marker, see
+`docs/recovery-cascade.md` §3). Inbound API clients authenticate with
+the daemon-wide bearer token only.
+
+`auth_token_present` on the `sessions` response is informational only.
+GET reads and POST sends both work regardless of its value.
+
+---
+
+## 2. Quickstart
+
+Assume `TOKEN=$(cat ~/.pollypm/api-token)` and the daemon is on the
+default `127.0.0.1:8765`.
+
+**List every chat surface:**
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:8765/api/v1/chat/sessions \
+  | jq '.sessions[] | {session_name, surface_type, project, present: .window.present}'
+```
+
+Sample output:
+
+```json
+{"session_name": "operator",          "surface_type": "operator",  "project": null,      "present": true}
+{"session_name": "architect_samblog", "surface_type": "architect", "project": "samblog", "present": true}
+{"session_name": "advisor_samblog",   "surface_type": "advisor",   "project": "samblog", "present": true}
+{"session_name": "task-samblog-47",   "surface_type": "worker",    "project": "samblog", "present": true}
+```
+
+**Pull the last 20 messages from Polly:**
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:8765/api/v1/chat/operator/messages?limit=20" \
+  | jq '.messages[] | {ts, role, type, text: (.text[:80])}'
+```
+
+**Send a message into the architect for `samblog`:**
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://127.0.0.1:8765/api/v1/chat/architect_samblog/send \
+  -d '{"text": "What is blocking samblog/47 right now?"}'
+```
+
+That last call will return `409 unsafe_mid_stream` if the architect is
+actively streaming output (see §5.3). Override with
+`"safety": "loose"` if you want to queue the text anyway.
+
+---
+
+## 3. Endpoint reference
+
+All endpoints are mounted under `/api/v1/chat/` on the PollyPM web API
+(`src/pollypm/web_api/app.py`). All responses are JSON. All endpoints
+require `Authorization: Bearer <token>`; absent or wrong token returns
+`401 Unauthorized` (handled by the daemon-wide auth middleware, not by
+the chat router).
+
+### 3.1 `GET /api/v1/chat/sessions`
+
+Enumerate every chat surface the daemon currently knows about.
+Discovery endpoint for clients that don't know session names a priori.
+No query params.
+
+**Response:**
+
+```json
+{
+  "sessions": [
+    {
+      "session_name": "operator",
+      "surface_type": "operator",
+      "persona": "Polly",
+      "project": null,
+      "window": {
+        "tmux_session": "storage-closet",
+        "window_name": "pm-operator",
+        "present": true,
+        "pane_id": "%17"
+      },
+      "transcript": {
+        "source": "jsonl",
+        "path": "~/.claude/projects/-Users-sam-dev-pollypm/abc.jsonl",
+        "last_write": "2026-05-21T20:48:11Z"
+      },
+      "auth_token_present": true
+    }
+  ]
+}
+```
+
+Field notes:
+
+- `window.present=false` when the configured window doesn't exist in
+  tmux. The transcript path may still be readable (the agent crashed
+  but the JSONL was flushed) — render the surface as greyed-out, not
+  as deleted.
+- `transcript.source` is one of `jsonl`, `capture`, or `null`. `null`
+  means we have neither a JSONL on disk nor a live pane to capture
+  from; `GET /messages` against this surface returns `messages: []`.
+
+### 3.2 `GET /api/v1/chat/{session_name}/messages`
+
+Pull a window of messages from a single session's transcript.
+
+**Path params:**
+
+| Param | Meaning |
+|---|---|
+| `session_name` | Canonical session key. For operator/architect/advisor: the key from `config.sessions`. For workers: the computed `task-<project>-<task_number>` string. |
+
+**Query params:**
+
+| Param | Default | Meaning |
+|---|---|---|
+| `since` | none | ISO-8601 lower bound on message timestamp (exclusive). |
+| `since_id` | none | Message id (string). Return messages strictly after this id. If both `since` and `since_id` are passed, `since_id` wins. |
+| `limit` | `100` | Max messages, capped at `500`. Values above 500 silently clamp. |
+| `direction` | `desc` | `desc` (newest first) or `asc`. Pagination cursors assume the same direction. |
+| `include_subagents` | `false` | When `true`, inline subagent transcripts inside their `subagent_result` parent's `metadata.subagent_transcript[]`. See §5.2. |
+| `include_thinking` | `false` | Include `type=thinking` blocks. Default off — usually noisy. |
+| `include_system_events` | `true` | Include compaction markers and session-start events. Set `false` for a cleaner feed. |
+| `source` | `auto` | `auto` (JSONL with capture fallback), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). |
+
+**Response:**
+
+```json
+{
+  "session_name": "operator",
+  "surface_type": "operator",
+  "persona": "Polly",
+  "transcript_source": "jsonl",
+  "transcript_path": "~/.claude/projects/-Users-sam-dev-pollypm/abc.jsonl",
+  "messages": [ /* MessageEnvelope[], see §4 */ ],
+  "has_more": false,
+  "next_cursor": "msg_xyz"
+}
+```
+
+`next_cursor` is the `id` of the last message returned; pass it back as
+`since_id` to fetch the next page when `has_more=true`.
+
+**Error codes:**
+
+| Status | Code | Meaning |
+|---|---|---|
+| 404 | `session_unknown` | `session_name` is not in `config.sessions` and not a live worker. |
+| 404 | `transcript_missing` | `source=jsonl` forced, but no JSONL exists. |
+| 400 | `invalid_since` | `since` is not ISO-8601 parseable. |
+| 400 | `invalid_source` | `source` is not one of the three allowed values. |
+
+**Curl:**
+
+```bash
+# Last 5 messages
+curl -sH "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:8765/api/v1/chat/operator/messages?limit=5"
+
+# Everything since a known message id, oldest first
+curl -sH "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:8765/api/v1/chat/architect_samblog/messages?since_id=msg_abc&direction=asc&limit=200"
+```
+
+### 3.3 `POST /api/v1/chat/{session_name}/send`
+
+Inject a message into the agent's input box via tmux. Returns
+synchronously after the send; does **not** wait for the agent to
+respond. Poll `GET /messages` for the reply.
+
+**Request body:**
+
+```json
+{
+  "text": "What is blocking samblog/47 right now?",
+  "press_enter": true,
+  "answer_to": null,
+  "selections": null,
+  "notes": null,
+  "safety": "strict",
+  "pane": null
+}
+```
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `text` | string | — | Free-text message. Required unless `selections` is set. |
+| `press_enter` | bool | `true` | Press Enter after typing. `false` to stage a long paste without submitting. |
+| `answer_to` | string | `null` | Id of the `ask_user` envelope this is replying to. See §5.5. |
+| `selections` | string[] | `null` | One or more option labels for an `ask_user` reply. Mutually exclusive with `text`. |
+| `notes` | string | `null` | Free-text addendum after a selection. |
+| `safety` | enum | `strict` | `strict` (reject mid-stream + mid-tool), `loose` (allow mid-stream with warning header), `force` (bypass all gates). |
+| `pane` | int | `null` | Pane index inside the window. `null` = primary pane. See §5.4. |
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "message_id": "msg_abc",
+  "session_name": "operator",
+  "window_target": "storage-closet:pm-operator",
+  "characters_sent": 47,
+  "method": "send_keys",
+  "press_enter_at": "2026-05-21T20:53:12.500Z"
+}
+```
+
+- `message_id` is a server-minted correlation id; it appears in
+  subsequent transcript pulls as the `id` of the user message, so a
+  caller can match its send to the rendered turn.
+- `method` is `send_keys` for short messages, `paste_buffer` for
+  messages over 100 characters (the existing tmux client picks; see
+  issue #808 for why paste-buffer is the default for long text).
+- When `safety=loose` and the agent appeared streaming, the response
+  includes header `X-PollyPM-Warning: agent-may-be-streaming`.
+
+**Error codes:**
+
+| Status | Code | Meaning |
+|---|---|---|
+| 404 | `session_unknown` | session_name not in config and not a live worker. |
+| 503 | `window_missing` | Window configured but not in tmux. Restart the session. |
+| 409 | `pane_dead` | tmux says the pane is dead. |
+| 409 | `unsafe_mid_tool` | Open `tool_use` with no matching `tool_result`. Override with `safety=force`. See §5.1. |
+| 409 | `unsafe_mid_stream` | Heartbeat says agent streamed within last 2s. Override with `safety=loose` or `force`. See §5.3. |
+| 400 | `text_or_selections_required` | Body had neither `text` nor `selections`. |
+| 400 | `text_and_selections_exclusive` | Body had both. |
+| 400 | `answer_to_missing` | `answer_to` id not found in transcript. |
+| 400 | `answer_to_not_question` | `answer_to` references a non-`ask_user` message. |
+| 400 | `selections_no_question` | `selections` provided but `answer_to` is null. |
+| 400 | `selections_invalid` | One or more selections don't match the question's options. Response includes valid options. |
+
+**Curl examples:**
+
+```bash
+# Plain send
+curl -sX POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://127.0.0.1:8765/api/v1/chat/operator/send \
+  -d '{"text": "hello Polly"}'
+
+# Answer an AskUserQuestion
+curl -sX POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  http://127.0.0.1:8765/api/v1/chat/architect_samblog/send \
+  -d '{"answer_to": "msg_q1", "selections": ["dayjs"], "notes": "go light"}'
+```
+
+---
+
+## 4. MessageEnvelope schema
+
+Every entry in `messages[]` is the same shape. The `type` field tags
+which variant the envelope represents and what shape `metadata` takes.
+
+```json
+{
+  "id": "msg_abc",
+  "ts": "2026-05-21T20:53:12.123Z",
+  "role": "user" | "assistant" | "tool" | "system",
+  "actor": "Sam" | "Polly" | "Archie" | "Codex" | "system",
+  "type": "text" | "tool_use" | "tool_result" | "thinking" | "ask_user" | "file" | "subagent_spawn" | "subagent_result" | "system_event",
+  "text": "...display-ready string...",
+  "metadata": { "...": "type-specific" }
+}
+```
+
+`text` is always populated with a best-effort, one-line, human-readable
+rendering — even a `tool_use` envelope has `text` like `[Bash] git
+status` so a dumb client can render it without parsing `metadata`. The
+structured original lives in `metadata`.
+
+### Type catalog
+
+| Type | Role | When | Notes |
+|---|---|---|---|
+| `text` | user / assistant | Plain turn text | The 80% case. `metadata: {}`. |
+| `tool_use` | assistant | Tool call | `metadata`: `tool_use_id`, `tool_name`, `tool_input`. |
+| `tool_result` | tool | Tool return | `metadata`: `tool_use_id`, `is_error`, `content[]`. |
+| `thinking` | assistant | Extended-thinking block | Opt-in via `?include_thinking=true`. |
+| `ask_user` | assistant | `AskUserQuestion` tool | `metadata`: `questions[]`, `answered`, `answers`. See §5.5. |
+| `file` | assistant | `SendUserFile` tool | `metadata`: `files[]` (local paths), `caption`, `status`. |
+| `subagent_spawn` | assistant | `Task` tool call | `metadata`: `subagent_id`, `subagent_type`, `description`, `prompt`, `isolation`. |
+| `subagent_result` | tool | `Task` tool return | `metadata`: `subagent_id`, `summary`, `duration_ms`, `total_tokens`, `worktree_path`, `subagent_transcript` (null unless §5.2). |
+| `system_event` | system | Compaction, session-start, error | `metadata.subtype` ∈ `compaction`, `session_start`, `session_resume`, `error`. |
+
+### Example payloads
+
+`tool_use`:
+
+```json
+{
+  "type": "tool_use",
+  "text": "[Bash] git status",
+  "metadata": {
+    "tool_use_id": "toolu_abc",
+    "tool_name": "Bash",
+    "tool_input": {"command": "git status", "description": "Show working tree status"}
+  }
+}
+```
+
+`tool_result` (linked by `tool_use_id`):
+
+```json
+{
+  "type": "tool_result",
+  "text": "M src/foo.py\nA tests/bar.py",
+  "metadata": {
+    "tool_use_id": "toolu_abc",
+    "is_error": false,
+    "content": [{"type": "text", "text": "M src/foo.py\nA tests/bar.py"}]
+  }
+}
+```
+
+`ask_user`:
+
+```json
+{
+  "id": "msg_q1",
+  "type": "ask_user",
+  "text": "Which library should we use for date formatting?",
+  "metadata": {
+    "questions": [{
+      "question": "Which library should we use for date formatting?",
+      "header": "Library",
+      "multiSelect": false,
+      "options": [
+        {"label": "date-fns", "description": "Modular, tree-shakeable"},
+        {"label": "dayjs",    "description": "Lightweight Moment.js replacement"},
+        {"label": "luxon",    "description": "Immutable, locale-aware"}
+      ]
+    }],
+    "answered": false,
+    "answers": null
+  }
+}
+```
+
+Once answered, the envelope reappears with `answered=true` and
+`answers` populated.
+
+`file`:
+
+```json
+{
+  "type": "file",
+  "text": "[file] ~/Desktop/report.pdf",
+  "metadata": {
+    "files": ["~/Desktop/report.pdf"],
+    "caption": "Here's the report",
+    "status": "proactive"
+  }
+}
+```
+
+`subagent_spawn` / `subagent_result` (paired by `subagent_id`):
+
+```json
+{
+  "type": "subagent_spawn",
+  "text": "[subagent] Fix #1234 sweep dedupe",
+  "metadata": {
+    "subagent_id": "a8a0c7ddcd5e43028",
+    "subagent_type": "general-purpose",
+    "description": "Fix #1234 sweep dedupe",
+    "prompt": "...full prompt...",
+    "isolation": "worktree",
+    "run_in_background": true
+  }
+}
+```
+
+```json
+{
+  "type": "subagent_result",
+  "text": "Done. PR #1235 pushed.",
+  "metadata": {
+    "subagent_id": "a8a0c7ddcd5e43028",
+    "summary": "Agent 'Fix #1234' completed",
+    "duration_ms": 159150,
+    "total_tokens": 45533,
+    "worktree_path": "/Users/sam/dev/pollypm/.claude/worktrees/agent-a8a0c7ddcd5e43028",
+    "result_body_truncated": false,
+    "subagent_transcript": null
+  }
+}
+```
+
+When `?include_subagents=true`, `subagent_transcript` becomes a
+`MessageEnvelope[]`. Recursive — a subagent's own subagents nest the
+same way.
+
+`system_event`:
+
+```json
+{
+  "type": "system_event",
+  "text": "Conversation compacted (123k tokens → 32k)",
+  "metadata": {"subtype": "compaction", "tokens_before": 123000, "tokens_after": 32000}
+}
+```
+
+---
+
+## 5. Edge cases ("Claude's fancy stuff")
+
+The same twelve gates Sam called out in the design spec
+(`chat-endpoints-spec.md` §4). Each has a defined behavior, an override
+where applicable, and a reason it exists.
+
+### 5.1 Mid-tool sends (`409 unsafe_mid_tool`)
+
+The agent's last turn has a `tool_use` block whose `tool_use_id` has
+no matching `tool_result` later in the transcript — it's paused
+waiting for the tool to return.
+
+**Why:** sending arbitrary text via `send_keys` while the agent's loop
+isn't reading stdin is at best a no-op; at worst the next turn picks
+the typed text out of Claude Code's input buffer and prepends it to
+the user's next real message, confusing the agent.
+
+**Behavior:** GET surfaces the open `tool_use` normally. POST with
+`safety=strict` (default) returns `409 unsafe_mid_tool`. `safety=force`
+overrides.
+
+**When to override:** interrupting a wedged tool call (e.g. Bash on a
+hung network request) by sending Ctrl-C followed by a recovery
+instruction.
+
+### 5.2 Subagents (Task / Agent tool)
+
+Claude can spawn subagents via the `Task` tool. Each subagent gets its
+own JSONL at the path in the parent's `task-notification.output-file`
+block.
+
+**Default:** parent transcript surfaces `subagent_spawn` +
+`subagent_result` envelopes; the subagent's full transcript is NOT
+inlined.
+
+**Opt-in:** `?include_subagents=true` populates
+`subagent_result.metadata.subagent_transcript[]`. Recursive — a
+subagent's subagents nest the same way. The server resolves the
+transcript path automatically; clients never need to walk
+`task-notification` blocks themselves.
+
+### 5.3 Mid-stream sends (`409 unsafe_mid_stream`)
+
+The agent is currently emitting output — the session heartbeat fired
+within the last 2 seconds.
+
+**Why:** typing into the input box during a stream queues characters
+with a race. They can interleave with the agent's own output frame,
+garbling the display and occasionally producing the "phantom user
+message" failure (typed characters land inside the agent's previous
+turn as if the agent typed them).
+
+**Behavior:**
+
+- `safety=strict` (default) — reject with `409 unsafe_mid_stream`.
+- `safety=loose` — allow, with response header
+  `X-PollyPM-Warning: agent-may-be-streaming`.
+- `safety=force` — bypass all safety gates.
+
+**When to override:** stop-the-world messages (`STOP`, a correction,
+mid-stream context-update). Reach for `loose` first; use `force` only
+if `loose` also rejects.
+
+### 5.4 Multi-pane (split-window) sessions
+
+PollyPM doesn't split agent windows itself, but some users do
+manually. The window now has multiple panes, only one of which is the
+Claude process.
+
+**Behavior:** POST accepts `pane=<index>` in the body; default is the
+first pane in window-pane-list order (which is almost always the
+Claude pane). GET never differentiates panes — transcripts are
+one-per-Claude-process, not one-per-pane. If you don't know which
+pane, list them via `tmux list-panes -t <window>` on the daemon host.
+
+### 5.5 Answering `AskUserQuestion`
+
+The agent emitted an `ask_user` envelope (§4). In Claude Code's UI,
+the user clicks a button; in tmux, the user types the option label.
+
+```json
+{
+  "answer_to": "msg_q1",
+  "selections": ["dayjs"],
+  "notes": "actually, prefer luxon if dayjs has no timezone story"
+}
+```
+
+Translation rules:
+
+- `selections: ["dayjs"]` → typed as `dayjs\n`.
+- `selections: ["dayjs"]` + `notes: "..."` → typed as
+  `dayjs\n...notes...\n`.
+- Multi-select `selections: ["a", "b"]` → typed as newline-separated
+  labels. If your install needs a different delimiter, fall back to
+  plain `text`.
+
+If a selection label doesn't exactly match any option, the API returns
+`400 selections_invalid` with the valid labels in the response body.
+
+**OPEN QUESTION (Sam to confirm):** the exact stdin format Claude Code
+expects for AskUserQuestion replies. Phase 1 assumes "type the option
+label verbatim, newline-terminated." If you find a session where this
+doesn't work, fall back to free-text `text` sends and let the agent
+parse the natural-language answer.
+
+### 5.6 Compaction events
+
+Claude Code occasionally compacts the conversation, producing a
+`system_event` with `metadata.subtype=compaction`. Included by default
+in GET; filter out with `?include_system_events=false` if your UI
+doesn't render them. Don't drop them silently if the user might wonder
+why the conversation "jumps" — render at least a horizontal rule.
+
+### 5.7 Stale JSONL → tmux capture fallback
+
+The JSONL exists but hasn't been written for >60s and the tmux pane is
+live — usually means Claude Code hasn't flushed mid-stream.
+
+**Behavior (under `source=auto`):** fall back to
+`tmux capture-pane -p -S -3000`. Each captured line becomes one
+envelope with `type=text` and `metadata.from_capture=true`. Ids are
+synthetic (`cap_<hash>`), stable across reads.
+
+Force pure JSONL with `?source=jsonl` (accepts `transcript_missing`
+errors). Force pure capture with `?source=capture`.
+
+### 5.8 New session, no transcript yet
+
+The session was just spawned; no Claude turn has landed in the JSONL.
+GET returns `messages: []` with `transcript_source: null`. **Not** an
+error; render an empty pane.
+
+### 5.9 Configured session, window missing
+
+The session is in `config.sessions` but the window is not in tmux
+(process crashed, user killed the pane).
+
+- GET still works against the on-disk transcript.
+- POST returns `503 window_missing`. Restart via
+  `pm session restart <session_name>` and retry.
+
+### 5.10 Bracket-paste interactions
+
+Claude Code's input box understands tmux bracket-paste sequences.
+PollyPM's `tmux/client.py::send_keys` already picks the `paste_buffer`
+method for text >100 chars to avoid character-level interleaving on
+concurrent sends (issue #808). The POST endpoint just delegates — no
+new logic. The response's `method` field tells you which path was
+taken.
+
+### 5.11 Concurrent sends from multiple clients
+
+Two clients POST to the same session simultaneously. The paste-buffer
+mechanism prevents character-level interleaving within a message, but
+Enter presses can still interleave at message-boundary granularity, so
+ordering is racy. Phase 1 documents this as known behavior; future
+work could serialize POSTs per-session via a daemon-side lock.
+
+### 5.12 Codex sessions (non-Claude)
+
+PollyPM also drives Codex (per memory: the `codex-fixer` tmux
+session). Codex doesn't write the Claude Code JSONL shape, so the
+server detects Codex via `SessionConfig.provider` and falls back to
+`tmux capture-pane` automatically. Envelope `type` is always `text`
+(Codex's tool calls aren't structured the way Claude Code's are). If
+you need structured tool data, use a Claude session.
+
+---
+
+## 6. CLI alternative — `pm chat`
+
+The `pm chat` CLI is a thin client over these endpoints. It exists
+because typing curl with bearer-token plumbing every time gets old.
+
+```
+pm chat list
+pm chat history <session_name> [--limit N] [--json] [--include-subagents]
+pm chat send <session_name> <text> [--safety strict|loose|force]
+pm chat send <session_name> --answer-to <msg_id> --selection <label> [--notes "..."]
+```
+
+- `pm chat list` → `GET /api/v1/chat/sessions`.
+- `pm chat history` → `GET /api/v1/chat/<session>/messages`. Renders
+  envelopes with sensible default formatting; pass `--json` for the
+  raw payload.
+- `pm chat send` → `POST /api/v1/chat/<session>/send`. Default
+  `safety=strict`; prompts to bump to `loose` interactively if the
+  daemon returns `unsafe_mid_stream` and stdin is a tty.
+
+If you find yourself reaching for `curl | jq` against the chat API,
+check `pm chat --help` first — most ad-hoc cases are already there.
+
+---
+
+## 7. Troubleshooting
+
+Common failures and what to check.
+
+### (a) Every request returns `401 Unauthorized`
+
+Bearer token is wrong, missing, or empty.
+
+```bash
+ls -l ~/.pollypm/api-token         # exists, non-empty?
+wc -c < ~/.pollypm/api-token       # should be ~64
+```
+
+If empty, restart the daemon (`pm up`) — it mints a fresh token on
+startup when missing.
+
+### (b) `GET /messages` returns `messages: []` for a session you know is active
+
+Three likely reasons:
+
+1. **Session was just spawned.** No turn has landed in the JSONL yet.
+   Wait, or pass `?source=capture` to read the live pane directly.
+2. **Wrong `session_name`.** Workers use the computed
+   `task-<project>-<task_number>` form, not the human-readable
+   description. Confirm via `GET /api/v1/chat/sessions`.
+3. **JSONL path resolution failed.** Check `transcript.source` in the
+   `sessions` response — `null` means the daemon couldn't find a
+   JSONL or a live pane.
+
+### (c) `POST /send` keeps returning `409 unsafe_mid_stream`
+
+The heartbeat thinks the agent is streaming. Either:
+
+- The agent really is — poll `GET /messages?limit=1` until the latest
+  envelope's `ts` is more than 2s old, then retry.
+- The agent crashed mid-stream and never wrote a final heartbeat. The
+  2s window will never expire on its own. Confirm with
+  `tmux capture-pane -t <window>` (is anything actually changing?);
+  if not, override with `safety=loose` once.
+
+### (d) `POST /send` returns `503 window_missing`
+
+The agent's tmux window is gone. The on-disk transcript is still
+readable, but you can't send until the session is restarted:
+
+```bash
+pm session restart <session_name>
+```
+
+### (e) AskUserQuestion replies don't register
+
+You POSTed with `answer_to` + `selections`, but the agent ignored the
+selection.
+
+1. **Was the selection label exact?** Case and punctuation matter.
+   `dayjs` and `Dayjs` are different labels.
+2. **Did the agent see the input?** Pull `GET /messages?limit=3` after
+   the POST — there should be a `text` envelope with `role=user`
+   containing your selection. If yes but the agent ignored it, the
+   `AskUserQuestion` stdin protocol may have changed (see §5.5 open
+   question). File a bug.
+
+### (f) Subagent transcripts come back empty under `?include_subagents=true`
+
+`subagent_result` is there, but `metadata.subagent_transcript` is
+`null` or `[]`. Either the subagent's `output-file` doesn't exist on
+disk yet (subagent crashed before flushing), or it's a Codex subagent
+(no JSONL) — Codex subagents surface as `subagent_result` with
+`subagent_transcript: null` and nothing structured to inline.
+
+### (g) Transcript appears truncated or out of order
+
+Two gotchas:
+
+1. **You hit the `limit` cap.** Default 100, max 500. If `has_more`,
+   paginate with `since_id=<next_cursor>`.
+2. **Compaction.** A compaction event can leave the visible turn
+   count smaller than expected. Pre-compaction messages are still in
+   the JSONL but the model's working context no longer references
+   them.
+
+### (h) `pm chat send` works but my curl doesn't
+
+Three things to check:
+
+- Content-Type header (`Content-Type: application/json`).
+- Body is valid JSON (jq it first).
+- Right session_name (worker sessions are `task-<project>-<task_number>`,
+  hyphen between project and number, not underscore).
+
+---
+
+## 8. Cross-references
+
+- Source spec: `docs/project-specs/chat-endpoints-spec.md` (authoritative
+  design doc this reference is derived from).
+- Recovery cascade and the `[PollyPM-Auth: ...]` marker contract:
+  `docs/recovery-cascade.md` — explains why the per-session `auth_token`
+  field exists and why it's NOT what inbound API clients use.
+- Cockpit interaction surfaces: `docs/cockpit-interaction-contract.md`.
+- Web API mount point: `src/pollypm/web_api/app.py`.
+- Tmux client (paste-buffer behavior): `src/pollypm/tmux/client.py`
+  and issue #808 for the concurrent-send rationale.

--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -1,10 +1,9 @@
 # Chat HTTP API reference
 
-> **Status:** Reference doc for endpoints landing in PRs #2043, #2044,
-> #2045, #2047. Will be cross-checked against final implementation
-> before merge. Treat the contracts here as the *intended* shape — the
-> P3 send endpoint in particular (#2043) is still in fix-loop, so
-> field names and error codes may shift before merge.
+> **Status:** Reference doc for the chat API. This PR is stacked behind
+> #2043/#2045/#2047 and will land once those merge. The contracts below
+> match the merged P1 #2044 and the open implementation branches; if
+> either drifts pre-merge, this doc updates first.
 
 Reference for the `/api/v1/chat/*` endpoints — the HTTP surface for
 reading transcripts from, and sending messages into, the four live
@@ -200,8 +199,9 @@ Pull a window of messages from a single session's transcript.
 | `limit` | `100` | Max messages, must be `1..500`. Values outside that range return `422 validation_error` (FastAPI Pydantic-level rejection). |
 | `direction` | `desc` | `desc` (newest first) or `asc`. Pagination cursors assume the same direction. |
 | `include_subagents` | `false` | When `true`, inline subagent transcripts inside their `subagent_result` parent's `metadata.subagent_transcript[]`. See §5.2. |
-| `include_thinking` | `false` | Include `type=thinking` blocks. Default off — usually noisy. |
 | `source` | `auto` | `auto` (JSONL with capture fallback when archive is missing or >60s stale), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). Any other value returns `422 validation_error`. |
+
+> Note: A `type="thinking"` envelope is planned but not yet implemented — tracked in [#2048](https://github.com/samhotchkiss/pollypm/issues/2048).
 
 **Response:**
 
@@ -351,7 +351,7 @@ which variant the envelope represents and what shape `metadata` takes.
   "ts": "2026-05-21T20:53:12.123Z",
   "role": "user" | "assistant" | "tool" | "system",
   "actor": "Sam" | "Polly" | "Archie" | "Codex" | "system",
-  "type": "text" | "tool_use" | "tool_result" | "thinking" | "ask_user" | "file" | "subagent_spawn" | "subagent_result" | "system_event",
+  "type": "text" | "tool_use" | "tool_result" | "ask_user" | "file" | "subagent_spawn" | "subagent_result" | "system_event",
   "text": "...display-ready string...",
   "metadata": { "...": "type-specific" }
 }
@@ -369,7 +369,6 @@ structured original lives in `metadata`.
 | `text` | user / assistant | Plain turn text | The 80% case. `metadata: {}`. |
 | `tool_use` | assistant | Tool call | `metadata`: `tool_use_id`, `tool_name`, `tool_input`. |
 | `tool_result` | tool | Tool return | `metadata`: `tool_use_id`, `is_error`, `content[]`. |
-| `thinking` | assistant | Extended-thinking block | Opt-in via `?include_thinking=true`. |
 | `ask_user` | assistant | `AskUserQuestion` tool | `metadata`: `questions[]`, `answered`, `answers`. See §5.5. |
 | `file` | assistant | `SendUserFile` tool | `metadata`: `files[]` (local paths), `caption`, `status`. |
 | `subagent_spawn` | assistant | `Task` tool call | `metadata`: `subagent_id`, `subagent_type`, `description`, `prompt`, `isolation`. |

--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -229,7 +229,7 @@ when `has_more=true`.
 |---|---|---|
 | 404 | `session_unknown` | `session_name` is not in `config.sessions` and not a live worker. |
 | 404 | `archive_missing` | `source=jsonl` forced, but no `events.jsonl` archive exists for this session. |
-| 503 | `archive_unreadable` | The events.jsonl archive exists but cannot be read (permissions, partial write). Only emitted when `source=jsonl` is explicit. |
+| 503 | `archive_unreadable` | Permissions denied, IO error, or other filesystem read failure on the events.jsonl archive. Only emitted with explicit `source=jsonl`. Malformed JSON lines are silently skipped — they do NOT trigger this. |
 | 503 | `window_missing` | Only emitted when `source=capture` is explicit AND the configured tmux window doesn't exist. |
 | 503 | `capture_unavailable` | Only emitted when `source=capture` is explicit AND TmuxClient is unavailable. |
 | 503 | `capture_failed` | Only emitted when `source=capture` is explicit AND the capture-pane command raised. |
@@ -628,11 +628,23 @@ Translation rules:
 If a selection label doesn't exactly match any option, the API returns
 `400 selections_invalid` with the valid labels in the response body.
 
-**OPEN QUESTION (Sam to confirm):** the exact stdin format Claude Code
-expects for AskUserQuestion replies. Phase 1 assumes "type the option
-label verbatim, newline-terminated." If you find a session where this
-doesn't work, fall back to free-text `text` sends and let the agent
-parse the natural-language answer.
+**AskUserQuestion answer format.** The shipped `_build_answer_text`
+(chat_send.py) joins selected option labels with newlines. If `notes`
+is provided, it's appended after another newline. The trailing newline
+is controlled by `press_enter` (default true). Example:
+`selections=["A", "B"]`, `notes="extra context"`, `press_enter=true`
+produces stdin = `"A\nB\nextra context\n"`. If Claude Code's actual
+stdin parser turns out to expect something different (e.g., option
+index instead of label), file a follow-up issue rather than blocking;
+clients can also send freeform `text` instead of structured
+`selections` to test other formats.
+
+```
+# Answer an ask_user message with a selection (positional text="" required):
+pm chat send <session> "" --answer-to msg_abc --selection "Option A"
+# With notes:
+pm chat send <session> "" --answer-to msg_abc --selection "Option A" --notes "context"
+```
 
 ### 5.6 Compaction events
 
@@ -742,7 +754,16 @@ pm chat send <session_name> <text> [--no-enter]
   maps to `press_enter=false`. `--selection` is repeatable for
   multi-select `AskUserQuestion` replies. `--pane` forwards the
   explicit pane index per §5.4 — omit it to let the server target the
-  default active pane.
+  default active pane. When answering an `AskUserQuestion` via
+  `--answer-to`/`--selection`, the positional `<text>` argument is
+  still required — pass an empty string:
+
+  ```
+  # Answer an ask_user message with a selection (positional text="" required):
+  pm chat send <session> "" --answer-to msg_abc --selection "Option A"
+  # With notes:
+  pm chat send <session> "" --answer-to msg_abc --selection "Option A" --notes "context"
+  ```
 
 On any 4xx/5xx, `pm chat` prints the JSON error body to stderr and
 exits non-zero. There is no interactive retry — re-run the command

--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -1,6 +1,6 @@
 # Chat HTTP API reference
 
-> **Status:** Reference doc for the chat API. P1 (#2044), P2 (#2045 GET), and P3 (#2043 POST send) are merged to main. The pm chat CLI in #2047 is the final PR in the stack; this doc lands once it merges.
+> **Status:** Reference doc for the chat API. P1 (#2044), P2 (#2045 GET), P3 (#2043 POST send), and P4 (#2047 pm chat CLI) are all merged to main. This doc is the published reference.
 
 Reference for the `/api/v1/chat/*` endpoints — the HTTP surface for
 reading transcripts from, and sending messages into, the four live
@@ -56,8 +56,10 @@ The chat API reuses PollyPM's existing daemon-wide bearer-token auth.
 
 - Token lives at `~/.pollypm/api-token` (created on first `pm up`).
 - Pass it via `Authorization: Bearer <token>` on every request.
-- The daemon listens on `127.0.0.1:8765` by default. Remote access
-  requires `pm serve --host 0.0.0.0` (and is your problem to firewall).
+- The daemon listens on `127.0.0.1:8765` by default. For remote access,
+  use `pm serve --allow-remote --host 0.0.0.0`. Without `--allow-remote`,
+  non-loopback binds are rejected. Defense in depth: even on Tailscale,
+  authenticated devices must still present the bearer token.
 
 The chat API does **not** use the per-session `auth_token` field on
 `SessionConfig`. That token is for outbound PollyPM → agent control
@@ -227,6 +229,11 @@ when `has_more=true`.
 |---|---|---|
 | 404 | `session_unknown` | `session_name` is not in `config.sessions` and not a live worker. |
 | 404 | `archive_missing` | `source=jsonl` forced, but no `events.jsonl` archive exists for this session. |
+| 503 | `archive_unreadable` | The events.jsonl archive exists but cannot be read (permissions, partial write). Only emitted when `source=jsonl` is explicit. |
+| 503 | `window_missing` | Only emitted when `source=capture` is explicit AND the configured tmux window doesn't exist. |
+| 503 | `capture_unavailable` | Only emitted when `source=capture` is explicit AND TmuxClient is unavailable. |
+| 503 | `capture_failed` | Only emitted when `source=capture` is explicit AND the capture-pane command raised. |
+| 503 | `service_unavailable` | Worker session lookup failed (work-service outage). Only emitted for worker `session_name`s. |
 | 400 | `invalid_request` | `since` is not ISO-8601 parseable. (Other request-shape errors share this code; see the message body for the offending field.) |
 | 422 | `validation_error` | FastAPI's standard Pydantic rejection envelope — returned for out-of-range `limit`, unknown `source`, unknown `direction`, etc. Shape is FastAPI's default `{"detail": [{"loc": [...], "msg": "...", "type": "..."}]}`, NOT the chat router's `{code, message, hint}` envelope. |
 
@@ -297,8 +304,23 @@ respond. Poll `GET /messages` for the reply.
   for messages over 100 characters (see issue #808 for why
   paste-buffer is the default for long text).
 - `press_enter_at` is `null` when `press_enter=false`.
-- When `safety=loose` and the agent appeared streaming, the response
-  includes header `X-PollyPM-Warning: agent-may-be-streaming`.
+- Under `safety=loose`, the response may include an `X-PollyPM-Warning`
+  header describing which best-effort signal was unavailable:
+  - `agent-may-be-streaming` — heartbeat shows the session streamed
+    within the last 2s.
+  - `heartbeat-unavailable` — pg heartbeat lookup failed; mid-stream
+    gate was best-effort.
+  - `transcript-unavailable` — transcript file unreadable; mid-tool
+    detection was best-effort.
+
+  Under `safety=force`, all gates are bypassed silently (no warning
+  header is emitted for ignored signals).
+
+`safety=force` precisely bypasses the mid-tool, mid-stream,
+missing-transcript, missing-heartbeat, and unavailable-signal gates.
+It does **not** bypass pane/window validation: `409 pane_invalid`,
+`409 pane_dead`, `503 window_missing`, `503 tmux_unavailable`, and
+`503 send_failed` are still fail-closed.
 
 **Error codes:**
 
@@ -310,6 +332,11 @@ respond. Poll `GET /messages` for the reply.
 | 409 | `pane_invalid` | Explicit `pane` index doesn't exist in the target window's `list_panes` output. See §5.4. |
 | 409 | `unsafe_mid_tool` | Latest assistant turn has an open `tool_use` with no matching `tool_result`. Override with `safety=force`. See §5.1. |
 | 409 | `unsafe_mid_stream` | Heartbeat shows the session streamed within the last 2s. Override with `safety=loose` (warn-and-send) or `safety=force` (bypass). See §5.3. |
+| 409 | `unsafe_unavailable_transcript` | Strict mode + the transcript file is unreadable. Caller can override with `safety=force`. |
+| 409 | `unsafe_unavailable_heartbeat` | Strict mode + heartbeat lookup failed (pg outage). Override with `safety=force`. |
+| 503 | `tmux_unavailable` | tmux binary not found or unresponsive (`FileNotFoundError`, `TimeoutExpired`, `CalledProcessError`). |
+| 503 | `send_failed` | tmux `send_keys` raised a generic error (paste-buffer fail, `OSError` post-validation). |
+| 503 | `service_unavailable` | Worker session lookup failed (work-service outage). Only emitted for worker `session_name`s. |
 | 400 | `answer_to_missing` | `answer_to` id was not found in the session's recent transcript. |
 | 400 | `selections_no_question` | `answer_to` references a message that isn't an `ask_user` envelope. |
 | 400 | `selections_invalid` | One or more selections don't match the question's option labels. Response message includes the valid options. |
@@ -535,10 +562,21 @@ turn as if the agent typed them).
 
 **Behavior:**
 
-- `safety=strict` (default) — reject with `409 unsafe_mid_stream`.
-- `safety=loose` — allow, with response header
-  `X-PollyPM-Warning: agent-may-be-streaming`.
-- `safety=force` — bypass all safety gates.
+- `safety=strict` (default) — reject with `409 unsafe_mid_stream`. If
+  the signal source itself is unavailable, strict mode also rejects
+  with `409 unsafe_unavailable_transcript` (transcript unreadable) or
+  `409 unsafe_unavailable_heartbeat` (pg outage).
+- `safety=loose` — allow, with one of these response headers
+  describing which signal was best-effort:
+  - `X-PollyPM-Warning: agent-may-be-streaming` — heartbeat fresh <2s.
+  - `X-PollyPM-Warning: heartbeat-unavailable` — pg heartbeat lookup
+    failed.
+  - `X-PollyPM-Warning: transcript-unavailable` — transcript
+    unreadable.
+- `safety=force` — bypass mid-tool, mid-stream, missing-transcript,
+  missing-heartbeat, and unavailable-signal gates. Does NOT bypass
+  pane/window validation (`409 pane_invalid`, `409 pane_dead`,
+  `503 window_missing`, `503 tmux_unavailable`, `503 send_failed`).
 
 **When to override:** stop-the-world messages (`STOP`, a correction,
 mid-stream context-update). Reach for `loose` first; use `force` only
@@ -616,9 +654,15 @@ live — usually means Claude Code hasn't flushed mid-stream.
 envelope with `type=text` and `metadata.from_capture=true`. Ids are
 synthetic (`cap_<hash>`), stable across reads.
 
-Force pure JSONL with `?source=jsonl` (accept the possibility of a
-`404 archive_missing` response). Force pure capture with
-`?source=capture`.
+Source-mode behavior:
+
+- `source=auto` (default): JSONL archive first, capture-pane fallback
+  on stale/missing. Fail-soft — returns empty `messages` if both fail.
+- `source=jsonl` (explicit): JSONL only. Returns `404 archive_missing`
+  if absent, `503 archive_unreadable` on read failure.
+- `source=capture` (explicit): tmux capture only. Returns
+  `503 window_missing` / `503 capture_unavailable` / `503 capture_failed`
+  on the respective failures.
 
 ### 5.8 New session, no transcript yet
 
@@ -664,9 +708,6 @@ you need structured tool data, use a Claude session.
 ---
 
 ## 6. CLI alternative — `pm chat`
-
-> The `pm chat` CLI lands in PR #2047 — these commands work once that
-> merges. The HTTP endpoints (§3) are usable directly today via `curl`.
 
 The `pm chat` CLI is a thin client over these endpoints. It exists
 because typing curl with bearer-token plumbing every time gets old.

--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -1,9 +1,6 @@
 # Chat HTTP API reference
 
-> **Status:** Reference doc for the chat API. This PR is stacked behind
-> #2043/#2045/#2047 and will land once those merge. The contracts below
-> match the merged P1 #2044 and the open implementation branches; if
-> either drifts pre-merge, this doc updates first.
+> **Status:** Reference doc for the chat API. P1 (#2044), P2 (#2045 GET), and P3 (#2043 POST send) are merged to main. The pm chat CLI in #2047 is the final PR in the stack; this doc lands once it merges.
 
 Reference for the `/api/v1/chat/*` endpoints — the HTTP surface for
 reading transcripts from, and sending messages into, the four live
@@ -198,7 +195,7 @@ Pull a window of messages from a single session's transcript.
 | `since_id` | none | Message id (string). Return messages strictly after this id. Both `since` and `since_id` are applied if passed together (the `since` lower-bound is applied first, then the cursor walk). |
 | `limit` | `100` | Max messages, must be `1..500`. Values outside that range return `422 validation_error` (FastAPI Pydantic-level rejection). |
 | `direction` | `desc` | `desc` (newest first) or `asc`. Pagination cursors assume the same direction. |
-| `include_subagents` | `false` | When `true`, inline subagent transcripts inside their `subagent_result` parent's `metadata.subagent_transcript[]`. See §5.2. |
+| `include_subagents` | `false` | DEFERRED — server returns 422 if true. Re-enabled when #2052 lands ingestor-side subagent normalization. |
 | `source` | `auto` | `auto` (JSONL with capture fallback when archive is missing or >60s stale), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). Any other value returns `422 validation_error`. |
 
 > Note: A `type="thinking"` envelope is planned but not yet implemented — tracked in [#2048](https://github.com/samhotchkiss/pollypm/issues/2048).
@@ -247,10 +244,6 @@ curl -sH "Authorization: Bearer $TOKEN" \
 
 ### 3.3 `POST /api/v1/chat/{session_name}/send`
 
-> **Status:** P3 (#2043) implementation is in fix-loop; contracts
-> below may shift before merge. Cross-check against
-> `src/pollypm/web_api/routes/chat_send.py` at merge time.
-
 Inject a message into the agent's input box via tmux. Returns
 synchronously after the send; does **not** wait for the agent to
 respond. Poll `GET /messages` for the reply.
@@ -277,7 +270,7 @@ respond. Poll `GET /messages` for the reply.
 | `selections` | string[] | `[]` | One or more option labels for an `ask_user` reply. Only meaningful when `answer_to` is set. |
 | `notes` | string \| null | `null` | Free-text addendum after a selection. Also usable as the body of an `answer_to` reply when both `text` and `selections` are absent. |
 | `safety` | enum | `strict` | `strict` (reject mid-stream + mid-tool), `loose` (mid-tool still blocks, mid-stream allowed with warning header), `force` (bypass both gates). |
-| `pane` | int \| null | `null` | 0-based pane index inside the target window. `null` (or `0`) = primary/active pane. See §5.4. |
+| `pane` | int \| null | `null` | 0-based pane index inside the target window. `null` (or omitted) targets the default active pane (server uses the window-level send target). Any explicit integer (including `0`) validates against `list_panes` and targets that exact index; missing panes return `409 pane_invalid`, dead panes return `409 pane_dead`. See §5.4. |
 
 **Response:**
 
@@ -314,6 +307,7 @@ respond. Poll `GET /messages` for the reply.
 | 404 | `session_unknown` | session_name not in config and not a live worker. |
 | 503 | `window_missing` | Window configured but not present in tmux. Restart the session. |
 | 409 | `pane_dead` | tmux flagged the pane as dead. |
+| 409 | `pane_invalid` | Explicit `pane` index doesn't exist in the target window's `list_panes` output. See §5.4. |
 | 409 | `unsafe_mid_tool` | Latest assistant turn has an open `tool_use` with no matching `tool_result`. Override with `safety=force`. See §5.1. |
 | 409 | `unsafe_mid_stream` | Heartbeat shows the session streamed within the last 2s. Override with `safety=loose` (warn-and-send) or `safety=force` (bypass). See §5.3. |
 | 400 | `answer_to_missing` | `answer_to` id was not found in the session's recent transcript. |
@@ -372,7 +366,7 @@ structured original lives in `metadata`.
 | `ask_user` | assistant | `AskUserQuestion` tool | `metadata`: `questions[]`, `answered`, `answers`. See §5.5. |
 | `file` | assistant | `SendUserFile` tool | `metadata`: `files[]` (local paths), `caption`, `status`. |
 | `subagent_spawn` | assistant | `Task` tool call | `metadata`: `subagent_id`, `subagent_type`, `description`, `prompt`, `isolation`. |
-| `subagent_result` | tool | `Task` tool return | `metadata`: `subagent_id`, `summary`, `duration_ms`, `total_tokens`, `worktree_path`, `subagent_transcript` (null unless §5.2). |
+| `subagent_result` | tool | `Task` tool return | `metadata`: `subagent_id`, `summary`, `duration_ms`, `total_tokens`, `worktree_path`. Note: subagent_transcript inlining is deferred — see #2052. |
 | `system_event` | system | Compaction, session-start, error | `metadata.subtype` ∈ `compaction`, `session_start`, `session_resume`, `error`. |
 
 ### Example payloads
@@ -473,15 +467,12 @@ Once answered, the envelope reappears with `answered=true` and
     "duration_ms": 159150,
     "total_tokens": 45533,
     "worktree_path": "/Users/sam/dev/pollypm/.claude/worktrees/agent-a8a0c7ddcd5e43028",
-    "result_body_truncated": false,
-    "subagent_transcript": null
+    "result_body_truncated": false
   }
 }
 ```
 
-When `?include_subagents=true`, `subagent_transcript` becomes a
-`MessageEnvelope[]`. Recursive — a subagent's own subagents nest the
-same way.
+Note: subagent_transcript inlining is deferred — see #2052.
 
 `system_event`:
 
@@ -529,11 +520,7 @@ block.
 `subagent_result` envelopes; the subagent's full transcript is NOT
 inlined.
 
-**Opt-in:** `?include_subagents=true` populates
-`subagent_result.metadata.subagent_transcript[]`. Recursive — a
-subagent's subagents nest the same way. The server resolves the
-transcript path automatically; clients never need to walk
-`task-notification` blocks themselves.
+Note: subagent_transcript inlining is deferred — see #2052.
 
 ### 5.3 Mid-stream sends (`409 unsafe_mid_stream`)
 
@@ -563,9 +550,18 @@ PollyPM doesn't split agent windows itself, but some users do
 manually. The window now has multiple panes, only one of which is the
 Claude process.
 
-**Behavior:** POST accepts `pane=<index>` in the body; default is the
-first pane in window-pane-list order (which is almost always the
-Claude pane). GET never differentiates panes — transcripts are
+**Behavior:** POST accepts `pane=<index>` in the body. There are two
+modes:
+
+- `pane: null` (or the field omitted) — default active pane. The
+  server addresses the window-level send target and lets tmux pick the
+  active pane (almost always the Claude pane).
+- `pane: 0` (or any explicit integer `N`) — explicit pane index. The
+  server validates against `list_panes`; if the index doesn't exist
+  the response is `409 pane_invalid`, and if tmux flags the pane as
+  exited the response is `409 pane_dead`.
+
+GET never differentiates panes — transcripts are
 one-per-Claude-process, not one-per-pane. If you don't know which
 pane, list them via `tmux list-panes -t <window>` on the daemon host.
 
@@ -676,19 +672,40 @@ The `pm chat` CLI is a thin client over these endpoints. It exists
 because typing curl with bearer-token plumbing every time gets old.
 
 ```
-pm chat list
-pm chat history <session_name> [--limit N] [--json] [--include-subagents]
-pm chat send <session_name> <text> [--safety strict|loose|force]
-pm chat send <session_name> --answer-to <msg_id> --selection <label> [--notes "..."]
+pm chat list [--json]
+pm chat history <session_name> [--limit N] [--since ISO]
+                                [--since-id MSG_ID]
+                                [--direction desc|asc]
+                                [--include-subagents]
+                                [--source auto|jsonl|capture]
+                                [--json]
+pm chat send <session_name> <text> [--no-enter]
+                                   [--safety strict|loose|force]
+                                   [--answer-to MSG_ID]
+                                   [--selection LABEL]...
+                                   [--notes TEXT]
+                                   [--pane N]
+                                   [--json]
 ```
 
-- `pm chat list` → `GET /api/v1/chat/sessions`.
-- `pm chat history` → `GET /api/v1/chat/<session>/messages`. Renders
-  envelopes with sensible default formatting; pass `--json` for the
-  raw payload.
-- `pm chat send` → `POST /api/v1/chat/<session>/send`. Default
-  `safety=strict`; prompts to bump to `loose` interactively if the
-  daemon returns `unsafe_mid_stream` and stdin is a tty.
+- `pm chat list` → `GET /api/v1/chat/sessions`. Renders a fixed-column
+  table by default; `--json` emits the raw response envelope.
+- `pm chat history` → `GET /api/v1/chat/<session>/messages`. Forwards
+  every flag as the matching query param. `--since-id` is cursor
+  pagination (pass the previous response's `next_cursor`). `--pane` is
+  not exposed because GET never differentiates panes (§5.4).
+  `--include-subagents` is currently a no-op surface: the help text
+  flags it as deferred and the server returns `422 validation_error`
+  if you pass it until #2052 lands.
+- `pm chat send` → `POST /api/v1/chat/<session>/send`. `--no-enter`
+  maps to `press_enter=false`. `--selection` is repeatable for
+  multi-select `AskUserQuestion` replies. `--pane` forwards the
+  explicit pane index per §5.4 — omit it to let the server target the
+  default active pane.
+
+On any 4xx/5xx, `pm chat` prints the JSON error body to stderr and
+exits non-zero. There is no interactive retry — re-run the command
+yourself with a different `--safety` or `--pane` value.
 
 If you find yourself reaching for `curl | jq` against the chat API,
 check `pm chat --help` first — most ad-hoc cases are already there.
@@ -757,13 +774,9 @@ selection.
    `AskUserQuestion` stdin protocol may have changed (see §5.5 open
    question). File a bug.
 
-### (f) Subagent transcripts come back empty under `?include_subagents=true`
+### (f) `include_subagents=true` returns 422
 
-`subagent_result` is there, but `metadata.subagent_transcript` is
-`null` or `[]`. Either the subagent's `output-file` doesn't exist on
-disk yet (subagent crashed before flushing), or it's a Codex subagent
-(no JSONL) — Codex subagents surface as `subagent_result` with
-`subagent_transcript: null` and nothing structured to inline.
+`include_subagents=true` returns 422 until #2052 lands.
 
 ### (g) Transcript appears truncated or out of order
 


### PR DESCRIPTION
## Summary

- Adds `docs/api-chat-endpoints.md` — user-facing reference for the phase 1 chat HTTP API (PRs #2042–#2046).
- Covers all 3 endpoints (`GET /sessions`, `GET /{session}/messages`, `POST /{session}/send`) with query params, response shapes, error codes, and curl examples.
- Documents the `MessageEnvelope` schema for all 8 types (text, tool_use, tool_result, ask_user, file, subagent_spawn, subagent_result, system_event) plus `thinking`.
- Walks all 12 edge cases from the design spec §4: mid-tool / mid-stream gates, subagents, multi-pane, AskUserQuestion answering, compaction, stale-JSONL capture fallback, Codex sessions, etc.
- Includes `pm chat` CLI pointer (P4) and an 8-item troubleshooting guide.

Doc-only PR; no code changes.

## Test plan

- [ ] Render docs site locally (or just `glow docs/api-chat-endpoints.md`) and confirm tables/code blocks display correctly.
- [ ] Cross-check examples against the source spec at `~/Desktop/pollypm-chat-endpoints-spec.md` for accuracy.
- [ ] Have Sam clarify the two flagged open questions (AskUserQuestion stdin format in §5.5; multi-select delimiter).

Source spec: `~/Desktop/pollypm-chat-endpoints-spec.md` (drafted 2026-05-21).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>