### PR TITLE
feat(api): GET /api/v1/config[/projects/{key}] — Phase 2 read-only config (secrets redacted)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -916,8 +916,13 @@ paths:
         - **Name-substring match (case-insensitive):** any field whose
           key contains `api_key`, `apikey`, `token`, `secret`,
           `password`, `passwd`, `pwd`, `auth`, `private_key`,
-          `credential`, `credentials`, `access_key`, `pat`, `dsn`, or
+          `credential`, `credentials`, `access_key`, `dsn`, or
           `database_url`.
+        - **Name — exact / suffix match (case-insensitive):** keys
+          ending in `_PAT` (e.g. `GITHUB_PAT`, `GITLAB_PAT`), plus the
+          specific names `GITHUB_PAT` and `GITHUB_TOKEN`. The boundary
+          check keeps ordinary path keys (`path`, `project_path`,
+          `config_path`) visible.
         - **Value-shape — URL credentials:** values that parse as a
           URL with userinfo (`scheme://user:pass@host/...`) **or** with
           credential-bearing query params (`?password=...`,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -59,6 +59,13 @@ tags:
       recent messages, token usage, and account quotas. SSE streaming
       variant (`/dashboard/stream`) ships in a follow-up PR per Phase 2
       §3.2.
+  - name: Config
+    description: |
+      Read-only view of the loaded `PollyPMConfig`. Credential-shaped
+      fields (auth tokens, API keys, webhook secrets, anything matching
+      the redaction heuristic in `web_api/routes/config.py`) are replaced
+      with `"***"` before serialisation. Mutation is deferred to Phase 3
+      so config edits stay TOML-first and reviewable.
 
 paths:
   /health:
@@ -895,6 +902,52 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+
+  /config:
+    get:
+      tags: [Config]
+      operationId: getConfig
+      summary: Read the operator config (secrets redacted)
+      description: |
+        Returns the full loaded `PollyPMConfig` as a JSON-safe dict.
+        Every credential-shaped field — anything matching `auth`,
+        `token`, `secret`, `password`, `api_key`, `credential`,
+        `private_key` substrings in its name — is replaced with
+        `"***"` before the response leaves the process. Empty /
+        unset credential fields stay empty (so the operator can
+        distinguish "unset" from "hidden").
+      responses:
+        "200":
+          description: Redacted config snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConfigView"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /config/projects/{key}:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    get:
+      tags: [Config]
+      operationId: getProjectConfig
+      summary: Read one project's config block (secrets redacted)
+      description: |
+        Returns the `[projects.<key>]` config block as a flat dict.
+        Path-typed fields coerce to strings; enum fields to their
+        `.value`. Same redaction heuristic as `GET /config`.
+      responses:
+        "200":
+          description: Redacted per-project config block.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectConfigView"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /events:
     get:
@@ -2075,3 +2128,29 @@ components:
         actor: pm
         status: done
         metadata: {}
+
+    # ---- Config (Phase 2 §13, read-only) ----------------------------
+    ConfigView:
+      type: object
+      required: [config]
+      properties:
+        config:
+          type: object
+          additionalProperties: true
+          description: |
+            Redacted snapshot of the loaded `PollyPMConfig`. Shape is
+            open-ended (the underlying dataclass grows over time);
+            credential-shaped fields are replaced with `"***"`, paths
+            are strings, enums are their `.value`.
+    ProjectConfigView:
+      type: object
+      required: [key, project]
+      properties:
+        key:
+          type: string
+          description: Project key (slug) the config block belongs to.
+        project:
+          type: object
+          additionalProperties: true
+          description: |
+            Redacted snapshot of the `[projects.<key>]` config block.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -909,13 +909,32 @@ paths:
       operationId: getConfig
       summary: Read the operator config (secrets redacted)
       description: |
-        Returns the full loaded `PollyPMConfig` as a JSON-safe dict.
-        Every credential-shaped field — anything matching `auth`,
-        `token`, `secret`, `password`, `api_key`, `credential`,
-        `private_key` substrings in its name — is replaced with
-        `"***"` before the response leaves the process. Empty /
-        unset credential fields stay empty (so the operator can
-        distinguish "unset" from "hidden").
+        Returns the loaded `PollyPMConfig` with credential-bearing
+        values redacted to `"***"` before the response leaves the
+        process. Redaction applies on three layers:
+
+        - **Name-substring match (case-insensitive):** any field whose
+          key contains `api_key`, `apikey`, `token`, `secret`,
+          `password`, `passwd`, `pwd`, `auth`, `private_key`,
+          `credential`, `credentials`, `access_key`, `pat`, `dsn`, or
+          `database_url`.
+        - **Value-shape — URL credentials:** values that parse as a
+          URL with userinfo (`scheme://user:pass@host/...`) **or** with
+          credential-bearing query params (`?password=...`,
+          `?token=...`, `?api_key=...`, `?auth=...`, etc.).
+        - **Value-shape — vendor credential prefixes:** AWS access
+          keys (`AKIA…` / `ASIA…`), GitHub personal/OAuth/user/server/
+          refresh tokens (`ghp_` / `gho_` / `ghu_` / `ghs_` / `ghr_` /
+          `github_pat_…`), and Slack tokens (`xox[abprs]-…`).
+        - **Value-shape — libpq keyword DSNs:** whitespace-delimited
+          connection strings carrying `password=` / `passwd=` / `pwd=`
+          / `passfile=` tokens (e.g.
+          `host=db.example dbname=pollypm user=alice password=secretpw`).
+
+        Empty / unset credential fields stay empty (so the operator
+        can distinguish "unset" from "hidden"). Keep this description
+        in sync with `web_api/routes/config.py` if new shapes are
+        added.
       responses:
         "200":
           description: Redacted config snapshot.

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -20,7 +20,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from pollypm.config import PollyPMConfig
+from pollypm.config import PollyPMConfig, load_config
 from pollypm.web_api.auth import (
     make_bearer_auth_dependency,
     make_sse_auth_dependency,
@@ -97,9 +97,40 @@ def create_app(
         expose_headers=["Last-Event-ID", "X-PollyPM-Warning"],
     )
 
-    # Wire the config provider so every endpoint shares the same
-    # in-memory config rather than each route reloading from disk.
-    app.dependency_overrides[_config_provider] = lambda: config
+    # Wire the config provider. When the loaded config carries the
+    # on-disk ``config_path`` (always true for ``pm serve``), re-invoke
+    # :func:`load_config` on each request so TOML edits propagate
+    # without a server restart. ``load_config`` has an mtime-keyed
+    # cache, so an unchanged file is a single ``stat`` call — no
+    # re-parse cost (Codex round-2 P0 on PR #2056: the old
+    # ``lambda: config`` returned a startup-frozen snapshot).
+    #
+    # The fallback (no ``config_path``) keeps the in-memory snapshot —
+    # tests build :class:`PollyPMConfig` directly and never set
+    # ``config_path``, and we don't want them to depend on a real
+    # TOML on disk.
+    config_path = getattr(config, "config_path", None)
+    if config_path is not None:
+
+        def _reload_config() -> PollyPMConfig:
+            try:
+                return load_config(config_path)
+            except Exception:
+                # Disk read failure (file deleted between requests,
+                # transient permission glitch, malformed TOML mid-edit).
+                # Fall back to the startup snapshot rather than 500ing
+                # the endpoint — the operator can still see what
+                # ``pm serve`` booted with.
+                logger.warning(
+                    "load_config(%s) failed; serving startup snapshot",
+                    config_path,
+                    exc_info=True,
+                )
+                return config
+
+        app.dependency_overrides[_config_provider] = _reload_config
+    else:
+        app.dependency_overrides[_config_provider] = lambda: config
 
     # Exception handlers — turn all error paths into the spec's body
     # shape.

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -33,6 +33,7 @@ from pollypm.web_api.errors import (
 )
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
 from pollypm.web_api.routes import chat_send as chat_send_routes
+from pollypm.web_api.routes import config as config_routes
 from pollypm.web_api.routes import dashboard as dashboard_routes
 from pollypm.web_api.routes import events as events_routes
 from pollypm.web_api.routes import health as health_routes
@@ -120,6 +121,9 @@ def create_app(
     app.include_router(tasks_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(inbox_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(dashboard_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
+    # Phase 2 surface §13 — read-only config endpoints. Mutation is
+    # deferred to Phase 3 per the spec; config edits stay TOML-first.
+    app.include_router(config_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(events_routes.router, prefix=API_V1_PREFIX, dependencies=sse_auth_deps)
     # P2 of the chat-endpoints spec — GET /api/v1/chat/sessions and
     # GET /api/v1/chat/{session_name}/messages. Sits under the same

--- a/src/pollypm/web_api/routes/config.py
+++ b/src/pollypm/web_api/routes/config.py
@@ -202,6 +202,51 @@ def _value_looks_credential(value: Any) -> bool:
     return any(pattern.match(value) for pattern in _CREDENTIAL_VALUE_PATTERNS)
 
 
+# libpq keyword DSN credential-bearing field names (lowercase). The
+# libpq docs (https://www.postgresql.org/docs/current/libpq-connect.html)
+# list ``password`` and ``passfile`` as the auth-carrying keywords;
+# common short aliases (``passwd``, ``pwd``) are accepted by some
+# wrappers and tools, so we treat them as DSN secrets too.
+_LIBPQ_SECRET_KEYS: frozenset[str] = frozenset(
+    {"password", "passwd", "pwd", "passfile"},
+)
+
+
+# Matches whitespace-delimited libpq keyword=value tokens. libpq's
+# format is ``<keyword>=<value>`` with the value either bare (no
+# whitespace) or single-quoted (backslash escapes allowed inside). We
+# only need the keyword (group 1) for the secret-name check.
+_LIBPQ_TOKEN_RE = re.compile(
+    r"(?:^|\s)([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*"
+    r"(?:'(?:[^'\\]|\\.)*'|[^\s'][^\s]*)"
+)
+
+
+def _value_looks_libpq_dsn(value: Any) -> bool:
+    """Return True iff ``value`` parses as a libpq keyword DSN that
+    carries a credential-bearing field (``password`` / ``passwd`` /
+    ``pwd`` / ``passfile``).
+
+    Codex round-3 P0 on PR #2056: ``PG_CONN = "host=db.example
+    dbname=pollypm user=alice password=secretpw"`` is a real libpq
+    connection string but the carrier key ``PG_CONN`` doesn't match
+    ``_looks_secret`` and the value isn't URL-shaped, so the prior
+    redactor leaked the raw password.
+
+    The 2-token minimum prevents false positives on trivial
+    ``key=value`` config (e.g. ``mode=production``). The key-name
+    allowlist keeps the check narrow — DSNs that don't carry password
+    fields (``host=db dbname=x user=alice sslmode=require``) pass
+    through unchanged so observability isn't hurt.
+    """
+    if not isinstance(value, str) or not value or "=" not in value:
+        return False
+    tokens = _LIBPQ_TOKEN_RE.findall(value)
+    if len(tokens) < 2:
+        return False
+    return any(token.lower() in _LIBPQ_SECRET_KEYS for token in tokens)
+
+
 def _coerce_value(value: Any) -> Any:
     """Coerce a single config value into a JSON-friendly shape.
 
@@ -236,6 +281,12 @@ def _coerce_value(value: Any) -> Any:
     # PATs, Slack tokens, …). Backstops env entries whose key names
     # don't include any credential keyword (Codex round-2 P0 on PR #2056).
     if _value_looks_credential(value):
+        return REDACTED
+    # libpq keyword DSNs (whitespace-delimited ``host=… password=…``).
+    # The carrier key (e.g. ``PG_CONN``) need not match ``_looks_secret``
+    # and the value isn't URL-shape, so this is the only check that
+    # catches the format. Codex round-3 P0 on PR #2056.
+    if _value_looks_libpq_dsn(value):
         return REDACTED
     return value
 

--- a/src/pollypm/web_api/routes/config.py
+++ b/src/pollypm/web_api/routes/config.py
@@ -1,0 +1,252 @@
+"""Read-only config endpoints (Phase 2, surface §13 of the endpoints spec).
+
+Implements:
+
+- ``GET /api/v1/config`` — the operator's whole :class:`PollyPMConfig`,
+  serialised to a JSON-safe dict with every credential-shaped field
+  redacted to ``"***"``.
+- ``GET /api/v1/config/projects/{key}`` — the same redaction applied to
+  a single ``[projects.<key>]`` block (the per-project config view from
+  ``KnownProject``).
+
+Per ``~/Desktop/pollypm-phase2-endpoints-spec.md`` §13 (Config,
+read-only): mutation is deferred to Phase 3 — config edits should
+remain TOML-first so the user can review diffs.
+
+The handler intentionally does not import any work-service / pg-pool
+plumbing. The config is already loaded by the app factory and handed
+to us via :data:`ConfigDep`; we only need to flatten it into a
+JSON-friendly shape and walk it once to redact secrets.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from pollypm.web_api.errors import not_found
+from pollypm.web_api.routes._deps import ConfigDep
+
+router = APIRouter(tags=["Config"])
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+# Sentinel string the redactor substitutes for any field whose name
+# matches the credential heuristic. Kept identical to the spec §13.2
+# example so clients can rely on the literal string.
+REDACTED = "***"
+
+
+# Field-name substrings (lowercase) that mark a value as
+# credential-shaped. The endpoint walks every nested dict key and
+# redacts the value when any of these appear as a substring. The list
+# is intentionally broader than just the documented examples
+# (``auth_token``, ``api_key``, ``webhook_secret``) — anything that
+# *smells* credential-shaped should not leave the process even if a
+# future config field slips through review (spec §13 mission note:
+# "any field that smells like a token/key/credential…").
+_SECRET_NAME_SUBSTRINGS: tuple[str, ...] = (
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "api_key",
+    "apikey",
+    "credential",
+    "private_key",
+    "auth",  # matches auth_token, basic_auth, oauth_*, etc.
+)
+
+
+def _looks_secret(field_name: str) -> bool:
+    """Return True iff ``field_name`` matches the credential heuristic.
+
+    Case-insensitive substring match against
+    :data:`_SECRET_NAME_SUBSTRINGS`. The match is deliberately
+    over-eager — false positives (redacting a non-secret field whose
+    name happens to contain ``"auth"``) are operationally fine; false
+    negatives (leaking a real secret) are not.
+    """
+    lower = field_name.lower()
+    return any(needle in lower for needle in _SECRET_NAME_SUBSTRINGS)
+
+
+def _coerce_value(value: Any) -> Any:
+    """Coerce a single config value into a JSON-friendly shape.
+
+    Handles the non-JSON-native types the config dataclasses use:
+
+    - :class:`pathlib.Path` → ``str``
+    - :class:`enum.Enum` (incl. :class:`enum.StrEnum`) → ``.value``
+    - ``tuple`` → ``list``
+    - dataclasses → ``dataclasses.asdict`` then recursed
+    - dicts / lists → recursed element-wise
+    - everything else returned as-is (FastAPI's JSON encoder handles
+      ``datetime`` / ``bytes`` / etc. if any sneak in later)
+    """
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Enum):
+        return value.value
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _redact_dict(dataclasses.asdict(value))
+    if isinstance(value, dict):
+        return _redact_dict(value)
+    if isinstance(value, (list, tuple)):
+        return [_coerce_value(item) for item in value]
+    return value
+
+
+def _redact_dict(data: dict[Any, Any]) -> dict[str, Any]:
+    """Walk ``data`` and redact every credential-shaped key.
+
+    A key is redacted when its name matches :func:`_looks_secret`. The
+    value is replaced with :data:`REDACTED` **only when the original
+    value is truthy** — empty strings / ``None`` stay as-is so the
+    operator can tell "field unset" from "field set, value hidden"
+    (legacy sessions intentionally hold ``auth_token=""`` per the
+    :class:`SessionConfig` docstring; redacting that to ``"***"`` would
+    misrepresent the on-disk state).
+
+    Nested dicts and dataclasses recurse through :func:`_coerce_value`,
+    so the redaction applies at every depth.
+    """
+    out: dict[str, Any] = {}
+    for raw_key, value in data.items():
+        key = str(raw_key)
+        if _looks_secret(key) and value not in (None, "", b""):
+            out[key] = REDACTED
+            continue
+        out[key] = _coerce_value(value)
+    return out
+
+
+def _serialise_config(config: Any) -> dict[str, Any]:
+    """Return the full :class:`PollyPMConfig` as a redacted dict.
+
+    ``dataclasses.asdict`` recursively unpacks every nested dataclass
+    into plain dicts; we then walk the result via :func:`_redact_dict`
+    to (a) coerce :class:`Path` / :class:`Enum` values and (b) replace
+    credential-shaped fields with :data:`REDACTED`.
+    """
+    raw = dataclasses.asdict(config)
+    return _redact_dict(raw)
+
+
+def _serialise_project(project: Any) -> dict[str, Any]:
+    """Return a single ``KnownProject`` block as a redacted dict.
+
+    Same shape as the per-project entries in ``GET /config``, but
+    returned standalone for ``GET /config/projects/{key}``.
+    """
+    raw = dataclasses.asdict(project)
+    return _redact_dict(raw)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class ConfigView(BaseModel):
+    """``GET /api/v1/config`` envelope.
+
+    ``config`` is the flattened :class:`PollyPMConfig` with secrets
+    redacted to ``"***"``. The shape is open-ended (the underlying
+    dataclass grows over time) so we declare it as ``dict[str, Any]``
+    rather than reflecting every nested field into a Pydantic model;
+    the redaction guarantee is implemented by the route, not the
+    schema.
+    """
+
+    config: dict[str, Any] = Field(
+        description=(
+            "Redacted snapshot of the loaded PollyPMConfig. "
+            "Credential-shaped fields (auth_token, api_key, "
+            "webhook_secret, …) are replaced with '***'."
+        ),
+    )
+
+
+class ProjectConfigView(BaseModel):
+    """``GET /api/v1/config/projects/{key}`` envelope.
+
+    ``project`` mirrors one ``[projects.<key>]`` TOML block as a
+    flat dict (the :class:`KnownProject` dataclass). Path-typed fields
+    are coerced to strings; enum fields to their ``.value``. Credentials
+    are redacted by the same heuristic the full-config endpoint uses.
+    """
+
+    key: str
+    project: dict[str, Any] = Field(
+        description=(
+            "Redacted snapshot of the [projects.<key>] config block."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/config",
+    response_model=ConfigView,
+    summary="Read the operator config (secrets redacted)",
+    operation_id="getConfig",
+)
+def get_config_endpoint(config: ConfigDep) -> ConfigView:
+    """GET /api/v1/config — full config with secrets redacted.
+
+    Implementation note (spec §13.2): the loaded :class:`PollyPMConfig`
+    instance is reused from the request's dependency injector — no
+    extra disk read. A config edit between two requests just shows on
+    the next call.
+    """
+    return ConfigView(config=_serialise_config(config))
+
+
+@router.get(
+    "/config/projects/{key}",
+    response_model=ProjectConfigView,
+    summary="Read one project's config block (secrets redacted)",
+    operation_id="getProjectConfig",
+)
+def get_project_config_endpoint(key: str, config: ConfigDep) -> ProjectConfigView:
+    """GET /api/v1/config/projects/{key} — single-project view.
+
+    Returns 404 ``not_found`` when ``key`` isn't registered in
+    ``config.projects``. Redaction matches the full-config endpoint
+    (the same recursive walker handles both shapes).
+    """
+    project = config.projects.get(key) if config.projects else None
+    if project is None:
+        raise not_found(
+            f"Project not registered: {key}",
+            hint=(
+                "Use GET /api/v1/config to list every configured "
+                "project key, or check the [projects.*] sections in "
+                "your pollypm.toml."
+            ),
+        )
+    return ProjectConfigView(key=key, project=_serialise_project(project))
+
+
+__all__ = [
+    "ConfigView",
+    "ProjectConfigView",
+    "REDACTED",
+    "get_config_endpoint",
+    "get_project_config_endpoint",
+    "router",
+]

--- a/src/pollypm/web_api/routes/config.py
+++ b/src/pollypm/web_api/routes/config.py
@@ -22,10 +22,11 @@ JSON-friendly shape and walk it once to redact secrets.
 from __future__ import annotations
 
 import dataclasses
+import re
 from enum import Enum
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, urlsplit
 
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
@@ -60,11 +61,64 @@ _SECRET_NAME_SUBSTRINGS: tuple[str, ...] = (
     "secret",
     "password",
     "passwd",
+    "pwd",
     "api_key",
     "apikey",
     "credential",
+    "credentials",
     "private_key",
     "auth",  # matches auth_token, basic_auth, oauth_*, etc.
+    # Codex round-2 P0 on PR #2056: real env credentials whose key
+    # names lack "token"/"secret"/"api_key" still need redaction.
+    # ``access_key`` catches ``AWS_ACCESS_KEY_ID`` / ``*_ACCESS_KEY``;
+    # ``pat`` catches ``GITHUB_PAT`` / personal access tokens; ``dsn``
+    # and ``database_url`` cover DSN-style connection strings whose
+    # value-shape check might miss query-only password forms.
+    "access_key",
+    "pat",
+    "dsn",
+    "database_url",
+)
+
+
+# Value-shape regexes for well-known credential prefixes. Catches
+# environment values whose key names slipped through both
+# ``_looks_secret`` and the URL-userinfo check (Codex round-2 P0 on
+# PR #2056: ``AWS_ACCESS_KEY_ID = "AKIA..."``, ``GITHUB_PAT =
+# "ghp_..."``). Anchored so we don't accidentally match ordinary
+# strings that happen to contain "AKIA".
+_CREDENTIAL_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # AWS access key IDs — always start with AKIA/ASIA + 16 base32-ish chars.
+    re.compile(r"^(?:AKIA|ASIA)[0-9A-Z]{16}$"),
+    # GitHub personal / OAuth / user / server / refresh tokens. The
+    # ``_`` between prefix and body is part of the format; bodies are
+    # 36+ base64url chars in practice (current GitHub format).
+    re.compile(r"^gh[pousr]_[A-Za-z0-9_]{36,}$"),
+    # GitHub fine-grained PATs.
+    re.compile(r"^github_pat_[A-Za-z0-9_]{20,}$"),
+    # Slack bot/user/app tokens.
+    re.compile(r"^xox[abprs]-[A-Za-z0-9-]{10,}$"),
+)
+
+
+# Query-string parameter names (lowercase) whose values mark a URL as
+# carrying credentials outside the userinfo netloc. Catches DSN forms
+# like ``postgresql://host/db?user=alice&password=secret`` and libpq
+# variants that put auth in the query string. Codex round-2 P0 on
+# PR #2056 called out password-in-query explicitly.
+_URL_QUERY_SECRET_KEYS: frozenset[str] = frozenset(
+    {
+        "password",
+        "pwd",
+        "passwd",
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+        "auth",
+        "access_token",
+        "auth_token",
+    },
 )
 
 
@@ -82,15 +136,18 @@ def _looks_secret(field_name: str) -> bool:
 
 
 def _value_has_url_userinfo(value: Any) -> bool:
-    """Return True iff ``value`` parses as a URL carrying userinfo.
+    """Return True iff ``value`` parses as a URL carrying credentials.
 
     Catches credential-bearing connection strings whose *keys* don't
     match the secret-name heuristic — e.g. ``[storage].url``,
     ``[storage.pg].dsn``, or env entries like ``DATABASE_URL`` /
     ``POSTGRES_DSN`` / ``SENTRY_DSN`` shaped as
-    ``scheme://user:password@host/...``. Uses
-    :func:`urllib.parse.urlsplit` so the check is robust against
-    odd schemes (``postgresql+psycopg``, ``redis``, ``amqps``, ...).
+    ``scheme://user:password@host/...`` **or**
+    ``scheme://host/db?user=...&password=...`` (Codex round-2 P0 on
+    PR #2056 — query-string passwords leaked through the prior
+    userinfo-only check). Uses :func:`urllib.parse.urlsplit` so the
+    check is robust against odd schemes (``postgresql+psycopg``,
+    ``redis``, ``amqps``, ...).
 
     Only flags strings; non-string values fall through. We treat the
     whole value as tainted (rather than masking just the userinfo
@@ -109,12 +166,40 @@ def _value_has_url_userinfo(value: Any) -> bool:
     if not parts.scheme:
         return False
     try:
-        return bool(parts.username or parts.password)
+        if parts.username or parts.password:
+            return True
     except ValueError:
         # ``parts.username`` / ``.password`` can raise on malformed
         # percent-encoding in the netloc. If the netloc contains an
         # ``@``, that's still very likely userinfo — redact to be safe.
-        return "@" in (parts.netloc or "")
+        if "@" in (parts.netloc or ""):
+            return True
+    # Query-string passwords (libpq-style DSN auth, ``?api_key=...``,
+    # ``?token=...``). Some DSN dialects carry credentials only in the
+    # query, so userinfo-only redaction misses them.
+    if parts.query:
+        try:
+            params = parse_qs(parts.query, keep_blank_values=True)
+        except ValueError:
+            return False
+        for raw_key in params:
+            if raw_key.lower() in _URL_QUERY_SECRET_KEYS:
+                return True
+    return False
+
+
+def _value_looks_credential(value: Any) -> bool:
+    """Return True iff ``value`` matches a known credential value-shape.
+
+    Catches env entries whose key names slipped through ``_looks_secret``
+    (Codex round-2 P0 on PR #2056: ``AWS_ACCESS_KEY_ID = "AKIA..."``,
+    ``GITHUB_PAT = "ghp_..."``). The regex set is conservative — anchored
+    prefixes for vendor-specific token formats — so false positives on
+    ordinary strings are unlikely.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    return any(pattern.match(value) for pattern in _CREDENTIAL_VALUE_PATTERNS)
 
 
 def _coerce_value(value: Any) -> Any:
@@ -140,12 +225,17 @@ def _coerce_value(value: Any) -> Any:
         return _redact_dict(value)
     if isinstance(value, (list, tuple)):
         return [_coerce_value(item) for item in value]
-    # Value-shape redaction: any string that parses as a URL with
-    # userinfo (``scheme://user:pass@host/...``) is treated as a live
+    # Value-shape redaction: any string that parses as a URL carrying
+    # credentials (userinfo or password-in-query) is treated as a live
     # credential regardless of the key name it sits under. Catches
     # ``[storage].url`` / ``[storage.pg].dsn`` and env entries like
     # ``DATABASE_URL`` whose keys don't trigger ``_looks_secret``.
     if _value_has_url_userinfo(value):
+        return REDACTED
+    # Vendor-specific credential prefixes (AWS access keys, GitHub
+    # PATs, Slack tokens, …). Backstops env entries whose key names
+    # don't include any credential keyword (Codex round-2 P0 on PR #2056).
+    if _value_looks_credential(value):
         return REDACTED
     return value
 
@@ -252,10 +342,14 @@ class ProjectConfigView(BaseModel):
 def get_config_endpoint(config: ConfigDep) -> ConfigView:
     """GET /api/v1/config — full config with secrets redacted.
 
-    Implementation note (spec §13.2): the loaded :class:`PollyPMConfig`
-    instance is reused from the request's dependency injector — no
-    extra disk read. A config edit between two requests just shows on
-    the next call.
+    Implementation note (spec §13.2): the dependency provider
+    re-invokes :func:`pollypm.config.load_config` on every request so a
+    TOML edit between requests shows up on the next call. The loader
+    has an mtime-keyed cache (see ``_config_cache``), so unchanged
+    files are O(stat) — no extra parse work per request. Codex round-2
+    P0 on PR #2056 fixed the previous stale-snapshot behaviour where
+    ``GET /config`` reflected only what was loaded at ``pm serve``
+    startup.
     """
     return ConfigView(config=_serialise_config(config))
 

--- a/src/pollypm/web_api/routes/config.py
+++ b/src/pollypm/web_api/routes/config.py
@@ -25,6 +25,7 @@ import dataclasses
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
@@ -80,6 +81,42 @@ def _looks_secret(field_name: str) -> bool:
     return any(needle in lower for needle in _SECRET_NAME_SUBSTRINGS)
 
 
+def _value_has_url_userinfo(value: Any) -> bool:
+    """Return True iff ``value`` parses as a URL carrying userinfo.
+
+    Catches credential-bearing connection strings whose *keys* don't
+    match the secret-name heuristic — e.g. ``[storage].url``,
+    ``[storage.pg].dsn``, or env entries like ``DATABASE_URL`` /
+    ``POSTGRES_DSN`` / ``SENTRY_DSN`` shaped as
+    ``scheme://user:password@host/...``. Uses
+    :func:`urllib.parse.urlsplit` so the check is robust against
+    odd schemes (``postgresql+psycopg``, ``redis``, ``amqps``, ...).
+
+    Only flags strings; non-string values fall through. We treat the
+    whole value as tainted (rather than masking just the userinfo
+    portion) so we never accidentally leave fragments of the password
+    in the response.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        # Malformed URL — better to redact below if it *looked* like a
+        # URL, but ``urlsplit`` is permissive, so a raise here means
+        # the value definitely isn't a URL.
+        return False
+    if not parts.scheme:
+        return False
+    try:
+        return bool(parts.username or parts.password)
+    except ValueError:
+        # ``parts.username`` / ``.password`` can raise on malformed
+        # percent-encoding in the netloc. If the netloc contains an
+        # ``@``, that's still very likely userinfo — redact to be safe.
+        return "@" in (parts.netloc or "")
+
+
 def _coerce_value(value: Any) -> Any:
     """Coerce a single config value into a JSON-friendly shape.
 
@@ -103,6 +140,13 @@ def _coerce_value(value: Any) -> Any:
         return _redact_dict(value)
     if isinstance(value, (list, tuple)):
         return [_coerce_value(item) for item in value]
+    # Value-shape redaction: any string that parses as a URL with
+    # userinfo (``scheme://user:pass@host/...``) is treated as a live
+    # credential regardless of the key name it sits under. Catches
+    # ``[storage].url`` / ``[storage.pg].dsn`` and env entries like
+    # ``DATABASE_URL`` whose keys don't trigger ``_looks_secret``.
+    if _value_has_url_userinfo(value):
+        return REDACTED
     return value
 
 

--- a/src/pollypm/web_api/routes/config.py
+++ b/src/pollypm/web_api/routes/config.py
@@ -71,13 +71,43 @@ _SECRET_NAME_SUBSTRINGS: tuple[str, ...] = (
     # Codex round-2 P0 on PR #2056: real env credentials whose key
     # names lack "token"/"secret"/"api_key" still need redaction.
     # ``access_key`` catches ``AWS_ACCESS_KEY_ID`` / ``*_ACCESS_KEY``;
-    # ``pat`` catches ``GITHUB_PAT`` / personal access tokens; ``dsn``
-    # and ``database_url`` cover DSN-style connection strings whose
-    # value-shape check might miss query-only password forms.
+    # ``dsn`` and ``database_url`` cover DSN-style connection strings
+    # whose value-shape check might miss query-only password forms.
+    # NOTE: ``pat`` is intentionally NOT in this substring list — it
+    # falsely flags ordinary path keys (``path``, ``project_path``,
+    # ``config_path``). PAT detection lives in
+    # :data:`_SECRET_EXACT_NAMES_LOWER` (exact match) and
+    # :data:`_SECRET_NAME_SUFFIXES` (boundary-aware suffix match).
     "access_key",
-    "pat",
     "dsn",
     "database_url",
+)
+
+
+# Exact key names (compared case-insensitively against the lowercased
+# key) that always denote credentials. Used for provider-specific token
+# names whose substring form would over-redact ordinary keys — most
+# notably ``GITHUB_PAT`` (substring ``pat`` would match ``path``,
+# ``project_path``, ``config_path``). Codex round-4 P0 on PR #2056.
+_SECRET_EXACT_NAMES_LOWER: frozenset[str] = frozenset(
+    {
+        "github_pat",
+        "github_token",
+    },
+)
+
+
+# Suffixes (compared case-insensitively against the lowercased key)
+# that denote credentials when they form the *end* of a key name. This
+# is the boundary-aware replacement for the old raw ``pat`` substring:
+# ``_PAT`` matches ``GITHUB_PAT`` / ``GITLAB_PAT`` / ``WHATEVER_PAT``
+# but not ``path`` / ``compat_layer``. ``_TOKEN``, ``_KEY``, and
+# ``_SECRET`` are already covered by the substring list above; we keep
+# the suffix set narrow to ``_PAT`` to avoid duplication.
+_SECRET_NAME_SUFFIXES: frozenset[str] = frozenset(
+    {
+        "_pat",
+    },
 )
 
 
@@ -125,14 +155,31 @@ _URL_QUERY_SECRET_KEYS: frozenset[str] = frozenset(
 def _looks_secret(field_name: str) -> bool:
     """Return True iff ``field_name`` matches the credential heuristic.
 
-    Case-insensitive substring match against
-    :data:`_SECRET_NAME_SUBSTRINGS`. The match is deliberately
-    over-eager — false positives (redacting a non-secret field whose
-    name happens to contain ``"auth"``) are operationally fine; false
-    negatives (leaking a real secret) are not.
+    Three layers, all case-insensitive:
+
+    1. Substring match against :data:`_SECRET_NAME_SUBSTRINGS` (the
+       broad heuristic — ``token`` / ``secret`` / ``auth`` / …).
+    2. Exact match against :data:`_SECRET_EXACT_NAMES_LOWER` for
+       provider-specific token names whose substring form would
+       over-redact (``GITHUB_PAT``, ``GITHUB_TOKEN``).
+    3. Suffix match against :data:`_SECRET_NAME_SUFFIXES` so generic
+       ``*_PAT`` names redact without false-positiving ordinary path
+       keys (Codex round-4 P0 on PR #2056: ``path`` / ``project_path``
+       / ``config_path`` were over-redacted by a raw ``pat`` substring).
+
+    The match is deliberately over-eager on the *secret* side — false
+    positives (redacting a non-secret field whose name happens to
+    contain ``"auth"``) are operationally fine; false negatives
+    (leaking a real secret) are not. The PAT carve-outs above only
+    narrow detection where the prior heuristic measurably broke
+    operator visibility on non-secret keys.
     """
     lower = field_name.lower()
-    return any(needle in lower for needle in _SECRET_NAME_SUBSTRINGS)
+    if any(needle in lower for needle in _SECRET_NAME_SUBSTRINGS):
+        return True
+    if lower in _SECRET_EXACT_NAMES_LOWER:
+        return True
+    return any(lower.endswith(suffix) for suffix in _SECRET_NAME_SUFFIXES)
 
 
 def _value_has_url_userinfo(value: Any) -> bool:

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -31,10 +31,12 @@ from pollypm.config import (
 )
 from pollypm.models import (
     KnownProject,
+    PgStorageSettings,
     ProjectKind,
     ProviderKind,
     RuntimeKind,
     SessionConfig,
+    StorageSettings,
 )
 from pollypm.web_api import create_app, ensure_token
 from pollypm.web_api.routes.config import REDACTED
@@ -390,6 +392,147 @@ def test_known_project_credentials_redacted_in_per_project_view(
     for key, value in body["project"].items():
         if any(needle in key.lower() for needle in ("token", "secret", "api_key")):
             assert value == REDACTED, f"unredacted credential-shaped field: {key}"
+
+
+# ---------------------------------------------------------------------------
+# DSN / URL value-shape redaction (Codex P0 on PR #2056)
+# ---------------------------------------------------------------------------
+
+
+def test_storage_url_with_userinfo_is_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """``[storage].url`` carrying userinfo must be redacted.
+
+    The key ``url`` doesn't match the secret-name heuristic, so this
+    pins the value-shape check: anything that parses as
+    ``scheme://user:password@host/...`` is treated as a live
+    credential regardless of the key it sits under.
+    """
+    _ = token
+    config = _build_config(workspace_root=workspace_root, project_root=project_root)
+    config.storage = StorageSettings(
+        backend="postgres",
+        url="postgresql://user:urlpass@example.com/db",
+    )
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    assert body["config"]["storage"]["url"] == REDACTED
+    assert "urlpass" not in response_text(body)
+
+
+def test_storage_pg_dsn_with_userinfo_is_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """``[storage.pg].dsn`` carrying userinfo must be redacted."""
+    _ = token
+    config = _build_config(workspace_root=workspace_root, project_root=project_root)
+    config.storage = StorageSettings(
+        backend="postgres",
+        url="",
+        pg=PgStorageSettings(
+            dsn="postgresql://user:dsnpass@example.com/db",
+        ),
+    )
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    assert body["config"]["storage"]["pg"]["dsn"] == REDACTED
+    assert "dsnpass" not in response_text(body)
+
+
+def test_account_env_dsn_carriers_are_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Env entries with DSN/URL-shaped values must be redacted.
+
+    Codex's P0 called out ``DATABASE_URL``, ``POSTGRES_DSN``, and
+    ``SENTRY_DSN`` specifically — none of those keys match the
+    secret-name heuristic, so the value-shape check (URL with
+    userinfo) is what protects them.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "DATABASE_URL": "postgresql://user:dbpass@example.com/db",
+        "POSTGRES_DSN": "postgresql://user:pgdsnpass@example.com/db",
+        "SENTRY_DSN": "https://user:sentrypass@sentry.example.com/123",
+        "PUBLIC_FLAG": "ok",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["DATABASE_URL"] == REDACTED
+    assert env["POSTGRES_DSN"] == REDACTED
+    assert env["SENTRY_DSN"] == REDACTED
+    assert env["PUBLIC_FLAG"] == "ok"  # non-URL string untouched
+    raw = response_text(body)
+    assert "dbpass" not in raw
+    assert "pgdsnpass" not in raw
+    assert "sentrypass" not in raw
+
+
+def test_bare_url_without_userinfo_is_not_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Public URLs (no userinfo) pass through unchanged.
+
+    Over-redaction would hurt observability — a webhook callback URL
+    or a public docs link has no userinfo and should not be replaced
+    with ``"***"``.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "DOCS_URL": "https://example.com/api",
+        "API_BASE": "https://api.example.com/v1",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["DOCS_URL"] == "https://example.com/api"
+    assert env["API_BASE"] == "https://api.example.com/v1"
+
+
+def test_non_url_string_in_safe_field_is_not_redacted(
+    client: TestClient, auth_headers: dict[str, str],
+) -> None:
+    """Plain string values in non-secret fields remain visible.
+
+    The value-shape check only fires for URL-with-userinfo. Ordinary
+    string fields (project name, tmux session name, …) must round-trip
+    untouched so the operator can read their config back from the API.
+    """
+    body = client.get("/api/v1/config", headers=auth_headers).json()
+    assert body["config"]["project"]["tmux_session"] == "pollypm-test"
+    assert body["config"]["project"]["name"] == "PollyPM"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -731,6 +731,164 @@ def test_env_dsn_with_query_password_is_redacted(
 
 
 # ---------------------------------------------------------------------------
+# libpq keyword DSN redaction (Codex round-3 P0 on PR #2056)
+# ---------------------------------------------------------------------------
+
+
+def test_libpq_dsn_with_password_token_is_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """libpq keyword DSN with ``password=`` token must be redacted.
+
+    Codex round-3 P0 exact probe: ``PG_CONN = "host=db.example
+    dbname=pollypm user=alice password=secretpw"``. Carrier key
+    ``PG_CONN`` lacks every credential keyword, value isn't URL-shape,
+    and no vendor prefix matches — only the libpq value-shape catches
+    this.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "PG_CONN": "host=db.example dbname=pollypm user=alice password=secretpw",
+        "PUBLIC_FLAG": "ok",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["PG_CONN"] == REDACTED
+    assert env["PUBLIC_FLAG"] == "ok"
+    assert "secretpw" not in response_text(body)
+
+
+def test_libpq_dsn_without_password_token_not_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """libpq DSN with no credential token passes through unchanged.
+
+    Over-redaction would hurt observability — a DSN like
+    ``host=db dbname=x user=alice sslmode=require`` carries no
+    password and should remain visible so operators can read their
+    connection config back.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    safe_dsn = "host=db dbname=x user=alice sslmode=require"
+    config.accounts["codex_primary"].env = {
+        "PG_HOST_CONFIG": safe_dsn,
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["PG_HOST_CONFIG"] == safe_dsn
+
+
+def test_single_key_value_not_treated_as_dsn(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """A single ``key=value`` pair isn't a DSN — must not be redacted.
+
+    The 2-token minimum in ``_value_looks_libpq_dsn`` exists to keep
+    trivial config like ``mode=production`` out of scope. Even though
+    a hypothetical ``password=foo`` *would* match the secret keyword,
+    one token alone shouldn't be treated as a DSN value-shape.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "MODE": "mode=production",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["MODE"] == "mode=production"
+
+
+def test_libpq_dsn_with_quoted_password(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Quoted-value form (whitespace inside ``password='...'``) redacts.
+
+    libpq allows single-quoted values with embedded whitespace; the
+    tokenizer must still see ``password`` as one of the keyword tokens
+    even when its value contains spaces.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "PG_CONN": "host=db password='se cret pw'",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["PG_CONN"] == REDACTED
+    assert "se cret pw" not in response_text(body)
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI documents the value-shape redaction contract
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_describes_value_shape_redaction() -> None:
+    """``docs/api/openapi.yaml`` /config description mentions
+    value-shape redaction (libpq DSN, URL userinfo) not just the
+    keyword heuristic.
+
+    The redaction contract is security-critical and operator-visible;
+    clients shouldn't have to read the route source to know which
+    shapes get masked.
+    """
+    import yaml
+
+    contract_path = (
+        Path(__file__).resolve().parent.parent
+        / "docs"
+        / "api"
+        / "openapi.yaml"
+    )
+    contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+    description = contract["paths"]["/config"]["get"]["description"].lower()
+    assert "libpq" in description, description
+    assert "userinfo" in description, description
+
+
+# ---------------------------------------------------------------------------
 # Reload-on-edit (Codex round-2 P0 on PR #2056)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -1,0 +1,404 @@
+"""Tests for the Phase 2 read-only config endpoints (surface §13).
+
+Covers ``GET /api/v1/config`` and ``GET /api/v1/config/projects/{key}``:
+
+- happy path returns the full redacted config
+- credential-shaped fields (``auth_token``, ``api_key``, account
+  ``env`` secrets) are replaced with ``"***"``
+- per-project filter returns the right block; unknown key → 404
+- auth required on both endpoints
+- minimal config (no projects, no sessions) doesn't crash
+
+The test is self-contained: it builds a :class:`PollyPMConfig`
+in-memory and constructs the FastAPI app via
+:func:`pollypm.web_api.create_app`. Run with
+``pytest --noconftest tests/test_config_endpoint.py -v --timeout=120``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.models import (
+    KnownProject,
+    ProjectKind,
+    ProviderKind,
+    RuntimeKind,
+    SessionConfig,
+)
+from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.routes.config import REDACTED
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures (no conftest — runner uses --noconftest)
+# ---------------------------------------------------------------------------
+
+
+def _build_config(
+    *,
+    workspace_root: Path,
+    project_root: Path,
+    include_session_with_token: bool = True,
+    include_account_env_secret: bool = True,
+    projects: dict[str, KnownProject] | None = None,
+) -> PollyPMConfig:
+    base_dir = workspace_root / ".pollypm"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    state_db = base_dir / "state.db"
+
+    accounts: dict[str, AccountConfig] = {
+        "codex_primary": AccountConfig(
+            name="codex_primary",
+            provider=ProviderKind.CODEX,
+            email="codex@example.com",
+            runtime=RuntimeKind.LOCAL,
+            home=base_dir / "homes" / "codex_primary",
+            env=(
+                {
+                    "OPENAI_API_KEY": "sk-super-secret-12345",
+                    "PUBLIC_FLAG": "ok",
+                }
+                if include_account_env_secret
+                else {}
+            ),
+        ),
+    }
+
+    sessions: dict[str, SessionConfig] = {}
+    if include_session_with_token:
+        sessions["operator"] = SessionConfig(
+            name="operator",
+            role="operator",
+            provider=ProviderKind.CODEX,
+            account="codex_primary",
+            cwd=workspace_root,
+            project="myproj",
+            auth_token="deadbeef" * 8,  # 64-char hex; should be redacted
+        )
+
+    if projects is None:
+        projects = {
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        }
+
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace_root,
+            tmux_session="pollypm-test",
+            workspace_root=workspace_root,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=state_db,
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts=accounts,
+        sessions=sessions,
+        projects=projects,
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def token_path(tmp_path: Path) -> Path:
+    return tmp_path / "api-token"
+
+
+@pytest.fixture
+def token(token_path: Path) -> str:
+    value, _ = ensure_token(token_path)
+    return value
+
+
+@pytest.fixture
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def api_config(workspace_root: Path, project_root: Path) -> PollyPMConfig:
+    return _build_config(workspace_root=workspace_root, project_root=project_root)
+
+
+@pytest.fixture
+def client(api_config: PollyPMConfig, token_path: Path, token: str) -> TestClient:
+    _ = token  # ensure the token file exists before the app reads it
+    app = create_app(config=api_config, token_path=token_path)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_get_config_happy_path_returns_full_config(client: TestClient, auth_headers: dict[str, str]) -> None:
+    """``GET /api/v1/config`` returns the loaded config envelope."""
+    response = client.get("/api/v1/config", headers=auth_headers)
+    assert response.status_code == 200
+
+    body = response.json()
+    assert "config" in body, body
+    cfg = body["config"]
+
+    # Sanity: the obvious top-level fields are present.
+    assert cfg["project"]["name"] == "PollyPM"
+    assert cfg["project"]["tmux_session"] == "pollypm-test"
+    assert "myproj" in cfg["projects"]
+    assert cfg["projects"]["myproj"]["name"] == "My Project"
+    # Enum (StrEnum) → ``.value``; not the repr.
+    assert cfg["projects"]["myproj"]["kind"] == "git"
+
+
+def test_get_config_paths_coerced_to_strings(client: TestClient, auth_headers: dict[str, str], workspace_root: Path) -> None:
+    """``pathlib.Path`` values flatten to strings so the body is JSON-safe."""
+    body = client.get("/api/v1/config", headers=auth_headers).json()
+    root_dir = body["config"]["project"]["root_dir"]
+    assert isinstance(root_dir, str)
+    assert root_dir == str(workspace_root)
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def test_session_auth_token_is_redacted(client: TestClient, auth_headers: dict[str, str]) -> None:
+    """Session ``auth_token`` must never round-trip through the API."""
+    body = client.get("/api/v1/config", headers=auth_headers).json()
+    sessions = body["config"]["sessions"]
+    assert "operator" in sessions
+    assert sessions["operator"]["auth_token"] == REDACTED
+    # The literal token value must not appear anywhere in the response.
+    assert "deadbeef" not in response_text(body)
+
+
+def test_account_env_api_key_is_redacted(client: TestClient, auth_headers: dict[str, str]) -> None:
+    """Account ``env`` entries whose keys look secret are redacted.
+
+    The redaction walks every nested dict; an account's ``env`` map
+    holds the OS-level credential exports, so ``OPENAI_API_KEY`` must
+    flatten to ``"***"`` even though it's two levels deep.
+    """
+    body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["OPENAI_API_KEY"] == REDACTED
+    # Non-secret env keys pass through unchanged.
+    assert env["PUBLIC_FLAG"] == "ok"
+    assert "sk-super-secret-12345" not in response_text(body)
+
+
+def test_empty_auth_token_not_overwritten(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Legacy ``auth_token=""`` must stay empty (not become ``"***"``).
+
+    Sessions written before Lever 2 (#2012) hold an empty auth_token;
+    redacting that to ``"***"`` would misrepresent the on-disk state
+    (the operator can no longer tell "field unset" from "field hidden").
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_session_with_token=False,
+    )
+    # Add a session with an explicitly-empty auth_token.
+    config.sessions["legacy"] = SessionConfig(
+        name="legacy",
+        role="operator",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=workspace_root,
+        project="myproj",
+        auth_token="",
+    )
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    assert body["config"]["sessions"]["legacy"]["auth_token"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-project filter
+# ---------------------------------------------------------------------------
+
+
+def test_project_filter_returns_single_block(client: TestClient, auth_headers: dict[str, str]) -> None:
+    """``GET /config/projects/{key}`` returns just that project's block."""
+    response = client.get("/api/v1/config/projects/myproj", headers=auth_headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["key"] == "myproj"
+    assert body["project"]["name"] == "My Project"
+    assert body["project"]["kind"] == "git"
+    assert body["project"]["tracked"] is True
+
+
+def test_project_filter_unknown_key_returns_404(client: TestClient, auth_headers: dict[str, str]) -> None:
+    """Unknown project key → 404 ``not_found`` with the spec envelope."""
+    response = client.get("/api/v1/config/projects/does-not-exist", headers=auth_headers)
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "not_found"
+    assert "does-not-exist" in body["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_get_config_requires_auth(client: TestClient) -> None:
+    """No bearer → 401 (matches the rest of the API surface)."""
+    response = client.get("/api/v1/config")
+    assert response.status_code == 401
+
+
+def test_get_project_config_requires_auth(client: TestClient) -> None:
+    response = client.get("/api/v1/config/projects/myproj")
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_config_does_not_crash(
+    workspace_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Empty projects + empty sessions still serialises cleanly.
+
+    Fresh installs (or test fixtures that skip account setup) shouldn't
+    crash the endpoint just because dict-valued fields are empty.
+    """
+    _ = token
+    base_dir = workspace_root / ".pollypm"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace_root,
+            tmux_session="pollypm-min",
+            workspace_root=workspace_root,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="codex_primary"),
+        accounts={},
+        sessions={},
+        projects={},
+        memory=MemorySettings(backend="file"),
+    )
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        response = client.get("/api/v1/config", headers=auth_headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["config"]["projects"] == {}
+    assert body["config"]["sessions"] == {}
+    assert body["config"]["accounts"] == {}
+
+
+def test_known_project_credentials_redacted_in_per_project_view(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Per-project view also redacts credential-shaped fields.
+
+    ``KnownProject`` doesn't carry secrets today, but the per-project
+    serialiser shares the redaction walker with the full-config one —
+    this test pins the contract so a future credential-shaped field on
+    ``KnownProject`` can't accidentally leak.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+    )
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get(
+            "/api/v1/config/projects/myproj", headers=auth_headers,
+        ).json()
+    # Every key that looks credential-shaped must be ``"***"``; nothing
+    # in the canonical KnownProject shape should match today, so the
+    # block stays unredacted — but the walker still runs.
+    for key, value in body["project"].items():
+        if any(needle in key.lower() for needle in ("token", "secret", "api_key")):
+            assert value == REDACTED, f"unredacted credential-shaped field: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def response_text(body: object) -> str:
+    """Stringify the response for substring leak-checks."""
+    import json
+
+    return json.dumps(body, default=str)

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -536,6 +536,286 @@ def test_non_url_string_in_safe_field_is_not_redacted(
 
 
 # ---------------------------------------------------------------------------
+# Env-credential value-shape redaction (Codex round-2 P0 on PR #2056)
+# ---------------------------------------------------------------------------
+
+
+def test_aws_access_key_id_is_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """``AWS_ACCESS_KEY_ID`` env entries must be redacted.
+
+    The key name lacks ``token``/``secret``/``api_key`` so the
+    original keyword heuristic missed it. Both the expanded keyword
+    set (``access_key``) AND the value-shape regex (``^AKIA…``)
+    cover this — either alone suffices, both together is defence in
+    depth.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+        "PUBLIC_FLAG": "ok",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["AWS_ACCESS_KEY_ID"] == REDACTED
+    assert env["PUBLIC_FLAG"] == "ok"
+    assert "AKIAIOSFODNN7EXAMPLE" not in response_text(body)
+
+
+def test_github_pat_is_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """``GITHUB_PAT`` env entries must be redacted.
+
+    Key name lacks the original credential keywords; matched by the
+    new ``pat`` keyword AND by the ``^ghp_…`` value-shape regex.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "GITHUB_PAT": "ghp_" + "a" * 36,
+        "PUBLIC_FLAG": "ok",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["GITHUB_PAT"] == REDACTED
+    assert "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" not in response_text(body)
+
+
+def test_aws_secret_access_key_is_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """``AWS_SECRET_ACCESS_KEY`` must be redacted by the secret heuristic."""
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "PUBLIC_FLAG": "ok",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["AWS_SECRET_ACCESS_KEY"] == REDACTED
+    assert "wJalrXUtnFEMI" not in response_text(body)
+
+
+def test_value_shape_redaction_for_bare_credential_value(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Credential value-shape catches even fully-innocuous env key names.
+
+    If an operator names their env entry ``MY_KEY`` (no credential
+    keyword anywhere) but the value matches the AWS / GitHub /
+    Slack format, the value-shape backstop still redacts it.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    # AWS-shaped value (16 caps after AKIA) and a GitHub PAT shape —
+    # the env key name has no credential keyword, so only the
+    # value-shape backstop fires. Avoid Slack ``xox*`` literals here so
+    # GitHub push-protection's secret scanner doesn't reject the test
+    # for matching its Slack-token rule.
+    config.accounts["codex_primary"].env = {
+        "MY_ID": "AKIA" + "B" * 16,
+        "WEBHOOK": "ghp_" + "z" * 36,
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["MY_ID"] == REDACTED
+    assert env["WEBHOOK"] == REDACTED
+
+
+# ---------------------------------------------------------------------------
+# DSN-with-query-string-password redaction (Codex round-2 P0 on PR #2056)
+# ---------------------------------------------------------------------------
+
+
+def test_storage_pg_dsn_with_query_password_is_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """DSN with password in query string (not userinfo) must be redacted.
+
+    Codex round-2 P0 example:
+    ``postgresql://db.example/pollypm?user=alice&password=secretpw``.
+    The previous userinfo-only check missed this shape entirely.
+    Belt-and-suspenders: the ``dsn`` keyword now also triggers
+    ``_looks_secret`` so the key-name match also catches it.
+    """
+    _ = token
+    config = _build_config(workspace_root=workspace_root, project_root=project_root)
+    config.storage = StorageSettings(
+        backend="postgres",
+        url="",
+        pg=PgStorageSettings(
+            dsn="postgresql://db.example/pollypm?user=alice&password=secretpw",
+        ),
+    )
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    assert body["config"]["storage"]["pg"]["dsn"] == REDACTED
+    assert "secretpw" not in response_text(body)
+
+
+def test_env_dsn_with_query_password_is_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """An env DSN whose key isn't ``dsn`` must redact via value-shape."""
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        # No credential keyword in the key, password only in the query.
+        "PG_CONN": "postgresql://db.example/pollypm?user=alice&password=secretpw",
+        "PUBLIC_FLAG": "ok",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["PG_CONN"] == REDACTED
+    assert env["PUBLIC_FLAG"] == "ok"
+    assert "secretpw" not in response_text(body)
+
+
+# ---------------------------------------------------------------------------
+# Reload-on-edit (Codex round-2 P0 on PR #2056)
+# ---------------------------------------------------------------------------
+
+
+def test_get_config_reloads_on_disk_edit(
+    tmp_path: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """A TOML edit between two GETs must surface on the next call.
+
+    The previous wiring (``lambda: config``) returned the startup
+    snapshot, so the endpoint was stale until restart. The fix
+    re-invokes ``load_config`` per request; ``load_config`` is
+    mtime-cached so unchanged files are a single ``stat`` call.
+    """
+    _ = token
+    from pollypm.config import load_config
+
+    workspace_root = tmp_path / "ws"
+    workspace_root.mkdir()
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / ".pollypm").mkdir()
+
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"""
+[project]
+name = "PollyPM"
+root_dir = "{workspace_root.as_posix()}"
+tmux_session = "pollypm-reload"
+workspace_root = "{workspace_root.as_posix()}"
+
+[pollypm]
+controller_account = "codex_primary"
+
+[accounts.codex_primary]
+provider = "codex"
+email = "codex@example.com"
+
+[projects.alpha]
+path = "{project_root.as_posix()}"
+name = "Alpha"
+kind = "git"
+tracked = true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+        assert set(body["config"]["projects"].keys()) == {"alpha"}
+
+        # Edit the TOML on disk: add a second project. The
+        # mtime-keyed cache in ``load_config`` invalidates because the
+        # mtime changes; the dependency provider re-invokes
+        # ``load_config`` on the next request.
+        project_root_b = tmp_path / "proj_b"
+        project_root_b.mkdir()
+        (project_root_b / ".pollypm").mkdir()
+        # Bump mtime explicitly — some filesystems have 1s resolution
+        # and the test writes both files in the same second.
+        import os
+        import time
+
+        new_text = config_path.read_text(encoding="utf-8") + (
+            f"\n[projects.beta]\n"
+            f'path = "{project_root_b.as_posix()}"\n'
+            f'name = "Beta"\n'
+            f'kind = "git"\n'
+            f"tracked = true\n"
+        )
+        config_path.write_text(new_text, encoding="utf-8")
+        future = time.time() + 5
+        os.utime(config_path, (future, future))
+
+        body2 = client.get("/api/v1/config", headers=auth_headers).json()
+        assert set(body2["config"]["projects"].keys()) == {"alpha", "beta"}
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -667,6 +667,117 @@ def test_value_shape_redaction_for_bare_credential_value(
 
 
 # ---------------------------------------------------------------------------
+# PAT detection boundary (Codex round-4 P0 on PR #2056)
+# ---------------------------------------------------------------------------
+
+
+def test_path_keys_are_not_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Ordinary path-shaped keys must NOT be redacted by PAT detection.
+
+    Codex round-4 P0 on PR #2056 caught the prior raw ``pat`` substring
+    over-redacting ``path`` / ``project_path`` / ``config_path``. These
+    keys are core operator-visible config (project location, etc.) and
+    leaking PAT detection onto them broke the read-only config contract.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    # Stash a few innocuous path-shaped entries on the env map; the
+    # walker will see them at the same nesting depth as a real PAT.
+    config.accounts["codex_primary"].env = {
+        "path": "/tmp/project",
+        "project_path": "/tmp/project",
+        "config_path": "/tmp/pollypm.toml",
+        "PUBLIC_FLAG": "ok",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["path"] == "/tmp/project"
+    assert env["project_path"] == "/tmp/project"
+    assert env["config_path"] == "/tmp/pollypm.toml"
+    assert env["PUBLIC_FLAG"] == "ok"
+
+
+def test_github_pat_still_redacted_by_name(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """``GITHUB_PAT`` must still redact via exact name match.
+
+    Pins that the round-4 boundary fix didn't regress the round-2 PAT
+    coverage. Uses a value that doesn't match the ``^ghp_…`` regex so
+    only the name-side path can carry the redaction.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    # Value-shape regex deliberately won't match (no ``ghp_`` prefix);
+    # only the exact-name check protects this entry.
+    config.accounts["codex_primary"].env = {
+        "GITHUB_PAT": "not-shaped-like-a-real-pat-but-still-a-secret",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["GITHUB_PAT"] == REDACTED
+    assert "not-shaped-like-a-real-pat-but-still-a-secret" not in response_text(body)
+
+
+def test_provider_pat_suffixes_redacted(
+    workspace_root: Path,
+    project_root: Path,
+    token_path: Path,
+    token: str,
+    auth_headers: dict[str, str],
+) -> None:
+    """Generic ``*_PAT`` keys redact via suffix match.
+
+    The round-4 fix replaced the raw ``pat`` substring with a
+    boundary-aware ``_PAT`` suffix check. Any provider-prefixed PAT
+    name (``GITLAB_PAT``, ``BITBUCKET_PAT``, … or a custom
+    ``WHATEVER_PAT``) must still redact even though it's not in the
+    exact-name allowlist.
+    """
+    _ = token
+    config = _build_config(
+        workspace_root=workspace_root,
+        project_root=project_root,
+        include_account_env_secret=False,
+    )
+    config.accounts["codex_primary"].env = {
+        "WHATEVER_PAT": "opaque-token-value-12345",
+        "GITLAB_PAT": "glpat-deadbeefcafebabe",
+    }
+    app = create_app(config=config, token_path=token_path)
+    with TestClient(app) as client:
+        body = client.get("/api/v1/config", headers=auth_headers).json()
+    env = body["config"]["accounts"]["codex_primary"]["env"]
+    assert env["WHATEVER_PAT"] == REDACTED
+    assert env["GITLAB_PAT"] == REDACTED
+    raw = response_text(body)
+    assert "opaque-token-value-12345" not in raw
+    assert "glpat-deadbeefcafebabe" not in raw
+
+
+# ---------------------------------------------------------------------------
 # DSN-with-query-string-password redaction (Codex round-2 P0 on PR #2056)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements Phase 2 surface §11 / §13 of `~/Desktop/pollypm-phase2-endpoints-spec.md`:

- `GET /api/v1/config` — full `PollyPMConfig` snapshot, JSON-safe, with credential-shaped fields redacted to `"***"`.
- `GET /api/v1/config/projects/{key}` — single-project view of the `[projects.<key>]` block (404 on unknown key).

Mutation is deferred to Phase 3 per spec — config edits stay TOML-first.

## Redaction

Field names are checked case-insensitively against a substring list (`auth`, `token`, `secret`, `password`, `passwd`, `api_key`, `apikey`, `credential`, `private_key`). The walker recurses through every nested dict + dataclass, so account `env` entries like `OPENAI_API_KEY` redact at depth-3 too. Empty / `None` values stay as-is so the operator can distinguish "field unset" from "field hidden" (matches `SessionConfig.auth_token=""` legacy semantics).

## Test plan

- [x] `pytest --noconftest tests/test_config_endpoint.py -v --timeout=120` — 11 / 11 pass
- [x] `pytest tests/web_api/test_openapi_conformance.py` — 5 / 5 pass (yaml + impl conformance hold)
- [x] Manual smoke: `GET /api/v1/config` returns redacted session tokens + account env api keys
- [x] Unknown project key → typed 404 `not_found` with hint
- [x] Missing bearer → 401 on both endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)