### PR TITLE
feat(api): GET /api/v1/heartbeats[/{session}] — Phase 2 heartbeat reads

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -78,6 +78,14 @@ tags:
       Read-only ~/.pollypm/ disk-usage report. Mirrors
       `pm storage report --json` (#2040). Prune is CLI-only per the
       Phase 2 spec — no DELETE / POST endpoints here.
+  - name: Heartbeats
+    description: |
+      Per-session supervisor-heartbeat ledger reads. The list endpoint
+      returns one latest-tick row per configured session; the detail
+      endpoint adds the recent-tick history for one session. Reads go
+      through the canonical `pg_heartbeats` facade — same source the
+      cockpit and `pm sessions` consume. The SSE stream endpoint
+      (Phase 2 §11.1) ships separately.
 
 paths:
   /health:
@@ -1474,6 +1482,45 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /heartbeats:
+    get:
+      tags: [Heartbeats]
+      operationId: listHeartbeats
+      summary: Latest heartbeat per configured session
+      description: |
+        Returns one `HeartbeatLatest` row per enabled session in the
+        operator's config. Sessions that have never reported in get
+        `status="initializing"` and `last_tick_ts=null`. Disabled
+        sessions are filtered out — their absence from the ledger is
+        correct, not a bug.
+
+        Status classification matches `pm sessions`:
+        - `healthy`  — last tick ≤ 5 minutes old
+        - `stale`    — last tick > 5 minutes old
+        - `initializing` — no ledger row yet
+        - `unknown`  — ledger row exists but the timestamp is
+          unparseable
+
+        Backing-store outages bubble as `503 service_unavailable` so
+        callers can retry. We do **not** paper over a pg-pool outage
+        with an empty list — that would tell the cockpit "every session
+        is initializing" which is dangerously misleading.
+      responses:
+        "200":
+          description: One row per configured session, sorted by name.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HeartbeatsListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "503":
+          description: Heartbeats ledger unreachable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /storage/{subdir}:
     parameters:
       - in: path
@@ -1506,6 +1553,64 @@ paths:
           $ref: "#/components/responses/NotFound"
         "503":
           description: Storage tree scan failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /heartbeats/{session_name}:
+    parameters:
+      - in: path
+        name: session_name
+        required: true
+        schema: { type: string }
+        description: |
+          Session name to look up. May refer to a configured session
+          (`operator`, `architect_<project>`, …) or any session the
+          heartbeats ledger remembers — e.g. a task-worker that's been
+          reaped but still has rows on disk.
+    get:
+      tags: [Heartbeats]
+      operationId: getHeartbeat
+      summary: Latest heartbeat + recent history for one session
+      description: |
+        Returns the latest tick plus up to `limit` recent ticks (newest
+        first) for `session_name`. Configured-but-silent sessions
+        return 200 with `status="initializing"` and an empty `ticks`
+        list. Genuinely-unknown session names (not in config, not in
+        ledger) return `404 not_found`.
+
+        `limit` clamps silently at 200 (Phase 2 §11.3) — a caller
+        asking for 1000 ticks gets the top 200 plus `clamped=true`
+        rather than a 422.
+      parameters:
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, default: 20 }
+          description: |
+            Max history ticks (newest-first). Default 20, clamped at
+            200. Values > 200 succeed with `clamped: true` in the
+            response body.
+      responses:
+        "200":
+          description: Latest + recent ticks for the session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HeartbeatDetailResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: |
+            Session is not in config and not in the heartbeats ledger.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "503":
+          description: Heartbeats ledger unreachable.
           content:
             application/json:
               schema:
@@ -3081,3 +3186,113 @@ components:
             $ref: "#/components/schemas/StorageEntry"
         config_files:
           $ref: "#/components/schemas/StorageConfigFiles"
+
+    # ---- Heartbeats -------------------------------------------------
+    HeartbeatLatest:
+      type: object
+      required: [session_name, status]
+      description: |
+        Latest heartbeat snapshot for one session (Phase 2 §11.2).
+        `last_tick_ts` / `age_seconds` are null when no row exists
+        (status = `initializing`).
+      properties:
+        session_name: { type: string }
+        role:
+          type: string
+          nullable: true
+          description: Session role from config (e.g. `operator`, `architect`).
+        project:
+          type: string
+          nullable: true
+          description: Project key this session is bound to (when applicable).
+        status:
+          type: string
+          enum: [healthy, stale, initializing, unknown]
+          description: |
+            `healthy` (≤5m), `stale` (>5m), `initializing` (no row yet),
+            or `unknown` (row exists but timestamp unparseable).
+        last_tick_ts:
+          type: string
+          format: date-time
+          nullable: true
+        age_seconds:
+          type: integer
+          nullable: true
+        pane_command:
+          type: string
+          nullable: true
+        pane_dead:
+          type: boolean
+          default: false
+        log_bytes:
+          type: integer
+          default: 0
+        snapshot_path:
+          type: string
+          nullable: true
+        snapshot_hash:
+          type: string
+          nullable: true
+        tmux_window:
+          type: string
+          nullable: true
+        pane_id:
+          type: string
+          nullable: true
+
+    HeartbeatTick:
+      type: object
+      required: [ts]
+      description: |
+        One raw heartbeat row from the per-session history table
+        (Phase 2 §11.2). Returned newest-first by the detail endpoint.
+      properties:
+        ts:
+          type: string
+          format: date-time
+        pane_command:
+          type: string
+          nullable: true
+        pane_dead:
+          type: boolean
+          default: false
+        log_bytes:
+          type: integer
+          default: 0
+        snapshot_path:
+          type: string
+          nullable: true
+        snapshot_hash:
+          type: string
+          nullable: true
+        tmux_window:
+          type: string
+          nullable: true
+        pane_id:
+          type: string
+          nullable: true
+
+    HeartbeatsListResponse:
+      type: object
+      required: [heartbeats]
+      properties:
+        heartbeats:
+          type: array
+          items:
+            $ref: "#/components/schemas/HeartbeatLatest"
+
+    HeartbeatDetailResponse:
+      type: object
+      required: [latest, ticks, clamped]
+      properties:
+        latest:
+          $ref: "#/components/schemas/HeartbeatLatest"
+        ticks:
+          type: array
+          items:
+            $ref: "#/components/schemas/HeartbeatTick"
+        clamped:
+          type: boolean
+          description: |
+            True when the caller's `?limit` exceeded the route's 200-row
+            cap and was silently clamped (Phase 2 §11.3).

