### PR TITLE
feat(api): GET /api/v1/dashboard — Phase 2 dashboard aggregate state

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1249,6 +1249,14 @@ components:
 
     DashboardRollups:
       type: object
+      description: |
+        Aggregate counters mirrored from the cockpit rail. Under
+        `?project=<key>` only the project-derived counters
+        (`tracked_count`, `open_inbox_count`, `pending_plan_reviews`)
+        are narrowed; `alert_count` and the three `*_24h` activity
+        counters remain whole-system. The response envelope's
+        `scoped_fields` list enumerates which fields the filter
+        actually narrowed.
       required:
         - tracked_count
         - open_inbox_count
@@ -1291,15 +1299,29 @@ components:
         daemon_status:
           type: string
           description: |
-            `up` (active sessions present) or `down` (no active
-            sessions / supervisor unreachable). Per spec §3.3, a down
-            daemon is a normal operating mode, not a 503.
+            `up` (active sessions present anywhere in the system) or
+            `down` (no active sessions / supervisor unreachable).
+            Always derived from the unfiltered gather result —
+            `?project=` does NOT influence this field, so callers
+            polling per-project still see the true daemon health. Per
+            spec §3.3, a down daemon is a normal operating mode, not a
+            503.
         projects:
           type: array
           items:
             $ref: "#/components/schemas/Project"
         rollups:
           $ref: "#/components/schemas/DashboardRollups"
+        scoped_fields:
+          type: array
+          description: |
+            Names of response fields actually narrowed by `?project=`.
+            Empty when no filter is in effect. Lets clients tell which
+            counters reflect the requested project vs which remain
+            whole-system (see `DashboardRollups` for why the four
+            activity counters stay global).
+          items:
+            type: string
         active_sessions:
           type: array
           items:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -52,6 +52,13 @@ tags:
       Chat-surface discovery and message history. The discovery endpoint
       enumerates operator/architect/advisor/worker surfaces; the messages
       endpoint paginates each surface's envelope stream.
+  - name: Dashboard
+    description: |
+      Aggregate cockpit / rail state. Read-only snapshot of projects,
+      rollup counters, active sessions, recent commits, completed items,
+      recent messages, token usage, and account quotas. SSE streaming
+      variant (`/dashboard/stream`) ships in a follow-up PR per Phase 2
+      §3.2.
 
 paths:
   /health:
@@ -279,6 +286,64 @@ paths:
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/ValidationError"
+
+  /dashboard:
+    get:
+      tags: [Dashboard]
+      operationId: getDashboard
+      summary: Aggregate dashboard / cockpit state
+      description: |
+        Returns the operator's whole-system snapshot — the same shape
+        the cockpit rail computes. Read-only and eventually-consistent;
+        for sub-second freshness use the deferred `/dashboard/stream`
+        SSE channel (Phase 2 §3.2, follow-up PR).
+
+        Per spec §3.3:
+        - A daemon-down state is normal — the response carries
+          `daemon_status: "down"` with `active_sessions: []` and a 200
+          status; it is NOT a 503.
+        - A transient pg / work-service outage that breaks the gather
+          surfaces as `503 service_unavailable` so clients retry.
+        - `?project=<key>` narrows the project list, rollup counters,
+          and the per-project rows (commits, sessions, messages) to
+          one project — useful for the per-project drilldown view.
+      parameters:
+        - in: query
+          name: project
+          schema: { type: string }
+          description: Narrow the response to a single project key.
+        - in: query
+          name: include_token_history
+          schema: { type: boolean, default: false }
+          description: |
+            Include `daily_tokens` (last 30 days as `[date, tokens]`
+            pairs). Off by default — the list can be large.
+        - in: query
+          name: include_briefing
+          schema: { type: boolean, default: false }
+          description: |
+            Include the morning-briefing narrative in the response.
+            Off by default — the body can be megabytes.
+      responses:
+        "200":
+          description: Aggregate dashboard snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DashboardResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          description: |
+            Backing-store / gather failure (`service_unavailable`).
+            Distinct from a daemon-down state, which is returned as a
+            200 response with `daemon_status: "down"`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /chat/sessions:
     get:
@@ -1116,6 +1181,164 @@ components:
         actor: { type: string }
         status: { type: string }
         summary: { type: string }
+
+    # ---- Dashboard (Phase 2 §3) -------------------------------------
+    SessionActivity:
+      type: object
+      required: [name, role, project, project_label, status, description, age_seconds]
+      properties:
+        name: { type: string }
+        role: { type: string }
+        project: { type: string }
+        project_label: { type: string }
+        status: { type: string }
+        description: { type: string }
+        age_seconds: { type: number, format: float }
+
+    CommitInfo:
+      type: object
+      required: [hash, message, author, age_seconds, project]
+      properties:
+        hash: { type: string }
+        message: { type: string }
+        author: { type: string }
+        age_seconds: { type: number, format: float }
+        project: { type: string }
+
+    CompletedItem:
+      type: object
+      required: [title, kind, project, age_seconds]
+      properties:
+        title: { type: string }
+        kind:
+          type: string
+          description: |
+            One of `issue`, `commit`, or `pr`. Open-ended — clients
+            should treat unknown values like `issue`.
+        project: { type: string }
+        age_seconds: { type: number, format: float }
+
+    InboxPreview:
+      type: object
+      required: [sender, title, project, task_id, age_seconds]
+      properties:
+        sender: { type: string }
+        title: { type: string }
+        project: { type: string }
+        task_id: { type: string }
+        age_seconds: { type: number, format: float }
+
+    AccountQuotaUsage:
+      type: object
+      required: [account_name, provider, email, used_pct, summary, severity]
+      properties:
+        account_name: { type: string }
+        provider: { type: string }
+        email: { type: string }
+        used_pct: { type: integer }
+        summary: { type: string }
+        severity: { type: string }
+        limit_label:
+          type: string
+          default: limit
+        reset_at:
+          type: string
+          description: |
+            ISO-8601 timestamp string, or empty string when the
+            provider does not expose a reset window.
+
+    DashboardRollups:
+      type: object
+      required:
+        - tracked_count
+        - open_inbox_count
+        - pending_plan_reviews
+        - alert_count
+        - sweep_count_24h
+        - message_count_24h
+        - recovery_count_24h
+      properties:
+        tracked_count: { type: integer }
+        open_inbox_count: { type: integer }
+        pending_plan_reviews: { type: integer }
+        alert_count: { type: integer }
+        sweep_count_24h: { type: integer }
+        message_count_24h: { type: integer }
+        recovery_count_24h: { type: integer }
+
+    DashboardTokens:
+      type: object
+      required: [today, total]
+      properties:
+        today: { type: integer }
+        total: { type: integer }
+
+    DashboardResponse:
+      type: object
+      required:
+        - generated_at
+        - daemon_status
+        - projects
+        - rollups
+        - active_sessions
+        - recent_commits
+        - completed_items
+        - recent_messages
+        - tokens
+        - account_usages
+      properties:
+        generated_at: { type: string, format: date-time }
+        daemon_status:
+          type: string
+          description: |
+            `up` (active sessions present) or `down` (no active
+            sessions / supervisor unreachable). Per spec §3.3, a down
+            daemon is a normal operating mode, not a 503.
+        projects:
+          type: array
+          items:
+            $ref: "#/components/schemas/Project"
+        rollups:
+          $ref: "#/components/schemas/DashboardRollups"
+        active_sessions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionActivity"
+        recent_commits:
+          type: array
+          items:
+            $ref: "#/components/schemas/CommitInfo"
+        completed_items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CompletedItem"
+        recent_messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/InboxPreview"
+        tokens:
+          $ref: "#/components/schemas/DashboardTokens"
+        account_usages:
+          type: array
+          items:
+            $ref: "#/components/schemas/AccountQuotaUsage"
+        daily_tokens:
+          type: array
+          description: |
+            Optional `[date, tokens]` pairs (last 30 days). Only
+            populated when `?include_token_history=true`.
+          items:
+            type: array
+            minItems: 2
+            maxItems: 2
+            prefixItems:
+              - type: string
+              - type: integer
+        briefing:
+          type: string
+          description: |
+            Optional morning-briefing narrative. Only populated when
+            `?include_briefing=true`.
 
     ProjectDrilldown:
       allOf:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -304,9 +304,16 @@ paths:
           status; it is NOT a 503.
         - A transient pg / work-service outage that breaks the gather
           surfaces as `503 service_unavailable` so clients retry.
