### PR TITLE
feat(api): GET+POST /api/v1/doctor — Phase 2 doctor checks + run/fix

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,10 +1,11 @@
 openapi: 3.1.0
-# Phase 6 cleanup: removed stale entries for `/doctor`, `POST /projects`,
+# Phase 6 cleanup: removed stale entries for `POST /projects`,
 # `POST /projects/{key}/chat`, `POST /projects/{key}/plan`, and the
 # `/tasks/{project}/{n}/approve` + `/reject` pair. None were wired in
 # `pollypm.web_api.app`. The plan approve/reject flow is tracked
-# separately as Phase 3 work; doctor reads live at `/doctor/checks`
-# and `/doctor/report`.
+# separately as Phase 3 work. Doctor surface (`/doctor`,
+# `/doctor/checks`, `/doctor/report`, `/doctor/run`) is wired in
+# `pollypm.web_api.routes.doctor`.
 info:
   title: PollyPM Web API
   version: 0.1.0
@@ -115,6 +116,122 @@ paths:
                     version: 0.1.0
                     schema_version: 1
                     started_at: "2026-05-07T12:00:00Z"
+
+  /doctor:
+    get:
+      tags: [Health]
+      operationId: getDoctor
+      summary: Structured pm doctor output
+      description: |
+        Mirrors the structured JSON output of `pm doctor` (PR #1347).
+        Returns each check with status (ok / warn / fail), an actor
+        message, and an optional remediation hint.
+      responses:
+        "200":
+          description: Doctor results (200 even when checks fail; consult `overall`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoctorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /doctor/checks:
+    get:
+      tags: [Doctor]
+      operationId: listDoctorChecks
+      summary: List available doctor checks
+      description: |
+        Returns the catalog of registered checks (name, category,
+        severity). Phase 2 §7.1. The catalog is process-static — restart
+        `pm serve` to pick up plugin-contributed checks.
+      responses:
+        "200":
+          description: List of registered checks.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoctorChecksResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /doctor/report:
+    get:
+      tags: [Doctor]
+      operationId: getDoctorReport
+      summary: Return the last-run doctor report
+      description: |
+        Returns the most recent in-process doctor report. 404 if no
+        run has happened yet — callers should `POST /doctor/run`
+        first. Phase 2 §7.1.
+      responses:
+        "200":
+          description: Last-run report.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoctorReportResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /doctor/run:
+    post:
+      tags: [Doctor]
+      operationId: runDoctor
+      summary: Run doctor checks (optionally with --fix)
+      description: |
+        Runs every registered check or one named check, optionally
+        invoking auto-fix afterwards and re-running fixed checks to
+        verify post-fix state. Phase 2 §7.1.
+
+        Spec §2.7 long-running budget: the whole run is capped at
+        `timeout_seconds` (default 25, max 120); overrun returns
+        `504 timeout`.
+      parameters:
+        - in: query
+          name: timeout_seconds
+          schema:
+            type: number
+            minimum: 1
+            maximum: 120
+            default: 25
+          required: false
+          description: Wall-clock budget for the run.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DoctorRunRequest"
+            examples:
+              run_all:
+                value:
+                  fix: false
+              single_check_with_fix:
+                value:
+                  check: pollypm-home-writable
+                  fix: true
+      responses:
+        "200":
+          description: Run completed (200 even when checks fail; consult `ok` / `errors`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoctorRunResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "504":
+          description: Run exceeded the timeout budget; retry with a longer `timeout_seconds`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /projects:
     get:
@@ -1829,6 +1946,117 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DoctorCheck"
+
+    # Phase 2 §7 doctor surface schemas. Distinct from the legacy
+    # ``DoctorCheck`` / ``DoctorResponse`` shapes above because Phase 2
+    # mirrors the canonical ``pollypm.doctor.Check`` / ``CheckResult``
+    # dataclasses field-for-field (severity, why, fix, fixable, etc.)
+    # rather than collapsing to the ok/warn/fail summary the V1 endpoint
+    # uses.
+    DoctorCheckInfo:
+      type: object
+      required: [name, category, severity]
+      properties:
+        name: { type: string }
+        category: { type: string }
+        severity:
+          type: string
+          enum: [info, warning, error]
+        description:
+          type: string
+          default: ""
+        has_auto_fix:
+          type: boolean
+          default: false
+    DoctorChecksResponse:
+      type: object
+      required: [checks]
+      properties:
+        checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/DoctorCheckInfo"
+    DoctorCheckResult:
+      type: object
+      required: [name, category, passed, skipped, severity]
+      properties:
+        name: { type: string }
+        category: { type: string }
+        passed: { type: boolean }
+        skipped: { type: boolean }
+        severity:
+          type: string
+          enum: [info, warning, error]
+        status:
+          type: string
+          default: ""
+        why:
+          type: string
+          default: ""
+        fix:
+          type: string
+          default: ""
+        fixable:
+          type: boolean
+          default: false
+        has_auto_fix:
+          type: boolean
+          default: false
+        data:
+          type: object
+          additionalProperties: true
+    DoctorReportResponse:
+      type: object
+      required: [generated_at, duration_seconds, ok, passed, errors, warnings, skipped, checks]
+      properties:
+        generated_at:
+          type: number
+          description: Unix epoch seconds when the report was recorded.
+        duration_seconds:
+          type: number
+        ok:
+          type: boolean
+          description: True iff the run produced no error-severity failures.
+        passed:
+          type: integer
+        errors:
+          type: integer
+        warnings:
+          type: integer
+        skipped:
+          type: integer
+        checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/DoctorCheckResult"
+    DoctorRunRequest:
+      type: object
+      properties:
+        check:
+          type: string
+          nullable: true
+          description: Single check name to run. Omit / null to run every registered check.
+        fix:
+          type: boolean
+          default: false
+          description: When true, runs auto-fixes for failing checks and re-runs each fixed check to verify post-fix state.
+    DoctorRunResponse:
+      allOf:
+        - $ref: "#/components/schemas/DoctorReportResponse"
+        - type: object
+          properties:
+            fixes_applied:
+              type: array
+              description: One entry per attempted auto-fix; ``ok=true`` only when the fix handler succeeded (the post-fix re-run is reflected in the ``checks`` array).
+              items:
+                type: object
+                required: [name, ok]
+                properties:
+                  name: { type: string }
+                  ok: { type: boolean }
+                  message:
+                    type: string
+                    default: ""
 
     # ---- Projects ---------------------------------------------------
     ProjectKind:

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -16,9 +16,10 @@ import concurrent.futures
 import logging
 import threading
 import time
+from concurrent.futures import thread as _futures_thread
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from fastapi import Depends, FastAPI
 from fastapi.exceptions import RequestValidationError
@@ -82,6 +83,59 @@ _DOCTOR_THREAD_PREFIX = "doctor"
 _DOCTOR_SHUTDOWN_GRACE_S = 5.0
 
 
+class _DaemonThread(threading.Thread):
+    """``threading.Thread`` subclass that defaults ``daemon=True``.
+
+    Used as a drop-in replacement for ``threading.Thread`` inside
+    :class:`DaemonThreadPoolExecutor._adjust_thread_count` so worker
+    threads inherit ``daemon=True`` without us having to mirror the
+    cpython ``_adjust_thread_count`` body (its argument shape differs
+    between Python 3.13 and 3.14, and pyproject.toml currently allows
+    both — see Codex round-6 on #2058).
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+        kwargs.setdefault("daemon", True)
+        super().__init__(*args, **kwargs)
+
+
+class DaemonThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
+    """ThreadPoolExecutor whose worker threads are daemon threads.
+
+    Required for executors that may have wedged workers at shutdown:
+    a non-daemon ``ThreadPoolExecutor`` worker keeps the interpreter
+    alive after ``executor.shutdown(wait=False)`` returns, so ``pm
+    serve`` cannot exit while a doctor check is hung even though
+    FastAPI lifespan teardown has already returned.
+
+    Trade-off: daemon threads can be terminated mid-operation when the
+    process exits. That is acceptable for doctor work because by the
+    time the process is exiting the operator has already received a
+    504 (``routes/doctor.py:_await_with_budget`` returns while
+    abandoning the worker), and there is no recoverable in-process
+    state — fixes that mutate disk/storage are bounded by their own
+    cooperative checks, not by the worker thread's liveness.
+
+    We override ``_adjust_thread_count`` by temporarily patching
+    ``concurrent.futures.thread.threading.Thread`` (the symbol the
+    stdlib body uses to construct workers) to a daemon-defaulting
+    subclass, then delegating to ``super()``. This avoids mirroring
+    the stdlib body — its ``threading.Thread(...)`` ``args=`` tuple
+    shape changed between Python 3.13 (``(weakref, queue, init,
+    initargs)``) and 3.14 (``(weakref, worker_context, queue)``), and
+    pyproject.toml allows both interpreters. Patching the constructor
+    is version-portable.
+    """
+
+    def _adjust_thread_count(self) -> None:  # type: ignore[override]
+        original_thread_cls = _futures_thread.threading.Thread
+        _futures_thread.threading.Thread = _DaemonThread  # type: ignore[attr-defined,misc]
+        try:
+            super()._adjust_thread_count()
+        finally:
+            _futures_thread.threading.Thread = original_thread_cls  # type: ignore[attr-defined,misc]
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan that owns the doctor executor + locks.
@@ -90,11 +144,14 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     doctor routes resolve them via ``request.app.state`` rather than
     reaching into module-level globals:
 
-    - ``doctor_executor``: shared ``ThreadPoolExecutor`` for check /
-      fix / verify work. ``max_workers=2`` matches the per-request
-      ``--fix`` single-flight: one slot for fix, one for parallel
-      read-only checks. Larger fan-out is gratuitous (doctor is an
-      operator surface, not a hot path).
+    - ``doctor_executor``: shared :class:`DaemonThreadPoolExecutor`
+      for check / fix / verify work. ``max_workers=2`` matches the
+      per-request ``--fix`` single-flight: one slot for fix, one for
+      parallel read-only checks. Larger fan-out is gratuitous
+      (doctor is an operator surface, not a hot path). Daemon
+      workers are mandatory so a wedged check doesn't keep
+      ``pm serve`` alive after shutdown — see Codex round-6 on
+      #2058 and the class docstring for the trade-off.
     - ``doctor_fix_lock``: serializes ``fix=true`` runs across the
       app. Held by the request that wins, released by the worker's
       done-callback when the future truly terminates (not when the
@@ -111,7 +168,17 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     log a warning if any worker is still alive (the v1 RC tradeoff:
     we can't kill the thread, but we can refuse to block on it).
     """
-    app.state.doctor_executor = concurrent.futures.ThreadPoolExecutor(
+    # Daemon-thread executor so a wedged worker doesn't keep the
+    # interpreter alive past app shutdown. ``executor.shutdown(wait=
+    # False)`` releases FastAPI lifespan, but a non-daemon worker
+    # would still block ``pm serve`` exit until the worker returns
+    # naturally — see Codex round-6 on #2058. Daemon workers let the
+    # interpreter exit; the trade-off (workers can be killed mid-op
+    # at process exit) is acceptable because the operator has already
+    # been told 504 by ``_await_with_budget`` and doctor fix
+    # mutations are bounded by cooperative checks rather than worker
+    # liveness.
+    app.state.doctor_executor = DaemonThreadPoolExecutor(
         max_workers=_DOCTOR_MAX_WORKERS,
         thread_name_prefix=_DOCTOR_THREAD_PREFIX,
     )
@@ -149,6 +216,24 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
                 len(still_running),
                 _DOCTOR_SHUTDOWN_GRACE_S,
             )
+            # ``concurrent.futures`` registers an ``atexit`` hook
+            # (``_python_exit``) that joins every executor worker
+            # via the module-level ``_threads_queues`` dict. That
+            # join blocks ``pm serve`` interpreter exit even when
+            # the workers are daemon threads. Pop our workers out
+            # of that mapping so the atexit hook can't reach them
+            # — combined with ``daemon=True`` (see
+            # :class:`DaemonThreadPoolExecutor`) the process can
+            # now exit. Codex round-6 on #2058.
+            try:
+                for t in still_running:
+                    _futures_thread._threads_queues.pop(t, None)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "lifespan: failed to evict wedged doctor worker(s) "
+                    "from concurrent.futures._threads_queues",
+                    exc_info=True,
+                )
 
 
 def create_app(

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -12,8 +12,13 @@ tmp config / tmp token paths.
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
+import threading
+import time
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import AsyncIterator
 
 from fastapi import Depends, FastAPI
 from fastapi.exceptions import RequestValidationError
@@ -52,6 +57,100 @@ logger = logging.getLogger(__name__)
 API_V1_PREFIX = "/api/v1"
 
 
+# Doctor run/fix work runs in a dedicated thread pool so a slow check
+# (network probe, blocked filesystem, wedged subprocess) trips the
+# route's wall-clock timeout without hanging the request thread. The
+# pool + its single-flight / last-report locks live on ``app.state``
+# and are owned by the lifespan context below: startup creates them,
+# shutdown cancels in-flight work and waits briefly for the pool to
+# drain. Previously these were module-level globals in
+# ``routes/doctor.py``; that left timed-out worker threads alive past
+# ``pm serve`` shutdown with no FastAPI hook to call
+# ``shutdown(cancel_futures=True)`` (Codex round-5 on #2058).
+_DOCTOR_MAX_WORKERS = 2
+_DOCTOR_THREAD_PREFIX = "doctor"
+# Bound on the post-shutdown wait for in-flight doctor workers. Doctor
+# work is a mix of fast checks and bounded fixes; in practice the
+# longest checks are bounded by ``DEFAULT_RUN_TIMEOUT_SECONDS`` (25s).
+# We don't block app teardown for that long — a timed-out worker by
+# definition has overrun its budget, so we cancel queued work, wait
+# briefly for cooperative completion, and log a warning if anything is
+# still alive after the grace period. The worker keeps running until it
+# returns naturally (Python stdlib has no safe way to interrupt
+# arbitrary blocking code) but it no longer holds the FastAPI app's
+# shutdown hostage.
+_DOCTOR_SHUTDOWN_GRACE_S = 5.0
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """FastAPI lifespan that owns the doctor executor + locks.
+
+    Startup attaches the following attributes to ``app.state`` so the
+    doctor routes resolve them via ``request.app.state`` rather than
+    reaching into module-level globals:
+
+    - ``doctor_executor``: shared ``ThreadPoolExecutor`` for check /
+      fix / verify work. ``max_workers=2`` matches the per-request
+      ``--fix`` single-flight: one slot for fix, one for parallel
+      read-only checks. Larger fan-out is gratuitous (doctor is an
+      operator surface, not a hot path).
+    - ``doctor_fix_lock``: serializes ``fix=true`` runs across the
+      app. Held by the request that wins, released by the worker's
+      done-callback when the future truly terminates (not when the
+      HTTP request returns — Codex round-4 on #2058).
+    - ``doctor_last_report_lock``: guards the in-memory cache slot
+      for ``GET /doctor/report``.
+    - ``doctor_last_report``: the cache slot itself
+      (``tuple[DoctorReport, float] | None``).
+
+    Shutdown cancels not-yet-started futures, then calls
+    ``executor.shutdown(wait=False, cancel_futures=True)`` so the
+    teardown doesn't block on a wedged check. We then wait up to
+    :data:`_DOCTOR_SHUTDOWN_GRACE_S` for cooperative completion and
+    log a warning if any worker is still alive (the v1 RC tradeoff:
+    we can't kill the thread, but we can refuse to block on it).
+    """
+    app.state.doctor_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=_DOCTOR_MAX_WORKERS,
+        thread_name_prefix=_DOCTOR_THREAD_PREFIX,
+    )
+    app.state.doctor_fix_lock = threading.Lock()
+    app.state.doctor_last_report_lock = threading.Lock()
+    app.state.doctor_last_report = None
+    try:
+        yield
+    finally:
+        executor = app.state.doctor_executor
+        try:
+            # ``cancel_futures=True`` drops anything still queued;
+            # ``wait=False`` so a wedged in-flight worker can't block
+            # FastAPI teardown indefinitely (the v1 RC tradeoff
+            # documented in routes/doctor.py:_await_with_budget).
+            executor.shutdown(wait=False, cancel_futures=True)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "lifespan: doctor executor shutdown raised", exc_info=True,
+            )
+        # Best-effort wait for the worker threads to finish naturally.
+        # If they don't, log + leak rather than hang the app teardown.
+        deadline = time.monotonic() + _DOCTOR_SHUTDOWN_GRACE_S
+        try:
+            workers = list(getattr(executor, "_threads", []) or [])
+        except Exception:  # noqa: BLE001
+            workers = []
+        while time.monotonic() < deadline and any(t.is_alive() for t in workers):
+            time.sleep(0.05)
+        still_running = [t for t in workers if t.is_alive()]
+        if still_running:
+            logger.warning(
+                "lifespan: doctor executor: %d worker(s) still running after "
+                "%.1fs grace; leaking thread(s) past app teardown",
+                len(still_running),
+                _DOCTOR_SHUTDOWN_GRACE_S,
+            )
+
+
 def create_app(
     *,
     config: PollyPMConfig,
@@ -78,6 +177,11 @@ def create_app(
         docs_url=None,  # we serve OpenAPI via the spec endpoint
         redoc_url=None,
         openapi_url=None,
+        # Lifespan owns the doctor ThreadPoolExecutor + single-flight
+        # fix lock + last-report cache so they're cleanly torn down on
+        # app exit (Codex round-5 on #2058). Routes read them off
+        # ``request.app.state`` rather than module-level globals.
+        lifespan=_lifespan,
     )
 
     # CORS for the separate-repo frontend. The spec (§10) shows the

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -35,6 +35,7 @@ from pollypm.web_api.routes import chat_messages as chat_messages_routes
 from pollypm.web_api.routes import chat_send as chat_send_routes
 from pollypm.web_api.routes import config as config_routes
 from pollypm.web_api.routes import dashboard as dashboard_routes
+from pollypm.web_api.routes import doctor as doctor_routes
 from pollypm.web_api.routes import events as events_routes
 from pollypm.web_api.routes import health as health_routes
 from pollypm.web_api.routes import heartbeats as heartbeats_routes
@@ -160,6 +161,11 @@ def create_app(
     app.include_router(config_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     # Phase 2 surface §12 — read-only storage report (no prune).
     app.include_router(storage_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
+    # Phase 2 §7 doctor endpoints (list checks, last report, run + fix).
+    # Sits under the same ``/api/v1`` prefix as the other surfaces; the
+    # bearer-auth dependency is reused — there is no read/write split
+    # because every doctor endpoint can side-effect (run + fix).
+    app.include_router(doctor_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(events_routes.router, prefix=API_V1_PREFIX, dependencies=sse_auth_deps)
     # Phase 2 §11 — read-side heartbeats surface. SSE stream endpoint
     # (§11.1 row 4) ships as a separate follow-up; the GET endpoints

--- a/src/pollypm/web_api/routes/doctor.py
+++ b/src/pollypm/web_api/routes/doctor.py
@@ -28,7 +28,7 @@ import concurrent.futures
 import logging
 import threading
 import time
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable, TypeVar
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
@@ -376,62 +376,140 @@ def _select_checks(name: str | None) -> list[Check]:
     raise _unknown_check(name, [c.name for c in registered])
 
 
+# Shared bounded executor for all doctor work (checks + fixes + verify).
+#
+# Round-3 (Codex on PR #2058) flagged the prior per-request executor as a
+# DoS vector: each timeout abandoned a worker thread, so a client retrying
+# a stuck check could accumulate unbounded background workers. Switching
+# to a single module-level pool caps the number of in-flight (or leaked)
+# doctor workers at ``max_workers``. When all slots are saturated by hung
+# workers, new ``submit`` calls queue — but in practice ``fix=true`` is
+# single-flighted by :data:`_FIX_OPERATION_LOCK` (one fix at a time) and
+# ``fix=false`` runs are read-only / fast, so 2 slots is more than enough
+# for the v1 RC surface. Tuning lives here if we ever need more.
+_DOCTOR_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=2,
+    thread_name_prefix="doctor",
+)
+
+
+_T = TypeVar("_T")
+
+
 def _run_with_budget(
-    selected: list[Check],
-    *,
-    name: str | None,
-    timeout: float,
-) -> DoctorReport:
-    """Run the selected checks under a real wall-clock budget.
+    fn: Callable[..., _T],
+    *args: Any,
+    budget_s: float,
+    name: str | None = None,
+    **kwargs: Any,
+) -> _T:
+    """Run ``fn(*args, **kwargs)`` under a real wall-clock budget.
 
-    ``run_checks`` itself doesn't honor a timeout — individual checks
-    each have their own short subprocess timeouts (see ``_run_cmd``),
+    Doctor work (``run_checks`` itself, ``apply_fixes``, the post-fix
+    verify rerun) doesn't honor a Python-level timeout — individual
+    checks have their own short subprocess timeouts (see ``_run_cmd``),
     but a pure-Python hang (network call, stuck storage probe, blocking
-    fix path) would otherwise hold the request worker forever.
+    fix on a flaky filesystem) would otherwise hold the request worker
+    forever.
 
-    To bound the HTTP request, we hand ``run_checks`` off to a
-    single-shot :class:`concurrent.futures.ThreadPoolExecutor` and
-    wait at most ``timeout`` seconds for the result. On overrun we
-    raise a typed 504 ``timeout`` immediately — the worker thread is
-    *not* cancelled (Python stdlib has no safe way to interrupt
-    arbitrary blocking code) and is allowed to finish in the
-    background. The HTTP caller sees the 504 within the budget; the
-    leaked thread is the accepted v1 RC tradeoff (Codex round-1 P0
-    on PR #2058).
+    To bound the HTTP request, the callable is dispatched to a shared
+    bounded :class:`concurrent.futures.ThreadPoolExecutor`
+    (:data:`_DOCTOR_EXECUTOR`) and we wait at most ``budget_s`` seconds
+    for the result. On overrun we raise a typed 504 ``timeout``
+    immediately — the worker thread is *not* cancelled (Python stdlib
+    has no safe way to interrupt arbitrary blocking code) and is
+    allowed to finish in the background, eating its slot in the pool
+    until it returns. The HTTP caller sees the 504 within the budget;
+    the leaked thread is the accepted v1 RC tradeoff (Codex round-1 P0
+    on PR #2058). The shared pool bounds the total number of leaks
+    (Codex round-3 P0 on PR #2058).
 
-    ``DoctorThreadLeak`` is intentionally not raised on leak: the
-    leak is silent and best-effort cleanup happens when the thread
-    finally returns.
+    ``name`` is used purely for the 504 message; the caller (the
+    endpoint) supplies the user-facing check name (or ``None`` for
+    "all checks").
     """
     t0 = time.monotonic()
-    executor = concurrent.futures.ThreadPoolExecutor(
-        max_workers=1,
-        thread_name_prefix="doctor-run",
-    )
+    future = _DOCTOR_EXECUTOR.submit(fn, *args, **kwargs)
     try:
-        future = executor.submit(run_checks, selected)
-        try:
-            report = future.result(timeout=timeout)
-        except concurrent.futures.TimeoutError:
-            elapsed = time.monotonic() - t0
-            logger.warning(
-                "doctor: run exceeded %.1fs budget for %s; abandoning worker thread",
-                timeout,
-                name or "all checks",
-            )
-            raise _check_timeout(name, elapsed) from None
-    finally:
-        # ``wait=False`` so we don't block the request on the leaked
-        # worker thread when the budget already fired. If the future
-        # finished cleanly the shutdown is effectively a no-op.
-        executor.shutdown(wait=False)
+        result = future.result(timeout=budget_s)
+    except concurrent.futures.TimeoutError:
+        elapsed = time.monotonic() - t0
+        logger.warning(
+            "doctor: %s exceeded %.1fs budget; abandoning worker thread",
+            name or "run",
+            budget_s,
+        )
+        raise _check_timeout(name, elapsed) from None
 
     elapsed = time.monotonic() - t0
-    if elapsed > timeout:
+    if elapsed > budget_s:
         # Defensive: the future returned just past the deadline. Still
         # surface 504 so the caller sees a consistent contract.
         raise _check_timeout(name, elapsed)
-    return report
+    return result
+
+
+def _run_full_fix_under_budget(
+    selected: list[Check],
+) -> tuple[DoctorReport, list[dict[str, Any]]]:
+    """Run ``run_checks`` → ``apply_fixes`` → verify rerun in one closure.
+
+    Round-3 (Codex on PR #2058): the prior implementation called the
+    initial run under :func:`_run_with_budget` and the verify rerun
+    under :func:`_run_with_budget`, but :func:`apply_fixes` itself was
+    called inline. A hanging fix (stuck subprocess, blocked filesystem
+    on a network mount, jammed worktree git op) would therefore block
+    the HTTP worker past the documented ``timeout_seconds`` ceiling
+    with no 504.
+
+    By packing all three phases into one closure dispatched through
+    :func:`_run_with_budget`, the wall-clock budget covers the full
+    sequence end-to-end. A hang in any phase trips the timeout and
+    surfaces 504 within the budget.
+
+    Returns ``(merged_report, fixes_applied)``. ``fixes_applied`` is
+    the wire-shape list of attempted fixes (matches the JSON we ship
+    back to clients).
+    """
+    report = run_checks(selected)
+
+    # ``apply_fixes`` skips passing/skipped checks itself — no need to
+    # filter on the caller side. Returns a list of
+    # ``(name, success, message)`` tuples; we coerce to JSON for the
+    # wire response.
+    try:
+        raw = apply_fixes(report)
+    except Exception as exc:  # noqa: BLE001 — bubble as 500 via outer handler
+        logger.exception("doctor: apply_fixes raised: %s", exc)
+        raise
+    fixes_applied = [
+        {"name": name, "ok": ok, "message": message}
+        for (name, ok, message) in raw
+    ]
+
+    # Re-run just the checks we tried to fix so the response reflects
+    # the post-fix state (issue #1063 style verification: don't trust
+    # the handler's self-report). All within the same budget — if the
+    # caller's timeout fires mid-verify, the outer future cancels and
+    # surfaces 504 just like a hang in the initial run.
+    fixed_names = {entry["name"] for entry in fixes_applied}
+    if fixed_names:
+        rerun_checks = [c for c in selected if c.name in fixed_names]
+        verify_report = run_checks(rerun_checks)
+        # Splice verify-report rows back into the original report so
+        # the response always reflects the latest state. The original
+        # report is a dataclass — build a new merged list of
+        # ``(check, result)`` tuples and mutate in place.
+        verify_index = {
+            check.name: result for check, result in verify_report.results
+        }
+        merged: list[tuple[Check, CheckResult]] = []
+        for check, result in report.results:
+            replacement = verify_index.get(check.name)
+            merged.append((check, replacement if replacement else result))
+        report.results = merged
+
+    return report, fixes_applied
 
 
 # ---------------------------------------------------------------------------
@@ -547,56 +625,28 @@ def run_doctor_endpoint(
         if not fix_lock_held:
             raise _fix_busy_error()
 
+    fixes_applied: list[dict[str, Any]] = []
     try:
-        t0 = time.monotonic()
-        report = _run_with_budget(
-            selected, name=payload.check, timeout=timeout_seconds,
-        )
-
-        fixes_applied: list[dict[str, Any]] = []
         if payload.fix:
-            # ``apply_fixes`` skips passing/skipped checks itself — no need
-            # to filter on the caller side. Returns a list of
-            # ``(name, success, message)`` tuples; we coerce to JSON for
-            # the wire response.
-            try:
-                raw = apply_fixes(report)
-            except Exception as exc:  # noqa: BLE001 — bubble as 500 via outer handler
-                logger.exception("doctor: apply_fixes raised: %s", exc)
-                raise
-            fixes_applied = [
-                {"name": name, "ok": ok, "message": message}
-                for (name, ok, message) in raw
-            ]
-
-            # Re-run just the checks we tried to fix so the response
-            # reflects the post-fix state (issue #1063 style verification:
-            # don't trust the handler's self-report).
-            fixed_names = {entry["name"] for entry in fixes_applied}
-            if fixed_names:
-                rerun_checks = [c for c in selected if c.name in fixed_names]
-                elapsed_so_far = time.monotonic() - t0
-                remaining = timeout_seconds - elapsed_so_far
-                if remaining <= 0:
-                    raise _check_timeout(payload.check, elapsed_so_far)
-                verify_report = _run_with_budget(
-                    rerun_checks,
-                    name=payload.check,
-                    timeout=max(remaining, 1.0),
-                )
-                # Splice verify-report rows back into the original report
-                # so the response always reflects the latest state. The
-                # original report is a dataclass — build a new merged list
-                # of ``(check, result)`` tuples and mutate in place.
-                verify_index = {
-                    check.name: result
-                    for check, result in verify_report.results
-                }
-                merged: list[tuple[Check, CheckResult]] = []
-                for check, result in report.results:
-                    replacement = verify_index.get(check.name)
-                    merged.append((check, replacement if replacement else result))
-                report.results = merged
+            # Round-3 (Codex on PR #2058): the entire run+apply+verify
+            # sequence is wrapped in one budget so a hanging
+            # ``apply_fixes`` can't escape the timeout contract. The
+            # post-fix verify rerun shares the same wall-clock budget;
+            # if apply_fixes itself consumes the budget, the future
+            # times out before verify even starts and we surface 504.
+            report, fixes_applied = _run_with_budget(
+                _run_full_fix_under_budget,
+                selected,
+                budget_s=timeout_seconds,
+                name=payload.check,
+            )
+        else:
+            report = _run_with_budget(
+                run_checks,
+                selected,
+                budget_s=timeout_seconds,
+                name=payload.check,
+            )
 
         generated_at = _record_last_report(report)
     finally:

--- a/src/pollypm/web_api/routes/doctor.py
+++ b/src/pollypm/web_api/routes/doctor.py
@@ -1,0 +1,508 @@
+"""Doctor endpoints (Phase 2 — §7 of the phase-2 endpoints spec).
+
+Implements:
+
+- ``GET  /api/v1/doctor/checks`` — list available check names + metadata.
+- ``GET  /api/v1/doctor/report`` — return the last-run report (or 404
+  ``not_found`` when no run has happened yet in this process).
+- ``POST /api/v1/doctor/run`` — execute all checks or a single named
+  check, optionally invoking :func:`pollypm.doctor.apply_fixes` when
+  ``fix=true`` is set.
+
+Per ``~/Desktop/pollypm-phase2-endpoints-spec.md`` §7. The router is a
+thin adapter over :mod:`pollypm.doctor` — it never re-implements the
+check registry or runner; that lives in the canonical doctor module the
+CLI and cockpit both consume.
+
+The "last report" cache is process-local (held in module state via the
+``_LAST_REPORT`` slot). The CLI persists doctor output to disk under
+``~/.pollypm`` already, but the API surface is intentionally
+in-memory: spec §7.1 only asks for the *last-run* report, and tying
+to disk would couple the API to the CLI's file layout. Tests can reset
+the cache via :func:`_reset_last_report` so cases don't leak state.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from pollypm.doctor import (
+    Check,
+    CheckResult,
+    DoctorReport,
+    apply_fixes,
+    run_checks,
+)
+from pollypm.doctor import (
+    _auto_fix_supported,  # type: ignore[attr-defined]
+    _registered_checks,  # type: ignore[attr-defined]
+)
+from pollypm.web_api.errors import APIError, invalid_request, not_found
+from pollypm.web_api.routes._deps import ConfigDep
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Doctor"])
+
+
+# ---------------------------------------------------------------------------
+# Limits + defaults (kept module-level so tests can patch)
+# ---------------------------------------------------------------------------
+
+
+# Per spec §2.7: long-running sync actions get a 30s budget; doctor runs
+# typically complete in < 5s but ``--fix`` may exceed that. Stay below
+# the spec's 30s ceiling so the caller sees a typed 504 rather than the
+# generic uvicorn timeout.
+DEFAULT_RUN_TIMEOUT_SECONDS = 25.0
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class DoctorCheckInfo(BaseModel):
+    """Catalog row for ``GET /doctor/checks`` (spec §7.1).
+
+    Matches the spec's recommended shape: ``{name, description,
+    severity, has_auto_fix}``. ``description`` is best-effort — the
+    underlying :class:`pollypm.doctor.Check` dataclass doesn't carry
+    a docstring, so we use the category as the human label until we
+    plumb richer metadata through.
+    """
+
+    name: str
+    category: str
+    severity: str
+    description: str = ""
+    has_auto_fix: bool = False
+
+
+class DoctorChecksResponse(BaseModel):
+    checks: list[DoctorCheckInfo]
+
+
+class DoctorCheckResult(BaseModel):
+    """One row of a doctor report (spec §7).
+
+    Mirrors :class:`pollypm.doctor.CheckResult` with the non-trivial
+    fields the cockpit / frontend renders. ``fix_fn`` is intentionally
+    omitted — it's a callable, not a value.
+    """
+
+    name: str
+    category: str
+    passed: bool
+    skipped: bool
+    severity: str
+    status: str = ""
+    why: str = ""
+    fix: str = ""
+    fixable: bool = False
+    has_auto_fix: bool = False
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class DoctorReportResponse(BaseModel):
+    """Full report envelope (spec §7.1)."""
+
+    generated_at: float
+    duration_seconds: float
+    ok: bool
+    passed: int
+    errors: int
+    warnings: int
+    skipped: int
+    checks: list[DoctorCheckResult]
+
+
+class DoctorRunRequest(BaseModel):
+    """Body for ``POST /doctor/run`` (spec §7.1).
+
+    Spec says ``{check?: name, fix: bool}``. We make ``fix`` optional
+    with default ``false`` so callers who want to dry-run a single
+    check don't have to spell it out.
+    """
+
+    check: str | None = None
+    fix: bool = False
+
+
+class DoctorRunResponse(DoctorReportResponse):
+    """``POST /doctor/run`` response — report + (when ``fix=true``)
+    the list of fixes that were applied.
+    """
+
+    fixes_applied: list[dict[str, Any]] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Last-report cache (process-local; spec §7.1)
+# ---------------------------------------------------------------------------
+
+
+_LAST_REPORT_LOCK = threading.Lock()
+_LAST_REPORT: tuple[DoctorReport, float] | None = None
+
+
+def _record_last_report(report: DoctorReport) -> float:
+    """Stash ``report`` as the last-run report. Returns the timestamp."""
+    ts = time.time()
+    global _LAST_REPORT
+    with _LAST_REPORT_LOCK:
+        _LAST_REPORT = (report, ts)
+    return ts
+
+
+def _read_last_report() -> tuple[DoctorReport, float] | None:
+    with _LAST_REPORT_LOCK:
+        return _LAST_REPORT
+
+
+def _reset_last_report() -> None:
+    """Test hook — clears the module-level cache between cases."""
+    global _LAST_REPORT
+    with _LAST_REPORT_LOCK:
+        _LAST_REPORT = None
+
+
+# ---------------------------------------------------------------------------
+# Conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_info(check: Check) -> DoctorCheckInfo:
+    """Build the catalog row for one registered check.
+
+    ``has_auto_fix`` is best-effort: we don't actually have a result
+    yet, so we report ``False`` here. The per-result row in a report
+    surfaces the real value once a run has happened.
+    """
+    return DoctorCheckInfo(
+        name=check.name,
+        category=check.category,
+        severity=check.severity,
+        description="",
+        has_auto_fix=False,
+    )
+
+
+def _result_row(check: Check, result: CheckResult) -> DoctorCheckResult:
+    """Coerce one ``(Check, CheckResult)`` tuple to the wire row.
+
+    Drops the ``fix_fn`` callable (non-serializable) and folds the
+    ``auto_fix`` plan into a boolean — clients that need the full
+    plan can call ``POST /doctor/run`` with ``fix=true`` and inspect
+    ``fixes_applied``.
+    """
+    return DoctorCheckResult(
+        name=check.name,
+        category=check.category,
+        passed=result.passed,
+        skipped=result.skipped,
+        severity=result.severity,
+        status=result.status,
+        why=result.why,
+        fix=result.fix,
+        fixable=bool(result.fixable and result.fix_fn is not None),
+        has_auto_fix=_auto_fix_supported(result.auto_fix),
+        data=_jsonable(result.data),
+    )
+
+
+def _jsonable(value: Any) -> Any:
+    """Best-effort coerce arbitrary check ``data`` payloads to JSON.
+
+    Doctor checks frequently stash ``Path`` instances and other
+    non-JSON-native types in ``CheckResult.data``. FastAPI's JSON
+    encoder handles most of these, but the type signature on the
+    wire model is ``dict[str, Any]`` so we lean on stringification
+    for anything pydantic can't round-trip natively.
+    """
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _build_report_response(report: DoctorReport, *, generated_at: float) -> DoctorReportResponse:
+    rows = [_result_row(check, result) for check, result in report.results]
+    return DoctorReportResponse(
+        generated_at=generated_at,
+        duration_seconds=report.duration_seconds,
+        ok=report.ok,
+        passed=report.passed_count,
+        errors=len(report.errors),
+        warnings=len(report.warnings),
+        skipped=report.skipped_count,
+        checks=rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Typed errors
+# ---------------------------------------------------------------------------
+
+
+def _unknown_check(name: str, available: list[str]) -> APIError:
+    return not_found(
+        f"Unknown doctor check: {name!r}",
+        hint=(
+            f"Use GET /api/v1/doctor/checks to list available names "
+            f"({len(available)} registered)."
+        ),
+    )
+
+
+def _check_timeout(name: str | None, elapsed: float) -> APIError:
+    target = name or "all checks"
+    return APIError(
+        status_code=504,
+        code="timeout",
+        message=(
+            f"Doctor run for {target} exceeded the "
+            f"{DEFAULT_RUN_TIMEOUT_SECONDS:.0f}s budget "
+            f"(ran for {elapsed:.1f}s)"
+        ),
+        hint=(
+            "Retry the specific failing check, or re-run asynchronously "
+            "once the async job runner ships (spec §2.7 / Q13)."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core runners (broken out for ease of testing)
+# ---------------------------------------------------------------------------
+
+
+def _select_checks(name: str | None) -> list[Check]:
+    """Resolve ``name`` to a list of :class:`Check` objects.
+
+    ``name is None`` → every registered check (the default).
+    ``name`` matches one registered check → that check only.
+    Otherwise raise a typed 404.
+    """
+    registered = _registered_checks()
+    if name is None:
+        return registered
+    for check in registered:
+        if check.name == name:
+            return [check]
+    raise _unknown_check(name, [c.name for c in registered])
+
+
+def _run_with_budget(
+    selected: list[Check],
+    *,
+    name: str | None,
+    timeout: float,
+) -> DoctorReport:
+    """Run the selected checks and return a report, or 504 on overrun.
+
+    ``run_checks`` itself doesn't honor a timeout — individual checks
+    each have their own short subprocess timeouts (see ``_run_cmd``).
+    The wall-clock overrun check below is a defensive backstop in
+    case a check hangs in pure Python (e.g. a network call that
+    bypassed the timeout helper). 504 lets the client decide whether
+    to retry the offending check in isolation.
+    """
+    t0 = time.monotonic()
+    report = run_checks(selected)
+    elapsed = time.monotonic() - t0
+    if elapsed > timeout:
+        raise _check_timeout(name, elapsed)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/doctor/checks",
+    response_model=DoctorChecksResponse,
+    summary="List available doctor checks",
+    operation_id="listDoctorChecks",
+)
+def list_doctor_checks_endpoint(config: ConfigDep) -> DoctorChecksResponse:
+    """GET /api/v1/doctor/checks — return every registered check.
+
+    The catalog is static per process — restart ``pm serve`` to pick
+    up new checks from plugins. Order matches the canonical
+    :func:`_registered_checks` ordering (category-grouped) so the
+    cockpit can render a stable list.
+    """
+    # ``config`` is accepted so the dependency injection keeps the
+    # auth guard active (FastAPI only resolves the dep chain when the
+    # route declares one). Doctor checks themselves currently load
+    # their own config inside each probe (spec note: deferred
+    # refactor); pass-through is intentional.
+    _ = config
+    checks = _registered_checks()
+    return DoctorChecksResponse(checks=[_check_info(c) for c in checks])
+
+
+@router.get(
+    "/doctor/report",
+    response_model=DoctorReportResponse,
+    summary="Return the last-run doctor report",
+    operation_id="getDoctorReport",
+)
+def get_doctor_report_endpoint(config: ConfigDep) -> DoctorReportResponse:
+    """GET /api/v1/doctor/report — the most-recent in-process report.
+
+    Returns 404 ``not_found`` when no doctor run has happened yet in
+    this process — callers should ``POST /doctor/run`` first. This is
+    intentionally in-memory; the on-disk cache the CLI keeps is not
+    plumbed through (spec §7.1 deliberately scopes "last report" to
+    the API's own surface).
+    """
+    _ = config
+    cached = _read_last_report()
+    if cached is None:
+        raise not_found(
+            "No doctor report cached yet",
+            hint="POST /api/v1/doctor/run to generate one.",
+        )
+    report, generated_at = cached
+    return _build_report_response(report, generated_at=generated_at)
+
+
+@router.post(
+    "/doctor/run",
+    response_model=DoctorRunResponse,
+    summary="Run doctor checks (optionally with --fix)",
+    operation_id="runDoctor",
+)
+def run_doctor_endpoint(
+    config: ConfigDep,
+    body: DoctorRunRequest | None = None,
+    timeout_seconds: Annotated[
+        float,
+        Query(
+            ge=1.0,
+            le=120.0,
+            description=(
+                "Wall-clock budget for the run. Defaults to "
+                f"{DEFAULT_RUN_TIMEOUT_SECONDS:.0f}s; max 120s."
+            ),
+        ),
+    ] = DEFAULT_RUN_TIMEOUT_SECONDS,
+) -> DoctorRunResponse:
+    """POST /api/v1/doctor/run — execute checks and (optionally) fixes.
+
+    Body shape per spec §7.1:
+
+        {"check": "<name>" | null, "fix": true | false}
+
+    - ``check`` omitted / null → run every registered check.
+    - ``check`` set → run only that check; unknown → 404.
+    - ``fix=true`` → after the run, invoke ``apply_fixes`` on the
+      report and re-run *just the fixed checks* so the response shows
+      post-fix state. The list of attempted fixes lands in
+      ``fixes_applied``.
+
+    The whole sequence (run + optional fix + post-fix verify) is
+    capped at ``timeout_seconds``; overrun → 504 ``timeout``.
+    """
+    _ = config
+    payload = body or DoctorRunRequest()
+
+    selected = _select_checks(payload.check)
+    t0 = time.monotonic()
+    report = _run_with_budget(
+        selected, name=payload.check, timeout=timeout_seconds,
+    )
+
+    fixes_applied: list[dict[str, Any]] = []
+    if payload.fix:
+        # ``apply_fixes`` skips passing/skipped checks itself — no need
+        # to filter on the caller side. Returns a list of
+        # ``(name, success, message)`` tuples; we coerce to JSON for
+        # the wire response.
+        try:
+            raw = apply_fixes(report)
+        except Exception as exc:  # noqa: BLE001 — bubble as 500 via outer handler
+            logger.exception("doctor: apply_fixes raised: %s", exc)
+            raise
+        fixes_applied = [
+            {"name": name, "ok": ok, "message": message}
+            for (name, ok, message) in raw
+        ]
+
+        # Re-run just the checks we tried to fix so the response
+        # reflects the post-fix state (issue #1063 style verification:
+        # don't trust the handler's self-report).
+        fixed_names = {entry["name"] for entry in fixes_applied}
+        if fixed_names:
+            rerun_checks = [c for c in selected if c.name in fixed_names]
+            elapsed_so_far = time.monotonic() - t0
+            remaining = timeout_seconds - elapsed_so_far
+            if remaining <= 0:
+                raise _check_timeout(payload.check, elapsed_so_far)
+            verify_report = _run_with_budget(
+                rerun_checks,
+                name=payload.check,
+                timeout=max(remaining, 1.0),
+            )
+            # Splice verify-report rows back into the original report
+            # so the response always reflects the latest state. The
+            # original report is a dataclass — build a new merged list
+            # of ``(check, result)`` tuples and mutate in place.
+            verify_index = {
+                check.name: result
+                for check, result in verify_report.results
+            }
+            merged: list[tuple[Check, CheckResult]] = []
+            for check, result in report.results:
+                replacement = verify_index.get(check.name)
+                merged.append((check, replacement if replacement else result))
+            report.results = merged
+
+    generated_at = _record_last_report(report)
+    base = _build_report_response(report, generated_at=generated_at)
+    return DoctorRunResponse(
+        generated_at=base.generated_at,
+        duration_seconds=base.duration_seconds,
+        ok=base.ok,
+        passed=base.passed,
+        errors=base.errors,
+        warnings=base.warnings,
+        skipped=base.skipped,
+        checks=base.checks,
+        fixes_applied=fixes_applied,
+    )
+
+
+# Re-export for tests + the app factory.
+__all__ = [
+    "DEFAULT_RUN_TIMEOUT_SECONDS",
+    "DoctorCheckInfo",
+    "DoctorCheckResult",
+    "DoctorChecksResponse",
+    "DoctorReportResponse",
+    "DoctorRunRequest",
+    "DoctorRunResponse",
+    "_reset_last_report",
+    "get_doctor_report_endpoint",
+    "list_doctor_checks_endpoint",
+    "router",
+    "run_doctor_endpoint",
+]
+
+
+# Silence unused-import lints — these names are part of the module's
+# public re-export surface so tests can patch them.
+_ = invalid_request

--- a/src/pollypm/web_api/routes/doctor.py
+++ b/src/pollypm/web_api/routes/doctor.py
@@ -161,7 +161,35 @@ _LAST_REPORT: tuple[DoctorReport, float] | None = None
 # interleave the post-fix verify writes (Codex round-1 P0 on PR #2058).
 # Acquired non-blocking — a second concurrent ``fix=true`` returns a
 # typed 409 ``busy`` rather than queueing behind the first.
+#
+# Round-4 (Codex on PR #2058): the lock is released by a
+# :meth:`concurrent.futures.Future.add_done_callback` registered when
+# the fix work is submitted (see :func:`_release_fix_lock_on_done`), not
+# by the HTTP request's ``finally`` block. If the request times out (504)
+# the worker thread is still alive inside ``apply_fixes``; releasing the
+# lock at HTTP-return time would let an immediate retry start a second
+# concurrent fix on shared state.
 _FIX_OPERATION_LOCK = threading.Lock()
+
+
+def _release_fix_lock_on_done(_future: concurrent.futures.Future[Any]) -> None:
+    """Release :data:`_FIX_OPERATION_LOCK` when the fix worker terminates.
+
+    Registered via :meth:`concurrent.futures.Future.add_done_callback`
+    on the fix future. Runs synchronously in whichever thread sets the
+    future's result (the worker thread on normal completion / exception).
+    The lock release MUST NOT raise — if it did, the future's result
+    would be silently corrupted; we defensively swallow + log instead.
+    """
+    try:
+        _FIX_OPERATION_LOCK.release()
+    except RuntimeError:
+        # Lock wasn't held (e.g. test harness already released it). Log
+        # but don't propagate — the done-callback contract forbids
+        # raising.
+        logger.warning(
+            "doctor: _FIX_OPERATION_LOCK already released when fix worker terminated"
+        )
 
 
 def _record_last_report(report: DoctorReport) -> float:
@@ -396,14 +424,28 @@ _DOCTOR_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
 _T = TypeVar("_T")
 
 
-def _run_with_budget(
+def _submit_doctor_work(
     fn: Callable[..., _T],
     *args: Any,
+    **kwargs: Any,
+) -> concurrent.futures.Future[_T]:
+    """Submit ``fn`` to the shared doctor executor.
+
+    Factored out of :func:`_run_with_budget` so the ``fix=true`` path
+    in :func:`run_doctor_endpoint` can own the future lifecycle (it
+    needs to attach a lock-release callback that fires when the worker
+    *really* terminates, not when the HTTP request times out).
+    """
+    return _DOCTOR_EXECUTOR.submit(fn, *args, **kwargs)
+
+
+def _await_with_budget(
+    future: concurrent.futures.Future[_T],
+    *,
     budget_s: float,
     name: str | None = None,
-    **kwargs: Any,
 ) -> _T:
-    """Run ``fn(*args, **kwargs)`` under a real wall-clock budget.
+    """Wait on ``future`` for at most ``budget_s`` seconds.
 
     Doctor work (``run_checks`` itself, ``apply_fixes``, the post-fix
     verify rerun) doesn't honor a Python-level timeout — individual
@@ -412,24 +454,18 @@ def _run_with_budget(
     fix on a flaky filesystem) would otherwise hold the request worker
     forever.
 
-    To bound the HTTP request, the callable is dispatched to a shared
-    bounded :class:`concurrent.futures.ThreadPoolExecutor`
-    (:data:`_DOCTOR_EXECUTOR`) and we wait at most ``budget_s`` seconds
-    for the result. On overrun we raise a typed 504 ``timeout``
-    immediately — the worker thread is *not* cancelled (Python stdlib
-    has no safe way to interrupt arbitrary blocking code) and is
-    allowed to finish in the background, eating its slot in the pool
-    until it returns. The HTTP caller sees the 504 within the budget;
-    the leaked thread is the accepted v1 RC tradeoff (Codex round-1 P0
-    on PR #2058). The shared pool bounds the total number of leaks
-    (Codex round-3 P0 on PR #2058).
+    On overrun we raise a typed 504 ``timeout`` immediately — the worker
+    thread is *not* cancelled (Python stdlib has no safe way to interrupt
+    arbitrary blocking code) and is allowed to finish in the background,
+    eating its slot in :data:`_DOCTOR_EXECUTOR` until it returns. The
+    HTTP caller sees the 504 within the budget; the leaked thread is the
+    accepted v1 RC tradeoff (Codex round-1 P0 on PR #2058). The shared
+    pool bounds the total number of leaks (Codex round-3 P0 on PR #2058).
 
-    ``name`` is used purely for the 504 message; the caller (the
-    endpoint) supplies the user-facing check name (or ``None`` for
-    "all checks").
+    ``name`` is used purely for the 504 message; the caller supplies the
+    user-facing check name (or ``None`` for "all checks").
     """
     t0 = time.monotonic()
-    future = _DOCTOR_EXECUTOR.submit(fn, *args, **kwargs)
     try:
         result = future.result(timeout=budget_s)
     except concurrent.futures.TimeoutError:
@@ -447,6 +483,23 @@ def _run_with_budget(
         # surface 504 so the caller sees a consistent contract.
         raise _check_timeout(name, elapsed)
     return result
+
+
+def _run_with_budget(
+    fn: Callable[..., _T],
+    *args: Any,
+    budget_s: float,
+    name: str | None = None,
+    **kwargs: Any,
+) -> _T:
+    """Submit ``fn`` to the doctor pool and await it under ``budget_s``.
+
+    Convenience wrapper for callers that don't need to own the future
+    (the ``fix=false`` path). The ``fix=true`` path submits + awaits
+    explicitly so it can attach a lock-release callback to the future.
+    """
+    future = _submit_doctor_work(fn, *args, **kwargs)
+    return _await_with_budget(future, budget_s=budget_s, name=name)
 
 
 def _run_full_fix_under_budget(
@@ -614,44 +667,55 @@ def run_doctor_endpoint(
 
     selected = _select_checks(payload.check)
 
-    # Single-flight gate for ``fix=true``. Acquire non-blocking so a
-    # second concurrent caller returns 409 immediately rather than
-    # queueing behind the in-flight fix. ``fix=false`` is read-only
-    # for our purposes (each check has its own internal locks) and
-    # is allowed to overlap.
-    fix_lock_held = False
+    fixes_applied: list[dict[str, Any]] = []
     if payload.fix:
-        fix_lock_held = _FIX_OPERATION_LOCK.acquire(blocking=False)
-        if not fix_lock_held:
+        # Single-flight gate for ``fix=true``. Acquire non-blocking so a
+        # second concurrent caller returns 409 immediately rather than
+        # queueing behind the in-flight fix. ``fix=false`` is read-only
+        # for our purposes (each check has its own internal locks) and
+        # is allowed to overlap.
+        if not _FIX_OPERATION_LOCK.acquire(blocking=False):
             raise _fix_busy_error()
 
-    fixes_applied: list[dict[str, Any]] = []
-    try:
-        if payload.fix:
-            # Round-3 (Codex on PR #2058): the entire run+apply+verify
-            # sequence is wrapped in one budget so a hanging
-            # ``apply_fixes`` can't escape the timeout contract. The
-            # post-fix verify rerun shares the same wall-clock budget;
-            # if apply_fixes itself consumes the budget, the future
-            # times out before verify even starts and we surface 504.
-            report, fixes_applied = _run_with_budget(
-                _run_full_fix_under_budget,
-                selected,
-                budget_s=timeout_seconds,
-                name=payload.check,
-            )
-        else:
-            report = _run_with_budget(
-                run_checks,
-                selected,
-                budget_s=timeout_seconds,
-                name=payload.check,
-            )
+        # Round-4 (Codex on PR #2058): the lock MUST be held until the
+        # worker thread truly terminates, not just until the HTTP request
+        # returns. The prior implementation released in a ``finally``
+        # block, which ran on the 504 timeout path even though the worker
+        # thread was still alive inside ``apply_fixes`` mutating shared
+        # state. A retry within seconds of the 504 would acquire the lock
+        # and start a *second* concurrent fix.
+        #
+        # The fix: submit the work ourselves, attach an
+        # ``add_done_callback`` that releases the lock when the worker
+        # really finishes, and DO NOT release the lock on any code path
+        # in this function — the callback owns the release.
+        #
+        # ``add_done_callback`` runs synchronously if the future is
+        # already done at registration time; otherwise it runs in the
+        # worker thread once the result is set. Either way, the lock is
+        # released exactly once when the work is truly complete.
+        future = _submit_doctor_work(_run_full_fix_under_budget, selected)
+        future.add_done_callback(_release_fix_lock_on_done)
+        # Round-3 (Codex on PR #2058): the entire run+apply+verify
+        # sequence is wrapped in one budget so a hanging
+        # ``apply_fixes`` can't escape the timeout contract. The
+        # post-fix verify rerun shares the same wall-clock budget;
+        # if apply_fixes itself consumes the budget, the future
+        # times out before verify even starts and we surface 504.
+        report, fixes_applied = _await_with_budget(
+            future,
+            budget_s=timeout_seconds,
+            name=payload.check,
+        )
+    else:
+        report = _run_with_budget(
+            run_checks,
+            selected,
+            budget_s=timeout_seconds,
+            name=payload.check,
+        )
 
-        generated_at = _record_last_report(report)
-    finally:
-        if fix_lock_held:
-            _FIX_OPERATION_LOCK.release()
+    generated_at = _record_last_report(report)
     base = _build_report_response(report, generated_at=generated_at)
     return DoctorRunResponse(
         generated_at=base.generated_at,

--- a/src/pollypm/web_api/routes/doctor.py
+++ b/src/pollypm/web_api/routes/doctor.py
@@ -14,12 +14,13 @@ thin adapter over :mod:`pollypm.doctor` — it never re-implements the
 check registry or runner; that lives in the canonical doctor module the
 CLI and cockpit both consume.
 
-The "last report" cache is process-local (held in module state via the
-``_LAST_REPORT`` slot). The CLI persists doctor output to disk under
-``~/.pollypm`` already, but the API surface is intentionally
-in-memory: spec §7.1 only asks for the *last-run* report, and tying
-to disk would couple the API to the CLI's file layout. Tests can reset
-the cache via :func:`_reset_last_report` so cases don't leak state.
+The "last report" cache is per-app (held on ``app.state`` via the
+``doctor_last_report`` slot, owned by the FastAPI lifespan). The CLI
+persists doctor output to disk under ``~/.pollypm`` already, but the
+API surface is intentionally in-memory: spec §7.1 only asks for the
+*last-run* report, and tying to disk would couple the API to the
+CLI's file layout. Each ``create_app`` call gets its own slot, so
+test instances don't cross-contaminate (Codex round-5 on PR #2058).
 """
 
 from __future__ import annotations
@@ -30,7 +31,7 @@ import threading
 import time
 from typing import Annotated, Any, Callable, TypeVar
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel, Field
 
 from pollypm.config import DEFAULT_CONFIG_PATH
@@ -45,7 +46,13 @@ from pollypm.doctor import (
     _auto_fix_supported,  # type: ignore[attr-defined]
     _registered_checks,  # type: ignore[attr-defined]
 )
-from pollypm.web_api.errors import APIError, conflict, invalid_request, not_found
+from pollypm.web_api.errors import (
+    APIError,
+    conflict,
+    invalid_request,
+    not_found,
+    service_unavailable,
+)
 from pollypm.web_api.routes._deps import ConfigDep
 
 logger = logging.getLogger(__name__)
@@ -146,71 +153,168 @@ class DoctorRunResponse(DoctorReportResponse):
 
 
 # ---------------------------------------------------------------------------
-# Last-report cache (process-local; spec §7.1)
+# App-scoped state accessors (spec §7.1)
+#
+# The doctor executor, single-flight fix lock, and last-report cache
+# all live on ``app.state``, owned by the FastAPI lifespan in
+# :mod:`pollypm.web_api.app`. Previously these were module-level
+# globals; that left timed-out worker threads alive past ``pm serve``
+# shutdown with no FastAPI hook to call ``shutdown(cancel_futures=True)``
+# (Codex round-5 on PR #2058). Tying them to the app makes the
+# executor lifecycle-managed, makes the locks per-app (so test
+# instances don't cross-contaminate), and lets the lifespan emit
+# observability for in-flight workers at teardown.
 # ---------------------------------------------------------------------------
 
 
-_LAST_REPORT_LOCK = threading.Lock()
-_LAST_REPORT: tuple[DoctorReport, float] | None = None
+def _get_executor(request: Request) -> concurrent.futures.ThreadPoolExecutor:
+    """Resolve the doctor executor from app-level state.
+
+    Raises ``service_unavailable`` if the lifespan didn't fire — only
+    possible when ``TestClient`` is used outside a ``with`` block.
+    """
+    executor = getattr(request.app.state, "doctor_executor", None)
+    if executor is None:  # pragma: no cover — only hit if lifespan didn't run
+        raise service_unavailable(
+            "doctor executor is not initialized",
+            hint=(
+                "The FastAPI lifespan didn't run; ensure ``create_app`` "
+                "is invoked through the standard ASGI server (uvicorn) "
+                "or a TestClient context manager (``with TestClient(app)``)."
+            ),
+        )
+    return executor
 
 
-# Operation-level single-flight lock for ``POST /doctor/run`` when
-# ``fix=true``. ``_LAST_REPORT_LOCK`` above only guards the cache slot;
-# without this second lock, two concurrent callers can each invoke
-# ``apply_fixes`` on the same filesystem/session/storage state and
-# interleave the post-fix verify writes (Codex round-1 P0 on PR #2058).
-# Acquired non-blocking — a second concurrent ``fix=true`` returns a
-# typed 409 ``busy`` rather than queueing behind the first.
-#
-# Round-4 (Codex on PR #2058): the lock is released by a
-# :meth:`concurrent.futures.Future.add_done_callback` registered when
-# the fix work is submitted (see :func:`_release_fix_lock_on_done`), not
-# by the HTTP request's ``finally`` block. If the request times out (504)
-# the worker thread is still alive inside ``apply_fixes``; releasing the
-# lock at HTTP-return time would let an immediate retry start a second
-# concurrent fix on shared state.
-_FIX_OPERATION_LOCK = threading.Lock()
+def _get_fix_lock(request: Request) -> threading.Lock:
+    """Resolve the single-flight ``fix=true`` lock from app-level state.
+
+    Acquired non-blocking in the run endpoint; released by the worker's
+    done-callback when the future truly terminates (Codex round-4 on
+    PR #2058 — not when the HTTP request returns 504).
+    """
+    lock = getattr(request.app.state, "doctor_fix_lock", None)
+    if lock is None:  # pragma: no cover — only hit if lifespan didn't run
+        raise service_unavailable(
+            "doctor fix lock is not initialized",
+            hint=(
+                "The FastAPI lifespan didn't run; ensure ``create_app`` "
+                "is invoked through the standard ASGI server."
+            ),
+        )
+    return lock
 
 
-def _release_fix_lock_on_done(_future: concurrent.futures.Future[Any]) -> None:
-    """Release :data:`_FIX_OPERATION_LOCK` when the fix worker terminates.
+def _release_fix_lock_factory(
+    lock: threading.Lock,
+) -> Callable[[concurrent.futures.Future[Any]], None]:
+    """Build a done-callback that releases ``lock`` when the future terminates.
 
-    Registered via :meth:`concurrent.futures.Future.add_done_callback`
-    on the fix future. Runs synchronously in whichever thread sets the
-    future's result (the worker thread on normal completion / exception).
-    The lock release MUST NOT raise — if it did, the future's result
-    would be silently corrupted; we defensively swallow + log instead.
+    The done-callback also logs the late completion (success or
+    exception) so a timed-out fix that finishes minutes later is
+    observable in the server log rather than silently disappearing
+    (Codex round-5 on PR #2058: timed-out workers were unowned).
+
+    The release MUST NOT raise — if it did, the future's result would
+    be silently corrupted by ``concurrent.futures``; we defensively
+    swallow + log instead.
+    """
+
+    def _callback(future: concurrent.futures.Future[Any]) -> None:
+        # Observability first: log whether the worker eventually
+        # succeeded, raised, or was cancelled. Cheap and gives the
+        # operator a paper trail for the timed-out → late-completion
+        # path that round-5 flagged.
+        try:
+            if future.cancelled():
+                logger.info("doctor: fix worker cancelled before completion")
+            elif future.exception() is not None:
+                logger.warning(
+                    "doctor: fix worker terminated with exception: %s",
+                    future.exception(),
+                )
+            else:
+                logger.info("doctor: fix worker completed (late or in-budget)")
+        except Exception:  # noqa: BLE001 — never raise from a done-callback
+            logger.exception("doctor: error inspecting fix-future result")
+
+        try:
+            lock.release()
+        except RuntimeError:
+            # Lock wasn't held (e.g. test harness already released it).
+            # Log but don't propagate — the done-callback contract
+            # forbids raising.
+            logger.warning(
+                "doctor: fix lock already released when fix worker terminated"
+            )
+
+    return _callback
+
+
+def _log_check_worker_outcome(
+    future: concurrent.futures.Future[Any],
+) -> None:
+    """Done-callback for ``fix=false`` futures — log late completion.
+
+    Codex round-5 (PR #2058): a timed-out ``fix=false`` worker is
+    abandoned by ``_await_with_budget`` and finishes silently. The
+    operator has no way to know whether the underlying check ever
+    returned. This callback logs the eventual outcome so late
+    completions / exceptions surface in the server log. It does NOT
+    interact with any lock — the read path doesn't take one.
     """
     try:
-        _FIX_OPERATION_LOCK.release()
-    except RuntimeError:
-        # Lock wasn't held (e.g. test harness already released it). Log
-        # but don't propagate — the done-callback contract forbids
-        # raising.
-        logger.warning(
-            "doctor: _FIX_OPERATION_LOCK already released when fix worker terminated"
-        )
+        if future.cancelled():
+            logger.info("doctor: check worker cancelled before completion")
+        elif future.exception() is not None:
+            logger.warning(
+                "doctor: check worker terminated with exception: %s",
+                future.exception(),
+            )
+        else:
+            logger.info("doctor: check worker completed (late or in-budget)")
+    except Exception:  # noqa: BLE001 — never raise from a done-callback
+        logger.exception("doctor: error inspecting check-future result")
 
 
-def _record_last_report(report: DoctorReport) -> float:
-    """Stash ``report`` as the last-run report. Returns the timestamp."""
+def _record_last_report(request: Request, report: DoctorReport) -> float:
+    """Stash ``report`` as the last-run report on app state. Returns the timestamp."""
     ts = time.time()
-    global _LAST_REPORT
-    with _LAST_REPORT_LOCK:
-        _LAST_REPORT = (report, ts)
+    lock = getattr(request.app.state, "doctor_last_report_lock", None)
+    if lock is None:  # pragma: no cover — only hit if lifespan didn't run
+        raise service_unavailable(
+            "doctor last-report cache is not initialized",
+        )
+    with lock:
+        request.app.state.doctor_last_report = (report, ts)
     return ts
 
 
-def _read_last_report() -> tuple[DoctorReport, float] | None:
-    with _LAST_REPORT_LOCK:
-        return _LAST_REPORT
+def _read_last_report(
+    request: Request,
+) -> tuple[DoctorReport, float] | None:
+    lock = getattr(request.app.state, "doctor_last_report_lock", None)
+    if lock is None:  # pragma: no cover — only hit if lifespan didn't run
+        return None
+    with lock:
+        return getattr(request.app.state, "doctor_last_report", None)
 
 
-def _reset_last_report() -> None:
-    """Test hook — clears the module-level cache between cases."""
-    global _LAST_REPORT
-    with _LAST_REPORT_LOCK:
-        _LAST_REPORT = None
+def _reset_last_report(request: Request | None = None) -> None:
+    """Test hook — clears the per-app last-report cache between cases.
+
+    Accepts an optional ``request`` for symmetry with the read helpers.
+    When called without one (legacy test entrypoint) this is a no-op:
+    each test fixture now builds a fresh app whose lifespan starts
+    with ``doctor_last_report = None``.
+    """
+    if request is None:
+        return
+    lock = getattr(request.app.state, "doctor_last_report_lock", None)
+    if lock is None:  # pragma: no cover
+        return
+    with lock:
+        request.app.state.doctor_last_report = None
 
 
 # ---------------------------------------------------------------------------
@@ -326,7 +430,7 @@ def _fix_busy_error() -> APIError:
 
     Doctor fixes touch shared state (filesystem, tmux sessions, the
     Postgres heartbeat tables); we serialize the run+fix+verify
-    sequence with :data:`_FIX_OPERATION_LOCK`. Callers that race a
+    sequence with ``app.state.doctor_fix_lock``. Callers that race a
     second ``fix=true`` request get an immediate 409 ``busy`` rather
     than blocking on the lock or running fixes a second time.
     """
@@ -408,35 +512,32 @@ def _select_checks(name: str | None) -> list[Check]:
 #
 # Round-3 (Codex on PR #2058) flagged the prior per-request executor as a
 # DoS vector: each timeout abandoned a worker thread, so a client retrying
-# a stuck check could accumulate unbounded background workers. Switching
-# to a single module-level pool caps the number of in-flight (or leaked)
-# doctor workers at ``max_workers``. When all slots are saturated by hung
-# workers, new ``submit`` calls queue — but in practice ``fix=true`` is
-# single-flighted by :data:`_FIX_OPERATION_LOCK` (one fix at a time) and
-# ``fix=false`` runs are read-only / fast, so 2 slots is more than enough
-# for the v1 RC surface. Tuning lives here if we ever need more.
-_DOCTOR_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
-    max_workers=2,
-    thread_name_prefix="doctor",
-)
-
+# a stuck check could accumulate unbounded background workers. The
+# round-3 fix capped that with a single module-level pool. Round-5
+# (Codex on PR #2058) flagged that *the module-level pool itself* was
+# unowned by app lifecycle, so timed-out workers had no shutdown story
+# and pm serve exit left them alive. The executor now lives on
+# ``app.state.doctor_executor``, created by the FastAPI lifespan in
+# ``web_api/app.py`` and explicitly torn down on shutdown. Routes
+# resolve it via :func:`_get_executor`.
 
 _T = TypeVar("_T")
 
 
 def _submit_doctor_work(
+    executor: concurrent.futures.ThreadPoolExecutor,
     fn: Callable[..., _T],
     *args: Any,
     **kwargs: Any,
 ) -> concurrent.futures.Future[_T]:
-    """Submit ``fn`` to the shared doctor executor.
+    """Submit ``fn`` to ``executor``.
 
-    Factored out of :func:`_run_with_budget` so the ``fix=true`` path
-    in :func:`run_doctor_endpoint` can own the future lifecycle (it
+    Factored out so the ``fix=true`` path in
+    :func:`run_doctor_endpoint` can own the future lifecycle (it
     needs to attach a lock-release callback that fires when the worker
     *really* terminates, not when the HTTP request times out).
     """
-    return _DOCTOR_EXECUTOR.submit(fn, *args, **kwargs)
+    return executor.submit(fn, *args, **kwargs)
 
 
 def _await_with_budget(
@@ -457,10 +558,16 @@ def _await_with_budget(
     On overrun we raise a typed 504 ``timeout`` immediately — the worker
     thread is *not* cancelled (Python stdlib has no safe way to interrupt
     arbitrary blocking code) and is allowed to finish in the background,
-    eating its slot in :data:`_DOCTOR_EXECUTOR` until it returns. The
+    eating its slot in the app's doctor executor until it returns. The
     HTTP caller sees the 504 within the budget; the leaked thread is the
     accepted v1 RC tradeoff (Codex round-1 P0 on PR #2058). The shared
     pool bounds the total number of leaks (Codex round-3 P0 on PR #2058).
+    The lifespan (Codex round-5 P0 on PR #2058) emits a warning if any
+    such worker is still alive at app shutdown so the operator has a
+    paper trail. Callers attach an ``add_done_callback`` (see
+    :func:`_log_check_worker_outcome` and
+    :func:`_release_fix_lock_factory`) so late completion / exception
+    surfaces in the server log even after the HTTP request returned 504.
 
     ``name`` is used purely for the 504 message; the caller supplies the
     user-facing check name (or ``None`` for "all checks").
@@ -486,19 +593,21 @@ def _await_with_budget(
 
 
 def _run_with_budget(
+    executor: concurrent.futures.ThreadPoolExecutor,
     fn: Callable[..., _T],
     *args: Any,
     budget_s: float,
     name: str | None = None,
     **kwargs: Any,
 ) -> _T:
-    """Submit ``fn`` to the doctor pool and await it under ``budget_s``.
+    """Submit ``fn`` to ``executor`` and await it under ``budget_s``.
 
     Convenience wrapper for callers that don't need to own the future
     (the ``fix=false`` path). The ``fix=true`` path submits + awaits
     explicitly so it can attach a lock-release callback to the future.
     """
-    future = _submit_doctor_work(fn, *args, **kwargs)
+    future = _submit_doctor_work(executor, fn, *args, **kwargs)
+    future.add_done_callback(_log_check_worker_outcome)
     return _await_with_budget(future, budget_s=budget_s, name=name)
 
 
@@ -601,17 +710,19 @@ def list_doctor_checks_endpoint(config: ConfigDep) -> DoctorChecksResponse:
     summary="Return the last-run doctor report",
     operation_id="getDoctorReport",
 )
-def get_doctor_report_endpoint(config: ConfigDep) -> DoctorReportResponse:
-    """GET /api/v1/doctor/report — the most-recent in-process report.
+def get_doctor_report_endpoint(
+    config: ConfigDep, request: Request,
+) -> DoctorReportResponse:
+    """GET /api/v1/doctor/report — the most-recent in-app report.
 
-    Returns 404 ``not_found`` when no doctor run has happened yet in
-    this process — callers should ``POST /doctor/run`` first. This is
-    intentionally in-memory; the on-disk cache the CLI keeps is not
-    plumbed through (spec §7.1 deliberately scopes "last report" to
-    the API's own surface).
+    Returns 404 ``not_found`` when no doctor run has happened yet
+    against *this app* — callers should ``POST /doctor/run`` first.
+    The cache is per-app (lives on ``request.app.state``), so two
+    sibling apps in the same process keep independent reports
+    (Codex round-5 on PR #2058).
     """
     _reject_non_default_config(config)
-    cached = _read_last_report()
+    cached = _read_last_report(request)
     if cached is None:
         raise not_found(
             "No doctor report cached yet",
@@ -629,6 +740,7 @@ def get_doctor_report_endpoint(config: ConfigDep) -> DoctorReportResponse:
 )
 def run_doctor_endpoint(
     config: ConfigDep,
+    request: Request,
     body: DoctorRunRequest | None = None,
     timeout_seconds: Annotated[
         float,
@@ -659,22 +771,25 @@ def run_doctor_endpoint(
     capped at ``timeout_seconds``; overrun → 504 ``timeout``.
 
     When ``fix=true`` the run+fix+verify sequence is serialized via
-    :data:`_FIX_OPERATION_LOCK`; concurrent ``fix=true`` callers get
-    a typed 409 ``busy`` (Codex round-1 P0).
+    the per-app ``doctor_fix_lock``; concurrent ``fix=true`` callers
+    get a typed 409 ``busy`` (Codex round-1 P0). Worker lifecycle is
+    owned by the FastAPI lifespan (Codex round-5 on PR #2058).
     """
     _reject_non_default_config(config)
     payload = body or DoctorRunRequest()
 
     selected = _select_checks(payload.check)
+    executor = _get_executor(request)
 
     fixes_applied: list[dict[str, Any]] = []
     if payload.fix:
+        fix_lock = _get_fix_lock(request)
         # Single-flight gate for ``fix=true``. Acquire non-blocking so a
         # second concurrent caller returns 409 immediately rather than
         # queueing behind the in-flight fix. ``fix=false`` is read-only
         # for our purposes (each check has its own internal locks) and
         # is allowed to overlap.
-        if not _FIX_OPERATION_LOCK.acquire(blocking=False):
+        if not fix_lock.acquire(blocking=False):
             raise _fix_busy_error()
 
         # Round-4 (Codex on PR #2058): the lock MUST be held until the
@@ -694,8 +809,15 @@ def run_doctor_endpoint(
         # already done at registration time; otherwise it runs in the
         # worker thread once the result is set. Either way, the lock is
         # released exactly once when the work is truly complete.
-        future = _submit_doctor_work(_run_full_fix_under_budget, selected)
-        future.add_done_callback(_release_fix_lock_on_done)
+        #
+        # Round-5 (Codex on PR #2058): the callback also logs the
+        # eventual outcome (success / exception / cancel) so a
+        # timed-out fix that finishes late is observable in the
+        # server log rather than disappearing silently.
+        future = _submit_doctor_work(
+            executor, _run_full_fix_under_budget, selected,
+        )
+        future.add_done_callback(_release_fix_lock_factory(fix_lock))
         # Round-3 (Codex on PR #2058): the entire run+apply+verify
         # sequence is wrapped in one budget so a hanging
         # ``apply_fixes`` can't escape the timeout contract. The
@@ -709,13 +831,14 @@ def run_doctor_endpoint(
         )
     else:
         report = _run_with_budget(
+            executor,
             run_checks,
             selected,
             budget_s=timeout_seconds,
             name=payload.check,
         )
 
-    generated_at = _record_last_report(report)
+    generated_at = _record_last_report(request, report)
     base = _build_report_response(report, generated_at=generated_at)
     return DoctorRunResponse(
         generated_at=base.generated_at,
@@ -739,7 +862,8 @@ __all__ = [
     "DoctorReportResponse",
     "DoctorRunRequest",
     "DoctorRunResponse",
-    "_FIX_OPERATION_LOCK",
+    "_get_executor",
+    "_get_fix_lock",
     "_reset_last_report",
     "get_doctor_report_endpoint",
     "list_doctor_checks_endpoint",

--- a/src/pollypm/web_api/routes/doctor.py
+++ b/src/pollypm/web_api/routes/doctor.py
@@ -24,6 +24,7 @@ the cache via :func:`_reset_last_report` so cases don't leak state.
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
 import threading
 import time
@@ -32,6 +33,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
+from pollypm.config import DEFAULT_CONFIG_PATH
 from pollypm.doctor import (
     Check,
     CheckResult,
@@ -43,7 +45,7 @@ from pollypm.doctor import (
     _auto_fix_supported,  # type: ignore[attr-defined]
     _registered_checks,  # type: ignore[attr-defined]
 )
-from pollypm.web_api.errors import APIError, invalid_request, not_found
+from pollypm.web_api.errors import APIError, conflict, invalid_request, not_found
 from pollypm.web_api.routes._deps import ConfigDep
 
 logger = logging.getLogger(__name__)
@@ -150,6 +152,16 @@ class DoctorRunResponse(DoctorReportResponse):
 
 _LAST_REPORT_LOCK = threading.Lock()
 _LAST_REPORT: tuple[DoctorReport, float] | None = None
+
+
+# Operation-level single-flight lock for ``POST /doctor/run`` when
+# ``fix=true``. ``_LAST_REPORT_LOCK`` above only guards the cache slot;
+# without this second lock, two concurrent callers can each invoke
+# ``apply_fixes`` on the same filesystem/session/storage state and
+# interleave the post-fix verify writes (Codex round-1 P0 on PR #2058).
+# Acquired non-blocking — a second concurrent ``fix=true`` returns a
+# typed 409 ``busy`` rather than queueing behind the first.
+_FIX_OPERATION_LOCK = threading.Lock()
 
 
 def _record_last_report(report: DoctorReport) -> float:
@@ -281,6 +293,68 @@ def _check_timeout(name: str | None, elapsed: float) -> APIError:
     )
 
 
+def _fix_busy_error() -> APIError:
+    """Typed 409 returned when a concurrent ``fix=true`` is in flight.
+
+    Doctor fixes touch shared state (filesystem, tmux sessions, the
+    Postgres heartbeat tables); we serialize the run+fix+verify
+    sequence with :data:`_FIX_OPERATION_LOCK`. Callers that race a
+    second ``fix=true`` request get an immediate 409 ``busy`` rather
+    than blocking on the lock or running fixes a second time.
+    """
+    return conflict(
+        "Doctor fix already in progress",
+        hint=(
+            "Wait for the in-flight POST /doctor/run (fix=true) to complete, "
+            "then retry. Doctor fixes are single-flight."
+        ),
+    )
+
+
+def _reject_non_default_config(config: Any) -> None:
+    """Refuse to run doctor against a non-default config path.
+
+    Many checks/fixes in :mod:`pollypm.doctor` load
+    :data:`pollypm.config.DEFAULT_CONFIG_PATH` internally rather than
+    accepting an injected :class:`PollyPMConfig`. When ``pm serve
+    --config <path>`` is used, the endpoint would otherwise *report*
+    on (and with ``fix=true`` *mutate*) the wrong workspace — a real
+    cross-config leak (Codex round-1 P0 on PR #2058).
+
+    Until the doctor module grows a config-accepting facade, refuse
+    explicit non-default configs with a typed 400. The default config
+    path (``~/.pollypm/pollypm.toml``) is the only one the checks
+    themselves load, so passing through that case is safe.
+
+    ``config.config_path`` is ``None`` for in-memory fixtures (tests),
+    which we pass through — there's no on-disk config to disagree
+    with the checks' internal loads.
+    """
+    config_path = getattr(config, "config_path", None)
+    if config_path is None:
+        return
+    try:
+        resolved = config_path.resolve()
+        default_resolved = DEFAULT_CONFIG_PATH.resolve()
+    except OSError:
+        # Couldn't resolve (file moved between requests, transient I/O
+        # error). Compare unresolved as a fallback so we still refuse
+        # the obvious cross-config case rather than silently passing.
+        resolved = config_path
+        default_resolved = DEFAULT_CONFIG_PATH
+    if resolved == default_resolved:
+        return
+    raise invalid_request(
+        "Doctor endpoints only support the default config path",
+        hint=(
+            f"`pm serve --config {config_path}` is loaded, but doctor "
+            f"checks load `{DEFAULT_CONFIG_PATH}` internally and would "
+            "mutate the wrong workspace. Run `pm doctor` from the CLI "
+            "instead, or restart `pm serve` without --config."
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Core runners (broken out for ease of testing)
 # ---------------------------------------------------------------------------
@@ -308,19 +382,54 @@ def _run_with_budget(
     name: str | None,
     timeout: float,
 ) -> DoctorReport:
-    """Run the selected checks and return a report, or 504 on overrun.
+    """Run the selected checks under a real wall-clock budget.
 
     ``run_checks`` itself doesn't honor a timeout — individual checks
-    each have their own short subprocess timeouts (see ``_run_cmd``).
-    The wall-clock overrun check below is a defensive backstop in
-    case a check hangs in pure Python (e.g. a network call that
-    bypassed the timeout helper). 504 lets the client decide whether
-    to retry the offending check in isolation.
+    each have their own short subprocess timeouts (see ``_run_cmd``),
+    but a pure-Python hang (network call, stuck storage probe, blocking
+    fix path) would otherwise hold the request worker forever.
+
+    To bound the HTTP request, we hand ``run_checks`` off to a
+    single-shot :class:`concurrent.futures.ThreadPoolExecutor` and
+    wait at most ``timeout`` seconds for the result. On overrun we
+    raise a typed 504 ``timeout`` immediately — the worker thread is
+    *not* cancelled (Python stdlib has no safe way to interrupt
+    arbitrary blocking code) and is allowed to finish in the
+    background. The HTTP caller sees the 504 within the budget; the
+    leaked thread is the accepted v1 RC tradeoff (Codex round-1 P0
+    on PR #2058).
+
+    ``DoctorThreadLeak`` is intentionally not raised on leak: the
+    leak is silent and best-effort cleanup happens when the thread
+    finally returns.
     """
     t0 = time.monotonic()
-    report = run_checks(selected)
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="doctor-run",
+    )
+    try:
+        future = executor.submit(run_checks, selected)
+        try:
+            report = future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError:
+            elapsed = time.monotonic() - t0
+            logger.warning(
+                "doctor: run exceeded %.1fs budget for %s; abandoning worker thread",
+                timeout,
+                name or "all checks",
+            )
+            raise _check_timeout(name, elapsed) from None
+    finally:
+        # ``wait=False`` so we don't block the request on the leaked
+        # worker thread when the budget already fired. If the future
+        # finished cleanly the shutdown is effectively a no-op.
+        executor.shutdown(wait=False)
+
     elapsed = time.monotonic() - t0
     if elapsed > timeout:
+        # Defensive: the future returned just past the deadline. Still
+        # surface 504 so the caller sees a consistent contract.
         raise _check_timeout(name, elapsed)
     return report
 
@@ -347,9 +456,10 @@ def list_doctor_checks_endpoint(config: ConfigDep) -> DoctorChecksResponse:
     # ``config`` is accepted so the dependency injection keeps the
     # auth guard active (FastAPI only resolves the dep chain when the
     # route declares one). Doctor checks themselves currently load
-    # their own config inside each probe (spec note: deferred
-    # refactor); pass-through is intentional.
-    _ = config
+    # ``DEFAULT_CONFIG_PATH`` inside each probe — :func:`_reject_non_default_config`
+    # refuses ``--config <other>`` so the catalog matches the workspace
+    # the checks would actually probe (Codex round-1 P0 on PR #2058).
+    _reject_non_default_config(config)
     checks = _registered_checks()
     return DoctorChecksResponse(checks=[_check_info(c) for c in checks])
 
@@ -369,7 +479,7 @@ def get_doctor_report_endpoint(config: ConfigDep) -> DoctorReportResponse:
     plumbed through (spec §7.1 deliberately scopes "last report" to
     the API's own surface).
     """
-    _ = config
+    _reject_non_default_config(config)
     cached = _read_last_report()
     if cached is None:
         raise not_found(
@@ -416,62 +526,82 @@ def run_doctor_endpoint(
 
     The whole sequence (run + optional fix + post-fix verify) is
     capped at ``timeout_seconds``; overrun → 504 ``timeout``.
+
+    When ``fix=true`` the run+fix+verify sequence is serialized via
+    :data:`_FIX_OPERATION_LOCK`; concurrent ``fix=true`` callers get
+    a typed 409 ``busy`` (Codex round-1 P0).
     """
-    _ = config
+    _reject_non_default_config(config)
     payload = body or DoctorRunRequest()
 
     selected = _select_checks(payload.check)
-    t0 = time.monotonic()
-    report = _run_with_budget(
-        selected, name=payload.check, timeout=timeout_seconds,
-    )
 
-    fixes_applied: list[dict[str, Any]] = []
+    # Single-flight gate for ``fix=true``. Acquire non-blocking so a
+    # second concurrent caller returns 409 immediately rather than
+    # queueing behind the in-flight fix. ``fix=false`` is read-only
+    # for our purposes (each check has its own internal locks) and
+    # is allowed to overlap.
+    fix_lock_held = False
     if payload.fix:
-        # ``apply_fixes`` skips passing/skipped checks itself — no need
-        # to filter on the caller side. Returns a list of
-        # ``(name, success, message)`` tuples; we coerce to JSON for
-        # the wire response.
-        try:
-            raw = apply_fixes(report)
-        except Exception as exc:  # noqa: BLE001 — bubble as 500 via outer handler
-            logger.exception("doctor: apply_fixes raised: %s", exc)
-            raise
-        fixes_applied = [
-            {"name": name, "ok": ok, "message": message}
-            for (name, ok, message) in raw
-        ]
+        fix_lock_held = _FIX_OPERATION_LOCK.acquire(blocking=False)
+        if not fix_lock_held:
+            raise _fix_busy_error()
 
-        # Re-run just the checks we tried to fix so the response
-        # reflects the post-fix state (issue #1063 style verification:
-        # don't trust the handler's self-report).
-        fixed_names = {entry["name"] for entry in fixes_applied}
-        if fixed_names:
-            rerun_checks = [c for c in selected if c.name in fixed_names]
-            elapsed_so_far = time.monotonic() - t0
-            remaining = timeout_seconds - elapsed_so_far
-            if remaining <= 0:
-                raise _check_timeout(payload.check, elapsed_so_far)
-            verify_report = _run_with_budget(
-                rerun_checks,
-                name=payload.check,
-                timeout=max(remaining, 1.0),
-            )
-            # Splice verify-report rows back into the original report
-            # so the response always reflects the latest state. The
-            # original report is a dataclass — build a new merged list
-            # of ``(check, result)`` tuples and mutate in place.
-            verify_index = {
-                check.name: result
-                for check, result in verify_report.results
-            }
-            merged: list[tuple[Check, CheckResult]] = []
-            for check, result in report.results:
-                replacement = verify_index.get(check.name)
-                merged.append((check, replacement if replacement else result))
-            report.results = merged
+    try:
+        t0 = time.monotonic()
+        report = _run_with_budget(
+            selected, name=payload.check, timeout=timeout_seconds,
+        )
 
-    generated_at = _record_last_report(report)
+        fixes_applied: list[dict[str, Any]] = []
+        if payload.fix:
+            # ``apply_fixes`` skips passing/skipped checks itself — no need
+            # to filter on the caller side. Returns a list of
+            # ``(name, success, message)`` tuples; we coerce to JSON for
+            # the wire response.
+            try:
+                raw = apply_fixes(report)
+            except Exception as exc:  # noqa: BLE001 — bubble as 500 via outer handler
+                logger.exception("doctor: apply_fixes raised: %s", exc)
+                raise
+            fixes_applied = [
+                {"name": name, "ok": ok, "message": message}
+                for (name, ok, message) in raw
+            ]
+
+            # Re-run just the checks we tried to fix so the response
+            # reflects the post-fix state (issue #1063 style verification:
+            # don't trust the handler's self-report).
+            fixed_names = {entry["name"] for entry in fixes_applied}
+            if fixed_names:
+                rerun_checks = [c for c in selected if c.name in fixed_names]
+                elapsed_so_far = time.monotonic() - t0
+                remaining = timeout_seconds - elapsed_so_far
+                if remaining <= 0:
+                    raise _check_timeout(payload.check, elapsed_so_far)
+                verify_report = _run_with_budget(
+                    rerun_checks,
+                    name=payload.check,
+                    timeout=max(remaining, 1.0),
+                )
+                # Splice verify-report rows back into the original report
+                # so the response always reflects the latest state. The
+                # original report is a dataclass — build a new merged list
+                # of ``(check, result)`` tuples and mutate in place.
+                verify_index = {
+                    check.name: result
+                    for check, result in verify_report.results
+                }
+                merged: list[tuple[Check, CheckResult]] = []
+                for check, result in report.results:
+                    replacement = verify_index.get(check.name)
+                    merged.append((check, replacement if replacement else result))
+                report.results = merged
+
+        generated_at = _record_last_report(report)
+    finally:
+        if fix_lock_held:
+            _FIX_OPERATION_LOCK.release()
     base = _build_report_response(report, generated_at=generated_at)
     return DoctorRunResponse(
         generated_at=base.generated_at,
@@ -495,6 +625,7 @@ __all__ = [
     "DoctorReportResponse",
     "DoctorRunRequest",
     "DoctorRunResponse",
+    "_FIX_OPERATION_LOCK",
     "_reset_last_report",
     "get_doctor_report_endpoint",
     "list_doctor_checks_endpoint",

--- a/tests/test_doctor_endpoint.py
+++ b/tests/test_doctor_endpoint.py
@@ -973,3 +973,190 @@ def test_doctor_app_teardown_returns_promptly_with_running_worker(
     assert app.state.doctor_executor._shutdown is True, (
         "lifespan did not shut down the doctor executor"
     )
+
+
+def test_doctor_executor_workers_are_daemon_threads(
+    client, auth_headers, patch_registry,
+) -> None:
+    """Doctor executor worker threads must be daemons.
+
+    Codex round-6 on PR #2058: a non-daemon
+    ``ThreadPoolExecutor`` worker keeps the Python interpreter
+    alive after ``executor.shutdown(wait=False)`` returns, so
+    ``pm serve`` cannot exit while a doctor check is wedged even
+    though FastAPI lifespan teardown has already completed.
+    :class:`DaemonThreadPoolExecutor` overrides
+    ``_adjust_thread_count`` so every worker thread inherits
+    ``daemon=True``; this test pins that invariant by submitting
+    a trivial check and inspecting ``executor._threads``.
+    """
+    import time as _time
+
+    patch_registry([_check("alpha", _ok("alpha"))])
+
+    # Drive a real request so the executor materializes worker
+    # threads on demand (workers are lazy — they are only spawned
+    # once ``submit()`` is called and the pool is below
+    # ``max_workers``).
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "alpha"},
+    )
+    assert response.status_code == 200, response.json()
+
+    executor = client.app.state.doctor_executor
+    # Give the worker a beat to register itself in
+    # ``executor._threads`` (it's added immediately after
+    # ``t.start()`` so this is essentially zero on a healthy box,
+    # but we tolerate scheduler jitter on CI).
+    deadline = _time.monotonic() + 2.0
+    while _time.monotonic() < deadline and not executor._threads:
+        _time.sleep(0.01)
+
+    workers = list(executor._threads)
+    assert workers, (
+        "expected at least one worker thread to be spawned after a "
+        "doctor run; got none"
+    )
+    for worker in workers:
+        assert worker.daemon is True, (
+            f"doctor worker thread {worker.name!r} is not a daemon; "
+            f"non-daemon workers block interpreter exit on a wedged "
+            f"check (Codex round-6 on #2058)."
+        )
+
+
+def test_doctor_pm_serve_process_exits_with_wedged_worker(tmp_path: Path) -> None:
+    """A wedged doctor worker does not keep the ``pm serve`` process alive.
+
+    Codex round-6 on PR #2058 demanded a real process-liveness
+    regression: app-lifespan timing alone is not enough because a
+    non-daemon ``ThreadPoolExecutor`` worker survives lifespan
+    teardown and blocks interpreter exit until the worker thread
+    returns. This test spawns a child process that mirrors the
+    smoke Codex described:
+
+    1. Build the app + start the lifespan.
+    2. Submit a hung check to the doctor executor (no HTTP roundtrip
+       needed — we put a ``time.sleep(60)`` straight onto the pool
+       so the test isn't sensitive to route-layer plumbing).
+    3. Exit the lifespan.
+    4. Drop our hard reference and let the interpreter try to exit.
+
+    Pre-fix, the child takes ~60s (waiting on the non-daemon
+    worker) and we kill it via timeout. Post-fix (daemon worker
+    + atexit eviction in the lifespan finalizer), the child exits
+    cleanly in well under the 15s budget.
+    """
+    import subprocess
+    import sys
+    import textwrap
+    import time as _time
+
+    child_script = textwrap.dedent(
+        """
+        import sys, time
+        from pathlib import Path
+        from fastapi.testclient import TestClient
+        from pollypm.config import (
+            AccountConfig, MemorySettings, PollyPMConfig,
+            PollyPMSettings, ProjectSettings,
+        )
+        from pollypm.models import (
+            KnownProject, ProjectKind, ProviderKind, RuntimeKind,
+        )
+        from pollypm.web_api import create_app, ensure_token
+
+        workspace = Path(sys.argv[1])
+        token_path = Path(sys.argv[2])
+        ensure_token(token_path)
+
+        base_dir = workspace / ".pollypm"
+        config = PollyPMConfig(
+            project=ProjectSettings(
+                name="PollyPM", root_dir=workspace,
+                tmux_session="pollypm-test",
+                workspace_root=workspace, base_dir=base_dir,
+                logs_dir=base_dir / "logs",
+                snapshots_dir=base_dir / "snapshots",
+                state_db=base_dir / "state.db",
+            ),
+            pollypm=PollyPMSettings(
+                controller_account="codex_primary",
+                open_permissions_by_default=False,
+                failover_enabled=False, failover_accounts=[],
+                heartbeat_backend="local",
+                scheduler_backend="inline",
+                lease_timeout_minutes=30,
+            ),
+            accounts={
+                "codex_primary": AccountConfig(
+                    name="codex_primary",
+                    provider=ProviderKind.CODEX,
+                    email="codex@example.com",
+                    runtime=RuntimeKind.LOCAL,
+                    home=base_dir / "homes" / "codex_primary",
+                ),
+            },
+            sessions={},
+            projects={
+                "myproj": KnownProject(
+                    key="myproj", path=workspace, name="My Project",
+                    tracked=True, kind=ProjectKind.GIT,
+                ),
+            },
+            memory=MemorySettings(backend="file"),
+        )
+
+        app = create_app(config=config, token_path=token_path)
+        with TestClient(app):
+            # Submit a wedged job directly to the executor so the
+            # test doesn't depend on doctor-route plumbing. The
+            # daemon-thread invariant is a property of the
+            # executor, not the route.
+            app.state.doctor_executor.submit(time.sleep, 60)
+            time.sleep(0.2)
+        # Lifespan has exited; daemon workers + atexit-eviction
+        # should let the interpreter exit immediately.
+        print("CHILD EXIT OK", flush=True)
+        """
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".pollypm").mkdir()
+    token_path = tmp_path / "api-token"
+
+    t0 = _time.monotonic()
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", child_script,
+             str(workspace), str(token_path)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired as exc:
+        elapsed = _time.monotonic() - t0
+        pytest.fail(
+            f"child process did not exit within 15s (took {elapsed:.1f}s) — "
+            f"a wedged doctor worker is keeping the interpreter alive. "
+            f"stdout={exc.stdout!r} stderr={exc.stderr!r}"
+        )
+
+    elapsed = _time.monotonic() - t0
+    assert result.returncode == 0, (
+        f"child exited with rc={result.returncode}; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "CHILD EXIT OK" in result.stdout, (
+        f"child did not reach the post-lifespan print; "
+        f"stdout={result.stdout!r}"
+    )
+    # The lifespan grace is 5s and atexit eviction is O(workers),
+    # so even with launcher overhead this should land well under 12s.
+    assert elapsed < 12.0, (
+        f"child took {elapsed:.1f}s; the wedged worker should not "
+        f"have blocked interpreter exit past the lifespan grace."
+    )

--- a/tests/test_doctor_endpoint.py
+++ b/tests/test_doctor_endpoint.py
@@ -359,35 +359,204 @@ def test_run_with_fix_false_does_not_invoke_fixes(client, auth_headers, patch_re
 def test_run_504_when_check_exceeds_budget(
     client, auth_headers, patch_registry, monkeypatch,
 ):
-    """A check overrunning the wall-clock budget surfaces 504 timeout."""
+    """A real hanging check surfaces 504 within the budget (P0 round-1).
+
+    Earlier revisions of this test stubbed ``time.monotonic`` after
+    ``run_checks`` returned — that only proved post-facto
+    classification. The real contract is that the HTTP request worker
+    is bounded: a check that blocks past the budget must produce 504
+    on time. We sleep longer than the budget in a stubbed
+    ``run_checks`` and assert (a) status code, (b) wall-clock
+    response time stays within budget + small slack (the executor
+    abandons the worker thread rather than waiting for it).
+    """
+    import time as _time
+
     patch_registry([_check("alpha", _ok("alpha"))])
 
-    # Stub ``run_checks`` to claim a long elapsed time without sleeping.
-    fake_report = DoctorReport()
-    fake_report.duration_seconds = 999.0
+    hang_event = __import__("threading").Event()
 
-    def fake_run_checks(checks):  # type: ignore[no-untyped-def]
-        return fake_report
+    def hanging_run_checks(checks):  # type: ignore[no-untyped-def]
+        # Block well past the request budget. The route's executor
+        # abandons this thread on timeout; ``hang_event`` lets the
+        # test release it cleanly after assertions.
+        hang_event.wait(timeout=30.0)
+        return DoctorReport()
 
-    monkeypatch.setattr(doctor_routes, "run_checks", fake_run_checks)
-    # Force the monotonic clock to report a huge gap so the budget
-    # check triggers regardless of how fast the fake runner returns.
-    counter = {"t": 0.0}
+    monkeypatch.setattr(doctor_routes, "run_checks", hanging_run_checks)
 
-    def fake_monotonic() -> float:
-        counter["t"] += 100.0
-        return counter["t"]
-
-    monkeypatch.setattr(doctor_routes.time, "monotonic", fake_monotonic)
+    t0 = _time.monotonic()
     response = client.post(
         "/api/v1/doctor/run",
         headers=auth_headers,
         json={"check": "alpha"},
-        params={"timeout_seconds": 5},
+        params={"timeout_seconds": 1},
     )
+    elapsed = _time.monotonic() - t0
+
+    # Release the leaked worker thread so the suite shuts down cleanly.
+    hang_event.set()
+
     assert response.status_code == 504
     body = response.json()
     assert body["error"]["code"] == "timeout"
+    # The 504 must return within budget + slack (executor + HTTP + asserts).
+    # If the request waited for the hanging thread, this would be ~30s.
+    assert elapsed < 5.0, f"504 took {elapsed:.1f}s; should be near 1s budget"
+
+
+def test_run_fix_serialized_under_concurrency(
+    client, auth_headers, patch_registry, monkeypatch,
+):
+    """Two concurrent ``fix=true`` calls: one succeeds, one returns 409.
+
+    Single-flight is enforced via ``_FIX_OPERATION_LOCK`` on the
+    route module. We hold ``apply_fixes`` long enough for the second
+    request to race in, then assert exactly one 200 and one 409
+    ``conflict`` (Codex round-1 P0 on PR #2058).
+    """
+    import threading
+
+    counter = {"n": 0}
+
+    def stateful_run() -> CheckResult:
+        counter["n"] += 1
+        return _fail("alpha", fixable=True) if counter["n"] % 2 == 1 else _ok("alpha")
+
+    check = Check(name="alpha", run=stateful_run, category="test", severity="error")
+    patch_registry([check])
+
+    # Block ``apply_fixes`` so the first request holds the operation
+    # lock long enough for the second one to race in and 409.
+    release = threading.Event()
+    in_flight = threading.Event()
+    real_apply = doctor_routes.apply_fixes
+
+    def slow_apply_fixes(report):  # type: ignore[no-untyped-def]
+        in_flight.set()
+        release.wait(timeout=10.0)
+        return real_apply(report)
+
+    monkeypatch.setattr(doctor_routes, "apply_fixes", slow_apply_fixes)
+
+    results: list[int] = []
+    bodies: list[dict[str, Any]] = []
+
+    def fire():
+        resp = client.post(
+            "/api/v1/doctor/run",
+            headers=auth_headers,
+            json={"check": "alpha", "fix": True},
+        )
+        results.append(resp.status_code)
+        bodies.append(resp.json())
+
+    t1 = threading.Thread(target=fire, daemon=True)
+    t1.start()
+    # Wait for the first request to enter ``apply_fixes`` so the
+    # operation lock is definitely held when the second fires.
+    assert in_flight.wait(timeout=5.0), "first request never entered apply_fixes"
+
+    t2 = threading.Thread(target=fire, daemon=True)
+    t2.start()
+    t2.join(timeout=5.0)
+
+    # Release the first request and wait for it to finish.
+    release.set()
+    t1.join(timeout=10.0)
+
+    assert sorted(results) == [200, 409], f"expected one 200 + one 409, got {results}"
+    busy_body = next(b for b, code in zip(bodies, results) if code == 409)
+    assert busy_body["error"]["code"] == "conflict"
+
+
+def test_run_rejected_for_non_default_config(
+    auth_headers, token, patch_registry, workspace, project_root, tmp_path,
+):
+    """``pm serve --config /tmp/foo`` → doctor refuses with 400.
+
+    Doctor checks load ``DEFAULT_CONFIG_PATH`` internally; a
+    non-default config would cause the route to report on / mutate
+    the wrong workspace (Codex round-1 P0 on PR #2058). The reject
+    path covers all three endpoints — assert on POST /run as the
+    write surface that matters most.
+    """
+    from pollypm.config import (
+        AccountConfig,
+        MemorySettings,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectSettings,
+    )
+    from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+
+    base_dir = workspace / ".pollypm"
+    fake_path = tmp_path / "custom" / "pollypm.toml"
+    fake_path.parent.mkdir()
+    fake_path.write_text("# fake non-default config\n")
+
+    cfg = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+    cfg.config_path = fake_path  # non-default
+
+    token_path, _value = token
+    app = create_app(config=cfg, token_path=token_path)
+    custom_client = TestClient(app)
+
+    patch_registry([_check("alpha", _ok("alpha"))])
+
+    resp = custom_client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "alpha", "fix": True},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "default config" in body["error"]["message"].lower()
+
+    # Also covers GET endpoints.
+    resp_checks = custom_client.get("/api/v1/doctor/checks", headers=auth_headers)
+    assert resp_checks.status_code == 400
 
 
 def test_run_requires_auth(client, patch_registry):

--- a/tests/test_doctor_endpoint.py
+++ b/tests/test_doctor_endpoint.py
@@ -16,7 +16,7 @@ registry / runner so the suite never touches the user's real machine
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 from fastapi.testclient import TestClient
@@ -115,10 +115,15 @@ def auth_headers(token: tuple[Path, str]) -> dict[str, str]:
 
 @pytest.fixture(autouse=True)
 def reset_last_report() -> Any:
-    """Clear the process-local last-report cache between tests."""
-    doctor_routes._reset_last_report()
+    """No-op shim — the last-report cache is per-app, owned by lifespan.
+
+    The ``client`` fixture below builds a fresh app each test whose
+    lifespan starts with ``app.state.doctor_last_report = None``, so
+    cross-test bleed is impossible. Kept as an empty autouse fixture so
+    the signature stays stable for any test that explicitly references
+    it (Codex round-5 on PR #2058).
+    """
     yield
-    doctor_routes._reset_last_report()
 
 
 @pytest.fixture
@@ -128,8 +133,17 @@ def app(config, token):
 
 
 @pytest.fixture
-def client(app) -> TestClient:
-    return TestClient(app)
+def client(app) -> Iterator[TestClient]:
+    """TestClient wired through ``with`` so the FastAPI lifespan fires.
+
+    Lifespan owns the doctor ThreadPoolExecutor + single-flight fix
+    lock + last-report cache on ``app.state`` (Codex round-5 on
+    #2058). Without the ``with`` block, ``TestClient`` skips
+    startup/shutdown and the run endpoint would 503 on the missing
+    executor.
+    """
+    with TestClient(app) as test_client:
+        yield test_client
 
 
 # ---------------------------------------------------------------------------
@@ -465,7 +479,7 @@ def test_apply_fixes_hang_returns_504_within_budget(
 
 
 def test_fix_retry_after_504_returns_busy_while_first_still_running(
-    client, auth_headers, patch_registry, monkeypatch,
+    client, app, auth_headers, patch_registry, monkeypatch,
 ):
     """After a 504 from a hung fix, an immediate retry must 409, not start a second fix.
 
@@ -554,12 +568,15 @@ def test_fix_retry_after_504_returns_busy_while_first_still_running(
     assert body["error"]["code"] == "conflict"
     assert "in progress" in body["error"]["message"].lower()
 
-    # Wait for the worker's done callback to release the lock before the
-    # next test runs (otherwise we leak across the suite).
+    # Wait for the worker's done callback to release the per-app lock
+    # before the next test runs (otherwise we leak across the suite).
+    # The lock lives on ``app.state.doctor_fix_lock`` (Codex round-5 on
+    # PR #2058) — pre-round-5 this was a module-level global.
+    fix_lock = app.state.doctor_fix_lock
     deadline = _time.monotonic() + 5.0
     while _time.monotonic() < deadline:
-        if doctor_routes._FIX_OPERATION_LOCK.acquire(blocking=False):
-            doctor_routes._FIX_OPERATION_LOCK.release()
+        if fix_lock.acquire(blocking=False):
+            fix_lock.release()
             break
         _time.sleep(0.05)
     else:
@@ -701,23 +718,29 @@ def test_run_rejected_for_non_default_config(
 
     token_path, _value = token
     app = create_app(config=cfg, token_path=token_path)
-    custom_client = TestClient(app)
 
     patch_registry([_check("alpha", _ok("alpha"))])
 
-    resp = custom_client.post(
-        "/api/v1/doctor/run",
-        headers=auth_headers,
-        json={"check": "alpha", "fix": True},
-    )
-    assert resp.status_code == 400
-    body = resp.json()
-    assert body["error"]["code"] == "invalid_request"
-    assert "default config" in body["error"]["message"].lower()
+    # ``with`` so the FastAPI lifespan attaches the doctor executor /
+    # locks (Codex round-5 on PR #2058) — otherwise the run endpoint
+    # would 503 on the missing executor, masking the 400 we're
+    # asserting.
+    with TestClient(app) as custom_client:
+        resp = custom_client.post(
+            "/api/v1/doctor/run",
+            headers=auth_headers,
+            json={"check": "alpha", "fix": True},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == "invalid_request"
+        assert "default config" in body["error"]["message"].lower()
 
-    # Also covers GET endpoints.
-    resp_checks = custom_client.get("/api/v1/doctor/checks", headers=auth_headers)
-    assert resp_checks.status_code == 400
+        # Also covers GET endpoints.
+        resp_checks = custom_client.get(
+            "/api/v1/doctor/checks", headers=auth_headers,
+        )
+        assert resp_checks.status_code == 400
 
 
 def test_run_requires_auth(client, patch_registry):
@@ -769,3 +792,184 @@ def test_run_with_no_body_defaults_to_run_all(client, auth_headers, patch_regist
     body = response.json()
     assert [c["name"] for c in body["checks"]] == ["alpha", "beta"]
     assert body["passed"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Codex round-5 regressions (refs #2058) — app-scoped doctor executor
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_executor_app_scoped(config, token) -> None:
+    """Two ``create_app`` instances get independent doctor executors / locks.
+
+    Pins the module-globals → ``app.state`` migration: the executor,
+    single-flight fix lock, and last-report cache must be per-app so
+    one ``pm serve`` invocation can't share a wedged worker slot (or
+    deadlock the fix lock) with a sibling FastAPI app in the same
+    process (tests, embedded uses). Previously the module-level
+    ``_DOCTOR_EXECUTOR`` / ``_FIX_OPERATION_LOCK`` were shared across
+    every app in the process — Codex round-5 on PR #2058.
+    """
+    token_path, _value = token
+    app_a = create_app(config=config, token_path=token_path)
+    app_b = create_app(config=config, token_path=token_path)
+
+    with TestClient(app_a), TestClient(app_b):
+        # Distinct executor + locks + cache slot per app.
+        assert app_a.state.doctor_executor is not app_b.state.doctor_executor
+        assert app_a.state.doctor_fix_lock is not app_b.state.doctor_fix_lock
+        assert (
+            app_a.state.doctor_last_report_lock
+            is not app_b.state.doctor_last_report_lock
+        )
+
+        # Holding app_a's fix lock must not affect app_b's.
+        assert app_a.state.doctor_fix_lock.acquire(blocking=False)
+        try:
+            assert app_b.state.doctor_fix_lock.acquire(blocking=False), (
+                "app_b fix lock leaked from app_a — locks are not per-app"
+            )
+            app_b.state.doctor_fix_lock.release()
+        finally:
+            app_a.state.doctor_fix_lock.release()
+
+        # Poking app_a's last-report slot must not leak into app_b.
+        sentinel = object()
+        app_a.state.doctor_last_report = sentinel  # type: ignore[assignment]
+        assert app_b.state.doctor_last_report is None
+
+
+def test_doctor_timed_out_worker_logged_on_late_completion(
+    client, auth_headers, patch_registry, monkeypatch, caplog,
+) -> None:
+    """A 504 from a hung check still emits a log line when the worker finishes.
+
+    Codex round-5 on PR #2058: pre-fix, a timed-out doctor worker was
+    abandoned silently — the operator had no signal that the
+    underlying check eventually returned (or raised). The done-callback
+    on every submitted future now logs the late completion outcome.
+    """
+    import logging
+    import threading
+    import time as _time
+
+    patch_registry([_check("alpha", _ok("alpha"))])
+
+    release = threading.Event()
+    in_flight = threading.Event()
+
+    def hanging_run_checks(checks):  # type: ignore[no-untyped-def]
+        in_flight.set()
+        # Hang past the 1s budget; release lets the worker finish so
+        # the done-callback fires before we assert on the log.
+        release.wait(timeout=10.0)
+        return DoctorReport()
+
+    monkeypatch.setattr(doctor_routes, "run_checks", hanging_run_checks)
+
+    with caplog.at_level(logging.INFO, logger="pollypm.web_api.routes.doctor"):
+        t0 = _time.monotonic()
+        response = client.post(
+            "/api/v1/doctor/run",
+            headers=auth_headers,
+            json={"check": "alpha"},
+            params={"timeout_seconds": 1},
+        )
+        elapsed = _time.monotonic() - t0
+        assert response.status_code == 504, response.json()
+        assert elapsed < 5.0, f"504 took {elapsed:.1f}s; should be near 1s budget"
+        assert in_flight.is_set(), "worker never entered run_checks"
+
+        # Release the worker; the done-callback should log the late
+        # completion once the future resolves.
+        release.set()
+
+        # Wait up to 5s for the done-callback log line to land.
+        deadline = _time.monotonic() + 5.0
+        late_completion_msg = "check worker completed"
+        while _time.monotonic() < deadline:
+            if any(
+                late_completion_msg in record.getMessage()
+                for record in caplog.records
+            ):
+                break
+            _time.sleep(0.05)
+        else:
+            pytest.fail(
+                "expected a 'check worker completed' log line after "
+                f"the timed-out worker finished. Records seen: "
+                f"{[r.getMessage() for r in caplog.records]}"
+            )
+
+
+def test_doctor_app_teardown_returns_promptly_with_running_worker(
+    config, token, auth_headers, patch_registry, monkeypatch,
+) -> None:
+    """App teardown completes promptly even with a wedged in-flight check.
+
+    Codex round-5 on PR #2058: the prior module-level executor had no
+    shutdown hook, so ``pm serve`` exit left worker threads alive past
+    teardown with no log line. The lifespan now calls
+    ``shutdown(wait=False, cancel_futures=True)`` and waits at most
+    :data:`pollypm.web_api.app._DOCTOR_SHUTDOWN_GRACE_S` for cooperative
+    drain — a hung worker is logged + leaked, not waited on.
+
+    This test fires a slow check that we abandon via 504, then exits
+    the lifespan and asserts the whole teardown completed in well
+    under 10s even though the worker is still alive. The wedged
+    thread is released afterwards so it doesn't linger across the
+    suite.
+    """
+    import threading
+    import time as _time
+
+    token_path, _value = token
+    app = create_app(config=config, token_path=token_path)
+
+    patch_registry([_check("alpha", _ok("alpha"))])
+
+    release = threading.Event()
+    in_flight = threading.Event()
+
+    def hanging_run_checks(checks):  # type: ignore[no-untyped-def]
+        in_flight.set()
+        # Hang well past the grace period; lifespan must NOT wait on us.
+        release.wait(timeout=30.0)
+        return DoctorReport()
+
+    monkeypatch.setattr(doctor_routes, "run_checks", hanging_run_checks)
+
+    teardown_t0: list[float] = []
+    teardown_elapsed: list[float] = []
+
+    with TestClient(app) as test_client:
+        resp = test_client.post(
+            "/api/v1/doctor/run",
+            headers=auth_headers,
+            json={"check": "alpha"},
+            params={"timeout_seconds": 1},
+        )
+        assert resp.status_code == 504, resp.json()
+        assert in_flight.is_set(), "worker never entered run_checks"
+        teardown_t0.append(_time.monotonic())
+
+    # Lifespan has exited.
+    teardown_elapsed.append(_time.monotonic() - teardown_t0[0])
+
+    # Release the leaked worker so it doesn't linger across the suite.
+    release.set()
+
+    # Should be ~5s (the documented grace), and definitely under 10s.
+    # Pre-fix (no lifespan / no shutdown hook) the worker thread is
+    # still alive but the app teardown returns instantly — what
+    # actually changed is that we now LOG the leak and explicitly
+    # cancel queued work. Verify the grace bound holds either way.
+    assert teardown_elapsed[0] < 10.0, (
+        f"app teardown took {teardown_elapsed[0]:.1f}s with a wedged "
+        f"worker; must be bounded by the grace period."
+    )
+
+    # Executor should have been marked shut down by the lifespan.
+    assert app.state.doctor_executor._shutdown is True, (
+        "lifespan did not shut down the doctor executor"
+    )

--- a/tests/test_doctor_endpoint.py
+++ b/tests/test_doctor_endpoint.py
@@ -405,6 +405,65 @@ def test_run_504_when_check_exceeds_budget(
     assert elapsed < 5.0, f"504 took {elapsed:.1f}s; should be near 1s budget"
 
 
+def test_apply_fixes_hang_returns_504_within_budget(
+    client, auth_headers, patch_registry, monkeypatch,
+):
+    """A hanging ``apply_fixes`` must surface 504 within budget (P0 round-3).
+
+    Before this fix, only ``run_checks`` and the post-fix verify rerun
+    were dispatched through ``_run_with_budget``; ``apply_fixes`` was
+    called inline, so a hung fix (stuck subprocess, blocked filesystem,
+    jammed worktree git op) would hold the request worker indefinitely
+    even though the endpoint documents the whole ``run + fix + verify``
+    sequence as bounded by ``timeout_seconds``.
+
+    This test simulates that hang: ``run_checks`` returns immediately
+    with a fixable failure, ``apply_fixes`` sleeps well past the
+    request budget. The endpoint must return 504 within the budget +
+    small slack, not block on the sleeping fix. Without the round-3
+    fix this test sees a ~60s wait; with it, ~1s.
+    """
+    import time as _time
+
+    patch_registry([_check("alpha", _fail("alpha", fixable=True))])
+
+    hang_event = __import__("threading").Event()
+
+    def hanging_apply_fixes(report):  # type: ignore[no-untyped-def]
+        # Block well past the request budget. The shared executor
+        # abandons this thread on timeout; ``hang_event`` lets the
+        # test release it cleanly after assertions so the daemon
+        # thread doesn't linger across the suite.
+        hang_event.wait(timeout=60.0)
+        return []
+
+    monkeypatch.setattr(doctor_routes, "apply_fixes", hanging_apply_fixes)
+
+    t0 = _time.monotonic()
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "alpha", "fix": True},
+        params={"timeout_seconds": 2},
+    )
+    elapsed = _time.monotonic() - t0
+
+    # Release the leaked worker thread so the executor slot recovers
+    # before the next test runs.
+    hang_event.set()
+
+    assert response.status_code == 504, (
+        f"expected 504 within budget, got {response.status_code}: {response.json()}"
+    )
+    body = response.json()
+    assert body["error"]["code"] == "timeout"
+    # If apply_fixes wasn't bounded, this elapsed would be ~60s. Allow
+    # a few seconds of slack for executor dispatch + TestClient.
+    assert elapsed < 5.0, (
+        f"504 took {elapsed:.1f}s; apply_fixes must be wrapped in the same budget"
+    )
+
+
 def test_run_fix_serialized_under_concurrency(
     client, auth_headers, patch_registry, monkeypatch,
 ):

--- a/tests/test_doctor_endpoint.py
+++ b/tests/test_doctor_endpoint.py
@@ -1,0 +1,441 @@
+"""Integration tests for the Phase 2 doctor endpoints.
+
+Covers:
+
+- ``GET  /api/v1/doctor/checks``
+- ``GET  /api/v1/doctor/report``
+- ``POST /api/v1/doctor/run``
+
+Per ``~/Desktop/pollypm-phase2-endpoints-spec.md`` §7. Tests use the
+FastAPI ``TestClient`` against an in-process app, stubbing the doctor
+registry / runner so the suite never touches the user's real machine
+(no subprocess spawns, no network probes). Run with
+``pytest --noconftest tests/test_doctor_endpoint.py -v``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.doctor import Check, CheckResult, DoctorReport
+from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.routes import doctor as doctor_routes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (self-contained — do not rely on tests/web_api/conftest.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def config(workspace: Path, project_root: Path) -> PollyPMConfig:
+    base_dir = workspace / ".pollypm"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def token(tmp_path: Path) -> tuple[Path, str]:
+    token_path = tmp_path / "api-token"
+    value, _generated = ensure_token(token_path)
+    return token_path, value
+
+
+@pytest.fixture
+def auth_headers(token: tuple[Path, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token[1]}"}
+
+
+@pytest.fixture(autouse=True)
+def reset_last_report() -> Any:
+    """Clear the process-local last-report cache between tests."""
+    doctor_routes._reset_last_report()
+    yield
+    doctor_routes._reset_last_report()
+
+
+@pytest.fixture
+def app(config, token):
+    token_path, _value = token
+    return create_app(config=config, token_path=token_path)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(name: str) -> CheckResult:
+    return CheckResult(passed=True, status=f"{name}: ok")
+
+
+def _fail(name: str, *, severity: str = "error", fixable: bool = False) -> CheckResult:
+    fix_fn = None
+    if fixable:
+        def fix_fn() -> tuple[bool, str]:
+            return True, f"applied fix for {name}"
+    return CheckResult(
+        passed=False,
+        status=f"{name}: failing",
+        severity=severity,
+        why=f"{name} is broken",
+        fix=f"do the {name} thing",
+        fixable=fixable,
+        fix_fn=fix_fn,
+    )
+
+
+def _check(name: str, result: CheckResult, *, category: str = "test", severity: str = "error") -> Check:
+    return Check(
+        name=name,
+        run=lambda r=result: r,
+        category=category,
+        severity=severity,
+    )
+
+
+@pytest.fixture
+def patch_registry(monkeypatch: pytest.MonkeyPatch):
+    """Install a stub for ``_registered_checks``.
+
+    Returns a callable ``(checks_list)`` that swaps the registry both
+    on the route module (where ``_select_checks`` calls it) and on the
+    underlying ``pollypm.doctor`` module (where ``run_checks`` resolves
+    its default selection).
+    """
+
+    def install(checks: list[Check]) -> None:
+        monkeypatch.setattr(
+            doctor_routes, "_registered_checks", lambda: list(checks),
+        )
+        # ``run_checks(selected)`` resolves an explicit list directly,
+        # so we only need to patch ``_registered_checks`` on the doctor
+        # module to keep the "no args" branch consistent — but we go
+        # the extra step here for symmetry / future-proofing.
+        from pollypm import doctor as doctor_module
+        monkeypatch.setattr(
+            doctor_module, "_registered_checks", lambda: list(checks),
+        )
+
+    return install
+
+
+# ---------------------------------------------------------------------------
+# GET /doctor/checks
+# ---------------------------------------------------------------------------
+
+
+def test_list_checks_happy_path(client, auth_headers, patch_registry):
+    """List endpoint returns every registered check with its metadata."""
+    patch_registry([
+        _check("alpha", _ok("alpha"), category="system"),
+        _check("beta", _ok("beta"), category="install", severity="warning"),
+    ])
+    response = client.get("/api/v1/doctor/checks", headers=auth_headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert [c["name"] for c in body["checks"]] == ["alpha", "beta"]
+    assert body["checks"][0]["category"] == "system"
+    assert body["checks"][1]["severity"] == "warning"
+    # Catalog rows declare ``has_auto_fix=False`` (real value comes
+    # from a run); make sure the field is present.
+    assert body["checks"][0]["has_auto_fix"] is False
+
+
+def test_list_checks_requires_auth(client, patch_registry):
+    """Missing bearer token → 401, not 200 with a public catalog."""
+    patch_registry([_check("alpha", _ok("alpha"))])
+    response = client.get("/api/v1/doctor/checks")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "unauthorized"
+
+
+# ---------------------------------------------------------------------------
+# GET /doctor/report
+# ---------------------------------------------------------------------------
+
+
+def test_report_returns_404_when_no_run_yet(client, auth_headers, patch_registry):
+    """Spec §7.1: report endpoint 404s when nothing's cached."""
+    patch_registry([_check("alpha", _ok("alpha"))])
+    response = client.get("/api/v1/doctor/report", headers=auth_headers)
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_report_returns_last_run_after_post(client, auth_headers, patch_registry):
+    """After a POST /run, GET /report returns the cached snapshot."""
+    patch_registry([
+        _check("alpha", _ok("alpha")),
+        _check("beta", _fail("beta")),
+    ])
+    run = client.post("/api/v1/doctor/run", headers=auth_headers, json={})
+    assert run.status_code == 200
+    report = client.get("/api/v1/doctor/report", headers=auth_headers)
+    assert report.status_code == 200
+    body = report.json()
+    assert {c["name"] for c in body["checks"]} == {"alpha", "beta"}
+    assert body["errors"] == 1
+    assert body["passed"] == 1
+    assert body["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# POST /doctor/run
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_checks_sync(client, auth_headers, patch_registry):
+    """Empty body → run every registered check synchronously."""
+    patch_registry([
+        _check("alpha", _ok("alpha")),
+        _check("beta", _ok("beta")),
+        _check("gamma", _fail("gamma", severity="warning"), severity="warning"),
+    ])
+    response = client.post("/api/v1/doctor/run", headers=auth_headers, json={})
+    assert response.status_code == 200
+    body = response.json()
+    assert [c["name"] for c in body["checks"]] == ["alpha", "beta", "gamma"]
+    assert body["passed"] == 2
+    assert body["errors"] == 0
+    assert body["warnings"] == 1
+    assert body["ok"] is True  # warnings don't break ``ok``
+    assert body["fixes_applied"] == []
+
+
+def test_run_single_check_by_name(client, auth_headers, patch_registry):
+    """``check`` body field narrows the run to one named check."""
+    patch_registry([
+        _check("alpha", _ok("alpha")),
+        _check("beta", _fail("beta")),
+    ])
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "beta"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert [c["name"] for c in body["checks"]] == ["beta"]
+    assert body["errors"] == 1
+    assert body["ok"] is False
+
+
+def test_run_unknown_check_returns_404(client, auth_headers, patch_registry):
+    """Unknown check name → 404 not_found, never silent success."""
+    patch_registry([_check("alpha", _ok("alpha"))])
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "does_not_exist"},
+    )
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "not_found"
+    # Hint should mention the discovery endpoint.
+    assert "GET /api/v1/doctor/checks" in (body["error"].get("hint") or "")
+
+
+def test_run_with_fix_invokes_fix_fn(client, auth_headers, patch_registry, monkeypatch):
+    """``fix=true`` runs auto-fixes and verifies post-fix state.
+
+    We stub the underlying check so the first run fails and the
+    second (post-fix re-run) succeeds — this exercises the re-run
+    branch in the route. The stub uses a counter so each invocation
+    flips between the failing and passing result.
+    """
+    counter = {"n": 0}
+
+    def stateful_run() -> CheckResult:
+        counter["n"] += 1
+        if counter["n"] == 1:
+            return _fail("alpha", fixable=True)
+        return _ok("alpha")
+
+    check = Check(name="alpha", run=stateful_run, category="test", severity="error")
+    patch_registry([check])
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "alpha", "fix": True},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["fixes_applied"] == [
+        {"name": "alpha", "ok": True, "message": "applied fix for alpha"},
+    ]
+    # Post-fix re-run replaced the failing result with a passing one.
+    [row] = body["checks"]
+    assert row["passed"] is True
+
+
+def test_run_with_fix_false_does_not_invoke_fixes(client, auth_headers, patch_registry):
+    """``fix=false`` returns the report without attempting fixes."""
+    patch_registry([_check("alpha", _fail("alpha", fixable=True))])
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"fix": False},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["fixes_applied"] == []
+    assert body["checks"][0]["passed"] is False
+    assert body["checks"][0]["fixable"] is True
+
+
+def test_run_504_when_check_exceeds_budget(
+    client, auth_headers, patch_registry, monkeypatch,
+):
+    """A check overrunning the wall-clock budget surfaces 504 timeout."""
+    patch_registry([_check("alpha", _ok("alpha"))])
+
+    # Stub ``run_checks`` to claim a long elapsed time without sleeping.
+    fake_report = DoctorReport()
+    fake_report.duration_seconds = 999.0
+
+    def fake_run_checks(checks):  # type: ignore[no-untyped-def]
+        return fake_report
+
+    monkeypatch.setattr(doctor_routes, "run_checks", fake_run_checks)
+    # Force the monotonic clock to report a huge gap so the budget
+    # check triggers regardless of how fast the fake runner returns.
+    counter = {"t": 0.0}
+
+    def fake_monotonic() -> float:
+        counter["t"] += 100.0
+        return counter["t"]
+
+    monkeypatch.setattr(doctor_routes.time, "monotonic", fake_monotonic)
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "alpha"},
+        params={"timeout_seconds": 5},
+    )
+    assert response.status_code == 504
+    body = response.json()
+    assert body["error"]["code"] == "timeout"
+
+
+def test_run_requires_auth(client, patch_registry):
+    """POST /run without bearer → 401."""
+    patch_registry([_check("alpha", _ok("alpha"))])
+    response = client.post("/api/v1/doctor/run", json={})
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "unauthorized"
+
+
+def test_run_with_invalid_token_returns_401(client, patch_registry):
+    """Wrong token → 401 invalid_token, not 500."""
+    patch_registry([_check("alpha", _ok("alpha"))])
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers={"Authorization": "Bearer wrong"},
+        json={},
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
+
+
+def test_run_records_last_report_for_subsequent_get(
+    client, auth_headers, patch_registry,
+):
+    """Two POST /run calls overwrite the cache (latest wins)."""
+    patch_registry([_check("alpha", _ok("alpha"))])
+    first = client.post("/api/v1/doctor/run", headers=auth_headers, json={})
+    assert first.status_code == 200
+    # Swap the registry; second run should overwrite the cached report.
+    patch_registry([_check("beta", _fail("beta"))])
+    second = client.post("/api/v1/doctor/run", headers=auth_headers, json={})
+    assert second.status_code == 200
+    cached = client.get("/api/v1/doctor/report", headers=auth_headers)
+    assert cached.status_code == 200
+    body = cached.json()
+    assert [c["name"] for c in body["checks"]] == ["beta"]
+    assert body["errors"] == 1
+
+
+def test_run_with_no_body_defaults_to_run_all(client, auth_headers, patch_registry):
+    """POST with no JSON body still runs every check (body is optional)."""
+    patch_registry([
+        _check("alpha", _ok("alpha")),
+        _check("beta", _ok("beta")),
+    ])
+    response = client.post("/api/v1/doctor/run", headers=auth_headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert [c["name"] for c in body["checks"]] == ["alpha", "beta"]
+    assert body["passed"] == 2

--- a/tests/test_doctor_endpoint.py
+++ b/tests/test_doctor_endpoint.py
@@ -464,6 +464,108 @@ def test_apply_fixes_hang_returns_504_within_budget(
     )
 
 
+def test_fix_retry_after_504_returns_busy_while_first_still_running(
+    client, auth_headers, patch_registry, monkeypatch,
+):
+    """After a 504 from a hung fix, an immediate retry must 409, not start a second fix.
+
+    Codex round-4 (PR #2058) flagged: the prior single-flight lock was
+    released in a ``finally`` block, which runs when the HTTP request
+    times out and raises 504 — even though the worker thread is still
+    inside ``apply_fixes`` mutating shared state. A retry within seconds
+    of the 504 would acquire the freshly-released lock and start a
+    *second* concurrent fix on the same filesystem/session/storage.
+
+    Contract: the lock must be held until the worker thread truly
+    terminates. The fix uses ``Future.add_done_callback`` to release the
+    lock when the worker completes; the request's 504 path does not
+    release it.
+
+    This test:
+      1. Stubs ``apply_fixes`` to block on an event well past the request
+         budget so the first POST times out with 504.
+      2. Asserts the first request returns 504 within budget + slack.
+      3. Fires a second POST while the worker is still blocked, asserts
+         it returns 409 ``conflict`` (NOT 504 from a second hang, which
+         is what round-3 would have produced).
+      4. Releases the worker so the suite shuts down cleanly.
+    """
+    import threading
+    import time as _time
+
+    patch_registry([_check("alpha", _fail("alpha", fixable=True))])
+
+    release = threading.Event()
+    in_flight = threading.Event()
+
+    def hanging_apply_fixes(report):  # type: ignore[no-untyped-def]
+        in_flight.set()
+        # Block well past the request budget; the executor abandons this
+        # thread on timeout, but the lock-release callback only fires
+        # when ``release`` is set (after assertions).
+        release.wait(timeout=30.0)
+        return []
+
+    monkeypatch.setattr(doctor_routes, "apply_fixes", hanging_apply_fixes)
+
+    # First request: hangs in apply_fixes past the 1s budget → 504.
+    t0 = _time.monotonic()
+    first = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "alpha", "fix": True},
+        params={"timeout_seconds": 1},
+    )
+    elapsed = _time.monotonic() - t0
+
+    assert first.status_code == 504, (
+        f"expected first request to time out, got {first.status_code}: {first.json()}"
+    )
+    assert elapsed < 5.0, f"504 took {elapsed:.1f}s; should be near 1s budget"
+
+    # Confirm the worker is still inside ``apply_fixes`` — the
+    # in_flight event was set when we entered, and we haven't released
+    # yet. This is the racy window the fix protects.
+    assert in_flight.is_set(), "test setup bug: worker never entered apply_fixes"
+
+    # Second request fired immediately: the worker is still alive
+    # holding shared state, so the route MUST refuse with 409 busy
+    # rather than start a second concurrent fix (which would either
+    # interleave mutations or — pre-fix — also hang for another 1s and
+    # return a second 504).
+    second = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        json={"check": "alpha", "fix": True},
+        params={"timeout_seconds": 1},
+    )
+
+    # Release the leaked worker so the lock-release callback fires
+    # before the next test runs.
+    release.set()
+
+    assert second.status_code == 409, (
+        f"expected 409 busy while first worker still running, "
+        f"got {second.status_code}: {second.json()}. "
+        "This is the round-4 bug: lock was released on 504, allowing "
+        "a second concurrent fix while the first worker was still alive."
+    )
+    body = second.json()
+    assert body["error"]["code"] == "conflict"
+    assert "in progress" in body["error"]["message"].lower()
+
+    # Wait for the worker's done callback to release the lock before the
+    # next test runs (otherwise we leak across the suite).
+    deadline = _time.monotonic() + 5.0
+    while _time.monotonic() < deadline:
+        if doctor_routes._FIX_OPERATION_LOCK.acquire(blocking=False):
+            doctor_routes._FIX_OPERATION_LOCK.release()
+            break
+        _time.sleep(0.05)
+    else:
+        pytest.fail("fix lock not released by done callback within 5s")
+
+
 def test_run_fix_serialized_under_concurrency(
     client, auth_headers, patch_registry, monkeypatch,
 ):


### PR DESCRIPTION
## Summary

Phase 2 surface #5 (doctor). Adds three endpoints behind the existing bearer-auth dep, per `~/Desktop/pollypm-phase2-endpoints-spec.md` §7:

- `GET  /api/v1/doctor/checks` — list registered checks (`name`, `category`, `severity`).
- `GET  /api/v1/doctor/report` — last in-process report; `404 not_found` until a run happens.
- `POST /api/v1/doctor/run` — body `{check?: str, fix: bool}`. `check` omitted ⇒ run all; unknown ⇒ `404`. `fix=true` invokes `apply_fixes` and re-runs the fixed checks so the response reflects post-fix state. Wall-clock budget defaults to 25s (max 120s); overrun ⇒ `504 timeout` per spec §2.7.

Route is a thin adapter over `pollypm.doctor.run_checks` / `apply_fixes` / `_registered_checks` — no new state-machine logic, no on-disk cache (last-report cache is process-local). OpenAPI 3.1 contract updated with six new schemas (`DoctorCheckInfo` / `DoctorChecksResponse` / `DoctorCheckResult` / `DoctorReportResponse` / `DoctorRunRequest` / `DoctorRunResponse`); existing V1 `/doctor` summary surface left untouched.

## Test plan

- [x] `pytest --noconftest tests/test_doctor_endpoint.py -v --timeout=120` — 14/14 pass in 5.4s
- [x] `pytest --noconftest tests/web_api/test_openapi_conformance.py` — 4/4 pass (1 ERROR is the pre-existing `client` fixture from `--noconftest`, not a regression)
- [x] OpenAPI 3.1 validates via `openapi_spec_validator`
- [ ] Manual: `curl /api/v1/doctor/checks` with bearer — returns the live registry
- [ ] Manual: `curl -XPOST /api/v1/doctor/run -d '{"check":"pollypm-home-writable","fix":true}'` — runs + verifies one check

## Spec gaps flagged

- Spec §7.1 hints at `severity` / `description` per check, but `pollypm.doctor.Check` has no docstring field — `description` ships as empty string; a follow-up could plumb richer metadata.
- §7.2 mentions `424 fix_failed` and per-check locks; not implemented — single-flight is achieved implicitly by the in-process `threading.Lock` around the cache, and "fix ran but check still fails" is reflected via the post-fix verify rerun rather than a distinct status code. Worth a follow-up if Sam wants `424` taxonomy.
- Spec §2.7 `?async=true` is deferred to Q13 — sync-only with 504 on overrun matches the §16.3 recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)