### PR TITLE
feat(chat-api): P4 pm chat CLI (list/history/send)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,12 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
   "fastapi>=0.115.0",
+  # ``pm chat`` and ``pm sessions`` are first-class CLI surfaces that
+  # talk to the local Web API over HTTP, so the HTTP client has to be a
+  # runtime dependency — not a dev extra. Without this, ``pm --help``
+  # crashes on a no-dev install because ``cli.py`` imports
+  # ``chat_app`` unconditionally (#2047 packaging regression).
+  "httpx>=0.27.0",
   "packaging>=23.0",
   "pyyaml>=6.0",
   "sqlalchemy>=2.0",
@@ -25,7 +31,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "httpx>=0.27.0",
+  # httpx promoted to runtime dependency above (#2047) — it is no
+  # longer dev-only now that ``pm chat`` ships in the base CLI.
   "openapi-spec-validator>=0.7.0",
   "pytest>=8.4.0",
   "ruff>=0.15.12",

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -47,6 +47,7 @@ from pollypm.config import (
 from pollypm.cli_help import help_with_examples
 from pollypm.cli_features.alerts import alert_app, heartbeat_app, session_app
 from pollypm.cli_features.audit import audit_app
+from pollypm.cli_features.chat import chat_app
 from pollypm.launch_executor import LaunchPlanExecutor
 from pollypm.launch_state import (
     LaunchProbe,
@@ -169,6 +170,7 @@ _NOTIFY_HELP = help_with_examples(
 app = typer.Typer(help=_APP_HELP, invoke_without_command=True, no_args_is_help=False)
 app.add_typer(alert_app, name="alert")
 app.add_typer(audit_app, name="audit")
+app.add_typer(chat_app, name="chat")
 app.add_typer(session_app, name="session")
 app.add_typer(heartbeat_app, name="heartbeat")
 app.add_typer(issue_app, name="issue")

--- a/src/pollypm/cli_features/chat.py
+++ b/src/pollypm/cli_features/chat.py
@@ -1,0 +1,494 @@
+"""``pm chat`` CLI group — HTTP client for the chat endpoints.
+
+Contract:
+- Inputs: Typer arguments/options for the three subcommands
+  (``list`` / ``history <session>`` / ``send <session> <text>``).
+- Outputs: ``chat_app`` Typer mounted under the root ``pm`` app.
+- Side effects: HTTPS requests to ``http://127.0.0.1:8765/api/v1/chat/``
+  via :mod:`httpx`, reading the bearer token from
+  ``~/.pollypm/api-token`` (same auth model as the rest of the Web API
+  surface and ``pm sessions``). Read-only for ``list``/``history``;
+  ``send`` POSTs and triggers tmux input on the daemon side.
+- Invariants: this is Sam's user-test harness for the phase-1 chat
+  HTTP surface (`docs/pollypm-chat-endpoints-spec.md` §6 / PR P4).
+  Pure HTTP client — no business logic, no transcript parsing — so a
+  contract drift between client + server surfaces as the API's own
+  error payload, not as a CLI crash.
+
+Errors:
+- Network failures and 4xx/5xx responses print the JSON error body
+  verbatim (or the raw text if the body isn't JSON) on stderr and
+  exit non-zero — the API is the source of truth for error shapes,
+  and surfacing them verbatim keeps this client thin.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+import typer
+
+from pollypm.cli_help import help_with_examples
+from pollypm.web_api.token import DEFAULT_TOKEN_PATH
+
+
+# Default to the same address ``pm serve`` binds to by default. The
+# ``POLLYPM_API_BASE`` env var lets a developer redirect the client at
+# a non-default port without touching the CLI surface — useful when
+# running ``pm serve --port 9000`` alongside the production daemon.
+_DEFAULT_BASE_URL = "http://127.0.0.1:8765"
+_BASE_URL_ENV = "POLLYPM_API_BASE"
+
+# Hard cap on response read so a misbehaving server can't blow client
+# memory. 25MB easily covers a multi-thousand-message transcript dump.
+_RESPONSE_BYTE_LIMIT = 25 * 1024 * 1024
+
+# Network timeout — generous to accommodate a JSONL-parse on a long
+# transcript, tight enough that a hung daemon surfaces as a CLI error
+# rather than blocking the operator's terminal indefinitely.
+_HTTP_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
+
+
+chat_app = typer.Typer(
+    help=help_with_examples(
+        "HTTP client for the chat endpoints (operator/architect/advisor/worker).",
+        [
+            ("pm chat list", "list every chat surface the daemon knows about"),
+            (
+                "pm chat history operator --limit 20",
+                "tail the 20 most-recent operator messages",
+            ),
+            (
+                'pm chat send architect_samblog "summarise the queue"',
+                "push a message into the Archie pane via tmux",
+            ),
+        ],
+        trailing=(
+            "Auth: reads the bearer token from ~/.pollypm/api-token "
+            "(same as `pm serve`). Base URL defaults to "
+            "http://127.0.0.1:8765 and can be overridden via the "
+            "POLLYPM_API_BASE environment variable. On 4xx/5xx the "
+            "JSON error body is printed verbatim and the command exits "
+            "non-zero."
+        ),
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Auth + base URL helpers.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_base_url() -> str:
+    """Return the base URL for chat API calls.
+
+    Honors ``POLLYPM_API_BASE`` so a developer can redirect the client
+    without rebuilding. The returned value has no trailing slash so
+    callers can safely concatenate ``/api/v1/chat/...`` paths.
+    """
+    raw = os.environ.get(_BASE_URL_ENV) or _DEFAULT_BASE_URL
+    return raw.rstrip("/")
+
+
+def _resolve_token_path() -> Path:
+    """Return the path to the bearer token file.
+
+    Re-resolved on every call (via :data:`DEFAULT_TOKEN_PATH`) so
+    monkeypatching the config home in tests is honored without
+    re-importing this module.
+    """
+    return Path(DEFAULT_TOKEN_PATH)
+
+
+def _load_token_or_die() -> str:
+    """Return the bearer token, exiting non-zero if it isn't present.
+
+    A missing token is a setup problem (the daemon hasn't been started
+    yet or the file was deleted) — we surface the absolute path so the
+    operator knows exactly where to look, then exit ``2`` to match the
+    ``BadParameter`` exit code used elsewhere in the CLI.
+    """
+    path = _resolve_token_path()
+    try:
+        if not path.exists():
+            typer.echo(
+                f"error: bearer token not found at {path}; run `pm serve` "
+                "once or `pm api regen-token` to provision.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        token = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        typer.echo(f"error: could not read token file {path}: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    if not token:
+        typer.echo(
+            f"error: token file {path} is empty; run `pm api regen-token`.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    return token
+
+
+# ---------------------------------------------------------------------------
+# HTTP plumbing.
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+
+def _emit_error_and_exit(response: httpx.Response) -> None:
+    """Print the API's error body verbatim and exit non-zero.
+
+    Per the spec, the server returns a JSON ``{code, message, ...}``
+    envelope for failures. We pretty-print it (2-space indent) so the
+    operator can read the ``code`` directly. If the body isn't JSON
+    (rare — likely a proxy or middleware fault), fall back to the raw
+    text so we never swallow the cause.
+    """
+    typer.echo(f"HTTP {response.status_code}", err=True)
+    body = response.text
+    try:
+        payload = response.json()
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True), err=True)
+    except (ValueError, json.JSONDecodeError):
+        if body:
+            typer.echo(body, err=True)
+    raise typer.Exit(code=1)
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Issue an authenticated request and return the decoded JSON body.
+
+    On any non-2xx response, prints the error body verbatim and exits.
+    On a network failure (connection refused, DNS error, timeout),
+    surfaces a one-line readable error referencing the base URL so the
+    operator knows whether to start ``pm serve``.
+    """
+    token = _load_token_or_die()
+    base = _resolve_base_url()
+    url = f"{base}{path}"
+    try:
+        response = httpx.request(
+            method,
+            url,
+            params=params,
+            json=json_body,
+            headers=_auth_headers(token),
+            timeout=_HTTP_TIMEOUT,
+        )
+    except httpx.RequestError as exc:
+        typer.echo(
+            f"error: could not reach {url}: {exc.__class__.__name__}: {exc}",
+            err=True,
+        )
+        typer.echo(
+            "hint: is `pm serve` running? "
+            f"(override base URL with {_BASE_URL_ENV}=...)",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+
+    if response.status_code >= 400:
+        _emit_error_and_exit(response)
+
+    try:
+        return response.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        typer.echo(
+            f"error: response from {url} was not JSON: {exc}", err=True
+        )
+        raise typer.Exit(code=1) from exc
+
+
+# ---------------------------------------------------------------------------
+# `pm chat list`
+# ---------------------------------------------------------------------------
+
+
+def _format_sessions_table(sessions: list[dict[str, Any]]) -> list[str]:
+    """Render the list-sessions response as a fixed-column text table.
+
+    Column widths are picked to keep ``session_name`` (which can be a
+    long ``task-<project>-<N>`` slug) intact while keeping the row
+    under a typical 120-column terminal. ``window`` collapses to ``y``
+    or ``n`` because the path itself is rarely useful at a glance — use
+    ``--json`` for the full window envelope.
+    """
+    lines = [
+        f"{'SESSION_NAME':<28} "
+        f"{'SURFACE':<10} "
+        f"{'PERSONA':<10} "
+        f"{'PROJECT':<14} "
+        f"{'WINDOW'}"
+    ]
+    for entry in sessions:
+        session_name = str(entry.get("session_name") or "?")
+        surface = str(entry.get("surface_type") or "?")
+        persona = entry.get("persona")
+        project = entry.get("project")
+        window = entry.get("window") or {}
+        present = bool(window.get("present")) if isinstance(window, dict) else False
+        lines.append(
+            f"{session_name:<28} "
+            f"{surface:<10} "
+            f"{(persona or '-'):<10} "
+            f"{(project or '-'):<14} "
+            f"{'y' if present else 'n'}"
+        )
+    return lines
+
+
+@chat_app.command(
+    "list",
+    help=(
+        "List every chat surface the daemon knows about. Combines "
+        "configured sessions (operator/architect/advisor) with live "
+        "worker windows. Use --json for the raw response envelope."
+    ),
+)
+def chat_list(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the raw JSON response body."
+    ),
+) -> None:
+    payload = _request("GET", "/api/v1/chat/sessions")
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    sessions = payload.get("sessions") or []
+    if not isinstance(sessions, list):
+        typer.echo("error: malformed response: `sessions` is not a list", err=True)
+        raise typer.Exit(code=1)
+    if not sessions:
+        typer.echo("(no chat surfaces registered)")
+        return
+    for line in _format_sessions_table(sessions):
+        typer.echo(line)
+
+
+# ---------------------------------------------------------------------------
+# `pm chat history <session_name>`
+# ---------------------------------------------------------------------------
+
+
+def _format_message_line(message: dict[str, Any]) -> str:
+    """Render one MessageEnvelope as a single human-readable line.
+
+    Layout: ``<ts>  <actor>  [<type>]  <text>``. ``text`` is left
+    intact (no truncation) so an operator running ``pm chat history``
+    sees the same content as the JSON consumer — the API is responsible
+    for keeping ``text`` display-ready.
+    """
+    ts = str(message.get("ts") or "?")
+    actor = str(message.get("actor") or message.get("role") or "?")
+    type_tag = str(message.get("type") or "?")
+    text = str(message.get("text") or "")
+    # Strip embedded newlines so each envelope stays on one line; the
+    # API's `text` field is already a display-ready summary, and a
+    # multi-line render here would break the at-a-glance scrollback
+    # the spec's user-test protocol depends on.
+    text = text.replace("\n", " ").replace("\r", " ")
+    return f"{ts}  {actor:<10}  [{type_tag}]  {text}"
+
+
+@chat_app.command(
+    "history",
+    help=(
+        "Pull message history for a chat surface. Filters narrow before "
+        "rendering. Use --json for the raw MessageEnvelope array."
+    ),
+)
+def chat_history(
+    session_name: str = typer.Argument(
+        ..., help="Canonical session name (e.g. operator, architect_samblog, task-samblog-47)."
+    ),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        help="Cap messages returned (server default is 100, max 500).",
+    ),
+    since: str | None = typer.Option(
+        None,
+        "--since",
+        help="ISO-8601 lower bound on message timestamp.",
+    ),
+    direction: str | None = typer.Option(
+        None,
+        "--direction",
+        help="`desc` (newest first; server default) or `asc`.",
+    ),
+    include_subagents: bool = typer.Option(
+        False,
+        "--include-subagents",
+        help="Inline subagent transcripts inside their parent message.",
+    ),
+    source: str | None = typer.Option(
+        None,
+        "--source",
+        help="`auto` (default), `jsonl`, or `capture`.",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the raw JSON response body."
+    ),
+) -> None:
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = limit
+    if since:
+        params["since"] = since
+    if direction:
+        params["direction"] = direction
+    if include_subagents:
+        # FastAPI bool query params accept the literal string "true".
+        params["include_subagents"] = "true"
+    if source:
+        params["source"] = source
+
+    payload = _request(
+        "GET",
+        f"/api/v1/chat/{session_name}/messages",
+        params=params or None,
+    )
+
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    messages = payload.get("messages") or []
+    if not isinstance(messages, list):
+        typer.echo(
+            "error: malformed response: `messages` is not a list", err=True
+        )
+        raise typer.Exit(code=1)
+    if not messages:
+        typer.echo(f"(no messages for {session_name})")
+        return
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        typer.echo(_format_message_line(message))
+
+
+# ---------------------------------------------------------------------------
+# `pm chat send <session_name> <text>`
+# ---------------------------------------------------------------------------
+
+
+@chat_app.command(
+    "send",
+    help=(
+        "Send a message into a chat surface. The daemon routes it through "
+        "tmux into the running CLI agent. Use --safety / --answer-to / "
+        "--selection for AskUserQuestion replies and mid-stream sends."
+    ),
+)
+def chat_send(
+    session_name: str = typer.Argument(
+        ..., help="Canonical session name (see `pm chat list`)."
+    ),
+    text: str = typer.Argument(
+        ...,
+        help=(
+            "Message body. Pass an empty string when answering an "
+            "AskUserQuestion via --selection only."
+        ),
+    ),
+    no_enter: bool = typer.Option(
+        False,
+        "--no-enter",
+        help=(
+            "Don't press Enter after sending; equivalent to "
+            "press_enter=false in the API body."
+        ),
+    ),
+    safety: str | None = typer.Option(
+        None,
+        "--safety",
+        help="strict (default) | loose | force. See spec §4.3.",
+    ),
+    answer_to: str | None = typer.Option(
+        None,
+        "--answer-to",
+        help="Message id this send is answering (for AskUserQuestion replies).",
+    ),
+    selection: list[str] = typer.Option(
+        [],
+        "--selection",
+        help=(
+            "Option label for an AskUserQuestion reply. Repeatable for "
+            "multi-select. Mutually exclusive with free-text per the API."
+        ),
+    ),
+    notes: str | None = typer.Option(
+        None,
+        "--notes",
+        help="Free-text addition appended after --selection values.",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the raw JSON response body."
+    ),
+) -> None:
+    body: dict[str, Any] = {
+        "text": text,
+        "press_enter": not no_enter,
+    }
+    if safety:
+        body["safety"] = safety
+    if answer_to:
+        body["answer_to"] = answer_to
+    if selection:
+        # Typer multi-option defaults to ``[]`` when omitted — only emit
+        # the field when the operator actually passed at least one.
+        body["selections"] = list(selection)
+    if notes is not None:
+        body["notes"] = notes
+
+    payload = _request(
+        "POST",
+        f"/api/v1/chat/{session_name}/send",
+        json_body=body,
+    )
+
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    # Pretty-print the response. The spec defines the exact fields, so
+    # render the ones an operator cares about per-line and drop the
+    # full envelope at the bottom of the block via JSON for fidelity.
+    ok = payload.get("ok")
+    message_id = payload.get("message_id") or "-"
+    target = payload.get("window_target") or "-"
+    method = payload.get("method") or "-"
+    chars = payload.get("characters_sent")
+    pressed_at = payload.get("press_enter_at") or "-"
+
+    typer.echo(f"ok:               {ok}")
+    typer.echo(f"message_id:       {message_id}")
+    typer.echo(f"session_name:     {payload.get('session_name') or session_name}")
+    typer.echo(f"window_target:    {target}")
+    typer.echo(f"characters_sent:  {chars if chars is not None else '-'}")
+    typer.echo(f"method:           {method}")
+    typer.echo(f"press_enter_at:   {pressed_at}")
+
+
+__all__ = [
+    "chat_app",
+    "chat_list",
+    "chat_history",
+    "chat_send",
+]

--- a/src/pollypm/cli_features/chat.py
+++ b/src/pollypm/cli_features/chat.py
@@ -43,10 +43,6 @@ from pollypm.web_api.token import DEFAULT_TOKEN_PATH
 _DEFAULT_BASE_URL = "http://127.0.0.1:8765"
 _BASE_URL_ENV = "POLLYPM_API_BASE"
 
-# Hard cap on response read so a misbehaving server can't blow client
-# memory. 25MB easily covers a multi-thousand-message transcript dump.
-_RESPONSE_BYTE_LIMIT = 25 * 1024 * 1024
-
 # Network timeout — generous to accommodate a JSONL-parse on a long
 # transcript, tight enough that a hung daemon surfaces as a CLI error
 # rather than blocking the operator's terminal indefinitely.

--- a/src/pollypm/cli_features/chat.py
+++ b/src/pollypm/cli_features/chat.py
@@ -322,6 +322,14 @@ def chat_history(
         "--since",
         help="ISO-8601 lower bound on message timestamp.",
     ),
+    since_id: str | None = typer.Option(
+        None,
+        "--since-id",
+        help=(
+            "Cursor pagination: return only messages strictly after this "
+            "message id. Forwarded to the server as `since_id`."
+        ),
+    ),
     direction: str | None = typer.Option(
         None,
         "--direction",
@@ -330,7 +338,10 @@ def chat_history(
     include_subagents: bool = typer.Option(
         False,
         "--include-subagents",
-        help="Inline subagent transcripts inside their parent message.",
+        help=(
+            "DEFERRED — see issue #2052. Currently the server returns "
+            "422 if this is true."
+        ),
     ),
     source: str | None = typer.Option(
         None,
@@ -346,6 +357,8 @@ def chat_history(
         params["limit"] = limit
     if since:
         params["since"] = since
+    if since_id:
+        params["since_id"] = since_id
     if direction:
         params["direction"] = direction
     if include_subagents:
@@ -434,6 +447,15 @@ def chat_send(
         "--notes",
         help="Free-text addition appended after --selection values.",
     ),
+    pane: int | None = typer.Option(
+        None,
+        "--pane",
+        help=(
+            "Explicit tmux pane index inside the target window. "
+            "Forwarded to the server as the `pane` body field; omit to "
+            "let the server pick its default pane."
+        ),
+    ),
     json_output: bool = typer.Option(
         False, "--json", help="Emit the raw JSON response body."
     ),
@@ -452,6 +474,8 @@ def chat_send(
         body["selections"] = list(selection)
     if notes is not None:
         body["notes"] = notes
+    if pane is not None:
+        body["pane"] = pane
 
     payload = _request(
         "POST",

--- a/tests/test_pm_chat_cli.py
+++ b/tests/test_pm_chat_cli.py
@@ -1,0 +1,609 @@
+"""Tests for ``pm chat`` — HTTP client CLI for chat endpoints (PR P4).
+
+The CLI is a thin wrapper around the chat HTTP surface defined in
+``docs/pollypm-chat-endpoints-spec.md``. Tests run via Typer's
+``CliRunner`` with ``httpx.request`` monkey-patched so we exercise
+argument parsing, request shaping, and response rendering without
+needing a live ``pm serve`` daemon.
+
+Token resolution is redirected at a tmp file per-test so we cover the
+"token present" / "token missing" branches without touching
+``~/.pollypm``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from pollypm.cli_features import chat as chat_mod
+
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding — fake httpx + tmp token.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Capture:
+    """Records what the fake httpx adapter saw."""
+
+    method: str = ""
+    url: str = ""
+    params: dict[str, Any] | None = None
+    json_body: dict[str, Any] | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+
+
+def _build_cli_app() -> typer.Typer:
+    """Mount ``chat_app`` under a parent Typer so subcommand dispatch
+    works the same as the production ``pollypm.cli.app``.
+    """
+    app = typer.Typer()
+    app.add_typer(chat_mod.chat_app, name="chat")
+
+    @app.command("_marker")
+    def _marker() -> None:  # pragma: no cover - presence-only
+        return None
+
+    return app
+
+
+def _install_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Write a fake token file and redirect the resolver at it.
+
+    Returns the token path so tests can also delete/blank it to drive
+    the missing-token branches.
+    """
+    token_path = tmp_path / "api-token"
+    token_path.write_text("test-token-abcdef", encoding="utf-8")
+    monkeypatch.setattr(chat_mod, "DEFAULT_TOKEN_PATH", token_path)
+    return token_path
+
+
+def _install_response(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    status_code: int = 200,
+    json_payload: Any = None,
+    text_payload: str | None = None,
+) -> _Capture:
+    """Stub ``httpx.request`` to return a canned response and capture
+    the outgoing request shape for assertions.
+    """
+    capture = _Capture()
+
+    def _fake_request(
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,  # noqa: A002 - matches httpx signature
+        headers: dict[str, str] | None = None,
+        timeout: Any = None,
+    ) -> httpx.Response:
+        capture.method = method
+        capture.url = url
+        capture.params = dict(params) if params else None
+        capture.json_body = dict(json) if json else None
+        capture.headers = dict(headers or {})
+        if json_payload is not None:
+            import json as _json_mod
+            body = _json_mod.dumps(json_payload).encode("utf-8")
+            request = httpx.Request(method, url)
+            return httpx.Response(
+                status_code,
+                content=body,
+                headers={"content-type": "application/json"},
+                request=request,
+            )
+        request = httpx.Request(method, url)
+        return httpx.Response(
+            status_code,
+            content=(text_payload or "").encode("utf-8"),
+            request=request,
+        )
+
+    monkeypatch.setattr(chat_mod.httpx, "request", _fake_request)
+    return capture
+
+
+# ---------------------------------------------------------------------------
+# `pm chat list`
+# ---------------------------------------------------------------------------
+
+
+class TestChatList:
+    def test_happy_path_renders_table(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(
+            monkeypatch,
+            json_payload={
+                "sessions": [
+                    {
+                        "session_name": "operator",
+                        "surface_type": "operator",
+                        "persona": "Polly",
+                        "project": None,
+                        "window": {"present": True},
+                    },
+                    {
+                        "session_name": "architect_samblog",
+                        "surface_type": "architect",
+                        "persona": "Archie",
+                        "project": "samblog",
+                        "window": {"present": False},
+                    },
+                ]
+            },
+        )
+
+        result = runner.invoke(_build_cli_app(), ["chat", "list"])
+        assert result.exit_code == 0, result.output
+        assert "SESSION_NAME" in result.output
+        assert "operator" in result.output
+        assert "architect_samblog" in result.output
+        assert "Polly" in result.output
+        assert "Archie" in result.output
+        # `present=True` → "y"; `present=False` → "n".
+        lines = {
+            line.split()[0]: line
+            for line in result.output.splitlines()
+            if line and not line.startswith("SESSION_NAME")
+        }
+        assert lines["operator"].rstrip().endswith("y")
+        assert lines["architect_samblog"].rstrip().endswith("n")
+        assert capture.method == "GET"
+        assert capture.url.endswith("/api/v1/chat/sessions")
+        assert capture.headers.get("Authorization") == "Bearer test-token-abcdef"
+
+    def test_json_flag_emits_raw_envelope(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        payload = {
+            "sessions": [
+                {
+                    "session_name": "operator",
+                    "surface_type": "operator",
+                    "persona": "Polly",
+                    "project": None,
+                    "window": {"present": True},
+                }
+            ]
+        }
+        _install_response(monkeypatch, json_payload=payload)
+        result = runner.invoke(_build_cli_app(), ["chat", "list", "--json"])
+        assert result.exit_code == 0, result.output
+        # Output must round-trip through json.loads — i.e. it's the raw
+        # envelope, not the pretty-printed table.
+        decoded = json.loads(result.output)
+        assert decoded == payload
+
+    def test_empty_sessions_list_friendly_message(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        _install_response(monkeypatch, json_payload={"sessions": []})
+        result = runner.invoke(_build_cli_app(), ["chat", "list"])
+        assert result.exit_code == 0, result.output
+        assert "no chat surfaces" in result.output
+
+    def test_401_unauthorized_prints_error_body(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        _install_response(
+            monkeypatch,
+            status_code=401,
+            json_payload={
+                "code": "invalid_token",
+                "message": "bearer token did not match",
+            },
+        )
+        result = runner.invoke(_build_cli_app(), ["chat", "list"])
+        assert result.exit_code != 0
+        # Error body must appear in mixed output verbatim.
+        assert "HTTP 401" in result.output
+        assert "invalid_token" in result.output
+
+    def test_network_failure_surfaces_readable_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+
+        def _boom(*_args, **_kwargs) -> httpx.Response:
+            raise httpx.ConnectError("Connection refused")
+
+        monkeypatch.setattr(chat_mod.httpx, "request", _boom)
+        result = runner.invoke(_build_cli_app(), ["chat", "list"])
+        assert result.exit_code != 0
+        assert "could not reach" in result.output
+        assert "pm serve" in result.output
+
+
+# ---------------------------------------------------------------------------
+# `pm chat history <session>`
+# ---------------------------------------------------------------------------
+
+
+class TestChatHistory:
+    def test_happy_path_renders_message_lines(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(
+            monkeypatch,
+            json_payload={
+                "session_name": "sess1",
+                "messages": [
+                    {
+                        "id": "msg_1",
+                        "ts": "2026-05-21T20:53:12.123Z",
+                        "role": "user",
+                        "actor": "Sam",
+                        "type": "text",
+                        "text": "hello",
+                    },
+                    {
+                        "id": "msg_2",
+                        "ts": "2026-05-21T20:53:15.500Z",
+                        "role": "assistant",
+                        "actor": "Polly",
+                        "type": "text",
+                        "text": "hi back",
+                    },
+                ],
+            },
+        )
+
+        result = runner.invoke(_build_cli_app(), ["chat", "history", "sess1"])
+        assert result.exit_code == 0, result.output
+        assert "Sam" in result.output
+        assert "Polly" in result.output
+        assert "[text]" in result.output
+        assert "hello" in result.output
+        assert "hi back" in result.output
+        assert capture.method == "GET"
+        assert capture.url.endswith("/api/v1/chat/sess1/messages")
+        # No filters → no query params emitted at all.
+        assert capture.params is None
+
+    def test_query_params_forwarded_for_limit_and_since(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(
+            monkeypatch, json_payload={"messages": []}
+        )
+        result = runner.invoke(
+            _build_cli_app(),
+            [
+                "chat",
+                "history",
+                "sess1",
+                "--limit",
+                "5",
+                "--since",
+                "2026-05-21",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert capture.params == {"limit": 5, "since": "2026-05-21"}
+
+    def test_include_subagents_sets_true_query_param(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(
+            monkeypatch, json_payload={"messages": []}
+        )
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "history", "sess1", "--include-subagents"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (capture.params or {}).get("include_subagents") == "true"
+
+    def test_direction_and_source_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(
+            monkeypatch, json_payload={"messages": []}
+        )
+        result = runner.invoke(
+            _build_cli_app(),
+            [
+                "chat",
+                "history",
+                "sess1",
+                "--direction",
+                "asc",
+                "--source",
+                "jsonl",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (capture.params or {}).get("direction") == "asc"
+        assert (capture.params or {}).get("source") == "jsonl"
+
+    def test_empty_messages_friendly_message(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        _install_response(monkeypatch, json_payload={"messages": []})
+        result = runner.invoke(
+            _build_cli_app(), ["chat", "history", "sess1"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "no messages for sess1" in result.output
+
+    def test_json_flag_emits_raw_envelope(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        payload = {
+            "messages": [
+                {
+                    "id": "msg_1",
+                    "ts": "2026-05-21T20:53:12Z",
+                    "role": "assistant",
+                    "actor": "Polly",
+                    "type": "text",
+                    "text": "hi",
+                }
+            ]
+        }
+        _install_response(monkeypatch, json_payload=payload)
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "history", "sess1", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == payload
+
+    def test_multiline_text_collapsed_to_single_line(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        _install_response(
+            monkeypatch,
+            json_payload={
+                "messages": [
+                    {
+                        "id": "msg_1",
+                        "ts": "2026-05-21T20:53:12Z",
+                        "role": "user",
+                        "actor": "Sam",
+                        "type": "text",
+                        "text": "line1\nline2\nline3",
+                    }
+                ]
+            },
+        )
+        result = runner.invoke(
+            _build_cli_app(), ["chat", "history", "sess1"]
+        )
+        assert result.exit_code == 0, result.output
+        # Exactly one body line (plus optional trailing newline). The
+        # envelope had two embedded newlines — both must be stripped.
+        non_empty = [
+            line for line in result.output.splitlines() if line.strip()
+        ]
+        assert len(non_empty) == 1
+        assert "line1 line2 line3" in non_empty[0]
+
+
+# ---------------------------------------------------------------------------
+# `pm chat send <session> <text>`
+# ---------------------------------------------------------------------------
+
+
+def _send_payload() -> dict[str, Any]:
+    """Canonical 200 response per spec §2.3."""
+    return {
+        "ok": True,
+        "message_id": "msg_abc",
+        "session_name": "sess1",
+        "window_target": "storage-closet:pm-operator",
+        "characters_sent": 5,
+        "method": "send_keys",
+        "press_enter_at": "2026-05-21T20:53:12.500Z",
+    }
+
+
+class TestChatSend:
+    def test_happy_path_posts_text_and_renders_response(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(monkeypatch, json_payload=_send_payload())
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "send", "sess1", "hello"],
+        )
+        assert result.exit_code == 0, result.output
+        assert capture.method == "POST"
+        assert capture.url.endswith("/api/v1/chat/sess1/send")
+        assert capture.json_body == {"text": "hello", "press_enter": True}
+        # Pretty-printed response surfaces the fields an operator cares about.
+        assert "message_id:" in result.output
+        assert "msg_abc" in result.output
+        assert "window_target:" in result.output
+        assert "storage-closet:pm-operator" in result.output
+
+    def test_no_enter_flag_sets_press_enter_false(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(monkeypatch, json_payload=_send_payload())
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "send", "sess1", "hello", "--no-enter"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (capture.json_body or {}).get("press_enter") is False
+
+    def test_selection_and_answer_to_for_ask_user(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(monkeypatch, json_payload=_send_payload())
+        result = runner.invoke(
+            _build_cli_app(),
+            [
+                "chat",
+                "send",
+                "sess1",
+                "",
+                "--answer-to",
+                "msg_abc",
+                "--selection",
+                "Option A",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        body = capture.json_body or {}
+        assert body.get("text") == ""
+        assert body.get("answer_to") == "msg_abc"
+        assert body.get("selections") == ["Option A"]
+
+    def test_repeated_selection_for_multi_select(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(monkeypatch, json_payload=_send_payload())
+        result = runner.invoke(
+            _build_cli_app(),
+            [
+                "chat",
+                "send",
+                "sess1",
+                "",
+                "--answer-to",
+                "msg_abc",
+                "--selection",
+                "A",
+                "--selection",
+                "B",
+                "--notes",
+                "fine either way",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        body = capture.json_body or {}
+        assert body.get("selections") == ["A", "B"]
+        assert body.get("notes") == "fine either way"
+
+    def test_safety_force_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(monkeypatch, json_payload=_send_payload())
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "send", "sess1", "x", "--safety", "force"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (capture.json_body or {}).get("safety") == "force"
+
+    def test_409_unsafe_mid_tool_prints_error_body(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        _install_response(
+            monkeypatch,
+            status_code=409,
+            json_payload={
+                "code": "unsafe_mid_tool",
+                "message": (
+                    "last assistant message has an open tool_use without "
+                    "a matching tool_result; pass --safety force to override"
+                ),
+            },
+        )
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "send", "sess1", "hello"],
+        )
+        assert result.exit_code != 0
+        assert "HTTP 409" in result.output
+        assert "unsafe_mid_tool" in result.output
+        assert "--safety force" in result.output
+
+    def test_send_json_flag_emits_raw_envelope(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        payload = _send_payload()
+        _install_response(monkeypatch, json_payload=payload)
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "send", "sess1", "hello", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == payload
+
+
+# ---------------------------------------------------------------------------
+# Token-resolution edge cases.
+# ---------------------------------------------------------------------------
+
+
+class TestTokenResolution:
+    def test_missing_token_file_exits_with_readable_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Point the resolver at a path that doesn't exist — must not
+        # touch real ~/.pollypm.
+        missing = tmp_path / "no-such-token"
+        monkeypatch.setattr(chat_mod, "DEFAULT_TOKEN_PATH", missing)
+        # No httpx stub — if we accidentally tried to make a request,
+        # the test would either crash or hit the network. The CLI must
+        # short-circuit before reaching httpx.
+        result = runner.invoke(_build_cli_app(), ["chat", "list"])
+        assert result.exit_code != 0
+        assert "bearer token not found" in result.output
+        assert str(missing) in result.output
+
+    def test_empty_token_file_exits_with_readable_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        token_path = tmp_path / "api-token"
+        token_path.write_text("   \n", encoding="utf-8")
+        monkeypatch.setattr(chat_mod, "DEFAULT_TOKEN_PATH", token_path)
+        result = runner.invoke(_build_cli_app(), ["chat", "list"])
+        assert result.exit_code != 0
+        assert "empty" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Base URL override via env var.
+# ---------------------------------------------------------------------------
+
+
+class TestBaseUrlOverride:
+    def test_env_var_overrides_default_base(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(monkeypatch, json_payload={"sessions": []})
+        monkeypatch.setenv("POLLYPM_API_BASE", "http://example.test:9999/")
+        result = runner.invoke(_build_cli_app(), ["chat", "list"])
+        assert result.exit_code == 0, result.output
+        # Trailing slash on the env var must be stripped so the joined
+        # URL doesn't end up with a double slash.
+        assert capture.url == "http://example.test:9999/api/v1/chat/sessions"

--- a/tests/test_pm_chat_cli.py
+++ b/tests/test_pm_chat_cli.py
@@ -317,6 +317,20 @@ class TestChatHistory:
         assert result.exit_code == 0, result.output
         assert (capture.params or {}).get("include_subagents") == "true"
 
+    def test_chat_history_passes_since_id(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(
+            monkeypatch, json_payload={"messages": []}
+        )
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "history", "sess1", "--since-id", "msg_abc"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (capture.params or {}).get("since_id") == "msg_abc"
+
     def test_direction_and_source_forwarded(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -507,6 +521,18 @@ class TestChatSend:
         body = capture.json_body or {}
         assert body.get("selections") == ["A", "B"]
         assert body.get("notes") == "fine either way"
+
+    def test_chat_send_passes_pane(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        capture = _install_response(monkeypatch, json_payload=_send_payload())
+        result = runner.invoke(
+            _build_cli_app(),
+            ["chat", "send", "sess1", "hello", "--pane", "1"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (capture.json_body or {}).get("pane") == 1
 
     def test_safety_force_forwarded(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/uv.lock
+++ b/uv.lock
@@ -499,6 +499,7 @@ version = "1.0.0rc3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
@@ -512,7 +513,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "openapi-spec-validator" },
     { name = "pytest" },
     { name = "ruff" },
@@ -526,7 +526,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.0" },
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "packaging", specifier = ">=23.0" },


### PR DESCRIPTION
## Summary

- Adds `pm chat list / history / send` — Sam's user-test harness for the phase-1 chat HTTP surface (docs/pollypm-chat-endpoints-spec.md §6, PR P4).
- Thin httpx client over `/api/v1/chat/*`. Auth reuses the existing `~/.pollypm/api-token`. Default base URL `http://127.0.0.1:8765`; override via `POLLYPM_API_BASE`.
- On 4xx/5xx the JSON error body is printed verbatim and the command exits non-zero — contract drift surfaces as the API's own error envelope, not a CLI crash.
- Additive only. Pg-only paths, no StateStore. v1 RC stability respected.

## Commands

- `pm chat list [--json]` → table with session_name / surface_type / persona / project / window-present-y|n
- `pm chat history <session_name> [--limit N] [--since ISO] [--direction asc|desc] [--include-subagents] [--source auto|jsonl|capture] [--json]`
- `pm chat send <session_name> <text> [--no-enter] [--safety strict|loose|force] [--answer-to MSG_ID] [--selection LABEL ...] [--notes TEXT] [--json]`

## Test plan

- [x] `pytest --noconftest tests/test_pm_chat_cli.py -v` — 22 cases pass (list happy/json/empty/401/network, history happy/limit-since/include-subagents/direction-source/empty/json/multiline, send happy/no-enter/answer-to/multi-select/safety/409/json, token missing/empty, base-URL env override)
- [ ] After P1-P3 land, run the spec §7 user-test protocol end-to-end against a live `pm serve`

## Notes / contract observations (deferred — flagged for follow-ups)

- Spec §2.2 allows `since_id`, `include_thinking`, and `include_system_events` but they aren't in the P4 CLI surface (out of scope per task brief). Easy to add when needed.
- Spec §2.3 send body allows `pane`; not exposed on CLI yet (also out of scope — multi-pane is §4.4 edge case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)