--- a/src/pollypm/storage/pg_heartbeats.py
+++ b/src/pollypm/storage/pg_heartbeats.py
@@ -127,6 +127,51 @@ def latest_heartbeat(
     return _row_to_heartbeat(row)
 
 
+def latest_heartbeats_bulk(
+    session_names: list[str],
+    *,
+    pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
+) -> dict[str, HeartbeatRecord]:
+    """Return ``{session_name: latest HeartbeatRecord}`` in ONE query.
+
+    Replacement for callers that previously looped :func:`latest_heartbeat`
+    once per session (N+1 round-trips → one). Uses ``DISTINCT ON
+    (session_name)`` ordered by ``id DESC`` so each session yields its
+    most-recent row (same selection as the single-session helper).
+
+    Sessions in ``session_names`` that have never reported in are absent
+    from the returned dict — callers map missing entries to whatever
+    "no heartbeat yet" sentinel they need (the heartbeats route maps to
+    ``status="initializing"``). Returns an empty dict when
+    ``session_names`` is empty (no query issued).
+    """
+    if not session_names:
+        return {}
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool(config)
+    # Deduplicate while preserving sane ordering for the bind list. ``%s``
+    # with a tuple expands to the IN-list via psycopg's standard
+    # parameterisation, no string interpolation.
+    unique_names = list(dict.fromkeys(session_names))
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (session_name)
+                   session_name, tmux_window, pane_id, pane_command, pane_dead,
+                   log_bytes, snapshot_path, snapshot_hash, created_at
+            FROM heartbeats
+            WHERE session_name = ANY(%s)
+            ORDER BY session_name, id DESC
+            """,
+            (unique_names,),
+        )
+        rows = cur.fetchall()
+    return {row[0]: _row_to_heartbeat(row) for row in rows}
+
+
 def recent_heartbeats(
     session_name: str,
     limit: int = 3,
@@ -209,6 +254,7 @@ def _row_to_heartbeat(row) -> HeartbeatRecord:
 __all__ = [
     "last_heartbeat_at",
     "latest_heartbeat",
+    "latest_heartbeats_bulk",
     "recent_heartbeats",
     "record_heartbeat",
 ]

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -37,6 +37,7 @@ from pollypm.web_api.routes import config as config_routes
 from pollypm.web_api.routes import dashboard as dashboard_routes
 from pollypm.web_api.routes import events as events_routes
 from pollypm.web_api.routes import health as health_routes
+from pollypm.web_api.routes import heartbeats as heartbeats_routes
 from pollypm.web_api.routes import inbox as inbox_routes
 from pollypm.web_api.routes import projects as projects_routes
 from pollypm.web_api.routes import sessions_admin as sessions_admin_routes
@@ -160,6 +161,16 @@ def create_app(
     # Phase 2 surface §12 — read-only storage report (no prune).
     app.include_router(storage_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(events_routes.router, prefix=API_V1_PREFIX, dependencies=sse_auth_deps)
+    # Phase 2 §11 — read-side heartbeats surface. SSE stream endpoint
+    # (§11.1 row 4) ships as a separate follow-up; the GET endpoints
+    # are independently mergeable because they go through the same
+    # ``pg_heartbeats`` facade the cockpit + ``pm sessions`` already
+    # consume.
+    app.include_router(
+        heartbeats_routes.router,
+        prefix=API_V1_PREFIX,
+        dependencies=auth_deps,
+    )
     # P2 of the chat-endpoints spec — GET /api/v1/chat/sessions and
     # GET /api/v1/chat/{session_name}/messages. Sits under the same
     # ``/chat`` prefix the P3 send endpoint shares so all

--- a/src/pollypm/web_api/routes/heartbeats.py
+++ b/src/pollypm/web_api/routes/heartbeats.py
@@ -267,32 +267,48 @@ def list_heartbeats_endpoint(config: ConfigDep) -> HeartbeatsListResponse:
     caller can retry; we don't paper over a pg-pool outage with an
     empty list because that would tell the cockpit "every session is
     initializing" which is dangerously misleading.
-    """
-    from pollypm.storage.pg_heartbeats import latest_heartbeat as _latest
 
-    rows: list[HeartbeatLatest] = []
-    for session_name in _configured_session_names(config):
-        try:
-            record = _latest(session_name, config=config)
-        except Exception as exc:  # noqa: BLE001 — typed translation below
-            logger.warning(
-                "heartbeats: latest_heartbeat(%s) raised; surfacing 503",
-                session_name,
-                exc_info=True,
-            )
-            raise service_unavailable(
-                f"heartbeats ledger unavailable while reading session "
-                f"{session_name!r}: {exc.__class__.__name__}",
-                hint=(
-                    "The Postgres heartbeats facade is unreachable. "
-                    "Retry shortly; check `pm doctor` and pg pool health."
-                ),
-            ) from exc
-        rows.append(_row_to_latest(
+    Performance contract (pinned by
+    ``test_list_heartbeats_uses_bulk_query``): exactly ONE
+    ``pg_heartbeats`` query for N sessions, not N. The previous loop
+    was an N+1 read that hurt dashboard polling at session counts
+    >~10. See PR #2055 round 1.
+    """
+    from pollypm.storage.pg_heartbeats import (
+        latest_heartbeats_bulk as _latest_bulk,
+    )
+
+    session_names = _configured_session_names(config)
+    try:
+        records_by_name = _latest_bulk(session_names, config=config)
+    except Exception as exc:  # noqa: BLE001 — typed translation below
+        logger.warning(
+            "heartbeats: latest_heartbeats_bulk(%d sessions) raised; "
+            "surfacing 503",
+            len(session_names),
+            exc_info=True,
+        )
+        raise service_unavailable(
+            f"heartbeats ledger unavailable while listing "
+            f"{len(session_names)} session(s): {exc.__class__.__name__}",
+            hint=(
+                "The Postgres heartbeats facade is unreachable. "
+                "Retry shortly; check `pm doctor` and pg pool health."
+            ),
+        ) from exc
+
+    rows = [
+        _row_to_latest(
             config=config,
             session_name=session_name,
-            row=record,
-        ))
+            # Sessions missing from the bulk result have never reported
+            # in — map to None so ``_row_to_latest`` produces an
+            # ``initializing`` row (matches the previous per-session
+            # ``latest_heartbeat() -> None`` behaviour).
+            row=records_by_name.get(session_name),
+        )
+        for session_name in session_names
+    ]
     return HeartbeatsListResponse(heartbeats=rows)
 
 

--- a/src/pollypm/web_api/routes/heartbeats.py
+++ b/src/pollypm/web_api/routes/heartbeats.py
@@ -1,0 +1,409 @@
+"""Heartbeats GET endpoints (Phase 2 — §11 of the endpoints spec).
+
+Implements:
+
+- ``GET /api/v1/heartbeats`` — latest heartbeat row per configured
+  session.
+- ``GET /api/v1/heartbeats/{session_name}`` — single-session detail
+  with the recent-tick history attached.
+
+Reads-only — pg-only paths via the canonical
+:mod:`pollypm.storage.pg_heartbeats` facade so the surface composes
+with the cockpit / ``pm sessions`` / supervisor without becoming a
+second reader implementation. Phase 2 §11.1 also lists an SSE stream
+endpoint; that ships separately (see follow-up) so this PR stays
+focused on the read-side surface.
+
+The route classifies each session into ``healthy`` / ``stale`` /
+``unknown`` / ``initializing`` using the same 5-minute staleness
+threshold as :mod:`pollypm.cli_features.sessions_health` so the API
+agrees with the CLI summary verbatim.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+
+from pollypm.web_api.errors import not_found, service_unavailable
+from pollypm.web_api.routes._deps import ConfigDep
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Heartbeats"])
+
+
+# ---------------------------------------------------------------------------
+# Classification thresholds (kept in sync with sessions_health.py — picked
+# once, used everywhere)
+# ---------------------------------------------------------------------------
+
+
+# Heartbeats older than this are classified ``stale``. Five minutes
+# matches the cockpit-inbox "stuck pane" threshold and the watchdog's
+# escalation cadence.
+_STALE_HEARTBEAT_SECONDS = 5 * 60
+
+
+# Default + max for the per-session ``?limit`` query on the detail
+# endpoint. ``pg_heartbeats.recent_heartbeats`` accepts any positive
+# integer; we clamp at the route layer so a frontend can't ask for a
+# million rows in one shot (spec §11.3 — clamp without erroring).
+_DEFAULT_HISTORY_LIMIT = 20
+_MAX_HISTORY_LIMIT = 200
+
+
+# ---------------------------------------------------------------------------
+# Response models (spec §11.2)
+# ---------------------------------------------------------------------------
+
+
+class HeartbeatLatest(BaseModel):
+    """Latest heartbeat snapshot for one session (spec §11.2).
+
+    ``last_tick_ts`` is ``None`` for sessions that have never reported
+    in — the route flips ``status`` to ``"initializing"`` for that
+    case so the caller doesn't conflate a brand-new session with a
+    stale one (spec §11.3 edge case).
+    """
+
+    session_name: str
+    role: str | None = None
+    project: str | None = None
+    status: str
+    last_tick_ts: str | None = None
+    age_seconds: int | None = None
+    pane_command: str | None = None
+    pane_dead: bool = False
+    log_bytes: int = 0
+    snapshot_path: str | None = None
+    snapshot_hash: str | None = None
+    tmux_window: str | None = None
+    pane_id: str | None = None
+
+
+class HeartbeatTick(BaseModel):
+    """One raw heartbeat row from the history table (spec §11.2)."""
+
+    ts: str
+    pane_command: str | None = None
+    pane_dead: bool = False
+    log_bytes: int = 0
+    snapshot_path: str | None = None
+    snapshot_hash: str | None = None
+    tmux_window: str | None = None
+    pane_id: str | None = None
+
+
+class HeartbeatsListResponse(BaseModel):
+    """``GET /api/v1/heartbeats`` envelope."""
+
+    heartbeats: list[HeartbeatLatest]
+
+
+class HeartbeatDetailResponse(BaseModel):
+    """``GET /api/v1/heartbeats/{session_name}`` envelope.
+
+    ``ticks`` is the most-recent ``limit`` rows, newest first. ``clamped``
+    is ``True`` when the caller's ``?limit`` exceeded
+    :data:`_MAX_HISTORY_LIMIT` and the route silently clamped (spec
+    §11.3 — clamp without erroring).
+    """
+
+    latest: HeartbeatLatest
+    ticks: list[HeartbeatTick]
+    clamped: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _age_seconds(iso_timestamp: str | None) -> int | None:
+    """Return integer seconds since ``iso_timestamp`` or ``None``.
+
+    Returns ``None`` when the timestamp is missing or unparseable —
+    callers treat that as ``unknown`` (or ``initializing`` when no row
+    exists at all, see :func:`_classify_status`).
+    """
+    if not iso_timestamp:
+        return None
+    try:
+        when = datetime.fromisoformat(iso_timestamp)
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    return int(max(0, (datetime.now(UTC) - when).total_seconds()))
+
+
+def _classify_status(
+    *,
+    has_record: bool,
+    age_seconds: int | None,
+) -> str:
+    """Map ``(record-exists?, age)`` to one of the spec's status strings.
+
+    Mirrors :func:`pollypm.cli_features.sessions_health._classify_status`
+    minus the ``missing`` (no tmux window) branch — heartbeats endpoint
+    doesn't probe tmux, only the ledger. The supervisor-side health
+    cascade adds the window-present check; the API surface stays
+    storage-only so a tmux outage doesn't 500 the read.
+    """
+    if not has_record:
+        return "initializing"
+    if age_seconds is None:
+        return "unknown"
+    if age_seconds > _STALE_HEARTBEAT_SECONDS:
+        return "stale"
+    return "healthy"
+
+
+def _session_meta(config, session_name: str) -> tuple[str | None, str | None]:
+    """Return ``(role, project)`` from the config or ``(None, None)``.
+
+    Used to enrich heartbeat rows so a single GET answers "which session
+    is this? which project does it belong to?" without the caller
+    having to cross-reference ``GET /chat/sessions``.
+    """
+    sessions = getattr(config, "sessions", {}) or {}
+    session = sessions.get(session_name)
+    if session is None:
+        return (None, None)
+    return (
+        getattr(session, "role", None),
+        getattr(session, "project", None),
+    )
+
+
+def _row_to_latest(
+    *,
+    config,
+    session_name: str,
+    row,
+) -> HeartbeatLatest:
+    """Pack a :class:`HeartbeatRecord` (or ``None``) into a wire row."""
+    role, project = _session_meta(config, session_name)
+    if row is None:
+        return HeartbeatLatest(
+            session_name=session_name,
+            role=role,
+            project=project,
+            status=_classify_status(has_record=False, age_seconds=None),
+        )
+    created_at = getattr(row, "created_at", None)
+    age = _age_seconds(created_at)
+    return HeartbeatLatest(
+        session_name=session_name,
+        role=role,
+        project=project,
+        status=_classify_status(has_record=True, age_seconds=age),
+        last_tick_ts=created_at,
+        age_seconds=age,
+        pane_command=getattr(row, "pane_command", None),
+        pane_dead=bool(getattr(row, "pane_dead", False)),
+        log_bytes=int(getattr(row, "log_bytes", 0) or 0),
+        snapshot_path=getattr(row, "snapshot_path", None),
+        snapshot_hash=getattr(row, "snapshot_hash", None),
+        tmux_window=getattr(row, "tmux_window", None),
+        pane_id=getattr(row, "pane_id", None),
+    )
+
+
+def _row_to_tick(row) -> HeartbeatTick:
+    return HeartbeatTick(
+        ts=getattr(row, "created_at", "") or "",
+        pane_command=getattr(row, "pane_command", None),
+        pane_dead=bool(getattr(row, "pane_dead", False)),
+        log_bytes=int(getattr(row, "log_bytes", 0) or 0),
+        snapshot_path=getattr(row, "snapshot_path", None),
+        snapshot_hash=getattr(row, "snapshot_hash", None),
+        tmux_window=getattr(row, "tmux_window", None),
+        pane_id=getattr(row, "pane_id", None),
+    )
+
+
+def _configured_session_names(config) -> list[str]:
+    """Return the list of session names to enumerate.
+
+    Honors ``enabled`` on each :class:`pollypm.models.SessionConfig` so
+    a disabled session doesn't appear with status ``initializing`` (it
+    would be misleading — disabled sessions never run, so the ledger
+    not having a row for them is correct, not a bug). Returned sorted
+    for stable ordering.
+    """
+    sessions = getattr(config, "sessions", {}) or {}
+    return sorted(
+        name
+        for name, session in sessions.items()
+        if getattr(session, "enabled", True)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/heartbeats",
+    response_model=HeartbeatsListResponse,
+    summary="Latest heartbeat per configured session",
+    operation_id="listHeartbeats",
+)
+def list_heartbeats_endpoint(config: ConfigDep) -> HeartbeatsListResponse:
+    """GET /api/v1/heartbeats — one ``HeartbeatLatest`` row per session.
+
+    Sessions that have never reported in get ``status="initializing"``
+    and ``last_tick_ts=null``. Disabled sessions are filtered out
+    (their absence from the ledger is correct, not a bug).
+
+    Backing-store outages bubble as 503 ``service_unavailable`` so the
+    caller can retry; we don't paper over a pg-pool outage with an
+    empty list because that would tell the cockpit "every session is
+    initializing" which is dangerously misleading.
+    """
+    from pollypm.storage.pg_heartbeats import latest_heartbeat as _latest
+
+    rows: list[HeartbeatLatest] = []
+    for session_name in _configured_session_names(config):
+        try:
+            record = _latest(session_name, config=config)
+        except Exception as exc:  # noqa: BLE001 — typed translation below
+            logger.warning(
+                "heartbeats: latest_heartbeat(%s) raised; surfacing 503",
+                session_name,
+                exc_info=True,
+            )
+            raise service_unavailable(
+                f"heartbeats ledger unavailable while reading session "
+                f"{session_name!r}: {exc.__class__.__name__}",
+                hint=(
+                    "The Postgres heartbeats facade is unreachable. "
+                    "Retry shortly; check `pm doctor` and pg pool health."
+                ),
+            ) from exc
+        rows.append(_row_to_latest(
+            config=config,
+            session_name=session_name,
+            row=record,
+        ))
+    return HeartbeatsListResponse(heartbeats=rows)
+
+
+@router.get(
+    "/heartbeats/{session_name}",
+    response_model=HeartbeatDetailResponse,
+    summary="Latest heartbeat + recent history for one session",
+    operation_id="getHeartbeat",
+)
+def get_heartbeat_endpoint(
+    session_name: str,
+    config: ConfigDep,
+    limit: Annotated[int, Query(
+        ge=1,
+        # No ``le=`` — spec §11.3 says clamp rather than 422 so a
+        # cockpit pull with ``?limit=500`` succeeds with ``clamped:true``
+        # instead of asking the user to retune their query.
+        description=(
+            f"Max history ticks (default {_DEFAULT_HISTORY_LIMIT}, "
+            f"clamped at {_MAX_HISTORY_LIMIT})."
+        ),
+    )] = _DEFAULT_HISTORY_LIMIT,
+) -> HeartbeatDetailResponse:
+    """GET /api/v1/heartbeats/{session_name} — detail + recent ticks.
+
+    404 ``not_found`` when ``session_name`` is neither in the config
+    nor in the heartbeats ledger — i.e. nothing in the system has ever
+    heard of that session. Configured-but-never-reported sessions get
+    a 200 with ``status="initializing"`` and an empty ``ticks`` list.
+    """
+    from pollypm.storage.pg_heartbeats import (
+        latest_heartbeat as _latest,
+        recent_heartbeats as _recent,
+    )
+
+    clamped = False
+    effective_limit = limit
+    if effective_limit > _MAX_HISTORY_LIMIT:
+        effective_limit = _MAX_HISTORY_LIMIT
+        clamped = True
+
+    configured = _configured_session_names(config)
+    is_configured = session_name in configured
+
+    try:
+        latest_row = _latest(session_name, config=config)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "heartbeats: latest_heartbeat(%s) raised; surfacing 503",
+            session_name,
+            exc_info=True,
+        )
+        raise service_unavailable(
+            f"heartbeats ledger unavailable while reading session "
+            f"{session_name!r}: {exc.__class__.__name__}",
+            hint=(
+                "The Postgres heartbeats facade is unreachable. "
+                "Retry shortly; check `pm doctor` and pg pool health."
+            ),
+        ) from exc
+
+    if not is_configured and latest_row is None:
+        raise not_found(
+            f"No heartbeat ledger entry or configured session named "
+            f"{session_name!r}.",
+            hint=(
+                "Use GET /api/v1/heartbeats to discover sessions the "
+                "supervisor has heard from, or check config.sessions."
+            ),
+        )
+
+    latest = _row_to_latest(
+        config=config,
+        session_name=session_name,
+        row=latest_row,
+    )
+
+    try:
+        history_rows = _recent(
+            session_name,
+            effective_limit,
+            config=config,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "heartbeats: recent_heartbeats(%s) raised; surfacing 503",
+            session_name,
+            exc_info=True,
+        )
+        raise service_unavailable(
+            f"heartbeats history unavailable for session "
+            f"{session_name!r}: {exc.__class__.__name__}",
+            hint=(
+                "The Postgres heartbeats facade is unreachable. "
+                "Retry shortly; check `pm doctor` and pg pool health."
+            ),
+        ) from exc
+
+    return HeartbeatDetailResponse(
+        latest=latest,
+        ticks=[_row_to_tick(row) for row in history_rows],
+        clamped=clamped,
+    )
+
+
+__all__ = [
+    "HeartbeatDetailResponse",
+    "HeartbeatLatest",
+    "HeartbeatTick",
+    "HeartbeatsListResponse",
+    "get_heartbeat_endpoint",
+    "list_heartbeats_endpoint",
+    "router",
+]

--- a/src/pollypm/web_api/routes/heartbeats.py
+++ b/src/pollypm/web_api/routes/heartbeats.py
@@ -23,12 +23,12 @@ agrees with the CLI summary verbatim.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel
 
+from pollypm import session_health
 from pollypm.web_api.errors import not_found, service_unavailable
 from pollypm.web_api.routes._deps import ConfigDep
 
@@ -38,15 +38,13 @@ router = APIRouter(tags=["Heartbeats"])
 
 
 # ---------------------------------------------------------------------------
-# Classification thresholds (kept in sync with sessions_health.py — picked
-# once, used everywhere)
+# Classification — delegated to the shared :mod:`pollypm.session_health`
+# helper layer (Codex PR #2055 round 2). The heartbeat staleness threshold
+# and the ``healthy`` / ``stale`` / ``unknown`` predicate are owned there
+# so the API and ``pm sessions`` CLI cannot drift. We keep ONLY the
+# endpoint-specific ``initializing`` override here — when no ledger row
+# exists at all, that's a brand-new session, not a stale one.
 # ---------------------------------------------------------------------------
-
-
-# Heartbeats older than this are classified ``stale``. Five minutes
-# matches the cockpit-inbox "stuck pane" threshold and the watchdog's
-# escalation cadence.
-_STALE_HEARTBEAT_SECONDS = 5 * 60
 
 
 # Default + max for the per-session ``?limit`` query on the detail
@@ -124,24 +122,6 @@ class HeartbeatDetailResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _age_seconds(iso_timestamp: str | None) -> int | None:
-    """Return integer seconds since ``iso_timestamp`` or ``None``.
-
-    Returns ``None`` when the timestamp is missing or unparseable —
-    callers treat that as ``unknown`` (or ``initializing`` when no row
-    exists at all, see :func:`_classify_status`).
-    """
-    if not iso_timestamp:
-        return None
-    try:
-        when = datetime.fromisoformat(iso_timestamp)
-    except (TypeError, ValueError):
-        return None
-    if when.tzinfo is None:
-        when = when.replace(tzinfo=UTC)
-    return int(max(0, (datetime.now(UTC) - when).total_seconds()))
-
-
 def _classify_status(
     *,
     has_record: bool,
@@ -149,19 +129,27 @@ def _classify_status(
 ) -> str:
     """Map ``(record-exists?, age)`` to one of the spec's status strings.
 
-    Mirrors :func:`pollypm.cli_features.sessions_health._classify_status`
-    minus the ``missing`` (no tmux window) branch — heartbeats endpoint
-    doesn't probe tmux, only the ledger. The supervisor-side health
-    cascade adds the window-present check; the API surface stays
-    storage-only so a tmux outage doesn't 500 the read.
+    Single-source delegation to
+    :func:`pollypm.session_health.classify_status` (Codex PR #2055 round
+    2) — the ``healthy`` / ``stale`` / ``unknown`` threshold is owned
+    there. We layer ONE endpoint-specific override on top: when no
+    ledger row exists at all, return ``"initializing"`` so the caller
+    doesn't conflate a brand-new session with a stale one (spec §11.3
+    edge case). Heartbeats endpoint doesn't probe tmux, so we always
+    pass ``window_present=True`` — the supervisor-side health cascade
+    adds the window-present check; the API stays storage-only so a tmux
+    outage doesn't 500 a read.
+
+    Resolved through the ``session_health`` module attribute (not a
+    bound name) so test patches on
+    ``pollypm.session_health.classify_status`` flow through verbatim.
     """
     if not has_record:
         return "initializing"
-    if age_seconds is None:
-        return "unknown"
-    if age_seconds > _STALE_HEARTBEAT_SECONDS:
-        return "stale"
-    return "healthy"
+    return session_health.classify_status(
+        window_present=True,
+        age_seconds=age_seconds,
+    )
 
 
 def _session_meta(config, session_name: str) -> tuple[str | None, str | None]:
@@ -197,7 +185,7 @@ def _row_to_latest(
             status=_classify_status(has_record=False, age_seconds=None),
         )
     created_at = getattr(row, "created_at", None)
-    age = _age_seconds(created_at)
+    age = session_health.age_seconds(created_at)
     return HeartbeatLatest(
         session_name=session_name,
         role=role,

--- a/tests/test_heartbeats_endpoint.py
+++ b/tests/test_heartbeats_endpoint.py
@@ -446,6 +446,51 @@ def test_list_heartbeats_missing_sessions_show_initializing(
         assert row["age_seconds"] is None
 
 
+def test_heartbeat_status_uses_shared_classify(
+    client, auth_headers, monkeypatch,
+):
+    """Regression: heartbeats endpoint delegates to ``session_health.classify_status``.
+
+    Codex PR #2055 round 2 caught that the route had reimplemented the
+    ``healthy`` / ``stale`` / ``unknown`` predicate locally, drifting
+    from the canonical :mod:`pollypm.session_health` source of truth.
+    Patch the shared classifier to return a sentinel string and confirm
+    the endpoint surfaces it verbatim — proving the route reads through
+    the shared helper rather than a private copy. If a future refactor
+    reintroduces a local predicate, this test fails immediately.
+
+    The "no ledger row" override (``initializing``) remains endpoint-
+    specific (see :func:`_classify_status` in
+    :mod:`pollypm.web_api.routes.heartbeats`); the sentinel here covers
+    only the rows-present path that delegates to the shared helper.
+    """
+    from pollypm import session_health as _session_health
+
+    captured: list[dict] = []
+
+    def fake_classify(*, window_present: bool, age_seconds):
+        captured.append(
+            {"window_present": window_present, "age_seconds": age_seconds},
+        )
+        return "sentinel-status"
+
+    monkeypatch.setattr(_session_health, "classify_status", fake_classify)
+    _install_latest_bulk(monkeypatch, by_session={
+        "operator": _record("operator", age_seconds=15),
+    })
+    body = client.get("/api/v1/heartbeats", headers=auth_headers).json()
+    statuses = {row["session_name"]: row["status"] for row in body["heartbeats"]}
+    # Row-present session goes through the patched classifier.
+    assert statuses["operator"] == "sentinel-status"
+    # The endpoint-specific override still wins for rows-absent.
+    assert statuses["architect_myproj"] == "initializing"
+    # The route called the shared classifier with the storage-only
+    # contract: window_present=True (no tmux probe), age_seconds=int.
+    assert captured, "classify_status was not invoked"
+    assert captured[0]["window_present"] is True
+    assert isinstance(captured[0]["age_seconds"], int)
+
+
 def test_list_heartbeats_requires_bearer_auth(client):
     response = client.get("/api/v1/heartbeats")
     assert response.status_code == 401

--- a/tests/test_heartbeats_endpoint.py
+++ b/tests/test_heartbeats_endpoint.py
@@ -214,6 +214,38 @@ def _install_latest(
     return calls
 
 
+def _install_latest_bulk(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    by_session: dict[str, HeartbeatRecord] | None = None,
+    raises: Exception | None = None,
+) -> list[list[str]]:
+    """Stub ``pg_heartbeats.latest_heartbeats_bulk`` for the route.
+
+    The list endpoint calls the bulk helper exactly once per request
+    (PR #2055 round 1 — N+1 → 1). Returns a list the stub appends each
+    invocation's ``session_names`` to so tests can pin the call count.
+    """
+    invocations: list[list[str]] = []
+    table = dict(by_session or {})
+
+    def fake(session_names, *, pool=None, config=None):  # noqa: ARG001
+        invocations.append(list(session_names))
+        if raises is not None:
+            raise raises
+        return {
+            name: rec
+            for name, rec in table.items()
+            if name in session_names
+        }
+
+    monkeypatch.setattr(
+        "pollypm.storage.pg_heartbeats.latest_heartbeats_bulk",
+        fake,
+    )
+    return invocations
+
+
 def _install_recent(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -245,7 +277,7 @@ def _install_recent(
 def test_list_heartbeats_happy_path_returns_row_per_session(
     client, auth_headers, monkeypatch,
 ):
-    calls = _install_latest(monkeypatch, by_session={
+    invocations = _install_latest_bulk(monkeypatch, by_session={
         "operator": _record("operator", age_seconds=15),
         "architect_myproj": _record("architect_myproj", age_seconds=30),
     })
@@ -255,7 +287,8 @@ def test_list_heartbeats_happy_path_returns_row_per_session(
     names = [row["session_name"] for row in body["heartbeats"]]
     # Sorted; "disabled_session" filtered out because enabled=False.
     assert names == ["architect_myproj", "operator"]
-    assert "disabled_session" not in calls
+    # Bulk helper is called once with the enabled-only set.
+    assert invocations == [["architect_myproj", "operator"]]
     # Statuses healthy when age <= 5min.
     statuses = {row["session_name"]: row["status"] for row in body["heartbeats"]}
     assert statuses == {"operator": "healthy", "architect_myproj": "healthy"}
@@ -272,7 +305,7 @@ def test_list_heartbeats_happy_path_returns_row_per_session(
 def test_list_heartbeats_classifies_stale_when_older_than_five_minutes(
     client, auth_headers, monkeypatch,
 ):
-    _install_latest(monkeypatch, by_session={
+    _install_latest_bulk(monkeypatch, by_session={
         "operator": _record("operator", age_seconds=600),  # 10 minutes
         "architect_myproj": _record("architect_myproj", age_seconds=30),
     })
@@ -286,7 +319,7 @@ def test_list_heartbeats_initializing_when_session_never_reported(
     client, auth_headers, monkeypatch,
 ):
     # ``operator`` has a record; ``architect_myproj`` does not.
-    _install_latest(monkeypatch, by_session={
+    _install_latest_bulk(monkeypatch, by_session={
         "operator": _record("operator", age_seconds=10),
     })
     body = client.get("/api/v1/heartbeats", headers=auth_headers).json()
@@ -307,21 +340,110 @@ def test_list_heartbeats_empty_when_no_sessions_configured(
     # Disable every configured session so the list collapses to empty.
     for session in config.sessions.values():
         session.enabled = False
-    calls = _install_latest(monkeypatch, by_session={})
+    invocations = _install_latest_bulk(monkeypatch, by_session={})
     body = client.get("/api/v1/heartbeats", headers=auth_headers).json()
     assert body == {"heartbeats": []}
-    assert calls == []
+    # Empty session list still calls the bulk helper once (it returns
+    # an empty dict without issuing a query — pinned in the unit
+    # test on the storage facade).
+    assert invocations == [[]]
 
 
 def test_list_heartbeats_facade_outage_returns_503(
     client, auth_headers, monkeypatch,
 ):
-    _install_latest(monkeypatch, raises=RuntimeError("pg pool exhausted"))
+    _install_latest_bulk(monkeypatch, raises=RuntimeError("pg pool exhausted"))
     response = client.get("/api/v1/heartbeats", headers=auth_headers)
     assert response.status_code == 503
     body = response.json()
     assert body["error"]["code"] == "service_unavailable"
     assert "ledger unavailable" in body["error"]["message"]
+
+
+def test_list_heartbeats_uses_bulk_query(
+    client, auth_headers, monkeypatch, config,
+):
+    """Regression: list endpoint issues ONE pg call for N sessions (not N).
+
+    Pins the PR #2055 round-1 fix — the previous implementation
+    looped ``latest_heartbeat`` once per session, an N+1 read that
+    hurt dashboard polling. If a future refactor reintroduces the
+    loop, this test fails immediately.
+    """
+    # Expand the configured-session set so N is unambiguously > 1.
+    base_session = next(iter(config.sessions.values()))
+    for i in range(5):
+        name = f"bulk_test_session_{i}"
+        config.sessions[name] = SessionConfig(
+            name=name,
+            role="advisor",
+            provider=base_session.provider,
+            account=base_session.account,
+            cwd=base_session.cwd,
+            project=base_session.project,
+            window_name=f"pm-bulk-{i}",
+        )
+    invocations = _install_latest_bulk(monkeypatch, by_session={})
+    response = client.get("/api/v1/heartbeats", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    # ONE bulk call for the whole list, not one per session.
+    assert len(invocations) == 1, (
+        f"expected 1 bulk call for N sessions, got {len(invocations)} "
+        f"(N+1 regression)"
+    )
+    # And it received every enabled session in the same shot.
+    received = set(invocations[0])
+    expected = {
+        name
+        for name, sess in config.sessions.items()
+        if getattr(sess, "enabled", True)
+    }
+    assert received == expected
+
+
+def test_list_heartbeats_missing_sessions_show_initializing(
+    client, auth_headers, monkeypatch, config,
+):
+    """Half the sessions report; the other half land as ``initializing``.
+
+    Confirms the bulk-helper -> route mapping fills the "no row yet"
+    gap with the same ``initializing`` sentinel the per-session loop
+    used before PR #2055 round 1.
+    """
+    base_session = next(iter(config.sessions.values()))
+    reported: dict[str, HeartbeatRecord] = {}
+    silent: list[str] = []
+    for i in range(6):
+        name = f"split_session_{i}"
+        config.sessions[name] = SessionConfig(
+            name=name,
+            role="advisor",
+            provider=base_session.provider,
+            account=base_session.account,
+            cwd=base_session.cwd,
+            project=base_session.project,
+            window_name=f"pm-split-{i}",
+        )
+        # Even-indexed sessions have a row; odd-indexed sessions don't.
+        if i % 2 == 0:
+            reported[name] = _record(name, age_seconds=30)
+        else:
+            silent.append(name)
+    _install_latest_bulk(monkeypatch, by_session=reported)
+    body = client.get("/api/v1/heartbeats", headers=auth_headers).json()
+    statuses = {row["session_name"]: row["status"] for row in body["heartbeats"]}
+    for name in reported:
+        assert statuses[name] == "healthy", (
+            f"reported session {name} should be healthy, got {statuses[name]}"
+        )
+    for name in silent:
+        assert statuses[name] == "initializing", (
+            f"silent session {name} should be initializing, got "
+            f"{statuses[name]}"
+        )
+        row = next(r for r in body["heartbeats"] if r["session_name"] == name)
+        assert row["last_tick_ts"] is None
+        assert row["age_seconds"] is None
 
 
 def test_list_heartbeats_requires_bearer_auth(client):

--- a/tests/test_heartbeats_endpoint.py
+++ b/tests/test_heartbeats_endpoint.py
@@ -1,0 +1,496 @@
+"""Integration tests for Phase 2 §11 heartbeats GET endpoints.
+
+Covers ``GET /api/v1/heartbeats`` and
+``GET /api/v1/heartbeats/{session_name}`` against the FastAPI
+``TestClient``. The route reads the ``pg_heartbeats`` facade; tests
+monkeypatch the two read functions (``latest_heartbeat`` /
+``recent_heartbeats``) on the route module so the suite never touches
+Postgres.
+
+Run with ``pytest --noconftest tests/test_heartbeats_endpoint.py -v
+--timeout=120`` so the per-project conftest (which requires a real pg
+harness) is skipped — these tests are self-contained.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.models import (
+    KnownProject,
+    ProjectKind,
+    ProviderKind,
+    RuntimeKind,
+    SessionConfig,
+)
+from pollypm.storage.records import HeartbeatRecord
+from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.routes import heartbeats as heartbeats_routes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def config(workspace: Path, project_root: Path) -> PollyPMConfig:
+    base_dir = workspace / ".pollypm"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator",
+                provider=ProviderKind.CLAUDE,
+                account="codex_primary",
+                cwd=workspace,
+                project="myproj",
+                window_name="pm-operator",
+            ),
+            "architect_myproj": SessionConfig(
+                name="architect_myproj",
+                role="architect",
+                provider=ProviderKind.CLAUDE,
+                account="codex_primary",
+                cwd=workspace,
+                project="myproj",
+                window_name="pm-architect-myproj",
+            ),
+            "disabled_session": SessionConfig(
+                name="disabled_session",
+                role="advisor",
+                provider=ProviderKind.CLAUDE,
+                account="codex_primary",
+                cwd=workspace,
+                project="myproj",
+                window_name="pm-disabled",
+                enabled=False,
+            ),
+        },
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def token(tmp_path: Path) -> tuple[Path, str]:
+    token_path = tmp_path / "api-token"
+    value, _ = ensure_token(token_path)
+    return token_path, value
+
+
+@pytest.fixture
+def auth_headers(token: tuple[Path, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token[1]}"}
+
+
+@pytest.fixture
+def client(config: PollyPMConfig, token: tuple[Path, str]) -> TestClient:
+    token_path, _ = token
+    app = create_app(config=config, token_path=token_path)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _record(
+    session_name: str,
+    *,
+    age_seconds: int = 10,
+    pane_dead: bool = False,
+    pane_command: str = "claude",
+    log_bytes: int = 1024,
+    snapshot_hash: str = "abc123",
+) -> HeartbeatRecord:
+    """Build a :class:`HeartbeatRecord` with a relative-age timestamp."""
+    ts = (datetime.now(UTC) - timedelta(seconds=age_seconds)).isoformat()
+    return HeartbeatRecord(
+        session_name=session_name,
+        tmux_window=f"pollypm-test-storage-closet:{session_name}",
+        pane_id="%42",
+        pane_command=pane_command,
+        pane_dead=pane_dead,
+        log_bytes=log_bytes,
+        snapshot_path=f"/tmp/snapshots/{session_name}.txt",
+        snapshot_hash=snapshot_hash,
+        created_at=ts,
+    )
+
+
+def _install_latest(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    by_session: dict[str, HeartbeatRecord | None] | None = None,
+    raises: Exception | None = None,
+) -> list[str]:
+    """Stub ``pg_heartbeats.latest_heartbeat`` for the route.
+
+    Routes import the symbol inside the function body, so we patch on
+    the source module (``pollypm.storage.pg_heartbeats``) and the
+    route's local rebinding resolves to the stub.
+
+    Returns a list the stub appends each session name to — handy for
+    asserting which sessions the endpoint enumerated.
+    """
+    calls: list[str] = []
+    table = dict(by_session or {})
+
+    def fake(session_name: str, *, pool=None, config=None):  # noqa: ARG001
+        calls.append(session_name)
+        if raises is not None:
+            raise raises
+        return table.get(session_name)
+
+    monkeypatch.setattr(
+        "pollypm.storage.pg_heartbeats.latest_heartbeat",
+        fake,
+    )
+    return calls
+
+
+def _install_recent(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    by_session: dict[str, list[HeartbeatRecord]] | None = None,
+    raises: Exception | None = None,
+) -> list[tuple[str, int]]:
+    """Stub ``pg_heartbeats.recent_heartbeats`` for the route."""
+    calls: list[tuple[str, int]] = []
+    table = dict(by_session or {})
+
+    def fake(session_name: str, limit: int = 3, *, pool=None, config=None):  # noqa: ARG001
+        calls.append((session_name, int(limit)))
+        if raises is not None:
+            raise raises
+        return list(table.get(session_name, []))
+
+    monkeypatch.setattr(
+        "pollypm.storage.pg_heartbeats.recent_heartbeats",
+        fake,
+    )
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# /heartbeats — list
+# ---------------------------------------------------------------------------
+
+
+def test_list_heartbeats_happy_path_returns_row_per_session(
+    client, auth_headers, monkeypatch,
+):
+    calls = _install_latest(monkeypatch, by_session={
+        "operator": _record("operator", age_seconds=15),
+        "architect_myproj": _record("architect_myproj", age_seconds=30),
+    })
+    response = client.get("/api/v1/heartbeats", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    names = [row["session_name"] for row in body["heartbeats"]]
+    # Sorted; "disabled_session" filtered out because enabled=False.
+    assert names == ["architect_myproj", "operator"]
+    assert "disabled_session" not in calls
+    # Statuses healthy when age <= 5min.
+    statuses = {row["session_name"]: row["status"] for row in body["heartbeats"]}
+    assert statuses == {"operator": "healthy", "architect_myproj": "healthy"}
+    # Role + project enrichment from config.
+    operator = next(row for row in body["heartbeats"] if row["session_name"] == "operator")
+    assert operator["role"] == "operator"
+    assert operator["project"] == "myproj"
+    assert operator["last_tick_ts"] is not None
+    assert operator["age_seconds"] is not None and operator["age_seconds"] >= 0
+    assert operator["pane_command"] == "claude"
+    assert operator["snapshot_hash"] == "abc123"
+
+
+def test_list_heartbeats_classifies_stale_when_older_than_five_minutes(
+    client, auth_headers, monkeypatch,
+):
+    _install_latest(monkeypatch, by_session={
+        "operator": _record("operator", age_seconds=600),  # 10 minutes
+        "architect_myproj": _record("architect_myproj", age_seconds=30),
+    })
+    body = client.get("/api/v1/heartbeats", headers=auth_headers).json()
+    statuses = {row["session_name"]: row["status"] for row in body["heartbeats"]}
+    assert statuses["operator"] == "stale"
+    assert statuses["architect_myproj"] == "healthy"
+
+
+def test_list_heartbeats_initializing_when_session_never_reported(
+    client, auth_headers, monkeypatch,
+):
+    # ``operator`` has a record; ``architect_myproj`` does not.
+    _install_latest(monkeypatch, by_session={
+        "operator": _record("operator", age_seconds=10),
+    })
+    body = client.get("/api/v1/heartbeats", headers=auth_headers).json()
+    statuses = {row["session_name"]: row["status"] for row in body["heartbeats"]}
+    assert statuses["operator"] == "healthy"
+    assert statuses["architect_myproj"] == "initializing"
+    arch = next(
+        row for row in body["heartbeats"]
+        if row["session_name"] == "architect_myproj"
+    )
+    assert arch["last_tick_ts"] is None
+    assert arch["age_seconds"] is None
+
+
+def test_list_heartbeats_empty_when_no_sessions_configured(
+    client, auth_headers, monkeypatch, config,
+):
+    # Disable every configured session so the list collapses to empty.
+    for session in config.sessions.values():
+        session.enabled = False
+    calls = _install_latest(monkeypatch, by_session={})
+    body = client.get("/api/v1/heartbeats", headers=auth_headers).json()
+    assert body == {"heartbeats": []}
+    assert calls == []
+
+
+def test_list_heartbeats_facade_outage_returns_503(
+    client, auth_headers, monkeypatch,
+):
+    _install_latest(monkeypatch, raises=RuntimeError("pg pool exhausted"))
+    response = client.get("/api/v1/heartbeats", headers=auth_headers)
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["code"] == "service_unavailable"
+    assert "ledger unavailable" in body["error"]["message"]
+
+
+def test_list_heartbeats_requires_bearer_auth(client):
+    response = client.get("/api/v1/heartbeats")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] in {"unauthorized", "invalid_token"}
+
+
+def test_list_heartbeats_rejects_wrong_token(client):
+    response = client.get(
+        "/api/v1/heartbeats",
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
+
+
+# ---------------------------------------------------------------------------
+# /heartbeats/{session_name} — detail
+# ---------------------------------------------------------------------------
+
+
+def test_detail_returns_latest_plus_history(
+    client, auth_headers, monkeypatch,
+):
+    latest = _record("operator", age_seconds=10, snapshot_hash="latest")
+    history = [
+        _record("operator", age_seconds=10, snapshot_hash="latest"),
+        _record("operator", age_seconds=20, snapshot_hash="prev1"),
+        _record("operator", age_seconds=30, snapshot_hash="prev2"),
+    ]
+    _install_latest(monkeypatch, by_session={"operator": latest})
+    recent_calls = _install_recent(
+        monkeypatch, by_session={"operator": history},
+    )
+    response = client.get(
+        "/api/v1/heartbeats/operator?limit=10", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["latest"]["session_name"] == "operator"
+    assert body["latest"]["status"] == "healthy"
+    assert body["latest"]["snapshot_hash"] == "latest"
+    assert len(body["ticks"]) == 3
+    hashes = [tick["snapshot_hash"] for tick in body["ticks"]]
+    assert hashes == ["latest", "prev1", "prev2"]
+    assert body["clamped"] is False
+    assert recent_calls == [("operator", 10)]
+
+
+def test_detail_404_when_session_unknown(
+    client, auth_headers, monkeypatch,
+):
+    _install_latest(monkeypatch, by_session={})
+    _install_recent(monkeypatch, by_session={})
+    response = client.get(
+        "/api/v1/heartbeats/does-not-exist", headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_detail_returns_initializing_for_configured_but_silent_session(
+    client, auth_headers, monkeypatch,
+):
+    # Session exists in config but no row in ledger → status=initializing,
+    # ticks=[]. NOT a 404.
+    _install_latest(monkeypatch, by_session={})
+    _install_recent(monkeypatch, by_session={})
+    response = client.get(
+        "/api/v1/heartbeats/operator", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["latest"]["session_name"] == "operator"
+    assert body["latest"]["status"] == "initializing"
+    assert body["latest"]["last_tick_ts"] is None
+    assert body["ticks"] == []
+
+
+def test_detail_returns_detail_for_unconfigured_session_with_ledger_row(
+    client, auth_headers, monkeypatch,
+):
+    # Session is not in config (e.g. a worker that's since been
+    # reaped) but the ledger remembers it — return the row, don't 404.
+    ghost = _record("task-myproj-9", age_seconds=120)
+    _install_latest(monkeypatch, by_session={"task-myproj-9": ghost})
+    _install_recent(monkeypatch, by_session={"task-myproj-9": [ghost]})
+    response = client.get(
+        "/api/v1/heartbeats/task-myproj-9", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["latest"]["session_name"] == "task-myproj-9"
+    # No config row → role/project come back as null.
+    assert body["latest"]["role"] is None
+    assert body["latest"]["project"] is None
+    assert len(body["ticks"]) == 1
+
+
+def test_detail_clamps_limit_at_max(
+    client, auth_headers, monkeypatch,
+):
+    _install_latest(monkeypatch, by_session={
+        "operator": _record("operator", age_seconds=5),
+    })
+    recent_calls = _install_recent(monkeypatch, by_session={"operator": []})
+    response = client.get(
+        "/api/v1/heartbeats/operator?limit=1000", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["clamped"] is True
+    # Route should pass the clamped value (200) to the facade.
+    assert recent_calls == [("operator", 200)]
+
+
+def test_detail_facade_outage_on_latest_returns_503(
+    client, auth_headers, monkeypatch,
+):
+    _install_latest(monkeypatch, raises=RuntimeError("pg unreachable"))
+    _install_recent(monkeypatch, by_session={})
+    response = client.get(
+        "/api/v1/heartbeats/operator", headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "service_unavailable"
+
+
+def test_detail_facade_outage_on_history_returns_503(
+    client, auth_headers, monkeypatch,
+):
+    _install_latest(monkeypatch, by_session={
+        "operator": _record("operator", age_seconds=5),
+    })
+    _install_recent(monkeypatch, raises=RuntimeError("pg recent unreachable"))
+    response = client.get(
+        "/api/v1/heartbeats/operator", headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "service_unavailable"
+
+
+def test_detail_requires_bearer_auth(client):
+    response = client.get("/api/v1/heartbeats/operator")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] in {"unauthorized", "invalid_token"}
+
+
+def test_detail_rejects_invalid_limit_below_one(
+    client, auth_headers, monkeypatch,
+):
+    _install_latest(monkeypatch, by_session={})
+    _install_recent(monkeypatch, by_session={})
+    response = client.get(
+        "/api/v1/heartbeats/operator?limit=0", headers=auth_headers,
+    )
+    # Pydantic ``ge=1`` rejects via the spec's 422 envelope.
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
+# ---------------------------------------------------------------------------
+# Module sanity
+# ---------------------------------------------------------------------------
+
+
+def test_router_module_exports_expected_handlers():
+    """Smoke test: the route module surfaces its handlers."""
+    assert hasattr(heartbeats_routes, "list_heartbeats_endpoint")
+    assert hasattr(heartbeats_routes, "get_heartbeat_endpoint")
+    assert heartbeats_routes.router is not None

--- a/tests/test_pg_heartbeats.py
+++ b/tests/test_pg_heartbeats.py
@@ -116,6 +116,58 @@ def test_pg_heartbeats_per_session_isolation(pg_schema_pool):
     assert len(recent_heartbeats("missing", pool=pg_schema_pool)) == 0
 
 
+def test_pg_heartbeats_latest_bulk_returns_one_row_per_session(pg_schema_pool):
+    """latest_heartbeats_bulk: DISTINCT ON one row per session, single query."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_heartbeats import (
+        latest_heartbeats_bulk,
+        record_heartbeat,
+    )
+
+    # Two writes for alpha (latest wins), one for beta, zero for gamma.
+    for log_bytes in (100, 200):
+        record_heartbeat(
+            session_name="worker-alpha",
+            tmux_window="alpha",
+            pane_id="%1",
+            pane_command="claude",
+            pane_dead=False,
+            log_bytes=log_bytes,
+            snapshot_path="/a",
+            snapshot_hash=f"a{log_bytes}",
+            pool=pg_schema_pool,
+        )
+    record_heartbeat(
+        session_name="worker-beta",
+        tmux_window="beta",
+        pane_id="%2",
+        pane_command="codex",
+        pane_dead=False,
+        log_bytes=42,
+        snapshot_path="/b",
+        snapshot_hash="b42",
+        pool=pg_schema_pool,
+    )
+
+    result = latest_heartbeats_bulk(
+        ["worker-alpha", "worker-beta", "worker-gamma"],
+        pool=pg_schema_pool,
+    )
+    # gamma never reported — absent from result, NOT a None key.
+    assert set(result.keys()) == {"worker-alpha", "worker-beta"}
+    assert result["worker-alpha"].log_bytes == 200  # latest
+    assert result["worker-alpha"].snapshot_hash == "a200"
+    assert result["worker-beta"].log_bytes == 42
+
+
+def test_pg_heartbeats_latest_bulk_empty_input_no_query(pg_schema_pool):
+    """latest_heartbeats_bulk([]) returns {} without issuing a query."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_heartbeats import latest_heartbeats_bulk
+
+    assert latest_heartbeats_bulk([], pool=pg_schema_pool) == {}
+
+
 def test_pg_heartbeats_last_heartbeat_at_from_messages(pg_schema_pool):
     """last_heartbeat_at reads from ``messages`` (heartbeat sweep events)."""
     _apply_initial_migrations(pg_schema_pool)


### PR DESCRIPTION
## Summary

Phase 2 §11 surface — read-side heartbeats endpoints (small focused PR; SSE stream deferred to follow-up).

- `GET /api/v1/heartbeats` — one `HeartbeatLatest` row per enabled session; classifies `healthy` / `stale` / `initializing` / `unknown` using the same 5-minute threshold as `pm sessions` so the API agrees with the CLI summary verbatim.
- `GET /api/v1/heartbeats/{session_name}` — latest + recent-tick history (`?limit` defaults 20, clamps at 200 per §11.3 rather than 422'ing).
- All reads go through the canonical `pollypm.storage.pg_heartbeats` facade — pg-only paths, no parallel reader.

### Design choices (worth a look during review)

- Facade outages -> `503 service_unavailable` (callers can retry; we deliberately do NOT collapse a pg-pool outage to an empty list because that would tell the cockpit "every session is initializing").
- Configured-but-silent session -> 200 with `status="initializing"` (not 404) so a brand-new session isn't conflated with one that's missing.
- Unknown session (not in config, not in ledger) -> 404 `not_found`.
- Ledger-only ghost session (e.g. reaped worker) -> 200 with `role`/`project` null.
- `?limit` clamps silently at 200 (per spec §11.3) with `clamped: true` in the response.

## Spec gaps flagged

- §11.1 row 4: SSE stream endpoint is deliberately deferred to a separate follow-up PR (per mission brief).
- The spec calls out `last_verdict` / `last_reason` fields on `HeartbeatLatest`, but the current `pg_heartbeats` facade + `HeartbeatRecord` dataclass don't carry a verdict column — those are derived by the supervisor's classifier, not stored in the heartbeats ledger. I omitted those two fields rather than fabricate them; if Sam wants them, they'd need to surface from the supervisor cascade (separate work).

## Test plan

- [x] `pytest --noconftest tests/test_heartbeats_endpoint.py -v --timeout=120` — 17 passed in 1.6s
- [x] `tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31` passes (OpenAPI doc still validates as 3.1)
- [x] `tests/web_api/test_openapi_conformance.py::test_implementation_openapi_validates_as_31` passes (auto-generated doc still valid)
- [x] `tests/web_api/test_openapi_conformance.py::test_contract_lists_phase_1_paths` passes (no regression to existing paths)

### Test cases covered (17)

- Happy paths: list + detail
- Status classification: healthy / stale / initializing
- Empty list when no sessions configured
- Disabled sessions filtered out
- 404 on truly-unknown session names
- Configured-but-silent session returns initializing (not 404)
- Ghost session in ledger but not config returns 200 with null role/project
- `?limit` clamping at 200
- Facade outage -> 503 on both list + detail endpoints
- Bearer auth required (list + detail)
- Wrong token -> 401 invalid_token
- `?limit=0` -> 422 validation_error

🤖 Generated with [Claude Code](https://claude.com/claude-code)