-        - `?project=<key>` narrows the project list, rollup counters,
-          and the per-project rows (commits, sessions, messages) to
-          one project — useful for the per-project drilldown view.
+        - `?project=<key>` narrows the response to one project. The
+          project list and per-project rows (sessions, commits,
+          completed items, recent messages) are scoped to that key,
+          along with the three project-derived rollup counters
+          (`tracked_count`, `open_inbox_count`, `pending_plan_reviews`).
+          The four global activity counters (`alert_count`,
+          `sweep_count_24h`, `message_count_24h`, `recovery_count_24h`)
+          and `daemon_status` remain workspace-wide. See the
+          `scoped_fields` array in the response for the authoritative
+          enumeration of which fields were narrowed.
       parameters:
         - in: query
           name: project

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -33,6 +33,7 @@ from pollypm.web_api.errors import (
 )
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
 from pollypm.web_api.routes import chat_send as chat_send_routes
+from pollypm.web_api.routes import dashboard as dashboard_routes
 from pollypm.web_api.routes import events as events_routes
 from pollypm.web_api.routes import health as health_routes
 from pollypm.web_api.routes import inbox as inbox_routes
@@ -118,6 +119,7 @@ def create_app(
     app.include_router(projects_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(tasks_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(inbox_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
+    app.include_router(dashboard_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(events_routes.router, prefix=API_V1_PREFIX, dependencies=sse_auth_deps)
     # P2 of the chat-endpoints spec — GET /api/v1/chat/sessions and
     # GET /api/v1/chat/{session_name}/messages. Sits under the same

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -1,0 +1,398 @@
+"""Dashboard read endpoint (Phase 2 — Q1, §3.1 of the Phase 2 spec).
+
+Implements ``GET /api/v1/dashboard`` per
+``~/Desktop/pollypm-phase2-endpoints-spec.md`` §3.1. The route is a
+thin adapter over :func:`pollypm.dashboard_data.gather` (the helper
+the cockpit rail renders from) plus :func:`pollypm.web_api.service.list_projects`.
+
+Out of scope for this PR:
+
+- ``GET /api/v1/dashboard/stream`` SSE (deferred to a follow-up PR;
+  spec §3.2).
+- ``?async=true`` long-op path (spec §2.7) — sync only for now.
+
+The route's behaviour mirrors the cockpit per spec §3.3 edge cases:
+
+- A missing daemon is a normal operating mode — return ``200`` with
+  ``daemon_status="down"`` instead of 503.
+- A transient ``gather`` failure (pg pool down, broken project)
+  surfaces as ``503 service_unavailable`` so clients retry rather than
+  treat empty data as truth.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from pollypm.web_api.errors import not_found, service_unavailable
+from pollypm.web_api.models import Project
+from pollypm.web_api.routes._deps import ConfigDep
+from pollypm.web_api.service import list_projects
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Dashboard"])
+
+
+# ---------------------------------------------------------------------------
+# Response models (spec §3.1 — mirror the cockpit dataclasses)
+# ---------------------------------------------------------------------------
+
+
+class SessionActivityModel(BaseModel):
+    """Active-session row for the dashboard (cockpit ``SessionActivity``)."""
+
+    name: str
+    role: str
+    project: str
+    project_label: str
+    status: str
+    description: str
+    age_seconds: float
+
+
+class CommitInfoModel(BaseModel):
+    """Recent commit row (cockpit ``CommitInfo``)."""
+
+    hash: str
+    message: str
+    author: str
+    age_seconds: float
+    project: str
+
+
+class CompletedItemModel(BaseModel):
+    """Recently-completed work item (cockpit ``CompletedItem``)."""
+
+    title: str
+    kind: str
+    project: str
+    age_seconds: float
+
+
+class InboxPreviewModel(BaseModel):
+    """Recent inbox preview row (cockpit ``InboxPreview``)."""
+
+    sender: str
+    title: str
+    project: str
+    task_id: str
+    age_seconds: float
+
+
+class AccountQuotaUsageModel(BaseModel):
+    """Per-account quota row (cockpit ``AccountQuotaUsage``)."""
+
+    account_name: str
+    provider: str
+    email: str
+    used_pct: int
+    summary: str
+    severity: str
+    limit_label: str = "limit"
+    reset_at: str = ""
+
+
+class DashboardRollups(BaseModel):
+    """Aggregate counters mirrored from the cockpit rail."""
+
+    tracked_count: int
+    open_inbox_count: int
+    pending_plan_reviews: int
+    alert_count: int
+    sweep_count_24h: int
+    message_count_24h: int
+    recovery_count_24h: int
+
+
+class DashboardTokens(BaseModel):
+    """Token-usage summary."""
+
+    today: int
+    total: int
+
+
+class DashboardResponse(BaseModel):
+    """``GET /api/v1/dashboard`` envelope (spec §3.1)."""
+
+    generated_at: datetime
+    daemon_status: str = Field(
+        description=(
+            "One of 'up' (active sessions present) or 'down' "
+            "(no active sessions / supervisor unreachable). Per spec "
+            "§3.3, a down daemon is a normal operating mode — not a 503."
+        ),
+    )
+    projects: list[Project]
+    rollups: DashboardRollups
+    active_sessions: list[SessionActivityModel]
+    recent_commits: list[CommitInfoModel]
+    completed_items: list[CompletedItemModel]
+    recent_messages: list[InboxPreviewModel]
+    tokens: DashboardTokens
+    account_usages: list[AccountQuotaUsageModel]
+    daily_tokens: list[list[Any]] | None = Field(
+        default=None,
+        description=(
+            "Optional ``[date, tokens]`` history (last 30 days). Only "
+            "populated when ``?include_token_history=true`` since the "
+            "list can be large."
+        ),
+    )
+    briefing: str | None = Field(
+        default=None,
+        description=(
+            "Optional morning-briefing narrative. Only populated when "
+            "``?include_briefing=true`` since the body can be megabytes."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapters (dataclass -> pydantic wire shape)
+# ---------------------------------------------------------------------------
+
+
+def _session_activity_to_wire(row: Any) -> SessionActivityModel:
+    return SessionActivityModel(
+        name=row.name,
+        role=row.role,
+        project=row.project,
+        project_label=row.project_label,
+        status=row.status,
+        description=row.description,
+        age_seconds=float(row.age_seconds),
+    )
+
+
+def _commit_to_wire(row: Any) -> CommitInfoModel:
+    return CommitInfoModel(
+        hash=row.hash,
+        message=row.message,
+        author=row.author,
+        age_seconds=float(row.age_seconds),
+        project=row.project,
+    )
+
+
+def _completed_to_wire(row: Any) -> CompletedItemModel:
+    return CompletedItemModel(
+        title=row.title,
+        kind=row.kind,
+        project=row.project,
+        age_seconds=float(row.age_seconds),
+    )
+
+
+def _inbox_preview_to_wire(row: Any) -> InboxPreviewModel:
+    return InboxPreviewModel(
+        sender=row.sender,
+        title=row.title,
+        project=row.project,
+        task_id=row.task_id,
+        age_seconds=float(row.age_seconds),
+    )
+
+
+def _account_usage_to_wire(row: Any) -> AccountQuotaUsageModel:
+    return AccountQuotaUsageModel(
+        account_name=row.account_name,
+        provider=row.provider,
+        email=row.email,
+        used_pct=int(row.used_pct),
+        summary=row.summary,
+        severity=row.severity,
+        limit_label=row.limit_label,
+        reset_at=row.reset_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gather wrapper (pg-only path; sqlite store-open lives in load_dashboard)
+# ---------------------------------------------------------------------------
+
+
+def _gather_dashboard(config: Any) -> Any:
+    """Call :func:`pollypm.dashboard_data.gather` for the route.
+
+    Passes ``store=None`` — :func:`gather` already branches on the
+    pg backend and opens its own pg facades. We do not open a
+    :class:`StateStore` here because the spec mandates pg-only paths
+    for new web-api code.
+    """
+    from pollypm.dashboard_data import gather
+
+    return gather(config, None)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/dashboard",
+    response_model=DashboardResponse,
+    summary="Aggregate dashboard / cockpit state",
+    operation_id="getDashboard",
+)
+def get_dashboard_endpoint(
+    config: ConfigDep,
+    project: Annotated[
+        str | None,
+        Query(description="Narrow projects + rollups to one project key."),
+    ] = None,
+    include_token_history: Annotated[
+        bool,
+        Query(
+            description=(
+                "Include the last 30 days of token usage as "
+                "``daily_tokens=[[date, tokens], ...]``. Default false — "
+                "the list can be large."
+            ),
+        ),
+    ] = False,
+    include_briefing: Annotated[
+        bool,
+        Query(
+            description=(
+                "Include the morning-briefing narrative in the response. "
+                "Default false — the body can be megabytes."
+            ),
+        ),
+    ] = False,
+) -> DashboardResponse:
+    """GET /api/v1/dashboard per Phase 2 spec §3.1.
+
+    Returns the operator's whole-system snapshot — same shape the
+    cockpit rail computes. Eventually-consistent: clients that need
+    sub-second freshness must use the deferred SSE channel
+    (``/dashboard/stream``, follow-up PR).
+    """
+    if project is not None and project not in config.projects:
+        raise not_found(
+            f"Project not registered: {project}",
+            hint="Drop ?project= to fetch the whole-system snapshot.",
+        )
+
+    # Projects view — list_projects is the authoritative cockpit row
+    # builder; reuse it so the rollups derived below match the project
+    # rows exactly.
+    try:
+        projects_all = list_projects(config)
+    except Exception as exc:  # noqa: BLE001
+        # list_projects swallows per-project failures internally; a
+        # raise here means the config itself is unreadable.
+        logger.warning("dashboard: list_projects failed: %s", exc)
+        raise service_unavailable(
+            "Failed to load project list for dashboard",
+            hint="Check `pm doctor` and config.toml health.",
+        ) from exc
+
+    if project is not None:
+        projects_view = [p for p in projects_all if p.key == project]
+    else:
+        projects_view = list(projects_all)
+
+    # Aggregate dashboard payload (active sessions, commits, tokens,
+    # …). Transient pg outages surface as 503 per spec §3.3 final
+    # bullet; a healthy daemon-down state is captured below as
+    # ``daemon_status="down"`` (200, not 503).
+    try:
+        data = _gather_dashboard(config)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("dashboard: gather failed: %s", exc)
+        raise service_unavailable(
+            "Dashboard gather failed; backing store may be unreachable",
+            hint="Retry shortly; check `pm doctor` for pg pool health.",
+        ) from exc
+
+    # Narrow per-project lists when ?project= is set so the response is
+    # self-consistent (a caller filtering to one project shouldn't see
+    # other projects' commits / inbox previews).
+    active_sessions = list(data.active_sessions)
+    recent_commits = list(data.recent_commits)
+    completed_items = list(data.completed_items)
+    recent_messages = list(data.recent_messages)
+    if project is not None:
+        active_sessions = [s for s in active_sessions if s.project == project]
+        recent_commits = [c for c in recent_commits if c.project == project]
+        completed_items = [c for c in completed_items if c.project == project]
+        recent_messages = [m for m in recent_messages if m.project == project]
+
+    # Rollups — derive from the (possibly project-narrowed) projects
+    # view so the counts match what the cockpit rail renders.
+    tracked_count = sum(1 for p in projects_view if p.tracked)
+    open_inbox_count = sum(p.open_inbox_count for p in projects_view)
+    pending_plan_reviews = sum(
+        1 for p in projects_view if p.pending_plan_review
+    )
+
+    rollups = DashboardRollups(
+        tracked_count=tracked_count,
+        open_inbox_count=open_inbox_count,
+        pending_plan_reviews=pending_plan_reviews,
+        alert_count=int(getattr(data, "alert_count", 0) or 0),
+        sweep_count_24h=int(getattr(data, "sweep_count_24h", 0) or 0),
+        message_count_24h=int(getattr(data, "message_count_24h", 0) or 0),
+        recovery_count_24h=int(getattr(data, "recovery_count_24h", 0) or 0),
+    )
+
+    daemon_status = "up" if active_sessions else "down"
+
+    daily_tokens: list[list[Any]] | None = None
+    if include_token_history:
+        daily_tokens = [
+            [str(date), int(tokens)]
+            for date, tokens in (data.daily_tokens or [])
+        ]
+
+    briefing: str | None = None
+    if include_briefing:
+        briefing = getattr(data, "briefing", "") or ""
+
+    return DashboardResponse(
+        generated_at=datetime.now(timezone.utc),
+        daemon_status=daemon_status,
+        projects=projects_view,
+        rollups=rollups,
+        active_sessions=[
+            _session_activity_to_wire(s) for s in active_sessions
+        ],
+        recent_commits=[_commit_to_wire(c) for c in recent_commits],
+        completed_items=[
+            _completed_to_wire(c) for c in completed_items
+        ],
+        recent_messages=[
+            _inbox_preview_to_wire(m) for m in recent_messages
+        ],
+        tokens=DashboardTokens(
+            today=int(getattr(data, "today_tokens", 0) or 0),
+            total=int(getattr(data, "total_tokens", 0) or 0),
+        ),
+        account_usages=[
+            _account_usage_to_wire(u)
+            for u in (data.account_usages or [])
+        ],
+        daily_tokens=daily_tokens,
+        briefing=briefing,
+    )
+
+
+__all__ = [
+    "AccountQuotaUsageModel",
+    "CommitInfoModel",
+    "CompletedItemModel",
+    "DashboardResponse",
+    "DashboardRollups",
+    "DashboardTokens",
+    "InboxPreviewModel",
+    "SessionActivityModel",
+    "get_dashboard_endpoint",
+    "router",
+]

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -349,10 +349,25 @@ def get_dashboard_endpoint(
     # Derive daemon health from the UNFILTERED gather result. This is a
     # system-wide signal — a caller polling ``?project=foo`` must still
     # see ``daemon_status="up"`` when the supervisor is healthy and the
-    # only live sessions happen to be on ``bar``. Reordered above the
+    # only live sessions happen to be on ``bar``. Computed above the
     # per-project list slice below so the filter cannot mask supervisor
     # state.
-    daemon_status = "up" if data.active_sessions else "down"
+    #
+    # We can't use ``bool(data.active_sessions)`` directly: ``gather``
+    # appends a ``SessionActivity`` for every planned launch in
+    # ``config.projects`` (see ``dashboard_data.gather`` around L823),
+    # and rows with no matching ``runtime_map`` entry are stamped with
+    # the synthetic ``status="unknown"`` sentinel. On a configured
+    # workspace with the supervisor down and no runtime rows in pg, the
+    # active-sessions list is still non-empty — so list-truthiness would
+    # report ``daemon_status="up"`` while the daemon is genuinely down
+    # (Codex review on #2057). Only rows whose status came from a real
+    # runtime record (anything other than ``"unknown"``) count as live.
+    daemon_status = (
+        "up"
+        if any(s.status != "unknown" for s in data.active_sessions)
+        else "down"
+    )
 
     # Narrow per-project lists when ?project= is set so the response is
     # self-consistent (a caller filtering to one project shouldn't see

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -99,7 +99,17 @@ class AccountQuotaUsageModel(BaseModel):
 
 
 class DashboardRollups(BaseModel):
-    """Aggregate counters mirrored from the cockpit rail."""
+    """Aggregate counters mirrored from the cockpit rail.
+
+    Under ``?project=<key>``, only the project-derived counters
+    (``tracked_count``, ``open_inbox_count``, ``pending_plan_reviews``)
+    are narrowed to that project. ``alert_count`` and the three
+    ``*_24h`` activity counters remain whole-system because the
+    underlying ``gather`` pipeline aggregates them globally before
+    returning (see :func:`pollypm.dashboard_data.gather`). The set of
+    fields actually narrowed for a given response is enumerated on the
+    envelope's ``scoped_fields`` list so clients don't have to guess.
+    """
 
     tracked_count: int
     open_inbox_count: int
@@ -123,13 +133,27 @@ class DashboardResponse(BaseModel):
     generated_at: datetime
     daemon_status: str = Field(
         description=(
-            "One of 'up' (active sessions present) or 'down' "
-            "(no active sessions / supervisor unreachable). Per spec "
-            "§3.3, a down daemon is a normal operating mode — not a 503."
+            "One of 'up' (active sessions present anywhere in the "
+            "system) or 'down' (no active sessions / supervisor "
+            "unreachable). Always derived from the unfiltered gather "
+            "result — ``?project=`` does NOT influence this field, so "
+            "callers polling per-project still see the true daemon "
+            "health. Per spec §3.3, a down daemon is a normal "
+            "operating mode — not a 503."
         ),
     )
     projects: list[Project]
     rollups: DashboardRollups
+    scoped_fields: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of response fields actually narrowed by "
+            "``?project=``. Empty when no filter is in effect. Lets "
+            "clients tell which counters reflect the requested project "
+            "vs which remain whole-system (see ``DashboardRollups`` "
+            "docstring for why a subset of rollups stay global)."
+        ),
+    )
     active_sessions: list[SessionActivityModel]
     recent_commits: list[CommitInfoModel]
     completed_items: list[CompletedItemModel]
@@ -245,7 +269,17 @@ def get_dashboard_endpoint(
     config: ConfigDep,
     project: Annotated[
         str | None,
-        Query(description="Narrow projects + rollups to one project key."),
+        Query(
+            description=(
+                "Narrow the per-project lists (projects, sessions, "
+                "commits, completed items, recent messages) and the "
+                "three project-derived rollup counters to one project "
+                "key. The response's ``scoped_fields`` enumerates the "
+                "exact fields narrowed; the four global activity "
+                "rollups (alert / sweep / message / recovery 24h) and "
+                "``daemon_status`` remain whole-system."
+            ),
+        ),
     ] = None,
     include_token_history: Annotated[
         bool,
@@ -312,6 +346,14 @@ def get_dashboard_endpoint(
             hint="Retry shortly; check `pm doctor` for pg pool health.",
         ) from exc
 
+    # Derive daemon health from the UNFILTERED gather result. This is a
+    # system-wide signal — a caller polling ``?project=foo`` must still
+    # see ``daemon_status="up"`` when the supervisor is healthy and the
+    # only live sessions happen to be on ``bar``. Reordered above the
+    # per-project list slice below so the filter cannot mask supervisor
+    # state.
+    daemon_status = "up" if data.active_sessions else "down"
+
     # Narrow per-project lists when ?project= is set so the response is
     # self-consistent (a caller filtering to one project shouldn't see
     # other projects' commits / inbox previews).
@@ -319,14 +361,35 @@ def get_dashboard_endpoint(
     recent_commits = list(data.recent_commits)
     completed_items = list(data.completed_items)
     recent_messages = list(data.recent_messages)
+    scoped_fields: list[str] = []
     if project is not None:
         active_sessions = [s for s in active_sessions if s.project == project]
         recent_commits = [c for c in recent_commits if c.project == project]
         completed_items = [c for c in completed_items if c.project == project]
         recent_messages = [m for m in recent_messages if m.project == project]
+        # Enumerate the fields that are actually project-scoped under
+        # ``?project=`` so clients don't have to guess which rollups
+        # were narrowed. The four ``rollups.*`` activity counters
+        # (alert_count, sweep_count_24h, message_count_24h,
+        # recovery_count_24h) are intentionally NOT listed — they are
+        # aggregated globally inside ``gather`` and re-scoping them
+        # would require new pg queries we deferred for the v1 RC
+        # minimal-diff window.
+        scoped_fields = [
+            "projects",
+            "active_sessions",
+            "recent_commits",
+            "completed_items",
+            "recent_messages",
+            "rollups.tracked_count",
+            "rollups.open_inbox_count",
+            "rollups.pending_plan_reviews",
+        ]
 
-    # Rollups — derive from the (possibly project-narrowed) projects
-    # view so the counts match what the cockpit rail renders.
+    # Rollups — project-derived counters narrow with ``?project=``;
+    # the four ``gather``-computed activity counters stay global and
+    # are documented as such on the response (see ``scoped_fields``
+    # above and the ``DashboardRollups`` docstring).
     tracked_count = sum(1 for p in projects_view if p.tracked)
     open_inbox_count = sum(p.open_inbox_count for p in projects_view)
     pending_plan_reviews = sum(
@@ -342,8 +405,6 @@ def get_dashboard_endpoint(
         message_count_24h=int(getattr(data, "message_count_24h", 0) or 0),
         recovery_count_24h=int(getattr(data, "recovery_count_24h", 0) or 0),
     )
-
-    daemon_status = "up" if active_sessions else "down"
 
     daily_tokens: list[list[Any]] | None = None
     if include_token_history:
@@ -361,6 +422,7 @@ def get_dashboard_endpoint(
         daemon_status=daemon_status,
         projects=projects_view,
         rollups=rollups,
+        scoped_fields=scoped_fields,
         active_sessions=[
             _session_activity_to_wire(s) for s in active_sessions
         ],

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -635,6 +635,75 @@ def test_dashboard_daemon_status_reflects_unfiltered_sessions(
     assert body["daemon_status"] == "up"
 
 
+def test_dashboard_daemon_status_down_when_only_unknown_sessions(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    """Regression for Codex round-2 review on PR #2057.
+
+    ``dashboard_data.gather`` appends a ``SessionActivity`` for every
+    planned launch in ``config.projects`` regardless of whether a
+    runtime row exists in pg — when no runtime is found, the row is
+    stamped with the synthetic ``status="unknown"`` sentinel. On a
+    configured workspace with the supervisor down, ``active_sessions``
+    is therefore non-empty even though the daemon is genuinely down.
+    ``daemon_status`` must look past the placeholder rows and only
+    treat real runtime-backed statuses as ``"up"``.
+    """
+    patch_list_projects([_api_project("myproj")])
+    patch_gather(_make_data(
+        active_sessions=[
+            # Only synthetic "unknown" placeholder rows — no runtime
+            # records in pg, daemon is down.
+            SessionActivity(
+                name="myproj-operator", role="operator", project="myproj",
+                project_label="My Project", status="unknown",
+                description="unknown", age_seconds=0.0,
+            ),
+            SessionActivity(
+                name="myproj-worker", role="worker", project="myproj",
+                project_label="My Project", status="unknown",
+                description="unknown", age_seconds=0.0,
+            ),
+        ],
+    ))
+
+    body = client.get("/api/v1/dashboard", headers=auth_headers).json()
+    # The placeholder rows pass through (the cockpit panel shows them
+    # too), but daemon_status must reflect liveness, not list-length.
+    assert len(body["active_sessions"]) == 2
+    assert body["daemon_status"] == "down"
+
+
+def test_dashboard_daemon_status_up_when_mixed_unknown_and_live(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    """A single live runtime row is enough to flip daemon_status="up",
+    even when surrounded by synthetic ``unknown`` placeholders for
+    other configured-but-not-running sessions.
+    """
+    patch_list_projects([
+        _api_project("myproj"),
+        _api_project("otherproj"),
+    ])
+    patch_gather(_make_data(
+        active_sessions=[
+            SessionActivity(
+                name="myproj-operator", role="operator", project="myproj",
+                project_label="My Project", status="unknown",
+                description="unknown", age_seconds=0.0,
+            ),
+            SessionActivity(
+                name="otherproj-worker", role="worker", project="otherproj",
+                project_label="Other Project", status="healthy",
+                description="idle", age_seconds=5.0,
+            ),
+        ],
+    ))
+
+    body = client.get("/api/v1/dashboard", headers=auth_headers).json()
+    assert body["daemon_status"] == "up"
+
+
 def test_dashboard_account_usages_passthrough(
     client, auth_headers, patch_gather, patch_list_projects,
 ):

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -522,6 +522,119 @@ def test_dashboard_503_when_list_projects_raises(
 # ---------------------------------------------------------------------------
 
 
+def test_dashboard_project_filter_keeps_global_activity_rollups(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    """Regression for Codex PR #2057 P0 #1.
+
+    Under ``?project=myproj`` the response must NOT silently inherit
+    cross-project alert / sweep / message / recovery counts as if they
+    were narrowed to ``myproj``. The gather pipeline aggregates these
+    four counters globally (sessions for other projects contribute),
+    so for the v1 RC minimal-diff window we surface them unchanged and
+    enumerate the actually-narrowed fields in ``scoped_fields`` so
+    clients can tell the difference.
+    """
+    patch_list_projects([
+        _api_project("myproj", open_inbox_count=3, pending_plan_review=True),
+        _api_project("otherproj", tracked=False, open_inbox_count=10),
+    ])
+    # The dashboard data here represents the WHOLE system; sessions /
+    # commits / inbox previews for "otherproj" are part of the global
+    # picture, and the four rollups below were computed across both
+    # projects.
+    patch_gather(_make_data(
+        active_sessions=[
+            SessionActivity(
+                name="otherproj-worker", role="worker", project="otherproj",
+                project_label="Other Project", status="running",
+                description="other work", age_seconds=5.0,
+            ),
+        ],
+        recent_commits=[
+            CommitInfo(hash="a", message="m1", author="s",
+                       age_seconds=1, project="otherproj"),
+        ],
+        alert_count=6,
+        sweep_count_24h=12,
+        message_count_24h=4,
+        recovery_count_24h=2,
+    ))
+
+    body = client.get(
+        "/api/v1/dashboard?project=myproj", headers=auth_headers,
+    ).json()
+
+    # Project-derived rollups follow the narrowed projects view.
+    rollups = body["rollups"]
+    assert rollups["tracked_count"] == 1
+    assert rollups["open_inbox_count"] == 3
+    assert rollups["pending_plan_reviews"] == 1
+    # Global activity rollups are surfaced unchanged (documented as
+    # not-narrowed via the ``scoped_fields`` contract below).
+    assert rollups["alert_count"] == 6
+    assert rollups["sweep_count_24h"] == 12
+    assert rollups["message_count_24h"] == 4
+    assert rollups["recovery_count_24h"] == 2
+
+    # Contract — the response enumerates exactly which fields the
+    # filter narrowed. The four global activity counters MUST NOT
+    # appear here; the project-derived rollups MUST.
+    scoped = set(body["scoped_fields"])
+    assert "rollups.tracked_count" in scoped
+    assert "rollups.open_inbox_count" in scoped
+    assert "rollups.pending_plan_reviews" in scoped
+    assert "rollups.alert_count" not in scoped
+    assert "rollups.sweep_count_24h" not in scoped
+    assert "rollups.message_count_24h" not in scoped
+    assert "rollups.recovery_count_24h" not in scoped
+
+
+def test_dashboard_scoped_fields_empty_without_filter(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    """Without ``?project=``, ``scoped_fields`` must be empty."""
+    patch_list_projects([_api_project("myproj")])
+    patch_gather(_make_data())
+    body = client.get("/api/v1/dashboard", headers=auth_headers).json()
+    assert body["scoped_fields"] == []
+
+
+def test_dashboard_daemon_status_reflects_unfiltered_sessions(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    """Regression for Codex PR #2057 P0 #2.
+
+    ``daemon_status`` is a system-wide health signal — it must be
+    derived from the UNFILTERED gather result. A caller polling
+    ``?project=foo`` (which has no live sessions) must still see
+    ``daemon_status="up"`` when the supervisor is healthy and another
+    project (``bar``) has active sessions.
+    """
+    patch_list_projects([
+        _api_project("myproj"),
+        _api_project("otherproj"),
+    ])
+    patch_gather(_make_data(
+        active_sessions=[
+            SessionActivity(
+                name="otherproj-worker", role="worker", project="otherproj",
+                project_label="Other Project", status="running",
+                description="busy", age_seconds=3.0,
+            ),
+        ],
+    ))
+
+    body = client.get(
+        "/api/v1/dashboard?project=myproj", headers=auth_headers,
+    ).json()
+    # Filtered active_sessions is empty because the only live session
+    # is for otherproj…
+    assert body["active_sessions"] == []
+    # …but daemon_status must still reflect the unfiltered truth.
+    assert body["daemon_status"] == "up"
+
+
 def test_dashboard_account_usages_passthrough(
     client, auth_headers, patch_gather, patch_list_projects,
 ):

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -1,0 +1,548 @@
+"""Integration tests for ``GET /api/v1/dashboard`` (Phase 2 §3.1).
+
+Mirrors the test style of ``tests/test_chat_messages_endpoint.py``:
+FastAPI ``TestClient`` against an in-process app, with the heavy
+``pollypm.dashboard_data.gather`` call monkeypatched so the suite
+never touches a live pg pool or tmux server.
+
+Run with ``pytest --noconftest tests/test_dashboard_endpoint.py -v
+--timeout=120`` — the per-project conftest requires a Postgres
+harness which these tests intentionally avoid.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.dashboard_data import (
+    AccountQuotaUsage,
+    CommitInfo,
+    CompletedItem,
+    DashboardData,
+    InboxPreview,
+    SessionActivity,
+)
+from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.routes import dashboard as dashboard_routes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def other_project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "otherproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def config(
+    workspace: Path, project_root: Path, other_project_root: Path,
+) -> PollyPMConfig:
+    base_dir = workspace / ".pollypm"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+            "otherproj": KnownProject(
+                key="otherproj",
+                path=other_project_root,
+                name="Other Project",
+                tracked=False,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def empty_config(workspace: Path) -> PollyPMConfig:
+    """Config with no projects + no accounts (spec §3.3 empty-config case)."""
+    base_dir = workspace / ".pollypm"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={},
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def token(tmp_path: Path) -> tuple[Path, str]:
+    token_path = tmp_path / "api-token"
+    value, _generated = ensure_token(token_path)
+    return token_path, value
+
+
+@pytest.fixture
+def auth_headers(token: tuple[Path, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token[1]}"}
+
+
+@pytest.fixture
+def app(config, token):
+    token_path, _value = token
+    return create_app(config=config, token_path=token_path)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_data(
+    *,
+    active_sessions: list[SessionActivity] | None = None,
+    recent_commits: list[CommitInfo] | None = None,
+    completed_items: list[CompletedItem] | None = None,
+    recent_messages: list[InboxPreview] | None = None,
+    daily_tokens: list[tuple[str, int]] | None = None,
+    today_tokens: int = 0,
+    total_tokens: int = 0,
+    sweep_count_24h: int = 0,
+    message_count_24h: int = 0,
+    recovery_count_24h: int = 0,
+    inbox_count: int = 0,
+    alert_count: int = 0,
+    account_usages: list[AccountQuotaUsage] | None = None,
+    briefing: str = "",
+) -> DashboardData:
+    return DashboardData(
+        active_sessions=active_sessions or [],
+        recent_commits=recent_commits or [],
+        completed_items=completed_items or [],
+        recent_messages=recent_messages or [],
+        daily_tokens=daily_tokens or [],
+        today_tokens=today_tokens,
+        total_tokens=total_tokens,
+        sweep_count_24h=sweep_count_24h,
+        message_count_24h=message_count_24h,
+        recovery_count_24h=recovery_count_24h,
+        inbox_count=inbox_count,
+        alert_count=alert_count,
+        account_usages=account_usages or [],
+        briefing=briefing,
+    )
+
+
+@pytest.fixture
+def patch_gather(monkeypatch: pytest.MonkeyPatch):
+    """Factory that swaps ``_gather_dashboard`` for a stub."""
+
+    def install(data: DashboardData) -> None:
+        monkeypatch.setattr(
+            dashboard_routes, "_gather_dashboard",
+            lambda _config: data,
+        )
+    return install
+
+
+@pytest.fixture
+def patch_list_projects(monkeypatch: pytest.MonkeyPatch):
+    """Factory that stubs ``list_projects`` so tests don't open a work-service.
+
+    The real :func:`pollypm.web_api.service.list_projects` tries to open
+    a work-service per project to gather state counts; without pg this
+    raises immediately and falls back to empty counts but spams logs.
+    Tests can install a deterministic project list via this fixture.
+    """
+
+    def install(projects: list[object]) -> None:
+        monkeypatch.setattr(
+            dashboard_routes, "list_projects",
+            lambda _config, **_kw: list(projects),
+        )
+    return install
+
+
+def _api_project(
+    key: str,
+    *,
+    tracked: bool = True,
+    open_inbox_count: int = 0,
+    pending_plan_review: bool = False,
+    name: str | None = None,
+    path: str = "/tmp/proj",
+) -> object:
+    # Use the real Project pydantic model so list_projects -> response
+    # round-trips correctly.
+    from pollypm.web_api.models import Project
+
+    return Project(
+        key=key,
+        name=name or key,
+        path=path,
+        tracked=tracked,
+        kind="git",
+        persona_name=None,
+        state=None,
+        glyph="ok",
+        task_counts={},
+        open_inbox_count=open_inbox_count,
+        pending_plan_review=pending_plan_review,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_returns_expected_shape(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    patch_list_projects([
+        _api_project("myproj", open_inbox_count=3, pending_plan_review=True),
+        _api_project("otherproj", tracked=False, open_inbox_count=1),
+    ])
+    patch_gather(_make_data(
+        active_sessions=[
+            SessionActivity(
+                name="operator", role="operator", project="myproj",
+                project_label="My Project", status="running",
+                description="thinking", age_seconds=12.5,
+            ),
+        ],
+        recent_commits=[
+            CommitInfo(
+                hash="abc1234", message="fix: thing", author="sam",
+                age_seconds=300.0, project="myproj",
+            ),
+        ],
+        today_tokens=1234,
+        total_tokens=98765,
+        alert_count=2,
+        sweep_count_24h=5,
+        message_count_24h=7,
+        recovery_count_24h=1,
+    ))
+
+    response = client.get("/api/v1/dashboard", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    # Envelope keys present
+    assert set(body.keys()) >= {
+        "generated_at", "daemon_status", "projects", "rollups",
+        "active_sessions", "recent_commits", "completed_items",
+        "recent_messages", "tokens", "account_usages",
+    }
+    # Projects passthrough
+    assert [p["key"] for p in body["projects"]] == ["myproj", "otherproj"]
+    # Rollups derived from project view
+    rollups = body["rollups"]
+    assert rollups["tracked_count"] == 1  # only myproj is tracked
+    assert rollups["open_inbox_count"] == 4
+    assert rollups["pending_plan_reviews"] == 1
+    assert rollups["alert_count"] == 2
+    assert rollups["sweep_count_24h"] == 5
+    assert rollups["message_count_24h"] == 7
+    assert rollups["recovery_count_24h"] == 1
+    # Sessions / commits passthrough
+    assert body["active_sessions"][0]["name"] == "operator"
+    assert body["recent_commits"][0]["hash"] == "abc1234"
+    # Tokens
+    assert body["tokens"] == {"today": 1234, "total": 98765}
+    # Daemon status driven by sessions presence
+    assert body["daemon_status"] == "up"
+    # Optional fields default off
+    assert body.get("daily_tokens") is None
+    assert body.get("briefing") is None
+
+
+def test_dashboard_daemon_down_when_no_active_sessions(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    # Spec §3.3: daemon-down is a normal mode — 200 with daemon_status="down"
+    patch_list_projects([_api_project("myproj")])
+    patch_gather(_make_data(active_sessions=[]))
+    response = client.get("/api/v1/dashboard", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["daemon_status"] == "down"
+    assert body["active_sessions"] == []
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_requires_bearer(client, patch_gather, patch_list_projects):
+    patch_list_projects([])
+    patch_gather(_make_data())
+    response = client.get("/api/v1/dashboard")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] in {"unauthorized", "invalid_token"}
+
+
+def test_dashboard_rejects_wrong_token(client, patch_gather, patch_list_projects):
+    patch_list_projects([])
+    patch_gather(_make_data())
+    response = client.get(
+        "/api/v1/dashboard",
+        headers={"Authorization": "Bearer bogus-token"},
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
+
+
+# ---------------------------------------------------------------------------
+# Optional filters
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_project_filter_narrows_view(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    patch_list_projects([
+        _api_project("myproj", open_inbox_count=3),
+        _api_project("otherproj", open_inbox_count=10),
+    ])
+    patch_gather(_make_data(
+        recent_commits=[
+            CommitInfo(hash="a", message="m1", author="s", age_seconds=1, project="myproj"),
+            CommitInfo(hash="b", message="m2", author="s", age_seconds=1, project="otherproj"),
+        ],
+        recent_messages=[
+            InboxPreview(sender="x", title="hi", project="otherproj",
+                         task_id="otherproj/1", age_seconds=1),
+        ],
+    ))
+
+    body = client.get(
+        "/api/v1/dashboard?project=myproj", headers=auth_headers,
+    ).json()
+    assert [p["key"] for p in body["projects"]] == ["myproj"]
+    # Cross-project rows filtered out
+    assert [c["hash"] for c in body["recent_commits"]] == ["a"]
+    assert body["recent_messages"] == []
+    # Rollups follow the narrowed project view
+    assert body["rollups"]["open_inbox_count"] == 3
+
+
+def test_dashboard_unknown_project_returns_404(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    patch_list_projects([_api_project("myproj")])
+    patch_gather(_make_data())
+    response = client.get(
+        "/api/v1/dashboard?project=missing", headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_dashboard_include_token_history(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    patch_list_projects([_api_project("myproj")])
+    patch_gather(_make_data(
+        daily_tokens=[("2026-05-20", 100), ("2026-05-21", 200)],
+        today_tokens=200,
+    ))
+    body = client.get(
+        "/api/v1/dashboard?include_token_history=true", headers=auth_headers,
+    ).json()
+    assert body["daily_tokens"] == [["2026-05-20", 100], ["2026-05-21", 200]]
+
+
+def test_dashboard_include_briefing(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    patch_list_projects([_api_project("myproj")])
+    patch_gather(_make_data(briefing="Last 24 hours: 3 commits."))
+    body = client.get(
+        "/api/v1/dashboard?include_briefing=true", headers=auth_headers,
+    ).json()
+    assert body["briefing"] == "Last 24 hours: 3 commits."
+
+
+# ---------------------------------------------------------------------------
+# Empty / edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_empty_config(
+    empty_config, token, patch_gather, patch_list_projects,
+):
+    # Spec §3.3-aligned: a workspace with no projects should still
+    # return a well-formed 200 response.
+    token_path, value = token
+    app = create_app(config=empty_config, token_path=token_path)
+    client = TestClient(app)
+    patch_list_projects([])
+    patch_gather(_make_data())
+    response = client.get(
+        "/api/v1/dashboard",
+        headers={"Authorization": f"Bearer {value}"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["projects"] == []
+    assert body["active_sessions"] == []
+    assert body["rollups"]["tracked_count"] == 0
+    assert body["rollups"]["open_inbox_count"] == 0
+    assert body["rollups"]["pending_plan_reviews"] == 0
+    assert body["daemon_status"] == "down"
+
+
+# ---------------------------------------------------------------------------
+# Service-unavailable handling
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_503_when_gather_raises(
+    client, auth_headers, patch_list_projects, monkeypatch,
+):
+    patch_list_projects([_api_project("myproj")])
+
+    def _boom(_config):
+        raise RuntimeError("pg pool down")
+
+    monkeypatch.setattr(dashboard_routes, "_gather_dashboard", _boom)
+    response = client.get("/api/v1/dashboard", headers=auth_headers)
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "service_unavailable"
+
+
+def test_dashboard_503_when_list_projects_raises(
+    client, auth_headers, patch_gather, monkeypatch,
+):
+    def _boom(_config, **_kw):
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(dashboard_routes, "list_projects", _boom)
+    patch_gather(_make_data())
+    response = client.get("/api/v1/dashboard", headers=auth_headers)
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "service_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Account usage passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_account_usages_passthrough(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    patch_list_projects([_api_project("myproj")])
+    patch_gather(_make_data(
+        account_usages=[
+            AccountQuotaUsage(
+                account_name="codex_primary",
+                provider="codex",
+                email="codex@example.com",
+                used_pct=42,
+                summary="42% used",
+                severity="ok",
+                limit_label="5h limit",
+                reset_at="2026-05-22T01:00:00Z",
+            ),
+        ],
+    ))
+    body = client.get("/api/v1/dashboard", headers=auth_headers).json()
+    assert len(body["account_usages"]) == 1
+    row = body["account_usages"][0]
+    assert row["account_name"] == "codex_primary"
+    assert row["used_pct"] == 42
+    assert row["reset_at"] == "2026-05-22T01:00:00Z"


### PR DESCRIPTION
## Summary

Phase 2 §3.1 — ships the read-only `GET /api/v1/dashboard` endpoint that returns the same whole-system snapshot the cockpit rail computes. Small focused PR; SSE streaming (§3.2) and `?async=true` long-op handling (§2.7) are deferred to follow-up PRs.

- New router at `src/pollypm/web_api/routes/dashboard.py` (one GET handler) that wraps `pollypm.dashboard_data.gather()` + `pollypm.web_api.service.list_projects()`. No new business logic — pure adapter.
- Filters per spec: `?project=<key>` (narrows projects + rollups + per-project rows), `?include_token_history=true`, `?include_briefing=true`.
- Daemon-down is normal — returns `200` with `daemon_status: "down"` and empty `active_sessions[]` (spec §3.3); transient gather/list_projects failures surface as `503 service_unavailable`.
- pg-only path: `gather(config, None)` lets the helper open its own pg facades. No `StateStore`.

## Test plan

- [x] 12 FastAPI TestClient cases in `tests/test_dashboard_endpoint.py` covering happy path, daemon-up/down, bearer auth (missing + wrong token), `?project` filter, unknown project 404, `include_token_history`, `include_briefing`, empty-config, gather-503, list_projects-503, account-usage passthrough.
- [x] Run: `pytest --noconftest tests/test_dashboard_endpoint.py -v` — 12 passed in 1.68s.
- [x] OpenAPI conformance suite still green (`tests/web_api/test_openapi_conformance.py` — 4 passed; the 1 pre-existing fixture error is a `--noconftest` artifact unrelated to this PR).
- [ ] Manual: `curl http://127.0.0.1:8765/api/v1/dashboard -H "Authorization: Bearer $(cat ~/.pollypm/api-token)" | jq .rollups` should match `pm` cockpit rail counters.

## OpenAPI

`docs/api/openapi.yaml` adds the `/dashboard` path with full parameter/response docs, a new `Dashboard` tag, and 7 new schemas (`DashboardResponse`, `DashboardRollups`, `DashboardTokens`, `SessionActivity`, `CommitInfo`, `CompletedItem`, `InboxPreview`, `AccountQuotaUsage`).

## Spec notes / ambiguities

- Spec §3.1 lists `pending_plan_reviews` in `rollups` but mentions `stuck_alerts` / `in_progress_tasks` / `review_tasks` as well — kept the four spec-explicit fields (`tracked_count`, `open_inbox_count`, `pending_plan_reviews`, `alert_count`) plus the three cockpit-native 24h counters (`sweep`, `message`, `recovery`). `in_progress_tasks` / `review_tasks` are already discoverable per-project from each `Project.task_counts` map; flagged for spec follow-up if Sam wants them denormalized.
- Spec §3.1 mentions `alerts: [Alert]` from heartbeats — left out of this PR (would require importing heartbeats/types.py and is bigger than the small-PR scope). `rollups.alert_count` carries the aggregate count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)