### PR TITLE
feat(api): GET+POST /api/v1/briefings — Phase 2 briefings list/render/regenerate

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2268,11 +2268,28 @@ paths:
               schema:
                 $ref: "#/components/schemas/BriefingResponse"
         "400":
-          $ref: "#/components/responses/InvalidRequest"
+          description: |
+            Bad request — currently emitted in two shapes:
+              * `body.project` was an empty / whitespace-only string.
+              * `type_name` is `morning` and the caller passed
+                `body.project`. Project-scoped morning briefings are
+                not yet implemented (morning is always whole-workspace).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: |
+            A regenerate for this `(type, project)` scope is already
+            running on the shared executor; retry after it completes.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "503":
           description: Provider plugin not loaded or regenerate failed.
           content:
@@ -2280,7 +2297,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "504":
-          description: Sync regenerate exceeded `timeout_seconds`.
+          description: |
+            Sync regenerate exceeded `timeout_seconds`. The request
+            returns immediately; the worker thread keeps running on
+            the shared executor so retries (after the run finishes)
+            do not duplicate work.
           content:
             application/json:
               schema:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4376,6 +4376,7 @@ components:
 
     RegenerateBriefingRequest:
       type: object
+      additionalProperties: false
       properties:
         project:
           type: string

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -98,6 +98,12 @@ tags:
       through the canonical `pg_heartbeats` facade — same source the
       cockpit and `pm sessions` consume. The SSE stream endpoint
       (Phase 2 §11.1) ships separately.
+  - name: Briefings
+    description: |
+      Briefing types (morning / weekly / plugin-contributed). List
+      registered types, render the most recent cached briefing, and
+      force-regenerate. Regenerate is sync with a configurable timeout;
+      slow providers surface as `504 timeout` per spec §2.7.
 
 paths:
   /health:
@@ -2104,8 +2110,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuditGrepResponse"
-        "400":
-          $ref: "#/components/responses/InvalidRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
 
@@ -2171,6 +2175,116 @@ paths:
           $ref: "#/components/responses/InvalidRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+
+  /briefings:
+    get:
+      tags: [Briefings]
+      operationId: listBriefingTypes
+      summary: List available briefing types
+      description: |
+        Returns every briefing type registered with the local registry.
+        Each entry includes an `available` flag — false when the type
+        is wired in but its provider plugin (e.g. `morning_briefing`)
+        is not loaded in this `pm serve` instance.
+      responses:
+        "200":
+          description: Briefing-type registry snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BriefingTypesResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /briefings/{type_name}:
+    parameters:
+      - in: path
+        name: type_name
+        required: true
+        schema: { type: string }
+        description: |
+          Briefing type identifier from `GET /briefings`. Built-in
+          types: `morning`.
+    get:
+      tags: [Briefings]
+      operationId: renderBriefing
+      summary: Render the most recently generated briefing of this type
+      description: |
+        Returns the cached briefing body (markdown + metadata) for the
+        latest run. 404 when nothing has been generated yet; 503 when
+        the provider plugin is not loaded.
+      responses:
+        "200":
+          description: Cached briefing body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BriefingResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          description: Provider plugin not loaded for this briefing type.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /briefings/{type_name}/regenerate:
+    parameters:
+      - in: path
+        name: type_name
+        required: true
+        schema: { type: string }
+        description: Briefing type identifier from `GET /briefings`.
+      - in: query
+        name: timeout_seconds
+        required: false
+        schema: { type: number, minimum: 1, maximum: 600, default: 30 }
+        description: |
+          Sync regenerate budget in seconds. On overrun the request
+          returns `504 timeout` (spec §2.7); the in-flight regenerate
+          runs to completion in the background.
+    post:
+      tags: [Briefings]
+      operationId: regenerateBriefing
+      summary: Force regenerate a briefing (sync)
+      description: |
+        Runs the regenerate pipeline (gather → synthesize → emit) and
+        returns the freshly produced body. Sync only in Phase 2;
+        `?async=true` + a job registry is deferred to Phase 2.5.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegenerateBriefingRequest"
+      responses:
+        "200":
+          description: Freshly regenerated briefing.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BriefingResponse"
+        "400":
+          $ref: "#/components/responses/InvalidRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          description: Provider plugin not loaded or regenerate failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "504":
+          description: Sync regenerate exceeded `timeout_seconds`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
 components:
   securitySchemes:
@@ -4180,3 +4294,73 @@ components:
             clean aggregation from one where archived rows were
             silently dropped without having to cross-check via
             `/audit/grep`. (Codex round-9 finding, PR #2062.)
+
+    # ---- Briefings --------------------------------------------------
+    BriefingTypeInfo:
+      type: object
+      required: [name, description, available]
+      properties:
+        name:
+          type: string
+          description: |
+            Stable identifier. Built-in: `morning`. Plugin-contributed
+            types register additional names at startup.
+        description:
+          type: string
+        available:
+          type: boolean
+          description: |
+            True when the provider plugin is loaded. False means the
+            type is wired in but cannot be rendered or regenerated.
+
+    BriefingTypesResponse:
+      type: object
+      required: [types]
+      properties:
+        types:
+          type: array
+          items:
+            $ref: "#/components/schemas/BriefingTypeInfo"
+
+    BriefingResponse:
+      type: object
+      required: [type, markdown, metadata]
+      properties:
+        type:
+          type: string
+          description: Briefing-type identifier.
+        generated_at:
+          type: string
+          format: date-time
+          nullable: true
+        date_local:
+          type: string
+          nullable: true
+          description: Local date the briefing refers to (`YYYY-MM-DD`).
+        mode:
+          type: string
+          nullable: true
+          description: |
+            Provider-specific render mode (e.g. `synthesized`, `fallback`,
+            `quiet-mode` for the morning briefing).
+        markdown:
+          type: string
+          description: The briefing body in Markdown.
+        metadata:
+          type: object
+          additionalProperties: true
+          description: |
+            Provider-specific structured metadata: priorities, watch
+            items, pinned flag, etc. Shape varies by briefing type.
+
+    RegenerateBriefingRequest:
+      type: object
+      properties:
+        project:
+          type: string
+          nullable: true
+          description: |
+            Optional project key narrowing the regenerate scope. The
+            built-in `morning` type rejects this field with `400` —
+            morning briefings are workspace-wide only. Plugin-contributed
+            types may honour it; check the type's docs.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4383,6 +4383,7 @@ components:
           nullable: true
           description: |
             Optional project key narrowing the regenerate scope. The
-            built-in `morning` type rejects this field with `400` —
-            morning briefings are workspace-wide only. Plugin-contributed
-            types may honour it; check the type's docs.
+            built-in `morning` type rejects this field with
+            `400 invalid_request` — morning briefings are
+            workspace-wide only. Plugin-contributed types may consume
+            `project` for per-project scope; consult the type's docs.

--- a/src/pollypm/briefings_bootstrap.py
+++ b/src/pollypm/briefings_bootstrap.py
@@ -26,8 +26,10 @@ filter-before-register contract).
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from pollypm.briefings_registry import (
+    BriefingArtifact,
     is_plugin_disabled_in_config,
     register_briefing_provider,
     register_briefing_render_provider,
@@ -39,31 +41,99 @@ logger = logging.getLogger(__name__)
 MORNING_BRIEFING_PLUGIN_NAME = "morning_briefing"
 MORNING_BRIEFING_TYPE_NAME = "morning"
 
+# Mirror of ``pollypm.plugins_builtin.morning_briefing.plugin._MORNING_BRIEFING_DESCRIPTION``.
+# Duplicated here so the disabled / import-failure branches (which
+# must NOT import the plugin tree — that's the whole point of those
+# branches) can still surface a meaningful blurb in
+# ``GET /api/v1/briefings`` (Codex round-15 on #2059).
+_MORNING_BRIEFING_DESCRIPTION_FALLBACK = (
+    "Daily morning briefing — yesterday's progress, today's "
+    "priorities, watch items. Fires at the configured local hour."
+)
+
+
+class _UnavailableMorningRenderProvider:
+    """Stand-in provider that surfaces ``morning`` as known-but-unavailable.
+
+    Registered in the disabled / import-failure branches so the Web
+    API's discovery endpoint still lists ``morning`` (with
+    ``available=false``) and ``GET/POST /briefings/morning`` return a
+    typed 503 ``service_unavailable`` instead of 404 ``not_found`` —
+    operators flipping ``[plugins].disabled = ["morning_briefing"]``
+    should see "known built-in disabled" not "unknown briefing type"
+    (Codex round-15 on #2059).
+
+    The route layer's ``is_available`` gate short-circuits before any
+    method here runs, so ``render_last`` / ``regenerate`` raising is
+    purely defense-in-depth — if the gate is ever bypassed the
+    exception becomes a typed 503 via the existing error envelope.
+    """
+
+    def render_last(self, _config: Any) -> BriefingArtifact | None:
+        raise RuntimeError(
+            "morning_briefing is disabled or unavailable; "
+            "render_last must not be called (the is_available "
+            "gate should have short-circuited the route)."
+        )
+
+    def regenerate(
+        self,
+        _config: Any,
+        project: str | None = None,  # noqa: ARG002
+    ) -> BriefingArtifact:
+        raise RuntimeError(
+            "morning_briefing is disabled or unavailable; "
+            "regenerate must not be called (the is_available "
+            "gate should have short-circuited the route)."
+        )
+
+
+def _morning_unavailable(_config: Any) -> bool:
+    """Availability adapter for the disabled / import-failure stub."""
+    return False
+
 
 def bootstrap_builtin_briefings(config: PollyPMConfig) -> None:
     """Install the built-in morning-briefing providers into the registry.
 
     Idempotent: registry slot assignment just rebinds. Safe to call on
     every ``create_app`` invocation. When the operator has disabled
-    ``morning_briefing`` via ``[plugins].disabled`` we clear any prior
-    registration instead of re-installing, mirroring the host's
-    filter-before-register contract (Codex round-3 / round-9 on #2059).
+    ``morning_briefing`` via ``[plugins].disabled`` we register a
+    known-disabled stub (``is_available`` returns ``False``) instead of
+    the real provider, mirroring the host's filter-before-register
+    contract (Codex round-3 / round-9 on #2059) while keeping
+    ``morning`` discoverable via ``GET /briefings`` so clients can
+    distinguish "built-in disabled" from "unknown type" (Codex round-15
+    on #2059).
 
     Import failures are logged and swallowed so a missing/broken plugin
     downgrades availability to ``false`` (the route's fail-soft
     posture) rather than crashing app startup. The except path also
-    clears any prior registration so a stale provider from a previous
-    app instance doesn't keep the registry reporting ``available=true``
-    (Codex round-14 on #2059).
+    replaces any prior registration with the same known-disabled stub
+    so a stale provider from a previous app instance doesn't keep the
+    registry reporting ``available=true`` (Codex round-14 on #2059).
     """
     if is_plugin_disabled_in_config(config, MORNING_BRIEFING_PLUGIN_NAME):
-        # Clear so a previously-enabled run's registration doesn't leak
-        # into this disabled-config app instance.
+        # Clear the inbox-list slot so the dashboard's briefing banner
+        # disappears, but register a known-disabled render provider so
+        # the Web API still surfaces ``morning`` in its discovery
+        # response (with ``available=false``) instead of treating it as
+        # an unknown briefing type — operators must be able to tell
+        # "built-in disabled" from "typo in URL" (Codex round-15 on
+        # #2059). The route's ``is_available`` gate short-circuits
+        # render/regenerate into a typed 503 ``service_unavailable``
+        # before the stub provider's methods can execute.
         register_briefing_provider(None)
-        register_briefing_render_provider(MORNING_BRIEFING_TYPE_NAME, None)
+        register_briefing_render_provider(
+            MORNING_BRIEFING_TYPE_NAME,
+            _UnavailableMorningRenderProvider(),
+            description=_MORNING_BRIEFING_DESCRIPTION_FALLBACK,
+            is_available=_morning_unavailable,
+        )
         logger.info(
             "briefings_bootstrap: %s disabled via [plugins].disabled; "
-            "Web API will report morning.available=false",
+            "Web API will report morning.available=false (type still "
+            "discoverable via GET /briefings)",
             MORNING_BRIEFING_PLUGIN_NAME,
         )
         return
@@ -80,19 +150,29 @@ def bootstrap_builtin_briefings(config: PollyPMConfig) -> None:
             MorningBriefingRenderProvider,
         )
     except Exception:  # noqa: BLE001
-        # Clear any prior registration so a previously-installed provider
-        # (e.g. from an earlier app instance, a test that pre-seeded the
-        # slot, or a plugin host run before this bootstrap was invoked)
-        # doesn't continue masquerading as the morning provider after we
-        # logged ``available=false``. Without this, ``GET /briefings``
-        # keeps reporting ``morning.available=true`` against a stale
-        # provider while the operator sees only the warning in logs
-        # (Codex round-14 on #2059).
+        # Replace any prior registration with a known-disabled stub so
+        # a previously-installed provider (e.g. from an earlier app
+        # instance, a test that pre-seeded the slot, or a plugin host
+        # run before this bootstrap was invoked) doesn't continue
+        # masquerading as the morning provider after we logged
+        # ``available=false``. Without this, ``GET /briefings`` keeps
+        # reporting ``morning.available=true`` against a stale provider
+        # while the operator sees only the warning in logs (Codex
+        # round-14 on #2059). The stub keeps ``morning`` discoverable
+        # via ``GET /briefings`` so clients can distinguish
+        # "known built-in unavailable" from "unknown briefing type"
+        # (Codex round-15 on #2059).
         register_briefing_provider(None)
-        register_briefing_render_provider(MORNING_BRIEFING_TYPE_NAME, None)
+        register_briefing_render_provider(
+            MORNING_BRIEFING_TYPE_NAME,
+            _UnavailableMorningRenderProvider(),
+            description=_MORNING_BRIEFING_DESCRIPTION_FALLBACK,
+            is_available=_morning_unavailable,
+        )
         logger.warning(
             "briefings_bootstrap: %s unavailable; "
-            "Web API will report morning.available=false",
+            "Web API will report morning.available=false (type still "
+            "discoverable via GET /briefings)",
             MORNING_BRIEFING_PLUGIN_NAME,
             exc_info=True,
         )

--- a/src/pollypm/briefings_bootstrap.py
+++ b/src/pollypm/briefings_bootstrap.py
@@ -69,6 +69,10 @@ def bootstrap_builtin_briefings(config: PollyPMConfig) -> None:
         from pollypm.plugins_builtin.morning_briefing.inbox import (
             list_briefings as _list_briefings,
         )
+        from pollypm.plugins_builtin.morning_briefing.plugin import (
+            _MORNING_BRIEFING_DESCRIPTION,
+            _morning_is_available,
+        )
         from pollypm.plugins_builtin.morning_briefing.render_facade import (
             MorningBriefingRenderProvider,
         )
@@ -82,9 +86,16 @@ def bootstrap_builtin_briefings(config: PollyPMConfig) -> None:
         return
 
     register_briefing_provider(_list_briefings)
+    # Pass description AND is_available so the registry mirrors the
+    # plugin host's ``_initialize`` registration (Codex round-13 on
+    # #2059: without ``is_available`` the registry's
+    # ``_default_is_available`` returns True unconditionally, so the
+    # per-request ``[plugins].disabled`` gate never runs in production).
     register_briefing_render_provider(
         MORNING_BRIEFING_TYPE_NAME,
         MorningBriefingRenderProvider(),
+        description=_MORNING_BRIEFING_DESCRIPTION,
+        is_available=_morning_is_available,
     )
 
 

--- a/src/pollypm/briefings_bootstrap.py
+++ b/src/pollypm/briefings_bootstrap.py
@@ -51,7 +51,10 @@ def bootstrap_builtin_briefings(config: PollyPMConfig) -> None:
 
     Import failures are logged and swallowed so a missing/broken plugin
     downgrades availability to ``false`` (the route's fail-soft
-    posture) rather than crashing app startup.
+    posture) rather than crashing app startup. The except path also
+    clears any prior registration so a stale provider from a previous
+    app instance doesn't keep the registry reporting ``available=true``
+    (Codex round-14 on #2059).
     """
     if is_plugin_disabled_in_config(config, MORNING_BRIEFING_PLUGIN_NAME):
         # Clear so a previously-enabled run's registration doesn't leak
@@ -77,6 +80,16 @@ def bootstrap_builtin_briefings(config: PollyPMConfig) -> None:
             MorningBriefingRenderProvider,
         )
     except Exception:  # noqa: BLE001
+        # Clear any prior registration so a previously-installed provider
+        # (e.g. from an earlier app instance, a test that pre-seeded the
+        # slot, or a plugin host run before this bootstrap was invoked)
+        # doesn't continue masquerading as the morning provider after we
+        # logged ``available=false``. Without this, ``GET /briefings``
+        # keeps reporting ``morning.available=true`` against a stale
+        # provider while the operator sees only the warning in logs
+        # (Codex round-14 on #2059).
+        register_briefing_provider(None)
+        register_briefing_render_provider(MORNING_BRIEFING_TYPE_NAME, None)
         logger.warning(
             "briefings_bootstrap: %s unavailable; "
             "Web API will report morning.available=false",

--- a/src/pollypm/briefings_bootstrap.py
+++ b/src/pollypm/briefings_bootstrap.py
@@ -1,0 +1,95 @@
+"""Sanctioned core → ``plugins_builtin`` edge for briefings wiring.
+
+``pm serve`` does not boot the full plugin host (which owns roster +
+job scheduling + cockpit rail registration — none of which the
+read/regenerate path needs). The morning_briefing plugin's
+``initialize`` hook is the canonical wiring point — it installs both
+the inbox-list provider and the render facade into
+:mod:`pollypm.briefings_registry`. This module mirrors that single
+wiring step for surfaces that bypass the plugin host (currently only
+the Web API in ``pm serve``).
+
+Boundary justification:
+The repo's documented core boundary forbids ``plugins_builtin``
+imports from arbitrary core modules; ``cli.py:201-207`` is the
+sanctioned edge for the CLI Typer apps. This module is the equivalent
+edge for the Web API (#2059 round-9): a single, narrowly-scoped seam
+that lets the API surface a plugin's render/regenerate without each
+route owning the plugin's import path. The Web API imports from
+:mod:`pollypm.briefings_bootstrap` — never from
+``pollypm.plugins_builtin.morning_briefing``.
+
+Honors ``config.plugins.disabled`` before wiring so the operator's
+rollback path takes effect immediately (the plugin host's
+filter-before-register contract).
+"""
+from __future__ import annotations
+
+import logging
+
+from pollypm.briefings_registry import (
+    is_plugin_disabled_in_config,
+    register_briefing_provider,
+    register_briefing_render_provider,
+)
+from pollypm.config import PollyPMConfig
+
+logger = logging.getLogger(__name__)
+
+MORNING_BRIEFING_PLUGIN_NAME = "morning_briefing"
+MORNING_BRIEFING_TYPE_NAME = "morning"
+
+
+def bootstrap_builtin_briefings(config: PollyPMConfig) -> None:
+    """Install the built-in morning-briefing providers into the registry.
+
+    Idempotent: registry slot assignment just rebinds. Safe to call on
+    every ``create_app`` invocation. When the operator has disabled
+    ``morning_briefing`` via ``[plugins].disabled`` we clear any prior
+    registration instead of re-installing, mirroring the host's
+    filter-before-register contract (Codex round-3 / round-9 on #2059).
+
+    Import failures are logged and swallowed so a missing/broken plugin
+    downgrades availability to ``false`` (the route's fail-soft
+    posture) rather than crashing app startup.
+    """
+    if is_plugin_disabled_in_config(config, MORNING_BRIEFING_PLUGIN_NAME):
+        # Clear so a previously-enabled run's registration doesn't leak
+        # into this disabled-config app instance.
+        register_briefing_provider(None)
+        register_briefing_render_provider(MORNING_BRIEFING_TYPE_NAME, None)
+        logger.info(
+            "briefings_bootstrap: %s disabled via [plugins].disabled; "
+            "Web API will report morning.available=false",
+            MORNING_BRIEFING_PLUGIN_NAME,
+        )
+        return
+
+    try:
+        from pollypm.plugins_builtin.morning_briefing.inbox import (
+            list_briefings as _list_briefings,
+        )
+        from pollypm.plugins_builtin.morning_briefing.render_facade import (
+            MorningBriefingRenderProvider,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "briefings_bootstrap: %s unavailable; "
+            "Web API will report morning.available=false",
+            MORNING_BRIEFING_PLUGIN_NAME,
+            exc_info=True,
+        )
+        return
+
+    register_briefing_provider(_list_briefings)
+    register_briefing_render_provider(
+        MORNING_BRIEFING_TYPE_NAME,
+        MorningBriefingRenderProvider(),
+    )
+
+
+__all__ = [
+    "MORNING_BRIEFING_PLUGIN_NAME",
+    "MORNING_BRIEFING_TYPE_NAME",
+    "bootstrap_builtin_briefings",
+]

--- a/src/pollypm/briefings_registry.py
+++ b/src/pollypm/briefings_registry.py
@@ -15,6 +15,16 @@ via :func:`register_briefing_provider`. The dashboard reads through
 :func:`list_briefings` so disabling the plugin downgrades the briefing
 banner to "absent" rather than breaking imports.
 
+Render / regenerate facade (added for #2059 round-9 Web API boundary fix):
+Beyond the inbox-list provider above, this module also exposes a
+per-type **render facade** so the Web API (and any other surface that
+needs to render or regenerate a briefing) can do so without importing
+``pollypm.plugins_builtin`` directly. See :class:`BriefingRenderProvider`
+and :func:`register_briefing_render_provider`. The ``morning_briefing``
+plugin installs its render provider in ``_initialize`` alongside
+``register_briefing_provider``; the Web API routes look it up by type
+name through :func:`get_briefing_render_provider`.
+
 Mirrors the registration-seam pattern established in
 :mod:`pollypm.approval_notifications` (see #1597 / #1363).
 """
@@ -22,8 +32,9 @@ Mirrors the registration-seam pattern established in
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Iterable, Protocol, runtime_checkable
+from typing import Any, Callable, Iterable, Mapping, Protocol, runtime_checkable
 
 
 logger = logging.getLogger(__name__)
@@ -114,10 +125,154 @@ def list_briefings(
         return []
 
 
+# ---------------------------------------------------------------------------
+# Render / regenerate facade (#2059 round-9 boundary fix)
+# ---------------------------------------------------------------------------
+#
+# The Web API needs more than the "list inbox entries" seam above — it
+# also renders the latest briefing body and force-regenerates on POST.
+# Previously the Web API imported ``pollypm.plugins_builtin.morning_briefing``
+# internals directly to do that, which violated the documented core →
+# ``plugins_builtin`` boundary (only ``cli.py`` is the sanctioned edge —
+# see ``cli.py:201-207``).
+#
+# This facade extends the registry so a plugin (today only
+# ``morning_briefing``; tomorrow any briefing plugin) can install a
+# render provider keyed by briefing-type name. The Web API consumes
+# adapters by name through :func:`get_briefing_render_provider` and never
+# learns the plugin's import path. Provider returns a typed
+# :class:`BriefingArtifact`; the route translates that into its pydantic
+# response model.
+
+
+@dataclass(frozen=True, slots=True)
+class BriefingArtifact:
+    """Provider-returned briefing payload.
+
+    Plain-data shape returned by :meth:`BriefingRenderProvider.render_last`
+    and :meth:`BriefingRenderProvider.regenerate`. Kept deliberately
+    minimal so plugins don't need to import the Web API's pydantic
+    models — the route layer maps fields onto its public schema.
+
+    Fields:
+        date_local:   ``YYYY-MM-DD`` the briefing is for (local TZ).
+        markdown:     Rendered briefing body the user sees.
+        mode:         Plugin-defined render mode (e.g. ``"synthesized"``).
+        generated_at: ISO 8601 timestamp. ``None`` if the plugin can't
+                      recover it (e.g. legacy on-disk entry).
+        metadata:     Free-form plugin metadata. The Web API surfaces
+                      it verbatim under ``metadata`` so cockpit/UI can
+                      consume plugin-specific fields without a schema
+                      bump per plugin.
+    """
+
+    date_local: str
+    markdown: str
+    mode: str | None = None
+    generated_at: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class BriefingRenderProvider(Protocol):
+    """Render / regenerate adapter installed per briefing-type name.
+
+    Implementations live in plugins. The ``morning_briefing`` plugin
+    installs its provider at plugin ``initialize`` time so the Web API
+    can render and regenerate without taking a hard import on the
+    plugin module tree.
+
+    Methods raise on bad config / provider failure — the route layer
+    wraps exceptions into the API's typed error envelope.
+    """
+
+    def render_last(self, config: Any) -> BriefingArtifact | None:
+        """Return the newest cached briefing, or ``None`` if there is none."""
+        ...
+
+    def regenerate(
+        self,
+        config: Any,
+        project: str | None = None,
+    ) -> BriefingArtifact:
+        """Force-fire the briefing pipeline.
+
+        ``project`` narrows scope when the briefing type supports it.
+        Providers MUST raise ``ValueError`` when they do not support
+        narrowing (the morning briefing today) — the route layer
+        translates that into a typed 400.
+        """
+        ...
+
+
+_render_providers: dict[str, BriefingRenderProvider] = {}
+
+
+def register_briefing_render_provider(
+    type_name: str,
+    provider: BriefingRenderProvider | None,
+) -> None:
+    """Install (or clear) a render / regenerate provider for a briefing type.
+
+    Plugins call this in their ``initialize`` hook. Passing ``None``
+    clears the slot (used by tests + the plugin-disable cleanup path).
+    The Web API consumes providers via :func:`get_briefing_render_provider`,
+    keeping ``plugins_builtin`` out of the core import graph.
+    """
+    if provider is None:
+        _render_providers.pop(type_name, None)
+        return
+    _render_providers[type_name] = provider
+
+
+def get_briefing_render_provider(
+    type_name: str,
+) -> BriefingRenderProvider | None:
+    """Return the provider installed for ``type_name``, or ``None``."""
+    return _render_providers.get(type_name)
+
+
+def registered_briefing_render_types() -> tuple[str, ...]:
+    """Return the briefing-type names that currently have a render provider."""
+    return tuple(sorted(_render_providers))
+
+
+# ---------------------------------------------------------------------------
+# Per-request plugin-disable check (#2059 round-9)
+# ---------------------------------------------------------------------------
+
+
+def is_plugin_disabled_in_config(config: Any, plugin_name: str) -> bool:
+    """Return True iff ``config.plugins.disabled`` contains ``plugin_name``.
+
+    The Web API's ConfigDep reloads config per request (#2056), so
+    surfaces that gate behavior on plugin-disabled state must re-check
+    the **current** request config rather than the startup snapshot.
+    Otherwise an operator who edits ``pollypm.toml`` to add
+    ``morning_briefing`` to ``[plugins].disabled`` mid-run keeps seeing
+    ``morning.available=true`` until ``pm serve`` restarts (Codex
+    round-9 on #2059).
+
+    Tolerant to objects that lack ``plugins`` / ``disabled`` (in-memory
+    test configs) — returns ``False`` in that case.
+    """
+    plugins = getattr(config, "plugins", None)
+    if plugins is None:
+        return False
+    disabled = getattr(plugins, "disabled", None) or ()
+    return plugin_name in set(disabled)
+
+
 __all__ = [
+    "BriefingArtifact",
     "BriefingEntryLike",
     "BriefingProvider",
+    "BriefingRenderProvider",
+    "get_briefing_render_provider",
     "is_briefing_provider_registered",
+    "is_plugin_disabled_in_config",
     "list_briefings",
     "register_briefing_provider",
+    "register_briefing_render_provider",
+    "registered_briefing_render_types",
 ]

--- a/src/pollypm/briefings_registry.py
+++ b/src/pollypm/briefings_registry.py
@@ -74,6 +74,20 @@ def register_briefing_provider(provider: BriefingProvider | None) -> None:
     _briefing_provider = provider
 
 
+def is_briefing_provider_registered() -> bool:
+    """Return True iff a briefing-inbox provider is currently registered.
+
+    Public availability probe so surfaces (web API, cockpit) can decide
+    whether to advertise the briefing type without reaching into the
+    module-private ``_briefing_provider`` slot. Mirrors host semantics:
+    when the ``morning_briefing`` plugin is disabled via
+    ``[plugins].disabled`` (or absent), no provider is registered and
+    this returns ``False`` (Codex round-3 on PR #2059: route was reading
+    the private slot to gate availability).
+    """
+    return _briefing_provider is not None
+
+
 def list_briefings(
     base_dir: Path,
     *,
@@ -103,6 +117,7 @@ def list_briefings(
 __all__ = [
     "BriefingEntryLike",
     "BriefingProvider",
+    "is_briefing_provider_registered",
     "list_briefings",
     "register_briefing_provider",
 ]

--- a/src/pollypm/briefings_registry.py
+++ b/src/pollypm/briefings_registry.py
@@ -205,30 +205,86 @@ class BriefingRenderProvider(Protocol):
         ...
 
 
-_render_providers: dict[str, BriefingRenderProvider] = {}
+@dataclass(frozen=True, slots=True)
+class BriefingRenderRegistration:
+    """Provider + metadata for one briefing type.
+
+    The Web API's ``GET /briefings`` discovery endpoint surfaces the
+    ``description`` to clients and uses ``is_available`` to compute
+    the per-request availability flag. Plugins supply both at
+    :func:`register_briefing_render_provider` time so the registry is
+    the single source of truth for what types exist, what they're for,
+    and whether they can run right now (Codex round-10 on #2059 —
+    previously the Web API maintained its own private ``_REGISTRY``
+    keyed only on ``"morning"`` and ignored plugin-contributed types
+    even though :func:`registered_briefing_render_types` exposed them).
+    """
+
+    provider: BriefingRenderProvider
+    description: str
+    is_available: Callable[[Any], bool]
+
+
+def _default_is_available(_config: Any) -> bool:
+    """Fallback availability check: a registered provider is available."""
+    return True
+
+
+_render_providers: dict[str, BriefingRenderRegistration] = {}
 
 
 def register_briefing_render_provider(
     type_name: str,
     provider: BriefingRenderProvider | None,
+    *,
+    description: str = "",
+    is_available: Callable[[Any], bool] | None = None,
 ) -> None:
     """Install (or clear) a render / regenerate provider for a briefing type.
 
-    Plugins call this in their ``initialize`` hook. Passing ``None``
+    Plugins call this in their ``initialize`` hook. Passing ``provider=None``
     clears the slot (used by tests + the plugin-disable cleanup path).
-    The Web API consumes providers via :func:`get_briefing_render_provider`,
-    keeping ``plugins_builtin`` out of the core import graph.
+    The Web API consumes providers via :func:`get_briefing_render_provider`
+    and surfaces ``description`` / ``is_available`` through its
+    discovery endpoint, keeping ``plugins_builtin`` out of the core
+    import graph.
+
+    ``description`` is the human-readable blurb returned by
+    ``GET /briefings`` for this type. ``is_available`` is called with
+    the per-request config and must return whether this type can render
+    now (e.g. plugin enabled, backing store reachable). Both keyword
+    args default to spec-compatible no-ops so legacy callers that only
+    pass a provider keep working — though new types should supply them
+    for the discovery endpoint to render usefully (Codex round-10 on
+    #2059).
     """
     if provider is None:
         _render_providers.pop(type_name, None)
         return
-    _render_providers[type_name] = provider
+    _render_providers[type_name] = BriefingRenderRegistration(
+        provider=provider,
+        description=description,
+        is_available=is_available or _default_is_available,
+    )
 
 
 def get_briefing_render_provider(
     type_name: str,
 ) -> BriefingRenderProvider | None:
     """Return the provider installed for ``type_name``, or ``None``."""
+    registration = _render_providers.get(type_name)
+    return registration.provider if registration is not None else None
+
+
+def get_briefing_render_registration(
+    type_name: str,
+) -> BriefingRenderRegistration | None:
+    """Return the full registration record for ``type_name`` (with metadata).
+
+    Used by surfaces that need the description / availability adapter
+    (the Web API's ``GET /briefings``). Returns ``None`` for unknown
+    type names.
+    """
     return _render_providers.get(type_name)
 
 
@@ -268,7 +324,9 @@ __all__ = [
     "BriefingEntryLike",
     "BriefingProvider",
     "BriefingRenderProvider",
+    "BriefingRenderRegistration",
     "get_briefing_render_provider",
+    "get_briefing_render_registration",
     "is_briefing_provider_registered",
     "is_plugin_disabled_in_config",
     "list_briefings",

--- a/src/pollypm/plugins_builtin/morning_briefing/plugin.py
+++ b/src/pollypm/plugins_builtin/morning_briefing/plugin.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from pollypm.briefings_registry import (
+    is_plugin_disabled_in_config,
     register_briefing_provider,
     register_briefing_render_provider,
 )
@@ -82,6 +83,36 @@ def _register_handlers(api: JobHandlerAPI) -> None:
     )
 
 
+_MORNING_BRIEFING_DESCRIPTION = (
+    "Daily morning briefing — yesterday's progress, today's "
+    "priorities, watch items. Fires at the configured local hour."
+)
+
+
+def _morning_is_available(config: object) -> bool:
+    """Per-request availability for the ``morning`` briefing type.
+
+    Two gates:
+
+    1. ``config.plugins.disabled`` must not contain ``morning_briefing``
+       (Codex round-9 on #2059: ``create_app`` reloads config per
+       request, so a mid-run edit to ``[plugins].disabled`` must flip
+       ``available=false`` without restarting ``pm serve``).
+    2. This very plugin must be the one currently installed — i.e. our
+       provider is the one in the registry slot, not a stale provider
+       from a torn-down test fixture.
+
+    Lives in the plugin (not in the route) so the registry is the
+    single source of truth for the per-type availability adapter
+    (Codex round-10 on #2059).
+    """
+    from pollypm.briefings_registry import get_briefing_render_provider
+
+    if is_plugin_disabled_in_config(config, "morning_briefing"):
+        return False
+    return get_briefing_render_provider(MorningBriefingRenderProvider.type_name) is not None
+
+
 def _initialize(api: PluginAPI) -> None:
     """Wire the briefing-inbox provider AND render facade for core surfaces.
 
@@ -93,14 +124,20 @@ def _initialize(api: PluginAPI) -> None:
 
     The Web API additionally renders / regenerates briefings through
     :func:`pollypm.briefings_registry.get_briefing_render_provider`.
-    We install the morning render facade here so the API never imports
-    ``plugins_builtin.morning_briefing`` directly (#2059 round-9).
+    We install the morning render facade here, along with its
+    user-facing ``description`` and per-request ``is_available``
+    adapter, so the Web API discovery endpoint can surface the type
+    without knowing anything plugin-specific (#2059 round-9 + #2059
+    round-10: the registry is the single source of truth for briefing
+    type metadata, not a private dict in the route module).
     """
     del api  # unused — both seams are accessed through the registry
     register_briefing_provider(list_briefings)
     register_briefing_render_provider(
         MorningBriefingRenderProvider.type_name,
         MorningBriefingRenderProvider(),
+        description=_MORNING_BRIEFING_DESCRIPTION,
+        is_available=_morning_is_available,
     )
 
 

--- a/src/pollypm/plugins_builtin/morning_briefing/plugin.py
+++ b/src/pollypm/plugins_builtin/morning_briefing/plugin.py
@@ -22,7 +22,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pollypm.briefings_registry import register_briefing_provider
+from pollypm.briefings_registry import (
+    register_briefing_provider,
+    register_briefing_render_provider,
+)
 from pollypm.plugin_api.v1 import (
     Capability,
     JobHandlerAPI,
@@ -37,6 +40,9 @@ from pollypm.plugins_builtin.morning_briefing.handlers.briefing_tick import (
 from pollypm.plugins_builtin.morning_briefing.inbox import (
     briefing_sweep_handler,
     list_briefings,
+)
+from pollypm.plugins_builtin.morning_briefing.render_facade import (
+    MorningBriefingRenderProvider,
 )
 
 
@@ -77,16 +83,25 @@ def _register_handlers(api: JobHandlerAPI) -> None:
 
 
 def _initialize(api: PluginAPI) -> None:
-    """Wire the briefing-inbox provider for core dashboard reads.
+    """Wire the briefing-inbox provider AND render facade for core surfaces.
 
     The dashboard surfaces briefings through
     :func:`pollypm.briefings_registry.list_briefings` so core never
     imports from this plugin. We register the real implementation here
     during plugin initialize; with the plugin disabled the dashboard
     sees no provider and renders without a briefing banner (#1363).
+
+    The Web API additionally renders / regenerates briefings through
+    :func:`pollypm.briefings_registry.get_briefing_render_provider`.
+    We install the morning render facade here so the API never imports
+    ``plugins_builtin.morning_briefing`` directly (#2059 round-9).
     """
-    del api  # unused — the dashboard reads briefings off the filesystem
+    del api  # unused — both seams are accessed through the registry
     register_briefing_provider(list_briefings)
+    register_briefing_render_provider(
+        MorningBriefingRenderProvider.type_name,
+        MorningBriefingRenderProvider(),
+    )
 
 
 def _register_roster(api: RosterAPI) -> None:

--- a/src/pollypm/plugins_builtin/morning_briefing/render_facade.py
+++ b/src/pollypm/plugins_builtin/morning_briefing/render_facade.py
@@ -20,12 +20,11 @@ With this module the boundary is restored:
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC
 from typing import Any
 
 from pollypm.briefings_registry import BriefingArtifact
 from pollypm.config import DEFAULT_CONFIG_PATH, resolve_config_path
-from pollypm.tz import get_timezone
 
 logger = logging.getLogger(__name__)
 
@@ -115,9 +114,16 @@ class MorningBriefingRenderProvider:
         config_path = getattr(config, "config_path", None) or DEFAULT_CONFIG_PATH
         settings = load_briefing_settings(resolve_config_path(config_path))
 
+        # Mirror the CLI's timezone-resolution precedence
+        # (``cli.py:_current_local_now`` -> ``_tick._local_now``):
+        #   ``[briefing].timezone`` -> ``[pollypm].timezone`` -> system TZ.
+        # The previous implementation only consulted ``[pollypm].timezone``,
+        # so a config with ``[pollypm].timezone="UTC"`` plus a
+        # ``[briefing].timezone="America/Los_Angeles"`` override would
+        # regenerate against the wrong local day / quiet-mode window.
+        # (Codex round-10 P0 on PR #2059.)
         fallback_tz = getattr(config.pollypm, "timezone", "") or ""
-        timezone = get_timezone(fallback_tz)
-        now_local = datetime.now(timezone)
+        now_local = _tick._local_now(settings, fallback_tz)
         state = load_state(base_dir)
 
         result = _tick.fire_briefing(

--- a/src/pollypm/plugins_builtin/morning_briefing/render_facade.py
+++ b/src/pollypm/plugins_builtin/morning_briefing/render_facade.py
@@ -1,0 +1,160 @@
+"""Render / regenerate adapter for the briefings core seam.
+
+This is the plugin-side implementation of
+:class:`pollypm.briefings_registry.BriefingRenderProvider` (added in
+#2059 round-9). The Web API was previously importing
+``pollypm.plugins_builtin.morning_briefing`` internals directly to
+render / regenerate the morning briefing — that violated the
+documented core → ``plugins_builtin`` boundary
+(``cli.py:201-207``; ``briefings_registry.py:10-16``).
+
+With this module the boundary is restored:
+
+- The plugin's ``_initialize`` hook constructs a
+  :class:`MorningBriefingRenderProvider` and installs it via
+  :func:`pollypm.briefings_registry.register_briefing_render_provider`.
+- The Web API looks the provider up by type name
+  (``"morning"``) through the registry and never imports
+  ``plugins_builtin``.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from pollypm.briefings_registry import BriefingArtifact
+from pollypm.config import DEFAULT_CONFIG_PATH, resolve_config_path
+from pollypm.tz import get_timezone
+
+logger = logging.getLogger(__name__)
+
+
+class MorningBriefingRenderProvider:
+    """Concrete :class:`BriefingRenderProvider` for the morning briefing.
+
+    Encapsulates everything the Web API used to import directly:
+    inbox read, settings load, state load, briefing-tick fire. The Web
+    API only sees this object through the registry seam.
+    """
+
+    type_name = "morning"
+
+    def render_last(self, config: Any) -> BriefingArtifact | None:
+        """Read the newest morning briefing off disk (spec §9.1 ``last``).
+
+        Late-bound imports so tests monkeypatching the underlying
+        modules (e.g. ``...morning_briefing.inbox.list_briefings``)
+        flow through to the call.
+        """
+        from pollypm.plugins_builtin.morning_briefing import inbox as _inbox
+
+        base_dir = config.project.base_dir
+        entries = _inbox.list_briefings(base_dir, status="all", limit=1)
+        if not entries:
+            return None
+        entry = entries[0]
+        read = _inbox.read_briefing(base_dir, entry.date_local)
+        if read is None:
+            # Metadata json existed during list_briefings but the body
+            # disappeared between calls (rare — atomic-write replaces
+            # both; treat as missing so the caller can regenerate).
+            return None
+        meta_entry, markdown = read
+        return BriefingArtifact(
+            date_local=meta_entry.date_local,
+            markdown=markdown,
+            mode=meta_entry.mode or None,
+            generated_at=meta_entry.created_at or None,
+            metadata={
+                "status": meta_entry.status,
+                "pinned": meta_entry.pinned,
+                "yesterday": meta_entry.yesterday,
+                "priorities": list(meta_entry.priorities),
+                "watch": list(meta_entry.watch),
+                **dict(meta_entry.meta),
+            },
+        )
+
+    def regenerate(
+        self,
+        config: Any,
+        project: str | None = None,
+    ) -> BriefingArtifact:
+        """Force-fire the morning briefing pipeline (spec §9.1 ``regenerate``).
+
+        Mirrors ``pm briefing now`` — runs gather → synthesize → emit
+        and writes to the inbox. Morning briefings are whole-workspace
+        only today; if ``project`` is set we raise ``ValueError`` and
+        the route layer translates that into a typed 400. (Codex
+        round-1 on PR #2059: silently ignoring ``project`` let clients
+        believe they had narrowed scope when they hadn't.)
+        """
+        # Late-bound imports — see ``render_last`` rationale.
+        from pollypm.plugins_builtin.morning_briefing.handlers import (
+            briefing_tick as _tick,
+        )
+        from pollypm.plugins_builtin.morning_briefing.settings import (
+            load_briefing_settings,
+        )
+        from pollypm.plugins_builtin.morning_briefing.state import load_state
+
+        if project is not None:
+            raise ValueError(
+                "project-scoped morning briefings are not implemented",
+            )
+
+        base_dir = config.project.base_dir
+        project_root = config.project.root_dir
+
+        # Prefer the path ``pm serve`` actually loaded (``config.config_path``)
+        # so a non-default ``--config`` is honored. Falling back to
+        # ``DEFAULT_CONFIG_PATH`` keeps the path working for tests that
+        # construct ``PollyPMConfig`` in memory. (Codex round-1 P0 on
+        # PR #2059.)
+        config_path = getattr(config, "config_path", None) or DEFAULT_CONFIG_PATH
+        settings = load_briefing_settings(resolve_config_path(config_path))
+
+        fallback_tz = getattr(config.pollypm, "timezone", "") or ""
+        timezone = get_timezone(fallback_tz)
+        now_local = datetime.now(timezone)
+        state = load_state(base_dir)
+
+        result = _tick.fire_briefing(
+            project_root=project_root,
+            base_dir=base_dir,
+            settings=settings,
+            now_local=now_local,
+            state=state,
+            config=config,
+            emit_to_inbox=True,
+        )
+        if not isinstance(result, dict) or not result.get("fired"):
+            reason = (
+                str(result.get("reason"))
+                if isinstance(result, dict) else "unknown"
+            )
+            # Surface as a runtime error — the route translates this
+            # into a typed 503. We deliberately don't depend on the
+            # Web API's error types from a plugin module.
+            raise RuntimeError(
+                f"briefing regenerate did not fire ({reason})",
+            )
+        draft = result.get("draft") or {}
+        return BriefingArtifact(
+            date_local=str(draft.get("date_local") or ""),
+            markdown=str(draft.get("markdown") or ""),
+            mode=str(draft.get("mode") or "") or None,
+            generated_at=now_local.astimezone(UTC).isoformat(),
+            metadata={
+                "emitted_to_inbox": bool(result.get("emitted", False)),
+                "yesterday": draft.get("yesterday"),
+                "priorities": list(draft.get("priorities") or []),
+                "watch": list(draft.get("watch") or []),
+                "quiet_mode": bool(result.get("quiet_mode", False)),
+                **dict(draft.get("meta") or {}),
+            },
+        )
+
+
+__all__ = ["MorningBriefingRenderProvider"]

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -339,14 +339,15 @@ def create_app(
     # in the API process (it owns roster + job scheduling + cockpit
     # rail registration — none of which the read/regenerate path
     # needs); the only piece the briefings routes consult is the
-    # registry seam (`pollypm.briefings_registry._briefing_provider`),
-    # which the ``morning_briefing`` plugin populates via
-    # ``register_briefing_provider`` during plugin ``initialize``.
+    # registry seam, which the ``morning_briefing`` plugin populates
+    # via ``register_briefing_provider`` during plugin ``initialize``.
     # Mirror that single call here so the API has the same provider
     # the cockpit + CLI use. The import is local so a future build
     # that disables the built-in plugin doesn't take a hard import
-    # on the plugin tree (Codex round-2 P0 on #2059).
-    _wire_briefings_provider()
+    # on the plugin tree (Codex round-2 P0 on #2059). The helper
+    # honors ``config.plugins.disabled`` before registering — same
+    # contract the plugin host enforces (Codex round-3 on #2059).
+    _wire_briefings_provider(config)
 
     # Health is exempt from auth per spec §3.
     app.include_router(health_routes.router, prefix=API_V1_PREFIX)
@@ -436,7 +437,10 @@ def create_app(
     return app
 
 
-def _wire_briefings_provider() -> None:
+_MORNING_BRIEFING_PLUGIN_NAME = "morning_briefing"
+
+
+def _wire_briefings_provider(config: PollyPMConfig) -> None:
     """Register the built-in morning-briefing provider for the API.
 
     The cockpit + ``pm briefing`` CLI rely on the plugin host running
@@ -448,14 +452,39 @@ def _wire_briefings_provider() -> None:
     ``GET /api/v1/briefings`` reports ``morning.available=false`` and
     render/regenerate return 503 in production.
 
+    Honors ``config.plugins.disabled`` before registering: when the
+    operator has disabled ``morning_briefing`` (the rollback/recovery
+    path), the host's ``filter-before-register`` semantics apply and
+    we must NOT register the provider — otherwise the API would
+    resurrect a disabled plugin from outside the host layer and report
+    ``available=true`` for a type the rest of the system treats as off
+    (Codex round-3 on #2059). We clear any prior registration in that
+    case so a previously-enabled-then-disabled run still reports
+    ``available=false`` for the new app instance.
+
     Re-running this on every ``create_app`` call is a no-op after the
-    first one: ``register_briefing_provider`` just rebinds the module
-    slot to the same callable. Import failures are logged and
-    swallowed — a missing plugin downgrades availability to ``false``
-    (the route's fail-soft posture), it must not crash app startup.
+    first one when enabled: ``register_briefing_provider`` just rebinds
+    the module slot to the same callable. Import failures are logged
+    and swallowed — a missing plugin downgrades availability to
+    ``false`` (the route's fail-soft posture), it must not crash app
+    startup.
     """
+    from pollypm.briefings_registry import register_briefing_provider
+
+    disabled = set(getattr(config.plugins, "disabled", ()) or ())
+    if _MORNING_BRIEFING_PLUGIN_NAME in disabled:
+        # Mirror plugin host's "filter disabled before registering"
+        # contract (see ExtensionHost._disabled_names check at
+        # plugin_host.py:659). Clear so a prior enabled run's
+        # registration doesn't leak into this disabled-config app.
+        register_briefing_provider(None)
+        logger.info(
+            "web_api: morning_briefing disabled via [plugins].disabled; "
+            "GET /api/v1/briefings will report morning.available=false",
+        )
+        return
+
     try:
-        from pollypm.briefings_registry import register_briefing_provider
         from pollypm.plugins_builtin.morning_briefing.inbox import (
             list_briefings as _list_briefings,
         )

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -138,13 +138,40 @@ class DaemonThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
             _futures_thread.threading.Thread = original_thread_cls  # type: ignore[attr-defined,misc]
 
 
+# Briefings regenerate uses a small dedicated thread pool so a slow
+# provider (LLM stall, GitHub rate-limit) trips the route's wall-clock
+# timeout without hanging the request thread. The pool + its in-flight
+# bookkeeping live on ``app.state`` and are owned by the lifespan
+# context below: startup creates them, shutdown cancels in-flight work
+# and waits briefly for cooperative completion. Previously these were
+# module-level globals in ``routes/briefings.py``; that left zombie
+# threads alive after ``pm serve`` shutdown because there was no
+# FastAPI hook to call ``shutdown(cancel_futures=True)`` (Codex
+# round-4 on #2059). Workers are daemon threads + evicted from
+# ``concurrent.futures._threads_queues`` on grace-period overrun so a
+# wedged provider can't keep the interpreter alive past app teardown
+# (Codex round-7 on #2059 — mirror the #2058 doctor-executor pattern).
+_BRIEFING_REGEN_MAX_WORKERS = 2
+_BRIEFING_REGEN_THREAD_PREFIX = "briefing-regen"
+# Bound on the post-shutdown wait for in-flight briefing workers.
+# Regenerate is bounded server-side by the route's wall-clock timeout
+# (~30s default per spec §2.7); we don't block app teardown that long
+# — a timed-out worker has already overrun its budget, so we cancel
+# queued work, wait briefly for cooperative completion, then evict
+# survivors so the interpreter can exit. Same shape as
+# :data:`_DOCTOR_SHUTDOWN_GRACE_S`.
+_BRIEFING_SHUTDOWN_GRACE_S = 5.0
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """FastAPI lifespan that owns the doctor executor + locks.
+    """FastAPI lifespan that owns the doctor + briefings executors.
 
     Startup attaches the following attributes to ``app.state`` so the
-    doctor routes resolve them via ``request.app.state`` rather than
-    reaching into module-level globals:
+    routes resolve them via ``request.app.state`` rather than reaching
+    into module-level globals:
+
+    Doctor (Codex round-5 on #2058):
 
     - ``doctor_executor``: shared :class:`DaemonThreadPoolExecutor`
       for check / fix / verify work. ``max_workers=2`` matches the
@@ -163,12 +190,30 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     - ``doctor_last_report``: the cache slot itself
       (``tuple[DoctorReport, float] | None``).
 
-    Shutdown cancels not-yet-started futures, then calls
-    ``executor.shutdown(wait=False, cancel_futures=True)`` so the
-    teardown doesn't block on a wedged check. We then wait up to
-    :data:`_DOCTOR_SHUTDOWN_GRACE_S` for cooperative completion and
-    log a warning if any worker is still alive (the v1 RC tradeoff:
-    we can't kill the thread, but we can refuse to block on it).
+    Briefings (Codex round-4 + round-7 on #2059):
+
+    - ``briefing_executor``: shared :class:`DaemonThreadPoolExecutor`
+      for regen work. ``max_workers=2`` is intentionally tiny — regen
+      is heavy (LLM + subprocess); combined with the per-scope
+      in-flight guard, this caps fan-out at "one concurrent regen per
+      (type, project)". Mirrors the doctor executor's daemon-thread
+      + atexit-eviction discipline so a wedged provider can't keep
+      ``pm serve`` alive after shutdown — Codex round-7 on #2059
+      flagged that the round-6 daemon-only change is not
+      process-safe without the eviction half from #2058.
+    - ``briefing_inflight``: ``{(type, project_key): Future}`` so
+      duplicate retries are rejected with 409 instead of stacking
+      work on the executor.
+    - ``briefing_inflight_lock``: guards the dict.
+
+    Shutdown cancels not-yet-started futures for each executor, then
+    calls ``executor.shutdown(wait=False, cancel_futures=True)`` so
+    the teardown doesn't block on a wedged worker. We then wait up to
+    the configured grace for cooperative completion and evict any
+    survivors from ``concurrent.futures._threads_queues`` so the
+    stdlib's ``_python_exit`` atexit hook can't join them and hold
+    the interpreter open (the v1 RC tradeoff: we can't kill the
+    thread, but we can refuse to block on it).
     """
     # Daemon-thread executor so a wedged worker doesn't keep the
     # interpreter alive past app shutdown. ``executor.shutdown(wait=
@@ -187,55 +232,104 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.doctor_fix_lock = threading.Lock()
     app.state.doctor_last_report_lock = threading.Lock()
     app.state.doctor_last_report = None
+    # Briefings executor reuses the same daemon-thread helper so a
+    # wedged regen provider (LLM stall, GitHub rate-limit) can't keep
+    # ``pm serve`` alive after shutdown. Codex round-7 on #2059 flagged
+    # that the round-6 daemon-only change isn't process-safe without
+    # mirroring the atexit eviction from #2058 — done at teardown
+    # below.
+    app.state.briefing_executor = DaemonThreadPoolExecutor(
+        max_workers=_BRIEFING_REGEN_MAX_WORKERS,
+        thread_name_prefix=_BRIEFING_REGEN_THREAD_PREFIX,
+    )
+    app.state.briefing_inflight: dict[tuple[str, str], concurrent.futures.Future[Any]] = {}
+    app.state.briefing_inflight_lock = threading.Lock()
     try:
         yield
     finally:
-        executor = app.state.doctor_executor
+        # Briefings teardown first: cancel in-flight registry entries,
+        # then run the shared shutdown helper. Doctor uses the same
+        # helper to inherit the cancel-futures + grace-wait + atexit
+        # eviction discipline.
         try:
-            # ``cancel_futures=True`` drops anything still queued;
-            # ``wait=False`` so a wedged in-flight worker can't block
-            # FastAPI teardown indefinitely (the v1 RC tradeoff
-            # documented in routes/doctor.py:_await_with_budget).
-            executor.shutdown(wait=False, cancel_futures=True)
+            with app.state.briefing_inflight_lock:
+                for future in list(app.state.briefing_inflight.values()):
+                    future.cancel()
+                app.state.briefing_inflight.clear()
         except Exception:  # noqa: BLE001
             logger.warning(
-                "lifespan: doctor executor shutdown raised", exc_info=True,
+                "lifespan: failed to clear briefing in-flight registry",
+                exc_info=True,
             )
-        # Best-effort wait for the worker threads to finish naturally.
-        # If they don't, log + leak rather than hang the app teardown.
-        deadline = time.monotonic() + _DOCTOR_SHUTDOWN_GRACE_S
+        _shutdown_daemon_executor(
+            app.state.briefing_executor,
+            label="briefing executor",
+            grace_s=_BRIEFING_SHUTDOWN_GRACE_S,
+        )
+        _shutdown_daemon_executor(
+            app.state.doctor_executor,
+            label="doctor executor",
+            grace_s=_DOCTOR_SHUTDOWN_GRACE_S,
+        )
+
+
+def _shutdown_daemon_executor(
+    executor: concurrent.futures.ThreadPoolExecutor,
+    *,
+    label: str,
+    grace_s: float,
+) -> None:
+    """Cancel + grace-wait + atexit-evict a daemon executor.
+
+    Shared between the doctor and briefings executors so both inherit
+    the same teardown discipline:
+
+    1. ``shutdown(wait=False, cancel_futures=True)`` drops queued
+       futures and releases lifespan immediately. A wedged in-flight
+       worker can't block FastAPI teardown — the v1 RC tradeoff
+       documented in routes/doctor.py:_await_with_budget and mirrored
+       for briefings on #2059.
+    2. Best-effort grace wait so cooperative workers can finish.
+    3. Survivors are popped from
+       ``concurrent.futures._threads_queues`` so the stdlib's
+       ``_python_exit`` atexit hook can't join them and keep
+       ``pm serve`` alive past interpreter teardown. Combined with
+       ``daemon=True`` workers (see :class:`DaemonThreadPoolExecutor`)
+       the process can actually exit. Codex round-6 on #2058 +
+       round-7 on #2059.
+    """
+    try:
+        executor.shutdown(wait=False, cancel_futures=True)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "lifespan: %s shutdown raised", label, exc_info=True,
+        )
+    deadline = time.monotonic() + grace_s
+    try:
+        workers = list(getattr(executor, "_threads", []) or [])
+    except Exception:  # noqa: BLE001
+        workers = []
+    while time.monotonic() < deadline and any(t.is_alive() for t in workers):
+        time.sleep(0.05)
+    still_running = [t for t in workers if t.is_alive()]
+    if still_running:
+        logger.warning(
+            "lifespan: %s: %d worker(s) still running after %.1fs grace; "
+            "leaking thread(s) past app teardown",
+            label,
+            len(still_running),
+            grace_s,
+        )
         try:
-            workers = list(getattr(executor, "_threads", []) or [])
+            for t in still_running:
+                _futures_thread._threads_queues.pop(t, None)
         except Exception:  # noqa: BLE001
-            workers = []
-        while time.monotonic() < deadline and any(t.is_alive() for t in workers):
-            time.sleep(0.05)
-        still_running = [t for t in workers if t.is_alive()]
-        if still_running:
             logger.warning(
-                "lifespan: doctor executor: %d worker(s) still running after "
-                "%.1fs grace; leaking thread(s) past app teardown",
-                len(still_running),
-                _DOCTOR_SHUTDOWN_GRACE_S,
+                "lifespan: failed to evict wedged %s worker(s) from "
+                "concurrent.futures._threads_queues",
+                label,
+                exc_info=True,
             )
-            # ``concurrent.futures`` registers an ``atexit`` hook
-            # (``_python_exit``) that joins every executor worker
-            # via the module-level ``_threads_queues`` dict. That
-            # join blocks ``pm serve`` interpreter exit even when
-            # the workers are daemon threads. Pop our workers out
-            # of that mapping so the atexit hook can't reach them
-            # — combined with ``daemon=True`` (see
-            # :class:`DaemonThreadPoolExecutor`) the process can
-            # now exit. Codex round-6 on #2058.
-            try:
-                for t in still_running:
-                    _futures_thread._threads_queues.pop(t, None)
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "lifespan: failed to evict wedged doctor worker(s) "
-                    "from concurrent.futures._threads_queues",
-                    exc_info=True,
-                )
 
 
 def create_app(
@@ -264,9 +358,11 @@ def create_app(
         docs_url=None,  # we serve OpenAPI via the spec endpoint
         redoc_url=None,
         openapi_url=None,
-        # Lifespan owns the doctor ThreadPoolExecutor + single-flight
-        # fix lock + last-report cache so they're cleanly torn down on
-        # app exit (Codex round-5 on #2058). Routes read them off
+        # Lifespan owns the doctor + briefings ThreadPoolExecutors,
+        # the doctor single-flight fix lock + last-report cache, and
+        # the briefings in-flight registry — so they're cleanly torn
+        # down on app exit (Codex round-5 on #2058 + round-4/round-7
+        # on #2059). Routes read them off
         # ``request.app.state`` rather than module-level globals.
         lifespan=_lifespan,
     )

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -208,12 +208,15 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     Shutdown cancels not-yet-started futures for each executor, then
     calls ``executor.shutdown(wait=False, cancel_futures=True)`` so
-    the teardown doesn't block on a wedged worker. We then wait up to
-    the configured grace for cooperative completion and evict any
-    survivors from ``concurrent.futures._threads_queues`` so the
-    stdlib's ``_python_exit`` atexit hook can't join them and hold
-    the interpreter open (the v1 RC tradeoff: we can't kill the
-    thread, but we can refuse to block on it).
+    the teardown doesn't block on a wedged worker (a running
+    ``ThreadPoolExecutor`` worker cannot be cancelled — ``wait=True``
+    would hang ``pm serve`` shutdown on a wedged provider; Codex
+    round-5 on #2059). We then wait up to the configured grace for
+    cooperative completion and evict any survivors from
+    ``concurrent.futures._threads_queues`` so the stdlib's
+    ``_python_exit`` atexit hook can't join them and hold the
+    interpreter open (the v1 RC tradeoff: we can't kill the thread,
+    but we can refuse to block on it).
     """
     # Daemon-thread executor so a wedged worker doesn't keep the
     # interpreter alive past app shutdown. ``executor.shutdown(wait=
@@ -286,10 +289,15 @@ def _shutdown_daemon_executor(
 
     1. ``shutdown(wait=False, cancel_futures=True)`` drops queued
        futures and releases lifespan immediately. A wedged in-flight
-       worker can't block FastAPI teardown — the v1 RC tradeoff
-       documented in routes/doctor.py:_await_with_budget and mirrored
-       for briefings on #2059.
+       worker can't block FastAPI teardown — a running
+       ``ThreadPoolExecutor`` worker cannot be cancelled, so
+       ``wait=True`` would block teardown forever on a wedged provider
+       (Codex round-5 on #2059, mirroring the doctor pattern from
+       #2058).
     2. Best-effort grace wait so cooperative workers can finish.
+       ``_threads`` is a private but stable attribute on
+       ``ThreadPoolExecutor`` (CPython 3.9+); used here purely as a
+       liveness probe so we don't ``join`` (which would block).
     3. Survivors are popped from
        ``concurrent.futures._threads_queues`` so the stdlib's
        ``_python_exit`` atexit hook can't join them and keep

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -333,6 +333,21 @@ def create_app(
     app.add_exception_handler(RequestValidationError, handle_validation_error)
     app.add_exception_handler(Exception, handle_unhandled_exception)
 
+    # Wire the briefings provider so /api/v1/briefings reports
+    # ``morning.available=true`` and render/regenerate don't 503 in
+    # normal ``pm serve`` use. The full plugin host isn't bootstrapped
+    # in the API process (it owns roster + job scheduling + cockpit
+    # rail registration — none of which the read/regenerate path
+    # needs); the only piece the briefings routes consult is the
+    # registry seam (`pollypm.briefings_registry._briefing_provider`),
+    # which the ``morning_briefing`` plugin populates via
+    # ``register_briefing_provider`` during plugin ``initialize``.
+    # Mirror that single call here so the API has the same provider
+    # the cockpit + CLI use. The import is local so a future build
+    # that disables the built-in plugin doesn't take a hard import
+    # on the plugin tree (Codex round-2 P0 on #2059).
+    _wire_briefings_provider()
+
     # Health is exempt from auth per spec §3.
     app.include_router(health_routes.router, prefix=API_V1_PREFIX)
 
@@ -419,6 +434,39 @@ def create_app(
         return JSONResponse(app.openapi())
 
     return app
+
+
+def _wire_briefings_provider() -> None:
+    """Register the built-in morning-briefing provider for the API.
+
+    The cockpit + ``pm briefing`` CLI rely on the plugin host running
+    every plugin's ``initialize`` hook, which for ``morning_briefing``
+    calls ``register_briefing_provider(list_briefings)`` (see
+    ``plugins_builtin/morning_briefing/plugin.py``). ``pm serve`` does
+    not boot the plugin host — it only loads config + builds the
+    FastAPI app — so without this nudge the API's
+    ``GET /api/v1/briefings`` reports ``morning.available=false`` and
+    render/regenerate return 503 in production.
+
+    Re-running this on every ``create_app`` call is a no-op after the
+    first one: ``register_briefing_provider`` just rebinds the module
+    slot to the same callable. Import failures are logged and
+    swallowed — a missing plugin downgrades availability to ``false``
+    (the route's fail-soft posture), it must not crash app startup.
+    """
+    try:
+        from pollypm.briefings_registry import register_briefing_provider
+        from pollypm.plugins_builtin.morning_briefing.inbox import (
+            list_briefings as _list_briefings,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "web_api: morning_briefing plugin unavailable; "
+            "GET /api/v1/briefings will report morning.available=false",
+            exc_info=True,
+        )
+        return
+    register_briefing_provider(_list_briefings)
 
 
 def _attach_security_scheme(app: FastAPI) -> None:

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -541,65 +541,29 @@ def create_app(
     return app
 
 
-_MORNING_BRIEFING_PLUGIN_NAME = "morning_briefing"
-
-
 def _wire_briefings_provider(config: PollyPMConfig) -> None:
-    """Register the built-in morning-briefing provider for the API.
+    """Bootstrap built-in briefing providers for the API.
 
-    The cockpit + ``pm briefing`` CLI rely on the plugin host running
-    every plugin's ``initialize`` hook, which for ``morning_briefing``
-    calls ``register_briefing_provider(list_briefings)`` (see
-    ``plugins_builtin/morning_briefing/plugin.py``). ``pm serve`` does
-    not boot the plugin host — it only loads config + builds the
-    FastAPI app — so without this nudge the API's
-    ``GET /api/v1/briefings`` reports ``morning.available=false`` and
-    render/regenerate return 503 in production.
+    Delegates to :func:`pollypm.briefings_bootstrap.bootstrap_builtin_briefings`
+    so the Web API never imports ``pollypm.plugins_builtin`` directly
+    (Codex round-9 on #2059: the prior implementation imported
+    ``plugins_builtin.morning_briefing.inbox`` from this module, which
+    violated the documented core boundary — see
+    ``briefings_registry.py`` module docstring + ``cli.py:201-207``).
 
-    Honors ``config.plugins.disabled`` before registering: when the
-    operator has disabled ``morning_briefing`` (the rollback/recovery
-    path), the host's ``filter-before-register`` semantics apply and
-    we must NOT register the provider — otherwise the API would
-    resurrect a disabled plugin from outside the host layer and report
-    ``available=true`` for a type the rest of the system treats as off
-    (Codex round-3 on #2059). We clear any prior registration in that
-    case so a previously-enabled-then-disabled run still reports
-    ``available=false`` for the new app instance.
+    ``pm serve`` doesn't boot the plugin host (which owns roster + job
+    scheduling — none of which the read/regenerate path needs); the
+    bootstrap helper mirrors the single registry-wiring step the
+    plugin's ``initialize`` hook performs so
+    ``GET /api/v1/briefings`` reports ``morning.available=true`` in
+    production. The bootstrap honors ``config.plugins.disabled``.
 
-    Re-running this on every ``create_app`` call is a no-op after the
-    first one when enabled: ``register_briefing_provider`` just rebinds
-    the module slot to the same callable. Import failures are logged
-    and swallowed — a missing plugin downgrades availability to
-    ``false`` (the route's fail-soft posture), it must not crash app
-    startup.
+    Re-running this on every ``create_app`` call is a no-op when
+    enabled (registry slots just rebind) and idempotent when disabled.
     """
-    from pollypm.briefings_registry import register_briefing_provider
+    from pollypm.briefings_bootstrap import bootstrap_builtin_briefings
 
-    disabled = set(getattr(config.plugins, "disabled", ()) or ())
-    if _MORNING_BRIEFING_PLUGIN_NAME in disabled:
-        # Mirror plugin host's "filter disabled before registering"
-        # contract (see ExtensionHost._disabled_names check at
-        # plugin_host.py:659). Clear so a prior enabled run's
-        # registration doesn't leak into this disabled-config app.
-        register_briefing_provider(None)
-        logger.info(
-            "web_api: morning_briefing disabled via [plugins].disabled; "
-            "GET /api/v1/briefings will report morning.available=false",
-        )
-        return
-
-    try:
-        from pollypm.plugins_builtin.morning_briefing.inbox import (
-            list_briefings as _list_briefings,
-        )
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "web_api: morning_briefing plugin unavailable; "
-            "GET /api/v1/briefings will report morning.available=false",
-            exc_info=True,
-        )
-        return
-    register_briefing_provider(_list_briefings)
+    bootstrap_builtin_briefings(config)
 
 
 def _attach_security_scheme(app: FastAPI) -> None:

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -38,6 +38,7 @@ from pollypm.web_api.errors import (
     handle_validation_error,
 )
 from pollypm.web_api.routes import audit as audit_routes
+from pollypm.web_api.routes import briefings as briefings_routes
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
 from pollypm.web_api.routes import chat_send as chat_send_routes
 from pollypm.web_api.routes import config as config_routes
@@ -356,6 +357,10 @@ def create_app(
     # bearer-auth dependency is reused — there is no read/write split
     # because every doctor endpoint can side-effect (run + fix).
     app.include_router(doctor_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
+    # Phase 2 surface §9 — briefings list/render/regenerate.
+    app.include_router(
+        briefings_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps,
+    )
     app.include_router(events_routes.router, prefix=API_V1_PREFIX, dependencies=sse_auth_deps)
     # Phase 2 §11 — read-side heartbeats surface. SSE stream endpoint
     # (§11.1 row 4) ships as a separate follow-up; the GET endpoints

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -1,0 +1,485 @@
+"""Briefings endpoints (Phase 2 — §9 of the phase-2 endpoints spec).
+
+Implements three routes under ``/api/v1/briefings``:
+
+- ``GET  /api/v1/briefings``                       — list briefing types
+- ``GET  /api/v1/briefings/{type_name}``           — render last generated
+- ``POST /api/v1/briefings/{type_name}/regenerate`` — force regenerate
+
+The phase-2 spec (``~/Desktop/pollypm-phase2-endpoints-spec.md`` §9)
+calls for a small, sync-only surface in this PR: long-running renders
+exceed a 30 s budget and return ``504 timeout`` (§2.7 / §9.2 third
+bullet). ``?async=true`` + a job registry is deferred to Phase 2.5.
+
+The route is a thin adapter over the existing briefing seam:
+
+- :func:`pollypm.briefings_registry.list_briefings` powers the discovery
+  endpoint (presence of a registered provider implies the type is
+  available).
+- :func:`pollypm.plugins_builtin.morning_briefing.inbox.list_briefings`
+  + :func:`pollypm.plugins_builtin.morning_briefing.inbox.read_briefing`
+  back the render endpoint (newest cached entry on disk).
+- :func:`pollypm.plugins_builtin.morning_briefing.handlers.briefing_tick.fire_briefing`
+  is the regenerate hook, wrapped in a thread-pool timeout so a slow
+  provider surfaces as ``504 timeout`` rather than hanging the request.
+
+Only one briefing type (``morning``) ships built-in today; the registry
+seam is honored so a future plugin can register additional types
+without touching this module. When the registry is empty, list returns
+an empty array (spec §9 / Phase 1 fail-soft posture).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+from datetime import UTC, datetime
+from typing import Annotated, Any, Callable
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from pollypm.web_api.errors import (
+    APIError,
+    invalid_request,
+    not_found,
+    service_unavailable,
+)
+from pollypm.web_api.routes._deps import ConfigDep
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Briefings"])
+
+
+# ---------------------------------------------------------------------------
+# Timeouts (kept module-level so tests can patch)
+# ---------------------------------------------------------------------------
+
+
+# Spec §2.7 — sync mode budget. Median morning briefing render is
+# 8–12 s today, so 30 s is comfortable for the happy path; pathological
+# providers (GitHub rate-limit, LLM stall) trip the 504 path.
+DEFAULT_REGENERATE_TIMEOUT_SECONDS = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Pydantic wire models
+# ---------------------------------------------------------------------------
+
+
+class BriefingTypeInfo(BaseModel):
+    """One entry in ``GET /briefings`` (spec §9.1)."""
+
+    name: str
+    description: str
+    available: bool = True
+
+
+class BriefingTypesResponse(BaseModel):
+    """``GET /api/v1/briefings`` envelope."""
+
+    types: list[BriefingTypeInfo]
+
+
+class BriefingResponse(BaseModel):
+    """``GET /briefings/{type}`` and the regenerate POST response."""
+
+    type: str
+    generated_at: datetime | None = None
+    date_local: str | None = None
+    mode: str | None = None
+    markdown: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RegenerateRequest(BaseModel):
+    """``POST /briefings/{type}/regenerate`` body.
+
+    ``project`` narrows the regenerate scope to a single project key.
+    Today's morning briefing ignores it (it's always whole-workspace);
+    we accept the field for forward compatibility so plugin-contributed
+    briefing types (e.g. per-project weekly) don't need a body-schema
+    bump later.
+    """
+
+    project: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Type registry (briefing-type name -> adapter)
+# ---------------------------------------------------------------------------
+
+
+# Each adapter exposes three callables: ``available()``, ``render()``,
+# ``regenerate()``. Built-in ``morning`` reads through the
+# ``briefings_registry`` seam so disabling the plugin downgrades the
+# type to "absent" instead of breaking imports.
+class _BriefingAdapter:
+    """Glue between the route and a concrete briefing implementation."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        description: str,
+        available: Callable[[Any], bool],
+        render_last: Callable[[Any], BriefingResponse | None],
+        regenerate: Callable[[Any, RegenerateRequest], BriefingResponse],
+    ) -> None:
+        self.name = name
+        self.description = description
+        self._available = available
+        self._render_last = render_last
+        self._regenerate = regenerate
+
+    def is_available(self, config: Any) -> bool:
+        try:
+            return bool(self._available(config))
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "briefings: availability probe failed for %s", self.name,
+                exc_info=True,
+            )
+            return False
+
+    def render_last(self, config: Any) -> BriefingResponse | None:
+        return self._render_last(config)
+
+    def regenerate(self, config: Any, body: RegenerateRequest) -> BriefingResponse:
+        return self._regenerate(config, body)
+
+
+def _morning_available(config: Any) -> bool:  # noqa: ARG001 — registry is module-level
+    """Return True iff the morning-briefing plugin is registered.
+
+    The :mod:`pollypm.briefings_registry` seam holds the active provider
+    callable; ``None`` means the plugin tree isn't loaded (config didn't
+    enable the plugin) and the type is reported as ``available=false``
+    so clients know not to attempt regenerate.
+    """
+    from pollypm.briefings_registry import _briefing_provider  # type: ignore[attr-defined]
+    return _briefing_provider is not None
+
+
+def _morning_render_last(config: Any) -> BriefingResponse | None:
+    """Read the newest morning briefing off disk (spec §9.1 ``last``)."""
+    from pollypm.plugins_builtin.morning_briefing import inbox as _inbox
+
+    base_dir = config.project.base_dir
+    entries = _inbox.list_briefings(base_dir, status="all", limit=1)
+    if not entries:
+        return None
+    entry = entries[0]
+    read = _inbox.read_briefing(base_dir, entry.date_local)
+    if read is None:
+        # The metadata json existed during list_briefings but the body
+        # disappeared between calls (rare — atomic-write replaces both;
+        # treat as missing so the caller can regenerate).
+        return None
+    _entry, markdown = read
+    return BriefingResponse(
+        type="morning",
+        generated_at=_parse_iso(_entry.created_at),
+        date_local=_entry.date_local,
+        mode=_entry.mode or None,
+        markdown=markdown,
+        metadata={
+            "status": _entry.status,
+            "pinned": _entry.pinned,
+            "yesterday": _entry.yesterday,
+            "priorities": list(_entry.priorities),
+            "watch": list(_entry.watch),
+            **dict(_entry.meta),
+        },
+    )
+
+
+def _morning_regenerate(config: Any, body: RegenerateRequest) -> BriefingResponse:  # noqa: ARG001
+    """Force-fire the morning briefing pipeline (spec §9.1 ``regenerate``).
+
+    Mirrors ``pm briefing now`` (see
+    :mod:`pollypm.plugins_builtin.morning_briefing.cli`): runs the full
+    gather → synthesize → emit chain and writes to the inbox. The
+    ``project`` body field is accepted for forward compat but ignored —
+    morning briefings are always whole-workspace today.
+    """
+    from pollypm.plugins_builtin.morning_briefing.handlers import (
+        briefing_tick as _tick,
+    )
+    from pollypm.plugins_builtin.morning_briefing.settings import (
+        load_briefing_settings,
+    )
+    from pollypm.plugins_builtin.morning_briefing.state import load_state
+    from pollypm.config import DEFAULT_CONFIG_PATH, resolve_config_path
+    from pollypm.tz import get_timezone
+
+    base_dir = config.project.base_dir
+    project_root = config.project.root_dir
+
+    # ``load_briefing_settings`` reads ``[briefing]`` overrides off the
+    # toml; resolve_config_path picks the same file ``load_config``
+    # used when the config was first loaded, so the settings reflect
+    # the operator's overrides (briefing hour, timezone, …).
+    settings = load_briefing_settings(resolve_config_path(DEFAULT_CONFIG_PATH))
+
+    fallback_tz = getattr(config.pollypm, "timezone", "") or ""
+    timezone = get_timezone(fallback_tz)
+    now_local = datetime.now(timezone)
+
+    state = load_state(base_dir)
+
+    result = _tick.fire_briefing(
+        project_root=project_root,
+        base_dir=base_dir,
+        settings=settings,
+        now_local=now_local,
+        state=state,
+        config=config,
+        emit_to_inbox=True,
+    )
+    if not isinstance(result, dict) or not result.get("fired"):
+        reason = (
+            str(result.get("reason"))
+            if isinstance(result, dict) else "unknown"
+        )
+        raise service_unavailable(
+            f"briefing regenerate did not fire ({reason})",
+            hint=(
+                "Check the morning_briefing plugin logs; the gather / "
+                "synthesize stage declined to produce a draft."
+            ),
+        )
+    draft = result.get("draft") or {}
+    return BriefingResponse(
+        type="morning",
+        generated_at=now_local.astimezone(UTC),
+        date_local=str(draft.get("date_local") or ""),
+        mode=str(draft.get("mode") or "") or None,
+        markdown=str(draft.get("markdown") or ""),
+        metadata={
+            "emitted_to_inbox": bool(result.get("emitted", False)),
+            "yesterday": draft.get("yesterday"),
+            "priorities": list(draft.get("priorities") or []),
+            "watch": list(draft.get("watch") or []),
+            "quiet_mode": bool(result.get("quiet_mode", False)),
+            **dict(draft.get("meta") or {}),
+        },
+    )
+
+
+_REGISTRY: dict[str, _BriefingAdapter] = {
+    "morning": _BriefingAdapter(
+        name="morning",
+        description=(
+            "Daily morning briefing — yesterday's progress, today's "
+            "priorities, watch items. Fires at the configured local hour."
+        ),
+        available=_morning_available,
+        render_last=_morning_render_last,
+        regenerate=_morning_regenerate,
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        candidate = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(candidate)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _lookup_type(type_name: str) -> _BriefingAdapter:
+    """Resolve a briefing type or raise 404."""
+    adapter = _REGISTRY.get(type_name)
+    if adapter is None:
+        raise not_found(
+            f"Unknown briefing type: {type_name!r}",
+            hint=(
+                "Use GET /api/v1/briefings to list available types. "
+                f"Known types: {sorted(_REGISTRY)}"
+            ),
+        )
+    return adapter
+
+
+def _timeout_error(type_name: str, seconds: float) -> APIError:
+    return APIError(
+        status_code=504,
+        code="timeout",
+        message=(
+            f"briefing {type_name!r} regenerate exceeded the "
+            f"{seconds:.0f}s sync budget"
+        ),
+        hint=(
+            "The provider is slow (LLM/network stall). Retry; future "
+            "phases will add ?async=true with a job registry (spec §2.7)."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/briefings",
+    response_model=BriefingTypesResponse,
+    summary="List available briefing types",
+    operation_id="listBriefingTypes",
+)
+def list_briefing_types_endpoint(config: ConfigDep) -> BriefingTypesResponse:
+    """GET /api/v1/briefings — discover briefing types.
+
+    Returns every type in the local registry, with ``available=false``
+    for types whose provider plugin isn't loaded. Clients can render a
+    "morning briefing not configured" hint without trying to regenerate
+    and getting a 5xx.
+    """
+    types = [
+        BriefingTypeInfo(
+            name=adapter.name,
+            description=adapter.description,
+            available=adapter.is_available(config),
+        )
+        for adapter in _REGISTRY.values()
+    ]
+    return BriefingTypesResponse(types=types)
+
+
+@router.get(
+    "/briefings/{type_name}",
+    response_model=BriefingResponse,
+    summary="Render the last generated briefing of this type",
+    operation_id="renderBriefing",
+)
+def render_briefing_endpoint(
+    type_name: str,
+    config: ConfigDep,
+) -> BriefingResponse:
+    """GET /api/v1/briefings/{type_name} — newest cached briefing.
+
+    Returns 404 ``not_found`` when no briefing has ever been generated
+    for this type (Phase 1 fail-soft posture: the cockpit treats
+    "missing" identically to "plugin not loaded"; the API surfaces it
+    as a typed 404 so the client can show a "regenerate" affordance).
+    """
+    adapter = _lookup_type(type_name)
+    if not adapter.is_available(config):
+        raise service_unavailable(
+            f"Briefing type {type_name!r} is registered but its provider "
+            "is not loaded",
+            hint=(
+                "Enable the corresponding plugin in pollypm.toml "
+                "(e.g. morning_briefing) and restart pm serve."
+            ),
+        )
+    response = adapter.render_last(config)
+    if response is None:
+        raise not_found(
+            f"No briefing has been generated for type {type_name!r}",
+            hint=(
+                "POST /api/v1/briefings/"
+                f"{type_name}/regenerate to produce one now."
+            ),
+        )
+    return response
+
+
+@router.post(
+    "/briefings/{type_name}/regenerate",
+    response_model=BriefingResponse,
+    summary="Force regenerate a briefing (sync)",
+    operation_id="regenerateBriefing",
+)
+def regenerate_briefing_endpoint(
+    type_name: str,
+    config: ConfigDep,
+    body: RegenerateRequest | None = None,
+    timeout_seconds: Annotated[float, Query(
+        ge=1.0, le=600.0,
+        description=(
+            "Sync regenerate budget in seconds. Capped at 600. Default "
+            f"{DEFAULT_REGENERATE_TIMEOUT_SECONDS:.0f}s per spec §2.7."
+        ),
+    )] = DEFAULT_REGENERATE_TIMEOUT_SECONDS,
+) -> BriefingResponse:
+    """POST /api/v1/briefings/{type_name}/regenerate — force regen.
+
+    Runs the regenerate path under a thread-pool timeout. On timeout
+    returns ``504 timeout`` per spec §2.7; the in-flight task is
+    cancelled best-effort (Python can't preempt arbitrary user code,
+    but the thread is detached so the request doesn't block forever).
+    """
+    adapter = _lookup_type(type_name)
+    if not adapter.is_available(config):
+        raise service_unavailable(
+            f"Briefing type {type_name!r} is registered but its provider "
+            "is not loaded",
+            hint=(
+                "Enable the corresponding plugin in pollypm.toml "
+                "(e.g. morning_briefing) and restart pm serve."
+            ),
+        )
+
+    request_body = body or RegenerateRequest()
+    if request_body.project is not None and not request_body.project.strip():
+        # An empty string vs. unset is almost always a client bug — the
+        # caller probably meant ``null``. Surface as 400 so the mistake
+        # is visible rather than silently ignored.
+        raise invalid_request(
+            "body.project must be a non-empty string or omitted",
+            hint="Drop the field entirely for whole-workspace regenerate.",
+        )
+
+    # Run the regenerate in a worker thread so we can enforce a wall
+    # clock timeout. ``fire_briefing`` is mostly I/O + subprocess
+    # (gather queries pg, synthesize shells out to the herald) so a
+    # thread executor is fine — we never need to interrupt CPU-bound
+    # work here.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(adapter.regenerate, config, request_body)
+        try:
+            return future.result(timeout=timeout_seconds)
+        except concurrent.futures.TimeoutError as exc:
+            # We can't cancel a running thread in Python; the daemon
+            # thread will finish in the background. Surface the timeout
+            # immediately so the client can retry.
+            future.cancel()
+            raise _timeout_error(type_name, timeout_seconds) from exc
+        except APIError:
+            # The adapter already raised a typed error — propagate.
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "briefings: regenerate failed for type %s", type_name,
+            )
+            raise service_unavailable(
+                f"briefing {type_name!r} regenerate failed: {exc}",
+                hint="Check the provider plugin logs.",
+            ) from exc
+
+
+__all__ = [
+    "BriefingResponse",
+    "BriefingTypeInfo",
+    "BriefingTypesResponse",
+    "DEFAULT_REGENERATE_TIMEOUT_SECONDS",
+    "RegenerateRequest",
+    "list_briefing_types_endpoint",
+    "regenerate_briefing_endpoint",
+    "render_briefing_endpoint",
+    "router",
+]

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -542,13 +542,44 @@ def regenerate_briefing_endpoint(
     # the executor's thread, so cleanup happens whether the request
     # 504'd or returned normally. Wrapped in its own try so a bookkeeping
     # exception can never propagate into the worker's result.
-    def _clear_inflight(fut: concurrent.futures.Future[Any]) -> None:
+    #
+    # We also observe ``future.exception()`` / completion here so that
+    # late terminal state — after the HTTP client already saw 504 — is
+    # logged. Without this, a provider that fails minutes after the 504
+    # is operationally invisible (Codex round-5 on #2059). We log the
+    # type/scope + repr(exc) only; the adapter is responsible for
+    # ensuring its exception message does not leak secrets.
+    inflight_key_log = inflight_key
+
+    def _on_regenerate_done(fut: concurrent.futures.Future[Any]) -> None:
         with inflight_lock:
             current = inflight.get(inflight_key)
             if current is fut:
                 inflight.pop(inflight_key, None)
+        try:
+            if fut.cancelled():
+                logger.info(
+                    "briefing regenerate %r cancelled", inflight_key_log,
+                )
+                return
+            exc = fut.exception()
+        except concurrent.futures.CancelledError:
+            logger.info(
+                "briefing regenerate %r cancelled", inflight_key_log,
+            )
+            return
+        if exc is not None:
+            logger.warning(
+                "briefing regenerate %r failed after worker completed: %r",
+                inflight_key_log,
+                exc,
+            )
+        else:
+            logger.info(
+                "briefing regenerate %r completed", inflight_key_log,
+            )
 
-    future.add_done_callback(_clear_inflight)
+    future.add_done_callback(_on_regenerate_done)
 
     try:
         return future.result(timeout=timeout_seconds)

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -37,7 +37,7 @@ import threading
 from datetime import UTC, datetime
 from typing import Annotated, Any, Callable
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel, Field
 
 from pollypm.web_api.errors import (
@@ -55,7 +55,8 @@ router = APIRouter(tags=["Briefings"])
 
 
 # ---------------------------------------------------------------------------
-# Timeouts + executor (kept module-level so tests can patch / share)
+# Timeouts (the executor + in-flight registry live on ``app.state``;
+# see :func:`pollypm.web_api.app._lifespan`).
 # ---------------------------------------------------------------------------
 
 
@@ -65,30 +66,43 @@ router = APIRouter(tags=["Briefings"])
 DEFAULT_REGENERATE_TIMEOUT_SECONDS = 30.0
 
 
-# Shared process-wide executor for regenerate work. The old code created
-# a fresh ``ThreadPoolExecutor`` per request via ``with`` — that meant
-# the context-manager exit called ``shutdown(wait=True)`` on the
-# timed-out worker, so the request blocked until the slow provider
-# finished even after the 504 was "raised". Reusing a bounded
-# module-level executor lets ``future.result(timeout=...)`` actually
-# return early; the worker thread keeps running in the background and
-# either finishes silently or its result is discarded.
-#
-# ``max_workers`` is intentionally tiny: regenerate is heavy (LLM +
-# subprocess) and we don't want a runaway client to spawn dozens of
-# parallel briefing renders. Combined with the in-flight guard below,
-# this gives us at most one concurrent regenerate per ``(type,
-# project)`` key while letting different briefing types fan out.
-_REGEN_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
-    max_workers=4,
-    thread_name_prefix="briefing-regen",
-)
+def _get_executor(request: Request) -> concurrent.futures.ThreadPoolExecutor:
+    """Resolve the briefings executor from app-level state.
 
-# In-flight registry — maps ``(type_name, project_key)`` to the
-# currently-running future. Used to reject duplicate retries with 409
-# ``conflict`` instead of stacking work on the executor.
-_INFLIGHT_LOCK = threading.Lock()
-_INFLIGHT: dict[tuple[str, str], concurrent.futures.Future[Any]] = {}
+    The executor's lifecycle is owned by the FastAPI lifespan context
+    (``app._lifespan`` in ``web_api/app.py``) so it's cleanly shut
+    down at app teardown — no zombie worker threads after ``pm
+    serve`` exits (Codex round-4 on #2059).
+    """
+    executor = getattr(request.app.state, "briefing_executor", None)
+    if executor is None:  # pragma: no cover — only hit if lifespan didn't run
+        raise service_unavailable(
+            "briefings executor is not initialized",
+            hint=(
+                "The FastAPI lifespan didn't run; ensure ``create_app`` "
+                "is invoked through the standard ASGI server (uvicorn) "
+                "or a TestClient context manager."
+            ),
+        )
+    return executor
+
+
+def _get_inflight(
+    request: Request,
+) -> tuple[dict[tuple[str, str], concurrent.futures.Future[Any]], threading.Lock]:
+    """Resolve the in-flight registry + its lock from app-level state."""
+    state = request.app.state
+    inflight = getattr(state, "briefing_inflight", None)
+    lock = getattr(state, "briefing_inflight_lock", None)
+    if inflight is None or lock is None:  # pragma: no cover
+        raise service_unavailable(
+            "briefings in-flight registry is not initialized",
+            hint=(
+                "The FastAPI lifespan didn't run; ensure ``create_app`` "
+                "is invoked through the standard ASGI server."
+            ),
+        )
+    return inflight, lock
 
 
 # ---------------------------------------------------------------------------
@@ -457,6 +471,7 @@ def render_briefing_endpoint(
 def regenerate_briefing_endpoint(
     type_name: str,
     config: ConfigDep,
+    request: Request,
     body: RegenerateRequest | None = None,
     timeout_seconds: Annotated[float, Query(
         ge=1.0, le=600.0,
@@ -504,8 +519,10 @@ def regenerate_briefing_endpoint(
     # future ``weekly/projA`` can run concurrently while preventing
     # duplicates of the same scope.
     inflight_key = (type_name, request_body.project or "")
-    with _INFLIGHT_LOCK:
-        existing = _INFLIGHT.get(inflight_key)
+    executor = _get_executor(request)
+    inflight, inflight_lock = _get_inflight(request)
+    with inflight_lock:
+        existing = inflight.get(inflight_key)
         if existing is not None and not existing.done():
             raise conflict(
                 (
@@ -518,18 +535,18 @@ def regenerate_briefing_endpoint(
                     "are deduplicated to protect the shared executor."
                 ),
             )
-        future = _REGEN_EXECUTOR.submit(adapter.regenerate, config, request_body)
-        _INFLIGHT[inflight_key] = future
+        future = executor.submit(adapter.regenerate, config, request_body)
+        inflight[inflight_key] = future
 
     # Detach the in-flight entry once the worker finishes — runs on
     # the executor's thread, so cleanup happens whether the request
     # 504'd or returned normally. Wrapped in its own try so a bookkeeping
     # exception can never propagate into the worker's result.
     def _clear_inflight(fut: concurrent.futures.Future[Any]) -> None:
-        with _INFLIGHT_LOCK:
-            current = _INFLIGHT.get(inflight_key)
+        with inflight_lock:
+            current = inflight.get(inflight_key)
             if current is fut:
-                _INFLIGHT.pop(inflight_key, None)
+                inflight.pop(inflight_key, None)
 
     future.add_done_callback(_clear_inflight)
 

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -403,6 +403,14 @@ def _timeout_error(type_name: str, seconds: float) -> APIError:
     response_model=BriefingTypesResponse,
     summary="List available briefing types",
     operation_id="listBriefingTypes",
+    # #2059 round-8: route decorators must enumerate the same error
+    # surface as ``docs/api/openapi.yaml`` so the live ``/openapi.json``
+    # served by ``pm serve`` matches the static spec generated clients
+    # consume. Without these entries FastAPI only advertises 200+422
+    # and the conformance check passes vacuously.
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+    },
 )
 def list_briefing_types_endpoint(config: ConfigDep) -> BriefingTypesResponse:
     """GET /api/v1/briefings — discover briefing types.
@@ -428,6 +436,15 @@ def list_briefing_types_endpoint(config: ConfigDep) -> BriefingTypesResponse:
     response_model=BriefingResponse,
     summary="Render the last generated briefing of this type",
     operation_id="renderBriefing",
+    # #2059 round-8: mirror static yaml :2032-2048 so the live OpenAPI
+    # exposes the typed 404 (no briefing rendered yet) and 503
+    # (provider plugin not loaded) branches generated clients depend
+    # on. See ``test_briefings_runtime_openapi_matches_static_error_codes``.
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "No briefing has been generated for this type."},
+        "503": {"description": "Provider plugin not loaded for this briefing type."},
+    },
 )
 def render_briefing_endpoint(
     type_name: str,
@@ -467,6 +484,43 @@ def render_briefing_endpoint(
     response_model=BriefingResponse,
     summary="Force regenerate a briefing (sync)",
     operation_id="regenerateBriefing",
+    # #2059 round-8: mirror static yaml :2079-2124 — the regenerate
+    # path has the richest error surface (400 invalid request, 404
+    # unknown type, 409 in-flight scope conflict, 503 provider
+    # unavailable, 504 sync timeout). Without these entries the live
+    # OpenAPI only listed 200+422 and clients had no way to branch on
+    # the typed envelopes the handler actually raises.
+    responses={
+        "400": {
+            "description": (
+                "Invalid request — empty/whitespace ``project`` or "
+                "``project`` passed with ``type_name='morning'`` "
+                "(morning is whole-workspace only in Phase 2)."
+            ),
+        },
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Unknown briefing type."},
+        "409": {
+            "description": (
+                "A regenerate for this ``(type, project)`` scope is "
+                "already running on the shared executor; retry after "
+                "it completes."
+            ),
+        },
+        "503": {
+            "description": (
+                "Provider plugin not loaded or backing store "
+                "unavailable for this briefing type."
+            ),
+        },
+        "504": {
+            "description": (
+                "Sync regenerate exceeded ``timeout_seconds``. The "
+                "worker keeps running on the shared executor so "
+                "retries (after it finishes) do not duplicate work."
+            ),
+        },
+    },
 )
 def regenerate_briefing_endpoint(
     type_name: str,

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -147,7 +147,16 @@ class RegenerateRequest(BaseModel):
     we accept the field for forward compatibility so plugin-contributed
     briefing types (e.g. per-project weekly) don't need a body-schema
     bump later.
+
+    ``extra='forbid'`` (Codex round-10 on #2059): a side-effecting
+    endpoint must surface client typos as 422 rather than silently
+    dropping the unknown field. A client POSTing
+    ``{"project_key": "myproj"}`` (a plausible mistake) used to validate
+    as ``{"project": None}`` and trigger a whole-workspace regenerate;
+    the request now rejects with ``extra_forbidden`` instead.
     """
+
+    model_config = {"extra": "forbid"}
 
     project: str | None = None
 
@@ -328,18 +337,109 @@ def _morning_regenerate(config: Any, body: RegenerateRequest) -> BriefingRespons
     return _artifact_to_response(_MORNING_BRIEFING_TYPE_NAME, artifact)
 
 
-_REGISTRY: dict[str, _BriefingAdapter] = {
-    "morning": _BriefingAdapter(
-        name="morning",
-        description=(
-            "Daily morning briefing — yesterday's progress, today's "
-            "priorities, watch items. Fires at the configured local hour."
-        ),
-        available=_morning_available,
-        render_last=_morning_render_last,
-        regenerate=_morning_regenerate,
-    ),
-}
+# Test-override slot. Production code path consults
+# :func:`pollypm.briefings_registry.get_briefing_render_registration`
+# (Codex round-10 on #2059: the registry is now the single source of
+# truth for briefing type discovery; the route used to keep its own
+# dict that ignored plugin-contributed types). Tests still monkeypatch
+# entries here to inject controllable stubs without going through the
+# plugin bootstrap path — see ``tests/test_briefings_endpoint.py``
+# fixture ``patched_registry``. When a name is in both ``_REGISTRY``
+# and the global registry, the override wins (tests beat plugins).
+_REGISTRY: dict[str, _BriefingAdapter] = {}
+
+
+def _registration_to_adapter(
+    type_name: str,
+    registration: Any,
+) -> _BriefingAdapter:
+    """Wrap a :class:`BriefingRenderRegistration` for the route layer.
+
+    The registry returns a (provider, description, is_available) record.
+    The route's :class:`_BriefingAdapter` expects three callables
+    (``available``, ``render_last``, ``regenerate``) — this glue
+    translates one to the other and centralizes the
+    ``BriefingArtifact`` → :class:`BriefingResponse` mapping.
+    """
+    provider = registration.provider
+
+    def _available(config: Any) -> bool:
+        return registration.is_available(config)
+
+    def _render_last(config: Any) -> BriefingResponse | None:
+        if not registration.is_available(config):
+            return None
+        artifact = provider.render_last(config)
+        if artifact is None:
+            return None
+        return _artifact_to_response(type_name, artifact)
+
+    def _regenerate(config: Any, body: RegenerateRequest) -> BriefingResponse:
+        if not registration.is_available(config):
+            raise service_unavailable(
+                f"briefing {type_name!r} provider is unavailable",
+                hint=(
+                    "Enable the corresponding plugin in pollypm.toml "
+                    "and re-trigger; or rely on the next briefing tick."
+                ),
+            )
+        try:
+            artifact = provider.regenerate(config, project=body.project)
+        except ValueError as exc:
+            raise invalid_request(
+                str(exc) or "project-scoped briefing not implemented",
+                hint=(
+                    f"Omit the `project` field — the {type_name} briefing "
+                    "is whole-workspace only."
+                ),
+            ) from exc
+        return _artifact_to_response(type_name, artifact)
+
+    return _BriefingAdapter(
+        name=type_name,
+        description=registration.description or f"Briefing type {type_name!r}",
+        available=_available,
+        render_last=_render_last,
+        regenerate=_regenerate,
+    )
+
+
+def _resolve_adapter(type_name: str) -> _BriefingAdapter | None:
+    """Return the live adapter for ``type_name`` or ``None`` if unknown.
+
+    Lookup order:
+    1. ``_REGISTRY`` override slot (test stubs).
+    2. :func:`pollypm.briefings_registry.get_briefing_render_registration`
+       — the plugin-installed provider + metadata.
+    """
+    override = _REGISTRY.get(type_name)
+    if override is not None:
+        return override
+    from pollypm.briefings_registry import get_briefing_render_registration
+
+    registration = get_briefing_render_registration(type_name)
+    if registration is None:
+        return None
+    return _registration_to_adapter(type_name, registration)
+
+
+def _all_adapters() -> list[_BriefingAdapter]:
+    """Return adapters for every known briefing type (override + registry).
+
+    Tests inject under ``_REGISTRY``; production registers through the
+    plugin bootstrap → :mod:`pollypm.briefings_registry`. We union the
+    two so the discovery endpoint surfaces both surfaces' types (test
+    stubs always win when the name collides).
+    """
+    from pollypm.briefings_registry import registered_briefing_render_types
+
+    names = set(_REGISTRY) | set(registered_briefing_render_types())
+    adapters: list[_BriefingAdapter] = []
+    for name in sorted(names):
+        adapter = _resolve_adapter(name)
+        if adapter is not None:
+            adapters.append(adapter)
+    return adapters
 
 
 # ---------------------------------------------------------------------------
@@ -361,14 +461,25 @@ def _parse_iso(value: str) -> datetime | None:
 
 
 def _lookup_type(type_name: str) -> _BriefingAdapter:
-    """Resolve a briefing type or raise 404."""
-    adapter = _REGISTRY.get(type_name)
+    """Resolve a briefing type or raise 404.
+
+    Consults the test-override slot first, then the
+    :mod:`pollypm.briefings_registry` plugin registrations (Codex
+    round-10 on #2059: a private route-owned dict ignored
+    plugin-contributed types like a future ``weekly`` even though they
+    were properly registered via
+    :func:`register_briefing_render_provider`).
+    """
+    adapter = _resolve_adapter(type_name)
     if adapter is None:
+        from pollypm.briefings_registry import registered_briefing_render_types
+
+        known = sorted(set(_REGISTRY) | set(registered_briefing_render_types()))
         raise not_found(
             f"Unknown briefing type: {type_name!r}",
             hint=(
                 "Use GET /api/v1/briefings to list available types. "
-                f"Known types: {sorted(_REGISTRY)}"
+                f"Known types: {known}"
             ),
         )
     return adapter
@@ -422,7 +533,7 @@ def list_briefing_types_endpoint(config: ConfigDep) -> BriefingTypesResponse:
             description=adapter.description,
             available=adapter.is_available(config),
         )
-        for adapter in _REGISTRY.values()
+        for adapter in _all_adapters()
     ]
     return BriefingTypesResponse(types=types)
 

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import threading
 from datetime import UTC, datetime
 from typing import Annotated, Any, Callable
 
@@ -41,6 +42,7 @@ from pydantic import BaseModel, Field
 
 from pollypm.web_api.errors import (
     APIError,
+    conflict,
     invalid_request,
     not_found,
     service_unavailable,
@@ -53,7 +55,7 @@ router = APIRouter(tags=["Briefings"])
 
 
 # ---------------------------------------------------------------------------
-# Timeouts (kept module-level so tests can patch)
+# Timeouts + executor (kept module-level so tests can patch / share)
 # ---------------------------------------------------------------------------
 
 
@@ -61,6 +63,32 @@ router = APIRouter(tags=["Briefings"])
 # 8–12 s today, so 30 s is comfortable for the happy path; pathological
 # providers (GitHub rate-limit, LLM stall) trip the 504 path.
 DEFAULT_REGENERATE_TIMEOUT_SECONDS = 30.0
+
+
+# Shared process-wide executor for regenerate work. The old code created
+# a fresh ``ThreadPoolExecutor`` per request via ``with`` — that meant
+# the context-manager exit called ``shutdown(wait=True)`` on the
+# timed-out worker, so the request blocked until the slow provider
+# finished even after the 504 was "raised". Reusing a bounded
+# module-level executor lets ``future.result(timeout=...)`` actually
+# return early; the worker thread keeps running in the background and
+# either finishes silently or its result is discarded.
+#
+# ``max_workers`` is intentionally tiny: regenerate is heavy (LLM +
+# subprocess) and we don't want a runaway client to spawn dozens of
+# parallel briefing renders. Combined with the in-flight guard below,
+# this gives us at most one concurrent regenerate per ``(type,
+# project)`` key while letting different briefing types fan out.
+_REGEN_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=4,
+    thread_name_prefix="briefing-regen",
+)
+
+# In-flight registry — maps ``(type_name, project_key)`` to the
+# currently-running future. Used to reject duplicate retries with 409
+# ``conflict`` instead of stacking work on the executor.
+_INFLIGHT_LOCK = threading.Lock()
+_INFLIGHT: dict[tuple[str, str], concurrent.futures.Future[Any]] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -195,14 +223,16 @@ def _morning_render_last(config: Any) -> BriefingResponse | None:
     )
 
 
-def _morning_regenerate(config: Any, body: RegenerateRequest) -> BriefingResponse:  # noqa: ARG001
+def _morning_regenerate(config: Any, body: RegenerateRequest) -> BriefingResponse:
     """Force-fire the morning briefing pipeline (spec §9.1 ``regenerate``).
 
     Mirrors ``pm briefing now`` (see
     :mod:`pollypm.plugins_builtin.morning_briefing.cli`): runs the full
     gather → synthesize → emit chain and writes to the inbox. The
-    ``project`` body field is accepted for forward compat but ignored —
-    morning briefings are always whole-workspace today.
+    ``project`` body field is rejected with 400 for the morning type —
+    morning briefings are whole-workspace only today (Phase 2 round-1
+    Codex feedback on #2059: the field used to be silently ignored,
+    which let a client think they'd narrowed scope when they hadn't).
     """
     from pollypm.plugins_builtin.morning_briefing.handlers import (
         briefing_tick as _tick,
@@ -214,14 +244,30 @@ def _morning_regenerate(config: Any, body: RegenerateRequest) -> BriefingRespons
     from pollypm.config import DEFAULT_CONFIG_PATH, resolve_config_path
     from pollypm.tz import get_timezone
 
+    if body.project is not None:
+        raise invalid_request(
+            "project-scoped morning briefings are not implemented",
+            hint=(
+                "Omit the `project` field — the morning briefing is "
+                "always whole-workspace. Per-project briefings will land "
+                "with the plugin-contributed briefing types."
+            ),
+        )
+
     base_dir = config.project.base_dir
     project_root = config.project.root_dir
 
     # ``load_briefing_settings`` reads ``[briefing]`` overrides off the
-    # toml; resolve_config_path picks the same file ``load_config``
-    # used when the config was first loaded, so the settings reflect
-    # the operator's overrides (briefing hour, timezone, …).
-    settings = load_briefing_settings(resolve_config_path(DEFAULT_CONFIG_PATH))
+    # toml. Prefer the path the running ``pm serve`` actually loaded
+    # (``config.config_path``) so a non-default ``--config`` flag is
+    # honored. Falling back to ``DEFAULT_CONFIG_PATH`` keeps the path
+    # working in tests that construct ``PollyPMConfig`` directly without
+    # touching disk. (Codex round-1 P0 on #2059: the old code always
+    # read ``DEFAULT_CONFIG_PATH``, so ``pm serve --config /tmp/foo``
+    # would write into ``foo``'s ``base_dir`` while honoring the
+    # default global TOML's briefing hour/timezone/quiet-mode.)
+    config_path = getattr(config, "config_path", None) or DEFAULT_CONFIG_PATH
+    settings = load_briefing_settings(resolve_config_path(config_path))
 
     fallback_tz = getattr(config.pollypm, "timezone", "") or ""
     timezone = get_timezone(fallback_tz)
@@ -418,10 +464,16 @@ def regenerate_briefing_endpoint(
 ) -> BriefingResponse:
     """POST /api/v1/briefings/{type_name}/regenerate — force regen.
 
-    Runs the regenerate path under a thread-pool timeout. On timeout
-    returns ``504 timeout`` per spec §2.7; the in-flight task is
-    cancelled best-effort (Python can't preempt arbitrary user code,
-    but the thread is detached so the request doesn't block forever).
+    Runs the regenerate path on a shared process-wide thread pool with
+    a wall-clock timeout. On timeout returns ``504 timeout`` per spec
+    §2.7 **immediately** — the worker keeps running in the background,
+    so the next-request retry (or the operator) doesn't have to wait
+    for the slow provider to finish.
+
+    Duplicate retries for the same ``(type, project)`` while a render
+    is still in flight are rejected with ``409 conflict``; this stops
+    a panicked client from queuing N redundant regenerates onto the
+    shared pool (Codex round-1 P0 on #2059).
     """
     adapter = _lookup_type(type_name)
     if not adapter.is_available(config):
@@ -444,32 +496,58 @@ def regenerate_briefing_endpoint(
             hint="Drop the field entirely for whole-workspace regenerate.",
         )
 
-    # Run the regenerate in a worker thread so we can enforce a wall
-    # clock timeout. ``fire_briefing`` is mostly I/O + subprocess
-    # (gather queries pg, synthesize shells out to the herald) so a
-    # thread executor is fine — we never need to interrupt CPU-bound
-    # work here.
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        future = pool.submit(adapter.regenerate, config, request_body)
-        try:
-            return future.result(timeout=timeout_seconds)
-        except concurrent.futures.TimeoutError as exc:
-            # We can't cancel a running thread in Python; the daemon
-            # thread will finish in the background. Surface the timeout
-            # immediately so the client can retry.
-            future.cancel()
-            raise _timeout_error(type_name, timeout_seconds) from exc
-        except APIError:
-            # The adapter already raised a typed error — propagate.
-            raise
-        except Exception as exc:  # noqa: BLE001
-            logger.exception(
-                "briefings: regenerate failed for type %s", type_name,
+    # In-flight key — separate by project so e.g. ``morning`` and a
+    # future ``weekly/projA`` can run concurrently while preventing
+    # duplicates of the same scope.
+    inflight_key = (type_name, request_body.project or "")
+    with _INFLIGHT_LOCK:
+        existing = _INFLIGHT.get(inflight_key)
+        if existing is not None and not existing.done():
+            raise conflict(
+                (
+                    f"briefing {type_name!r} regenerate already in "
+                    "progress for this scope"
+                ),
+                hint=(
+                    "Wait for the running regenerate to finish, then "
+                    "retry. Concurrent regenerates of the same scope "
+                    "are deduplicated to protect the shared executor."
+                ),
             )
-            raise service_unavailable(
-                f"briefing {type_name!r} regenerate failed: {exc}",
-                hint="Check the provider plugin logs.",
-            ) from exc
+        future = _REGEN_EXECUTOR.submit(adapter.regenerate, config, request_body)
+        _INFLIGHT[inflight_key] = future
+
+    # Detach the in-flight entry once the worker finishes — runs on
+    # the executor's thread, so cleanup happens whether the request
+    # 504'd or returned normally. Wrapped in its own try so a bookkeeping
+    # exception can never propagate into the worker's result.
+    def _clear_inflight(fut: concurrent.futures.Future[Any]) -> None:
+        with _INFLIGHT_LOCK:
+            current = _INFLIGHT.get(inflight_key)
+            if current is fut:
+                _INFLIGHT.pop(inflight_key, None)
+
+    future.add_done_callback(_clear_inflight)
+
+    try:
+        return future.result(timeout=timeout_seconds)
+    except concurrent.futures.TimeoutError as exc:
+        # Crucial: do NOT block on the future. The worker keeps
+        # running on the shared pool; the in-flight registry keeps
+        # tracking it so retries 409 instead of stacking. Returning
+        # here in <timeout_seconds + epsilon> is the contract.
+        raise _timeout_error(type_name, timeout_seconds) from exc
+    except APIError:
+        # The adapter already raised a typed error — propagate.
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "briefings: regenerate failed for type %s", type_name,
+        )
+        raise service_unavailable(
+            f"briefing {type_name!r} regenerate failed: {exc}",
+            hint="Check the provider plugin logs.",
+        ) from exc
 
 
 __all__ = [

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -183,11 +183,15 @@ def _morning_available(config: Any) -> bool:  # noqa: ARG001 — registry is mod
 
     The :mod:`pollypm.briefings_registry` seam holds the active provider
     callable; ``None`` means the plugin tree isn't loaded (config didn't
-    enable the plugin) and the type is reported as ``available=false``
-    so clients know not to attempt regenerate.
+    enable the plugin, or ``[plugins].disabled`` includes
+    ``morning_briefing``) and the type is reported as ``available=false``
+    so clients know not to attempt regenerate. Uses the public
+    :func:`is_briefing_provider_registered` helper instead of reaching
+    into the module-private slot (Codex round-3 on PR #2059).
     """
-    from pollypm.briefings_registry import _briefing_provider  # type: ignore[attr-defined]
-    return _briefing_provider is not None
+    from pollypm.briefings_registry import is_briefing_provider_registered
+
+    return is_briefing_provider_registered()
 
 
 def _morning_render_last(config: Any) -> BriefingResponse | None:

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -11,17 +11,21 @@ calls for a small, sync-only surface in this PR: long-running renders
 exceed a 30 s budget and return ``504 timeout`` (§2.7 / §9.2 third
 bullet). ``?async=true`` + a job registry is deferred to Phase 2.5.
 
-The route is a thin adapter over the existing briefing seam:
+The route is a thin adapter over the briefing registry seams:
 
-- :func:`pollypm.briefings_registry.list_briefings` powers the discovery
-  endpoint (presence of a registered provider implies the type is
-  available).
-- :func:`pollypm.plugins_builtin.morning_briefing.inbox.list_briefings`
-  + :func:`pollypm.plugins_builtin.morning_briefing.inbox.read_briefing`
-  back the render endpoint (newest cached entry on disk).
-- :func:`pollypm.plugins_builtin.morning_briefing.handlers.briefing_tick.fire_briefing`
-  is the regenerate hook, wrapped in a thread-pool timeout so a slow
-  provider surfaces as ``504 timeout`` rather than hanging the request.
+- :func:`pollypm.briefings_registry.list_briefings` powers availability
+  for the discovery endpoint (presence of a registered provider implies
+  the type is available).
+- :func:`pollypm.briefings_registry.get_briefing_render_provider` returns
+  the plugin-installed render adapter for ``{type_name}`` — the route
+  consumes its :class:`BriefingArtifact` outputs and never imports the
+  plugin tree directly (Codex round-9 on #2059: previously
+  ``pollypm.plugins_builtin.morning_briefing.inbox`` /
+  ``handlers.briefing_tick`` / ``settings`` / ``state`` were imported
+  here, which violated the documented core boundary).
+- The regenerate path wraps the provider call in a thread-pool timeout
+  so a slow provider surfaces as ``504 timeout`` rather than hanging
+  the request.
 
 Only one briefing type (``morning``) ships built-in today; the registry
 seam is honored so a future plugin can register additional types
@@ -192,144 +196,136 @@ class _BriefingAdapter:
         return self._regenerate(config, body)
 
 
-def _morning_available(config: Any) -> bool:  # noqa: ARG001 — registry is module-level
-    """Return True iff the morning-briefing plugin is registered.
+# Plugin name the morning briefing type is gated on. Kept as a route
+# module constant (rather than importing from
+# ``pollypm.briefings_bootstrap``) because this module's only contract
+# with the bootstrap is the registry's render-provider slot — we don't
+# want the route taking a hard dep on the bootstrap module.
+_MORNING_BRIEFING_PLUGIN_NAME = "morning_briefing"
+_MORNING_BRIEFING_TYPE_NAME = "morning"
 
-    The :mod:`pollypm.briefings_registry` seam holds the active provider
-    callable; ``None`` means the plugin tree isn't loaded (config didn't
-    enable the plugin, or ``[plugins].disabled`` includes
-    ``morning_briefing``) and the type is reported as ``available=false``
-    so clients know not to attempt regenerate. Uses the public
-    :func:`is_briefing_provider_registered` helper instead of reaching
-    into the module-private slot (Codex round-3 on PR #2059).
+
+def _artifact_to_response(
+    type_name: str,
+    artifact: Any,
+) -> BriefingResponse:
+    """Translate a registry :class:`BriefingArtifact` into the wire model."""
+    return BriefingResponse(
+        type=type_name,
+        generated_at=_parse_iso(artifact.generated_at or ""),
+        date_local=artifact.date_local or None,
+        mode=artifact.mode,
+        markdown=artifact.markdown,
+        metadata=dict(artifact.metadata or {}),
+    )
+
+
+def _morning_available(config: Any) -> bool:
+    """Return True iff the morning-briefing render provider is usable now.
+
+    Two gates:
+
+    1. ``config.plugins.disabled`` must not contain ``morning_briefing``.
+       This is the **per-request** disable check (Codex round-9 on
+       #2059): ``create_app`` reloads config every request (#2056),
+       so an operator editing ``pollypm.toml`` mid-run must see
+       ``available=false`` without restart even if the registry slot
+       is still populated from startup.
+    2. A render provider must be registered for the ``morning`` type
+       (the ``morning_briefing`` plugin's ``initialize`` hook /
+       :mod:`pollypm.briefings_bootstrap` installs it).
+
+    Both gates also indirectly cover the legacy
+    ``is_briefing_provider_registered`` semantics: when the plugin
+    bootstrap saw a disabled config it clears the registry slot, so
+    requirement (2) fails too. We check (1) explicitly so a request
+    that arrives between a config edit and the next bootstrap call
+    (in practice never happens — bootstrap runs at startup only —
+    but the contract should not depend on that ordering) still
+    reports correctly.
     """
-    from pollypm.briefings_registry import is_briefing_provider_registered
+    from pollypm.briefings_registry import (
+        get_briefing_render_provider,
+        is_plugin_disabled_in_config,
+    )
 
-    return is_briefing_provider_registered()
+    if is_plugin_disabled_in_config(config, _MORNING_BRIEFING_PLUGIN_NAME):
+        return False
+    return get_briefing_render_provider(_MORNING_BRIEFING_TYPE_NAME) is not None
 
 
 def _morning_render_last(config: Any) -> BriefingResponse | None:
-    """Read the newest morning briefing off disk (spec §9.1 ``last``)."""
-    from pollypm.plugins_builtin.morning_briefing import inbox as _inbox
+    """Read the newest morning briefing via the registered render provider.
 
-    base_dir = config.project.base_dir
-    entries = _inbox.list_briefings(base_dir, status="all", limit=1)
-    if not entries:
-        return None
-    entry = entries[0]
-    read = _inbox.read_briefing(base_dir, entry.date_local)
-    if read is None:
-        # The metadata json existed during list_briefings but the body
-        # disappeared between calls (rare — atomic-write replaces both;
-        # treat as missing so the caller can regenerate).
-        return None
-    _entry, markdown = read
-    return BriefingResponse(
-        type="morning",
-        generated_at=_parse_iso(_entry.created_at),
-        date_local=_entry.date_local,
-        mode=_entry.mode or None,
-        markdown=markdown,
-        metadata={
-            "status": _entry.status,
-            "pinned": _entry.pinned,
-            "yesterday": _entry.yesterday,
-            "priorities": list(_entry.priorities),
-            "watch": list(_entry.watch),
-            **dict(_entry.meta),
-        },
+    Honors the per-request plugin-disable check first (Codex round-9 on
+    #2059): a config flip to ``[plugins].disabled = ["morning_briefing"]``
+    must make render return ``None`` immediately, even if the registry
+    slot still references the previously-installed provider. The route
+    layer translates ``None`` into 404 / 503 per its existing rules.
+    """
+    from pollypm.briefings_registry import (
+        get_briefing_render_provider,
+        is_plugin_disabled_in_config,
     )
+
+    if is_plugin_disabled_in_config(config, _MORNING_BRIEFING_PLUGIN_NAME):
+        return None
+    provider = get_briefing_render_provider(_MORNING_BRIEFING_TYPE_NAME)
+    if provider is None:
+        return None
+    artifact = provider.render_last(config)
+    if artifact is None:
+        return None
+    return _artifact_to_response(_MORNING_BRIEFING_TYPE_NAME, artifact)
 
 
 def _morning_regenerate(config: Any, body: RegenerateRequest) -> BriefingResponse:
-    """Force-fire the morning briefing pipeline (spec §9.1 ``regenerate``).
+    """Force-fire the morning briefing via the registered render provider.
 
-    Mirrors ``pm briefing now`` (see
-    :mod:`pollypm.plugins_builtin.morning_briefing.cli`): runs the full
-    gather → synthesize → emit chain and writes to the inbox. The
-    ``project`` body field is rejected with 400 for the morning type —
-    morning briefings are whole-workspace only today (Phase 2 round-1
-    Codex feedback on #2059: the field used to be silently ignored,
-    which let a client think they'd narrowed scope when they hadn't).
+    Per-request plugin-disable check runs first (Codex round-9 on
+    #2059) — a disabled config returns 503 without ever calling into
+    the provider. ``ValueError`` from the provider (the morning
+    briefing's signal that ``project`` narrowing is not supported) is
+    translated into a typed 400; any other provider exception becomes
+    a 503 ``service_unavailable``.
     """
-    from pollypm.plugins_builtin.morning_briefing.handlers import (
-        briefing_tick as _tick,
+    from pollypm.briefings_registry import (
+        get_briefing_render_provider,
+        is_plugin_disabled_in_config,
     )
-    from pollypm.plugins_builtin.morning_briefing.settings import (
-        load_briefing_settings,
-    )
-    from pollypm.plugins_builtin.morning_briefing.state import load_state
-    from pollypm.config import DEFAULT_CONFIG_PATH, resolve_config_path
-    from pollypm.tz import get_timezone
 
-    if body.project is not None:
+    if is_plugin_disabled_in_config(config, _MORNING_BRIEFING_PLUGIN_NAME):
+        raise service_unavailable(
+            f"{_MORNING_BRIEFING_PLUGIN_NAME} is disabled in [plugins].disabled",
+            hint=(
+                "Remove `morning_briefing` from [plugins].disabled and "
+                "re-trigger; or rely on the next briefing tick."
+            ),
+        )
+    provider = get_briefing_render_provider(_MORNING_BRIEFING_TYPE_NAME)
+    if provider is None:
+        raise service_unavailable(
+            "morning briefing provider is not registered",
+            hint=(
+                "Enable the morning_briefing plugin and restart pm serve."
+            ),
+        )
+
+    try:
+        artifact = provider.regenerate(config, project=body.project)
+    except ValueError as exc:
+        # Spec §9.2: provider signals "project narrowing not supported"
+        # via ValueError. Translate to a typed 400 with the route's
+        # canonical hint (clients should omit `project` for morning).
         raise invalid_request(
-            "project-scoped morning briefings are not implemented",
+            str(exc) or "project-scoped morning briefings are not implemented",
             hint=(
                 "Omit the `project` field — the morning briefing is "
                 "always whole-workspace. Per-project briefings will land "
                 "with the plugin-contributed briefing types."
             ),
-        )
-
-    base_dir = config.project.base_dir
-    project_root = config.project.root_dir
-
-    # ``load_briefing_settings`` reads ``[briefing]`` overrides off the
-    # toml. Prefer the path the running ``pm serve`` actually loaded
-    # (``config.config_path``) so a non-default ``--config`` flag is
-    # honored. Falling back to ``DEFAULT_CONFIG_PATH`` keeps the path
-    # working in tests that construct ``PollyPMConfig`` directly without
-    # touching disk. (Codex round-1 P0 on #2059: the old code always
-    # read ``DEFAULT_CONFIG_PATH``, so ``pm serve --config /tmp/foo``
-    # would write into ``foo``'s ``base_dir`` while honoring the
-    # default global TOML's briefing hour/timezone/quiet-mode.)
-    config_path = getattr(config, "config_path", None) or DEFAULT_CONFIG_PATH
-    settings = load_briefing_settings(resolve_config_path(config_path))
-
-    fallback_tz = getattr(config.pollypm, "timezone", "") or ""
-    timezone = get_timezone(fallback_tz)
-    now_local = datetime.now(timezone)
-
-    state = load_state(base_dir)
-
-    result = _tick.fire_briefing(
-        project_root=project_root,
-        base_dir=base_dir,
-        settings=settings,
-        now_local=now_local,
-        state=state,
-        config=config,
-        emit_to_inbox=True,
-    )
-    if not isinstance(result, dict) or not result.get("fired"):
-        reason = (
-            str(result.get("reason"))
-            if isinstance(result, dict) else "unknown"
-        )
-        raise service_unavailable(
-            f"briefing regenerate did not fire ({reason})",
-            hint=(
-                "Check the morning_briefing plugin logs; the gather / "
-                "synthesize stage declined to produce a draft."
-            ),
-        )
-    draft = result.get("draft") or {}
-    return BriefingResponse(
-        type="morning",
-        generated_at=now_local.astimezone(UTC),
-        date_local=str(draft.get("date_local") or ""),
-        mode=str(draft.get("mode") or "") or None,
-        markdown=str(draft.get("markdown") or ""),
-        metadata={
-            "emitted_to_inbox": bool(result.get("emitted", False)),
-            "yesterday": draft.get("yesterday"),
-            "priorities": list(draft.get("priorities") or []),
-            "watch": list(draft.get("watch") or []),
-            "quiet_mode": bool(result.get("quiet_mode", False)),
-            **dict(draft.get("meta") or {}),
-        },
-    )
+        ) from exc
+    return _artifact_to_response(_MORNING_BRIEFING_TYPE_NAME, artifact)
 
 
 _REGISTRY: dict[str, _BriefingAdapter] = {

--- a/src/pollypm/web_api/routes/briefings.py
+++ b/src/pollypm/web_api/routes/briefings.py
@@ -143,10 +143,20 @@ class RegenerateRequest(BaseModel):
     """``POST /briefings/{type}/regenerate`` body.
 
     ``project`` narrows the regenerate scope to a single project key.
-    Today's morning briefing ignores it (it's always whole-workspace);
-    we accept the field for forward compatibility so plugin-contributed
-    briefing types (e.g. per-project weekly) don't need a body-schema
-    bump later.
+    Built-in ``morning`` rejects ``project`` with ``400 invalid_request``
+    — morning briefings are always whole-workspace, and silently
+    dropping the field would let a client think their per-project
+    request worked while the server force-generated a workspace-wide
+    inbox entry instead (Codex round-9 on #2059). Plugin-contributed
+    briefing types (e.g. per-project weekly) may consume ``project``
+    for per-project scope; consult the type's own documentation.
+
+    The docstring is intentionally part of the model: pydantic exposes
+    it via ``model_json_schema()["description"]`` which then surfaces
+    on the live ``/openapi.json``. Keep this paragraph in sync with the
+    static ``docs/api/openapi.yaml`` ``RegenerateBriefingRequest``
+    description so generated clients see the same contract on both
+    surfaces (Codex round-14 on #2059).
 
     ``extra='forbid'`` (Codex round-10 on #2059): a side-effecting
     endpoint must surface client typos as 422 rather than silently

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -32,6 +32,7 @@ from fastapi.testclient import TestClient
 from pollypm.config import (
     AccountConfig,
     MemorySettings,
+    PluginSettings,
     PollyPMConfig,
     PollyPMSettings,
     ProjectSettings,
@@ -674,3 +675,92 @@ def test_briefings_endpoint_available_in_default_create_app(
         "morning provider was not wired by create_app; "
         "render/regenerate would 503 in production"
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex round-3 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_morning_plugin_reports_unavailable(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+) -> None:
+    """`create_app` must honor ``[plugins].disabled`` before wiring.
+
+    Codex round-3 P0: round-2 wired the provider unconditionally, so a
+    config with ``[plugins].disabled = ["morning_briefing"]`` still
+    reported ``morning.available=true`` through the API — bypassing the
+    plugin host's filter-before-register contract. The disablement is
+    the operator rollback/recovery path; the API must not resurrect a
+    disabled plugin.
+
+    Asserts: with ``morning_briefing`` disabled in config,
+    ``GET /api/v1/briefings`` reports ``morning.available=false`` and
+    ``POST /api/v1/briefings/morning/regenerate`` returns 503
+    (service_unavailable).
+    """
+    # Restore the canonical morning adapter — earlier tests in this
+    # file mutate ``_REGISTRY["morning"]`` directly (without monkeypatch
+    # revert), leaving a stub whose ``available`` always returns True.
+    # We need the real ``_morning_available`` so this test exercises
+    # the production availability path.
+    from pollypm.web_api.routes import briefings as br
+    from pollypm.web_api.routes.briefings import (
+        _morning_available,
+        _morning_regenerate,
+        _morning_render_last,
+    )
+
+    br._REGISTRY["morning"] = br._BriefingAdapter(
+        name="morning",
+        description="Daily morning briefing — canonical adapter (test restore)",
+        available=_morning_available,
+        render_last=_morning_render_last,
+        regenerate=_morning_regenerate,
+    )
+
+    # Pre-seed a provider to prove disabled-config app clears it
+    # (the host's filter-before-register semantics — a previously
+    # enabled run's stale registration must not leak through).
+    from pollypm.briefings_registry import (
+        is_briefing_provider_registered,
+        register_briefing_provider,
+    )
+
+    def _stub_provider(_base, *, status="open", limit=None):  # noqa: ARG001
+        return []
+
+    register_briefing_provider(_stub_provider)
+    assert is_briefing_provider_registered()
+
+    api_config.plugins = PluginSettings(disabled=("morning_briefing",))
+
+    app = create_app(config=api_config, token_path=token_path)
+    client = TestClient(app)
+
+    # GET /api/v1/briefings — morning.available must be False
+    response = client.get("/api/v1/briefings", headers=auth_headers)
+    assert response.status_code == 200, response.json()
+    morning = next(
+        entry for entry in response.json()["types"] if entry["name"] == "morning"
+    )
+    assert morning["available"] is False, (
+        "morning provider was wired despite [plugins].disabled containing "
+        "morning_briefing — API bypassed the plugin-disable contract"
+    )
+
+    # POST /api/v1/briefings/morning/regenerate — 503 service_unavailable
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        json={},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503, response.json()
+    body = response.json()
+    assert body["error"]["code"] == "service_unavailable"
+
+    # Restore a clean registry for sibling tests that share module state.
+    register_briefing_provider(None)

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -135,9 +135,19 @@ def auth_headers(token: str) -> dict[str, str]:
 
 
 @pytest.fixture
-def client(api_config: PollyPMConfig, token_path: Path, token: str) -> TestClient:  # noqa: ARG001
+def client(
+    api_config: PollyPMConfig, token_path: Path, token: str,  # noqa: ARG001
+) -> Iterator[TestClient]:
+    """TestClient wired through ``with`` so the FastAPI lifespan fires.
+
+    Lifespan owns the briefings ThreadPoolExecutor + in-flight
+    registry on ``app.state`` (Codex round-4 on #2059). Without the
+    ``with`` block, ``TestClient`` skips startup/shutdown and the
+    regenerate endpoint would 503 on the missing executor.
+    """
     app = create_app(config=api_config, token_path=token_path)
-    return TestClient(app)
+    with TestClient(app) as test_client:
+        yield test_client
 
 
 # ---------------------------------------------------------------------------
@@ -184,21 +194,18 @@ def fake_state() -> _FakeAdapterState:
 
 @pytest.fixture(autouse=True)
 def _clear_briefing_inflight() -> "Iterator[None]":
-    """Reset the module-level in-flight registry between tests.
+    """No-op — the in-flight registry now lives on ``app.state``.
 
-    The regenerate endpoint dedupes concurrent runs by `(type, project)`
-    using a module-level dict; a previous test that triggered a 504
-    leaves the background thread running, which would 409 the next
-    request for the same scope. We drop the entry on teardown so each
-    test starts with a clean inflight table.
+    Previously a module-level dict in ``routes/briefings.py`` carried
+    in-flight regenerates across tests, so we needed to drop the entry
+    in setup/teardown to avoid 409-on-retry. With the lifespan-owned
+    registry (Codex round-4 on #2059) each ``client`` fixture builds a
+    fresh app whose ``app.state.briefing_inflight`` starts empty and
+    is cleared on lifespan exit, so cross-test bleed is impossible.
+    Kept as an empty fixture so the autouse signature stays stable for
+    any test that explicitly references it.
     """
-    from pollypm.web_api.routes import briefings as br
-
-    with br._INFLIGHT_LOCK:
-        br._INFLIGHT.clear()
     yield
-    with br._INFLIGHT_LOCK:
-        br._INFLIGHT.clear()
 
 
 @pytest.fixture
@@ -519,10 +526,10 @@ def test_briefings_uses_injected_config_not_default(
     )
 
     # Build a fresh client that uses the real ``_morning_regenerate``
-    # (no patched_registry fixture). The shared executor is module
-    # level, so we don't need to recreate it.
+    # (no patched_registry fixture). ``with TestClient(...)`` is
+    # required so the FastAPI lifespan boots the briefings executor on
+    # ``app.state`` (Codex round-4 on #2059).
     app = create_app(config=api_config, token_path=token_path)
-    client = TestClient(app)
 
     # Mark the morning provider as "available" without the real plugin
     # tree. Patch only the availability probe — render is unused here.
@@ -539,11 +546,12 @@ def test_briefings_uses_injected_config_not_default(
         regenerate=_morning_regenerate,
     )
 
-    response = client.post(
-        "/api/v1/briefings/morning/regenerate",
-        json={},
-        headers=auth_headers,
-    )
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/briefings/morning/regenerate",
+            json={},
+            headers=auth_headers,
+        )
     assert response.status_code == 200, response.json()
     # The stub captured at least one path. Crucially it must equal the
     # *custom* path, not the default ``~/.pollypm/pollypm.toml``.
@@ -618,13 +626,12 @@ def test_briefings_morning_rejects_project_param(
         regenerate=_morning_regenerate,
     )
     app = create_app(config=api_config, token_path=token_path)
-    client = TestClient(app)
-
-    response = client.post(
-        "/api/v1/briefings/morning/regenerate",
-        json={"project": "myproj"},
-        headers=auth_headers,
-    )
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/briefings/morning/regenerate",
+            json={"project": "myproj"},
+            headers=auth_headers,
+        )
     assert response.status_code == 400, response.json()
     body = response.json()
     assert body["error"]["code"] == "invalid_request"
@@ -664,9 +671,8 @@ def test_briefings_endpoint_available_in_default_create_app(
     register_briefing_provider(None)
 
     app = create_app(config=api_config, token_path=token_path)
-    client = TestClient(app)
-
-    response = client.get("/api/v1/briefings", headers=auth_headers)
+    with TestClient(app) as client:
+        response = client.get("/api/v1/briefings", headers=auth_headers)
     assert response.status_code == 200, response.json()
     morning = next(
         entry for entry in response.json()["types"] if entry["name"] == "morning"
@@ -739,28 +745,143 @@ def test_disabled_morning_plugin_reports_unavailable(
     api_config.plugins = PluginSettings(disabled=("morning_briefing",))
 
     app = create_app(config=api_config, token_path=token_path)
-    client = TestClient(app)
+    with TestClient(app) as client:
+        # GET /api/v1/briefings — morning.available must be False
+        response = client.get("/api/v1/briefings", headers=auth_headers)
+        assert response.status_code == 200, response.json()
+        morning = next(
+            entry for entry in response.json()["types"] if entry["name"] == "morning"
+        )
+        assert morning["available"] is False, (
+            "morning provider was wired despite [plugins].disabled containing "
+            "morning_briefing — API bypassed the plugin-disable contract"
+        )
 
-    # GET /api/v1/briefings — morning.available must be False
-    response = client.get("/api/v1/briefings", headers=auth_headers)
-    assert response.status_code == 200, response.json()
-    morning = next(
-        entry for entry in response.json()["types"] if entry["name"] == "morning"
-    )
-    assert morning["available"] is False, (
-        "morning provider was wired despite [plugins].disabled containing "
-        "morning_briefing — API bypassed the plugin-disable contract"
-    )
-
-    # POST /api/v1/briefings/morning/regenerate — 503 service_unavailable
-    response = client.post(
-        "/api/v1/briefings/morning/regenerate",
-        json={},
-        headers=auth_headers,
-    )
-    assert response.status_code == 503, response.json()
-    body = response.json()
-    assert body["error"]["code"] == "service_unavailable"
+        # POST /api/v1/briefings/morning/regenerate — 503 service_unavailable
+        response = client.post(
+            "/api/v1/briefings/morning/regenerate",
+            json={},
+            headers=auth_headers,
+        )
+        assert response.status_code == 503, response.json()
+        body = response.json()
+        assert body["error"]["code"] == "service_unavailable"
 
     # Restore a clean registry for sibling tests that share module state.
     register_briefing_provider(None)
+
+
+# ---------------------------------------------------------------------------
+# Codex round-4 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_briefings_executor_shut_down_on_app_teardown(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    fake_state: _FakeAdapterState,
+) -> None:
+    """The briefings executor + in-flight registry are torn down at exit.
+
+    Codex round-4 P0: the executor used to be a module-level global
+    with no FastAPI lifespan hook, so it outlived ``pm serve`` shutdown
+    and a slow regenerate kept its worker thread alive past app
+    teardown. The lifespan migration moves the executor onto
+    ``app.state`` and calls ``shutdown(wait=True, cancel_futures=True)``
+    on lifespan exit — this test exercises that contract.
+    """
+    from pollypm.web_api.routes import briefings as br
+
+    # Patch a stub adapter onto the module registry so the request
+    # path hits a controllable regenerate fn (no real plugin tree).
+    def _available(_config) -> bool:
+        return True
+
+    def _regenerate(_config, _body: RegenerateRequest) -> BriefingResponse:
+        # Sleep long enough that the in-flight future is still
+        # outstanding when we exit the lifespan context.
+        time.sleep(fake_state.regen_delay or 5.0)
+        return fake_state.regen
+
+    monkeypatch.setitem(
+        br._REGISTRY,
+        "morning",
+        _BriefingAdapter(
+            name="morning",
+            description="executor-teardown test",
+            available=_available,
+            render_last=lambda _c: None,
+            regenerate=_regenerate,
+        ),
+    )
+
+    fake_state.regen_delay = 30.0
+
+    app = create_app(config=api_config, token_path=token_path)
+
+    # Capture executor + inflight refs after startup so we can assert
+    # post-shutdown state outside the context manager.
+    executor_ref: list[Any] = []
+    inflight_ref: list[dict] = []
+
+    with TestClient(app) as client:
+        # Confirm the lifespan attached the executor / registry.
+        assert hasattr(app.state, "briefing_executor")
+        assert hasattr(app.state, "briefing_inflight")
+        executor_ref.append(app.state.briefing_executor)
+        inflight_ref.append(app.state.briefing_inflight)
+
+        # Fire a slow regenerate that we abandon via 504; the worker
+        # is still running when we exit the context.
+        response = client.post(
+            "/api/v1/briefings/morning/regenerate?timeout_seconds=1",
+            json={},
+            headers=auth_headers,
+        )
+        assert response.status_code == 504, response.json()
+
+        # The in-flight registry should hold the running future.
+        assert len(app.state.briefing_inflight) >= 0  # may have cleared if super fast
+
+    # After the lifespan exits:
+    # 1) the executor was shut down (no new submissions accepted)
+    assert executor_ref[0]._shutdown is True, (
+        "lifespan did not shut down the briefings executor"
+    )
+    # 2) the in-flight registry was cleared
+    assert inflight_ref[0] == {}, (
+        f"in-flight registry not cleared on shutdown: {inflight_ref[0]!r}"
+    )
+
+
+def test_briefings_inflight_isolated_per_app(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+) -> None:
+    """Two ``create_app`` instances get independent ``app.state`` registries.
+
+    Pins the module-globals → ``app.state`` migration: in-flight
+    bookkeeping on app A must not be visible to app B. Previously the
+    module-level dict was shared across every app in the process, which
+    would have let one ``pm serve`` invocation 409 a regenerate on a
+    sibling FastAPI app (e.g. tests, embedded uses).
+    """
+    app_a = create_app(config=api_config, token_path=token_path)
+    app_b = create_app(config=api_config, token_path=token_path)
+
+    with TestClient(app_a), TestClient(app_b):
+        # Distinct ThreadPoolExecutor + inflight + lock per app.
+        assert app_a.state.briefing_executor is not app_b.state.briefing_executor
+        assert app_a.state.briefing_inflight is not app_b.state.briefing_inflight
+        assert (
+            app_a.state.briefing_inflight_lock
+            is not app_b.state.briefing_inflight_lock
+        )
+
+        # Poking app_a's in-flight map must not leak into app_b.
+        app_a.state.briefing_inflight[("morning", "")] = object()  # type: ignore[assignment]
+        assert ("morning", "") not in app_b.state.briefing_inflight

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -1528,3 +1528,140 @@ def test_disabled_morning_plugin_per_request(
     finally:
         # Drop the global render provider so sibling tests start clean.
         register_briefing_render_provider("morning", None)
+
+
+# ---------------------------------------------------------------------------
+# Codex round-10 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_registered_briefing_types_surface_in_list_endpoint(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """Plugin-contributed types via the registry surface in ``GET /briefings``.
+
+    Codex round-10 on #2059: the route used to keep a private
+    ``_REGISTRY`` dict containing only ``"morning"``. Registering a
+    ``"weekly"`` provider via
+    :func:`pollypm.briefings_registry.register_briefing_render_provider`
+    would return ``("weekly",)`` from
+    :func:`registered_briefing_render_types`, but the route's list
+    endpoint and ``_lookup_type`` ignored it. With the round-10 fix the
+    registry is the single source of truth; this regression pins it.
+    """
+    from pollypm.briefings_registry import (
+        BriefingArtifact,
+        register_briefing_render_provider,
+    )
+
+    weekly_description = (
+        "Weekly digest — last 7 days of activity per project."
+    )
+
+    class _FakeWeeklyProvider:
+        def render_last(self, _config):  # type: ignore[no-untyped-def]
+            return None
+
+        def regenerate(self, _config, project=None):  # type: ignore[no-untyped-def]
+            return BriefingArtifact(
+                date_local="2026-05-22",
+                markdown="# Weekly\n",
+                mode="synthesized",
+            )
+
+    register_briefing_render_provider(
+        "weekly",
+        _FakeWeeklyProvider(),
+        description=weekly_description,
+        is_available=lambda _config: True,
+    )
+    try:
+        response = client.get("/api/v1/briefings", headers=auth_headers)
+        assert response.status_code == 200, response.json()
+        types_by_name = {
+            entry["name"]: entry for entry in response.json()["types"]
+        }
+        assert "weekly" in types_by_name, (
+            "register_briefing_render_provider('weekly', ...) should "
+            "make ``weekly`` show up in GET /briefings — the registry "
+            "is the single source of truth (Codex round-10 on #2059)."
+        )
+        assert types_by_name["weekly"]["description"] == weekly_description
+        assert types_by_name["weekly"]["available"] is True
+        # The morning override from ``patched_registry`` still wins for
+        # ``morning`` (test stubs beat plugin registrations).
+        assert "morning" in types_by_name
+    finally:
+        register_briefing_render_provider("weekly", None)
+
+
+def test_regenerate_rejects_unknown_field(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """``RegenerateRequest`` rejects unknown body fields with 422.
+
+    Codex round-10 on #2059: a typo like ``{"project_key": "myproj"}``
+    used to validate as ``{"project": None}`` and trigger a
+    whole-workspace regenerate — even though ``{"project": "myproj"}``
+    is intentionally rejected for the built-in ``morning`` type with a
+    400. For a side-effecting endpoint, unknown fields must surface as
+    422 instead of being silently dropped.
+    """
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        json={"project_key": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 422, response.json()
+    body = response.json()
+    # FastAPI / Pydantic v2 emits ``extra_forbidden`` in the error
+    # detail. We grep the rendered envelope rather than introspecting
+    # the precise FastAPI error shape so this still passes if the
+    # error envelope wrapper changes around the body.
+    rendered = repr(body).lower()
+    assert "extra_forbidden" in rendered or "extra fields" in rendered or "project_key" in rendered, (
+        "422 envelope should identify the unknown field "
+        "(``project_key``) or the ``extra_forbidden`` error type — "
+        f"got: {body!r}"
+    )
+
+
+def test_regenerate_request_schema_forbids_extras() -> None:
+    """Pin ``RegenerateBriefingRequest`` extras=forbid in runtime + static YAML.
+
+    Codex round-10 on #2059. Mirror of
+    ``tests/web_api/test_openapi_conformance.py::test_task_patch_request_schema_forbids_extras``
+    (#2064 round-12 / round-8 pattern): generated clients reading
+    ``docs/api/openapi.yaml`` must see ``additionalProperties: false``
+    on the regenerate request body so the typo
+    ``{"project_key": "myproj"}`` surfaces as a schema violation, not
+    a runtime-only 422. Runtime-vs-static parity is also pinned so a
+    future ``extra='allow'`` drift on either side trips here.
+    """
+    import yaml
+
+    contract_path = (
+        Path(__file__).resolve().parent.parent
+        / "docs" / "api" / "openapi.yaml"
+    )
+    contract = yaml.safe_load(contract_path.read_text())
+    static_schema = contract["components"]["schemas"]["RegenerateBriefingRequest"]
+    assert static_schema.get("additionalProperties") is False, (
+        "RegenerateBriefingRequest in docs/api/openapi.yaml must "
+        "declare ``additionalProperties: false`` to mirror the "
+        "runtime ``extra='forbid'`` config — generated clients would "
+        "otherwise treat unknown keys (e.g. ``project_key`` typo) as "
+        "valid even though the server returns 422 (#2059 round-10)."
+    )
+
+    runtime_schema = RegenerateRequest.model_json_schema()
+    assert runtime_schema.get("additionalProperties") is False, (
+        "Runtime RegenerateRequest no longer emits "
+        "``additionalProperties: false``. Restore "
+        "``model_config = {'extra': 'forbid'}`` on the Pydantic "
+        "model so the static YAML and the request validator agree."
+    )

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -1299,3 +1299,155 @@ def test_briefings_pm_serve_process_exits_with_wedged_worker(
         f"child took {elapsed:.1f}s; the wedged worker should not "
         f"have blocked interpreter exit past the lifespan grace."
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex round-9 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_web_api_does_not_import_plugins_builtin_directly() -> None:
+    """The Web API must consume briefings only through the registry seam.
+
+    Codex round-9 on #2059: previously ``web_api/app.py`` and
+    ``web_api/routes/briefings.py`` imported
+    ``pollypm.plugins_builtin.morning_briefing`` internals directly,
+    violating the core boundary documented at
+    ``briefings_registry.py:10-16`` and ``cli.py:201-207`` (``cli.py``
+    is the only sanctioned core → ``plugins_builtin`` edge for the
+    CLI; ``briefings_bootstrap.py`` is the matching sanctioned edge
+    for the Web API).
+
+    Greps every Python file under ``src/pollypm/web_api/`` and asserts
+    none of them imports ``pollypm.plugins_builtin``.
+    """
+    import re
+
+    web_api_root = Path(__file__).resolve().parent.parent / "src" / "pollypm" / "web_api"
+    assert web_api_root.is_dir(), web_api_root
+
+    # Match both ``from pollypm.plugins_builtin.X import ...`` and
+    # ``import pollypm.plugins_builtin.X``.
+    pattern = re.compile(
+        r"^\s*(?:from|import)\s+pollypm\.plugins_builtin\b",
+        re.MULTILINE,
+    )
+    offenders: list[tuple[Path, int, str]] = []
+    for path in sorted(web_api_root.rglob("*.py")):
+        text = path.read_text()
+        for match in pattern.finditer(text):
+            line_no = text[: match.start()].count("\n") + 1
+            offenders.append((path, line_no, match.group(0).strip()))
+
+    assert not offenders, (
+        "Web API modules must not import from pollypm.plugins_builtin "
+        "directly — go through pollypm.briefings_registry / "
+        "pollypm.briefings_bootstrap. Offenders:\n"
+        + "\n".join(f"  {p}:{ln}  {line}" for p, ln, line in offenders)
+    )
+
+
+def test_disabled_morning_plugin_per_request(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+) -> None:
+    """Plugin disablement must take effect per request, not per restart.
+
+    Codex round-9 on #2059: ``create_app`` reloads config every
+    request (Codex round-2 on #2056) but ``_wire_briefings_provider``
+    used to run only at startup, so flipping
+    ``[plugins].disabled = ["morning_briefing"]`` in ``pollypm.toml``
+    mid-run kept reporting ``morning.available=true`` (and 200 from
+    render/regenerate) until ``pm serve`` restarted. The fix:
+    ``_morning_available`` / ``_morning_render_last`` /
+    ``_morning_regenerate`` each call
+    :func:`pollypm.briefings_registry.is_plugin_disabled_in_config`
+    against the per-request ``ConfigDep`` config.
+
+    Test:
+    1. Build app with morning enabled — assert ``available=true``.
+    2. Override ``ConfigDep`` to return a config with
+       ``morning_briefing`` disabled.
+    3. WITHOUT restart, GET /api/v1/briefings →
+       ``morning.available=false``; POST regenerate → 503.
+    """
+    # Make sure the morning render provider IS registered (the test
+    # fixture for ``api_config`` does not set ``[plugins].disabled``,
+    # so ``create_app`` will install the provider).
+    from pollypm.briefings_registry import register_briefing_render_provider
+    from pollypm.web_api.routes import briefings as br
+    from pollypm.web_api.routes._deps import _config_provider
+
+    # Restore canonical adapter in case a sibling test mutated it.
+    br._REGISTRY["morning"] = br._BriefingAdapter(
+        name="morning",
+        description="Daily morning briefing — canonical adapter (test restore)",
+        available=br._morning_available,
+        render_last=br._morning_render_last,
+        regenerate=br._morning_regenerate,
+    )
+
+    app = create_app(config=api_config, token_path=token_path)
+    try:
+        with TestClient(app) as client:
+            # 1) Baseline: morning enabled → available=true
+            response = client.get("/api/v1/briefings", headers=auth_headers)
+            assert response.status_code == 200, response.json()
+            morning = next(
+                entry for entry in response.json()["types"]
+                if entry["name"] == "morning"
+            )
+            assert morning["available"] is True, (
+                "Morning provider was not wired at app startup — test "
+                "setup is wrong (need the bootstrap to install the "
+                "render provider)."
+            )
+
+            # 2) Flip [plugins].disabled on the per-request config
+            # WITHOUT touching the registry. The route's per-request
+            # disable check must downgrade availability immediately.
+            disabled_config = PollyPMConfig(
+                project=api_config.project,
+                pollypm=api_config.pollypm,
+                accounts=api_config.accounts,
+                sessions=api_config.sessions,
+                projects=api_config.projects,
+                memory=api_config.memory,
+                plugins=PluginSettings(disabled=("morning_briefing",)),
+            )
+            app.dependency_overrides[_config_provider] = lambda: disabled_config
+
+            # 3) GET /api/v1/briefings → morning.available=false
+            response = client.get("/api/v1/briefings", headers=auth_headers)
+            assert response.status_code == 200, response.json()
+            morning = next(
+                entry for entry in response.json()["types"]
+                if entry["name"] == "morning"
+            )
+            assert morning["available"] is False, (
+                "morning_briefing was added to [plugins].disabled "
+                "mid-run but the API still reports available=true — "
+                "the per-request plugin-disable check is not running."
+            )
+
+            # POST regenerate → 503 service_unavailable
+            response = client.post(
+                "/api/v1/briefings/morning/regenerate",
+                json={},
+                headers=auth_headers,
+            )
+            assert response.status_code == 503, response.json()
+            assert response.json()["error"]["code"] == "service_unavailable"
+
+            # Render (GET /api/v1/briefings/morning) also 503s — the
+            # availability gate fails the same way.
+            response = client.get(
+                "/api/v1/briefings/morning", headers=auth_headers,
+            )
+            assert response.status_code == 503, response.json()
+            assert response.json()["error"]["code"] == "service_unavailable"
+    finally:
+        # Drop the global render provider so sibling tests start clean.
+        register_briefing_render_provider("morning", None)

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -1817,3 +1817,138 @@ def test_disabled_morning_plugin_via_bootstrap_path(
             assert response.json()["error"]["code"] == "service_unavailable"
     finally:
         register_briefing_render_provider("morning", None)
+
+
+# ---------------------------------------------------------------------------
+# Codex round-14 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_clears_registry_on_morning_import_failure(
+    api_config: PollyPMConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failed bootstrap import must clear any pre-existing registration.
+
+    Codex round-14 on #2059: the ``except`` path used to only log and
+    return, leaving a stale provider (from an earlier app instance, a
+    test that pre-seeded the slot, or a plugin host run that fired
+    before bootstrap) installed. ``GET /briefings`` then continued
+    reporting ``morning.available=true`` against the stale provider
+    while the operator saw only the warning in logs.
+
+    This test pre-registers a stub, forces the morning_briefing
+    inbox import to raise during bootstrap, and asserts the registry
+    has been cleared for BOTH the inbox-list provider and the
+    render-provider slot.
+    """
+    from pollypm import briefings_bootstrap as bb
+    from pollypm.briefings_registry import (
+        BriefingArtifact,
+        get_briefing_render_provider,
+        is_briefing_provider_registered,
+        register_briefing_provider,
+        register_briefing_render_provider,
+    )
+
+    class _StubRenderProvider:
+        def render_last(self, _config):
+            return None
+
+        def regenerate(self, _config, project=None):  # noqa: ARG002
+            return BriefingArtifact(date_local="2026-05-22", markdown="")
+
+    def _stub_list_briefings(_base_dir, *, status="open", limit=None):  # noqa: ARG001
+        return []
+
+    # Pre-seed BOTH registry slots so we can detect them surviving the
+    # failed bootstrap.
+    register_briefing_provider(_stub_list_briefings)
+    register_briefing_render_provider(
+        "morning",
+        _StubRenderProvider(),
+        description="stub from a previous run",
+        is_available=lambda _cfg: True,
+    )
+
+    try:
+        assert is_briefing_provider_registered() is True
+        assert get_briefing_render_provider("morning") is not None
+
+        # Force the import inside the bootstrap try-block to raise. The
+        # try block imports from ``pollypm.plugins_builtin.morning_briefing.inbox``
+        # first; sabotaging that module's attribute lookup is enough to
+        # trigger the except path.
+        import sys
+
+        import pollypm.plugins_builtin.morning_briefing.inbox as inbox_mod
+
+        original_list = getattr(inbox_mod, "list_briefings", None)
+        try:
+            monkeypatch.delattr(inbox_mod, "list_briefings", raising=False)
+            # Make the ``from ... import list_briefings`` fail by
+            # ensuring re-imports of the inbox module also lack the
+            # attribute. Pop any cached attribute and force reload-on-
+            # next-import is heavy; deleting the attribute is enough
+            # because the ``from M import X`` statement re-binds X
+            # from the live module object after it's loaded.
+            bb.bootstrap_builtin_briefings(api_config)
+        finally:
+            # Restore so other tests in the file (and subsequent test
+            # files in the session) aren't poisoned.
+            if original_list is not None:
+                inbox_mod.list_briefings = original_list  # type: ignore[attr-defined]
+            sys.modules.pop("pollypm.plugins_builtin.morning_briefing.inbox", None)
+
+        # Both registry slots must be empty — the stale stub MUST NOT
+        # survive a failed bootstrap.
+        assert is_briefing_provider_registered() is False, (
+            "bootstrap import failure left a stale inbox-list provider "
+            "installed; GET /briefings would keep reporting "
+            "morning.available=true against the wrong provider."
+        )
+        assert get_briefing_render_provider("morning") is None, (
+            "bootstrap import failure left a stale render provider "
+            "installed; render/regenerate would run against the wrong "
+            "provider after the operator saw a warning in logs."
+        )
+    finally:
+        # Belt-and-suspenders cleanup for the rest of the suite.
+        register_briefing_provider(None)
+        register_briefing_render_provider("morning", None)
+
+
+def test_regenerate_request_docstring_says_morning_rejects_project() -> None:
+    """``RegenerateRequest`` model description must say morning rejects ``project``.
+
+    Codex round-14 on #2059: pydantic exposes the class docstring via
+    ``model_json_schema()["description"]``, which then surfaces on the
+    live ``/openapi.json``. The previous docstring said morning
+    "ignores" ``project`` — contradicting both the static
+    ``docs/api/openapi.yaml`` and actual runtime behavior (the morning
+    adapter raises ``400 invalid_request`` when ``project`` is set).
+    Generated clients reading the live spec saw the wrong contract.
+
+    This pin asserts the runtime schema's ``description`` field
+    accurately documents the rejection so a future drift back to
+    "ignores" trips here.
+    """
+    schema = RegenerateRequest.model_json_schema()
+    description = schema.get("description", "") or ""
+    lowered = description.lower()
+    assert "morning" in lowered, (
+        "RegenerateRequest description should mention morning by name "
+        "so clients reading /openapi.json see which built-in type "
+        "rejects project."
+    )
+    assert "reject" in lowered or "400" in lowered, (
+        "RegenerateRequest description should say morning REJECTS "
+        "project (or returns 400) — saying it 'ignores' the field "
+        f"contradicts runtime behavior. Got: {description!r}"
+    )
+    # Drift guard against the old wording.
+    assert "ignore" not in lowered, (
+        "RegenerateRequest description still says morning 'ignores' "
+        "project — runtime returns 400 invalid_request when project "
+        f"is set on morning. Got: {description!r}"
+    )

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -561,6 +561,83 @@ def test_briefings_uses_injected_config_not_default(
     assert captured_paths[0] == custom_toml.resolve()
 
 
+def test_regenerate_uses_briefing_settings_timezone_first(
+    api_config: PollyPMConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Regenerate must honor ``[briefing].timezone`` over ``[pollypm].timezone``.
+
+    Codex round-10 P0 on PR #2059: the API regenerate path computed
+    ``now_local`` from ``config.pollypm.timezone`` only, while the CLI
+    (``cli.py:_current_local_now``) and the scheduled tick
+    (``handlers/briefing_tick.py:_local_now`` /
+    ``_resolve_timezone``) prefer ``settings.timezone`` first and fall
+    back to the global ``[pollypm]`` timezone. With
+    ``[pollypm].timezone="UTC"`` and
+    ``[briefing].timezone="America/Los_Angeles"`` the API would render
+    against the wrong local day / quiet-mode window.
+
+    This regression captures the ``now_local`` argument the facade
+    passes to ``fire_briefing`` and asserts the timezone is the
+    briefing override, not the global fallback. It FAILS on the
+    round-9 head (tzinfo == UTC).
+    """
+    from zoneinfo import ZoneInfo
+
+    from pollypm.plugins_builtin.morning_briefing.render_facade import (
+        MorningBriefingRenderProvider,
+    )
+    from pollypm.plugins_builtin.morning_briefing.settings import (
+        BriefingSettings,
+    )
+
+    # Global TZ is UTC, briefing override is LA.
+    api_config.pollypm.timezone = "UTC"
+    api_config.config_path = tmp_path / "pollypm.toml"
+    api_config.config_path.write_text("")
+
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.morning_briefing.settings.load_briefing_settings",
+        lambda _path: BriefingSettings(timezone="America/Los_Angeles"),
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _fake_fire(**kwargs: Any) -> dict[str, Any]:
+        captured["now_local"] = kwargs["now_local"]
+        return {
+            "fired": True,
+            "emitted": False,
+            "draft": {
+                "date_local": "2026-05-22",
+                "mode": "test",
+                "markdown": "x",
+            },
+        }
+
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.morning_briefing.handlers.briefing_tick.fire_briefing",
+        _fake_fire,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.morning_briefing.state.load_state",
+        lambda _base: None,
+    )
+
+    artifact = MorningBriefingRenderProvider().regenerate(api_config)
+    assert artifact is not None
+
+    now_local = captured.get("now_local")
+    assert now_local is not None, "fire_briefing was not invoked"
+    # The briefing override wins — tzinfo must be Los_Angeles, not UTC.
+    assert now_local.tzinfo == ZoneInfo("America/Los_Angeles"), (
+        f"expected America/Los_Angeles, got {now_local.tzinfo!r}; "
+        "[briefing].timezone must take precedence over [pollypm].timezone "
+        "(parity with pm briefing now / scheduled tick)"
+    )
+
+
 def test_briefings_regenerate_timeout_is_non_blocking(
     client: TestClient,
     auth_headers: dict[str, str],

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -1,0 +1,434 @@
+"""Phase 2 §9 — briefings endpoint tests.
+
+Run via::
+
+    pytest --noconftest tests/test_briefings_endpoint.py -v --timeout=120
+
+The ``--noconftest`` flag skips the repo's heavy conftest (which spins
+up pg pools etc.); every fixture this test needs is defined inline.
+
+Coverage targets the three endpoints from
+``~/Desktop/pollypm-phase2-endpoints-spec.md`` §9:
+
+- ``GET /api/v1/briefings`` — list types
+- ``GET /api/v1/briefings/{type_name}`` — render last generated
+- ``POST /api/v1/briefings/{type_name}/regenerate`` — force regen
+
+The morning-briefing plugin's regenerate pipeline is fully mocked — we
+swap the adapter's callables for in-memory stubs so the tests never
+touch pg, git, or any LLM call.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.models import (
+    KnownProject,
+    ProjectKind,
+    ProviderKind,
+    RuntimeKind,
+)
+from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.routes import briefings as briefings_routes
+from pollypm.web_api.routes.briefings import (
+    BriefingResponse,
+    RegenerateRequest,
+    _BriefingAdapter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Config / app fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def api_config(project_root: Path, workspace_root: Path) -> PollyPMConfig:
+    base_dir = workspace_root / ".pollypm"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace_root,
+            tmux_session="pollypm-test",
+            workspace_root=workspace_root,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def token_path(tmp_path: Path) -> Path:
+    return tmp_path / "api-token"
+
+
+@pytest.fixture
+def token(token_path: Path) -> str:
+    value, _ = ensure_token(token_path)
+    return value
+
+
+@pytest.fixture
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def client(api_config: PollyPMConfig, token_path: Path, token: str) -> TestClient:  # noqa: ARG001
+    app = create_app(config=api_config, token_path=token_path)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Registry stubs
+# ---------------------------------------------------------------------------
+
+
+def _make_response(
+    *,
+    type_name: str = "morning",
+    markdown: str = "# Today\n\nThings happened.",
+    mode: str = "synthesized",
+    date_local: str = "2026-05-22",
+    metadata: dict | None = None,
+) -> BriefingResponse:
+    return BriefingResponse(
+        type=type_name,
+        generated_at=datetime(2026, 5, 22, 6, 30, 0, tzinfo=UTC),
+        date_local=date_local,
+        mode=mode,
+        markdown=markdown,
+        metadata=metadata or {"yesterday": "Test day", "priorities": []},
+    )
+
+
+class _FakeAdapterState:
+    """Mutable knobs the test fixture exposes for the patched adapter."""
+
+    def __init__(self) -> None:
+        self.available: bool = True
+        self.render: BriefingResponse | None = _make_response()
+        self.regen: BriefingResponse = _make_response(
+            markdown="# Regenerated\n\nFresh body.",
+        )
+        self.regen_delay: float = 0.0
+        self.regen_raise: BaseException | None = None
+
+
+@pytest.fixture
+def fake_state() -> _FakeAdapterState:
+    """Mutable adapter-control state shared across the test + the fixture."""
+    return _FakeAdapterState()
+
+
+@pytest.fixture
+def patched_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_state: _FakeAdapterState,
+) -> dict[str, _BriefingAdapter]:
+    """Install a controllable registry for tests.
+
+    The :class:`_FakeAdapterState` returned by :func:`fake_state` is the
+    knob clients tweak to drive behavior (timeout, unavailable, raise).
+    """
+
+    def _available(_config) -> bool:
+        return fake_state.available
+
+    def _render(_config) -> BriefingResponse | None:
+        return fake_state.render
+
+    def _regenerate(_config, _body: RegenerateRequest) -> BriefingResponse:
+        if fake_state.regen_delay > 0:
+            time.sleep(fake_state.regen_delay)
+        if fake_state.regen_raise is not None:
+            raise fake_state.regen_raise
+        return fake_state.regen
+
+    fake = _BriefingAdapter(
+        name="morning",
+        description="Test morning briefing",
+        available=_available,
+        render_last=_render,
+        regenerate=_regenerate,
+    )
+    registry: dict[str, _BriefingAdapter] = {"morning": fake}
+    monkeypatch.setattr(briefings_routes, "_REGISTRY", registry)
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_briefing_types(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """GET /api/v1/briefings returns the registry shape."""
+    response = client.get("/api/v1/briefings", headers=auth_headers)
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert "types" in body
+    assert isinstance(body["types"], list)
+    names = {entry["name"] for entry in body["types"]}
+    assert "morning" in names
+    morning = next(entry for entry in body["types"] if entry["name"] == "morning")
+    assert morning["available"] is True
+    assert "description" in morning and morning["description"]
+
+
+def test_list_briefing_types_marks_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+    fake_state: _FakeAdapterState,
+) -> None:
+    """A registered-but-not-loaded provider reports available=False."""
+    fake_state.available = False
+    response = client.get("/api/v1/briefings", headers=auth_headers)
+    assert response.status_code == 200
+    morning = next(
+        entry for entry in response.json()["types"] if entry["name"] == "morning"
+    )
+    assert morning["available"] is False
+
+
+def test_render_existing_briefing(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """GET /api/v1/briefings/morning returns the cached briefing body."""
+    response = client.get("/api/v1/briefings/morning", headers=auth_headers)
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["type"] == "morning"
+    assert body["markdown"].startswith("# Today")
+    assert body["date_local"] == "2026-05-22"
+    assert body["mode"] == "synthesized"
+    assert isinstance(body["metadata"], dict)
+
+
+def test_render_unknown_type_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """Unknown briefing types are a 404 ``not_found``."""
+    response = client.get("/api/v1/briefings/nonsense", headers=auth_headers)
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "not_found"
+    assert "nonsense" in body["error"]["message"]
+
+
+def test_render_missing_briefing_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+    fake_state: _FakeAdapterState,
+) -> None:
+    """No cached briefing on disk → 404 with a regenerate hint."""
+    fake_state.render = None
+    response = client.get("/api/v1/briefings/morning", headers=auth_headers)
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "not_found"
+    # Hint points the client at the regenerate verb.
+    assert "regenerate" in body["error"].get("hint", "").lower()
+
+
+def test_render_unavailable_provider_returns_503(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+    fake_state: _FakeAdapterState,
+) -> None:
+    """When provider isn't loaded, render returns 503 service_unavailable."""
+    fake_state.available = False
+    response = client.get("/api/v1/briefings/morning", headers=auth_headers)
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["code"] == "service_unavailable"
+
+
+def test_regenerate_happy_path_sync(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """POST regenerate returns the freshly produced briefing body."""
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        json={},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["type"] == "morning"
+    assert body["markdown"].startswith("# Regenerated")
+
+
+def test_regenerate_accepts_empty_body(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """Body is optional — clients can omit JSON entirely."""
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["type"] == "morning"
+
+
+def test_regenerate_rejects_blank_project_field(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """Empty-string project is a client bug; surface as 400."""
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        json={"project": "   "},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+
+
+def test_regenerate_timeout_returns_504(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+    fake_state: _FakeAdapterState,
+) -> None:
+    """Slow regenerate exceeds the budget → 504 ``timeout``."""
+    fake_state.regen_delay = 2.0
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate?timeout_seconds=1",
+        json={},
+        headers=auth_headers,
+    )
+    assert response.status_code == 504, response.json()
+    body = response.json()
+    assert body["error"]["code"] == "timeout"
+    assert "regenerate" in body["error"]["message"]
+
+
+def test_regenerate_unknown_type_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """Regenerate against an unknown type is 404."""
+    response = client.post(
+        "/api/v1/briefings/nope/regenerate",
+        json={},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_regenerate_provider_exception_returns_503(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+    fake_state: _FakeAdapterState,
+) -> None:
+    """Provider raises → 503 service_unavailable (not 500)."""
+    fake_state.regen_raise = RuntimeError("herald exploded")
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        json={},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["code"] == "service_unavailable"
+
+
+def test_auth_required_for_all_briefings_routes(
+    client: TestClient,
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+) -> None:
+    """Every briefings route demands a bearer token (spec §2.1)."""
+    no_auth: dict[str, str] = {}
+    # list
+    response = client.get("/api/v1/briefings", headers=no_auth)
+    assert response.status_code == 401
+    # render
+    response = client.get("/api/v1/briefings/morning", headers=no_auth)
+    assert response.status_code == 401
+    # regenerate
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        json={},
+        headers=no_auth,
+    )
+    assert response.status_code == 401

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -1450,21 +1450,15 @@ def test_disabled_morning_plugin_per_request(
     3. WITHOUT restart, GET /api/v1/briefings →
        ``morning.available=false``; POST regenerate → 503.
     """
-    # Make sure the morning render provider IS registered (the test
-    # fixture for ``api_config`` does not set ``[plugins].disabled``,
-    # so ``create_app`` will install the provider).
+    # Exercise the REAL bootstrap path (no ``_REGISTRY`` monkeypatch —
+    # Codex round-13 on #2059: monkeypatching ``br._REGISTRY`` masked the
+    # missing ``is_available`` kwarg in ``bootstrap_builtin_briefings``
+    # because the route's legacy ``_morning_available`` always re-checked
+    # config. With the registry as single source of truth the kwarg must
+    # flow through bootstrap).
     from pollypm.briefings_registry import register_briefing_render_provider
-    from pollypm.web_api.routes import briefings as br
+    from pollypm.web_api.routes import briefings as br  # noqa: F401
     from pollypm.web_api.routes._deps import _config_provider
-
-    # Restore canonical adapter in case a sibling test mutated it.
-    br._REGISTRY["morning"] = br._BriefingAdapter(
-        name="morning",
-        description="Daily morning briefing — canonical adapter (test restore)",
-        available=br._morning_available,
-        render_last=br._morning_render_last,
-        regenerate=br._morning_regenerate,
-    )
 
     app = create_app(config=api_config, token_path=token_path)
     try:
@@ -1710,3 +1704,116 @@ def test_regenerate_request_schema_declares_additional_properties_false() -> Non
     runtime_schema = RegenerateRequest.model_json_schema()
     assert static_schema.get("additionalProperties") is False
     assert runtime_schema.get("additionalProperties") is False
+
+
+# ---------------------------------------------------------------------------
+# Codex round-13 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_briefings_passes_is_available_callback(
+    api_config: PollyPMConfig,
+) -> None:
+    """``bootstrap_builtin_briefings`` must pass ``is_available`` AND
+    ``description`` through to ``register_briefing_render_provider``.
+
+    Codex round-13 on #2059: without ``is_available`` the registry's
+    ``_default_is_available`` returns ``True`` unconditionally and the
+    per-request ``[plugins].disabled`` gate never runs in production —
+    even though the plugin's own ``_initialize`` (which only runs when
+    the full plugin host boots, NOT in ``pm serve``) wires the adapter
+    correctly. This pin captures the kwargs the bootstrap forwards.
+    """
+    from pollypm import briefings_bootstrap as bb
+
+    captured: dict[str, object] = {}
+
+    def _capture(name, provider, *, description="", is_available=None):
+        captured["name"] = name
+        captured["provider"] = provider
+        captured["description"] = description
+        captured["is_available"] = is_available
+
+    # Patch on the bootstrap module — it imports the symbol by name.
+    import pytest as _pytest
+
+    with _pytest.MonkeyPatch.context() as mp:
+        mp.setattr(bb, "register_briefing_render_provider", _capture)
+        bb.bootstrap_builtin_briefings(api_config)
+
+    assert captured.get("name") == "morning"
+    assert captured.get("is_available") is not None, (
+        "bootstrap_builtin_briefings did not pass is_available — the "
+        "per-request plugin-disable gate will not run in production."
+    )
+    assert callable(captured["is_available"])
+    assert captured.get("description"), (
+        "bootstrap_builtin_briefings did not pass a non-empty "
+        "description — GET /briefings will surface an empty blurb."
+    )
+
+
+def test_disabled_morning_plugin_via_bootstrap_path(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+) -> None:
+    """Production bootstrap + disabled config ⇒ ``morning.available=false``.
+
+    End-to-end companion to
+    :func:`test_bootstrap_briefings_passes_is_available_callback`:
+    drives the registry through the real bootstrap (no monkeypatch on
+    ``br._REGISTRY``) and asserts the per-request disable gate
+    downgrades availability. Round-12 head fails this because
+    ``bootstrap_builtin_briefings`` omitted the ``is_available`` kwarg
+    so the registry's default-True adapter swallowed the disabled flag.
+    """
+    from pollypm.briefings_registry import register_briefing_render_provider
+    from pollypm.web_api.routes._deps import _config_provider
+
+    app = create_app(config=api_config, token_path=token_path)
+    try:
+        with TestClient(app) as client:
+            # Baseline: enabled config registers via bootstrap.
+            response = client.get("/api/v1/briefings", headers=auth_headers)
+            assert response.status_code == 200, response.json()
+            morning = next(
+                entry for entry in response.json()["types"]
+                if entry["name"] == "morning"
+            )
+            assert morning["available"] is True
+
+            # Flip [plugins].disabled per request — same registry slot.
+            disabled_config = PollyPMConfig(
+                project=api_config.project,
+                pollypm=api_config.pollypm,
+                accounts=api_config.accounts,
+                sessions=api_config.sessions,
+                projects=api_config.projects,
+                memory=api_config.memory,
+                plugins=PluginSettings(disabled=("morning_briefing",)),
+            )
+            app.dependency_overrides[_config_provider] = lambda: disabled_config
+
+            response = client.get("/api/v1/briefings", headers=auth_headers)
+            assert response.status_code == 200, response.json()
+            morning = next(
+                entry for entry in response.json()["types"]
+                if entry["name"] == "morning"
+            )
+            assert morning["available"] is False, (
+                "Production bootstrap path failed to wire is_available — "
+                "per-request plugin-disable gate did not flip availability."
+            )
+
+            # Render + regenerate also 503 through the registry-driven adapter.
+            response = client.post(
+                "/api/v1/briefings/morning/regenerate",
+                json={},
+                headers=auth_headers,
+            )
+            assert response.status_code == 503, response.json()
+            assert response.json()["error"]["code"] == "service_unavailable"
+    finally:
+        register_briefing_render_provider("morning", None)

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -1665,3 +1665,48 @@ def test_regenerate_request_schema_forbids_extras() -> None:
         "``model_config = {'extra': 'forbid'}`` on the Pydantic "
         "model so the static YAML and the request validator agree."
     )
+
+
+def test_regenerate_request_forbids_extras_runtime() -> None:
+    """Direct ``model_validate`` rejects unknown keys.
+
+    Codex round-11/12 on #2059 reported the HTTP-level
+    ``test_regenerate_rejects_unknown_field`` test as insufficient —
+    they wanted a direct ``RegenerateRequest.model_validate({...})``
+    regression that does not depend on FastAPI's request pipeline. The
+    HTTP envelope test stays (it covers the full 422 surface); this
+    pins the underlying Pydantic config so a future drift to
+    ``extra='ignore'`` or ``extra='allow'`` fails here even if FastAPI
+    swallows the violation upstream.
+    """
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as excinfo:
+        RegenerateRequest.model_validate({"projectt": "myproj"})
+    # ``extra_forbidden`` is the Pydantic v2 error type — pin it so a
+    # regression to ``extra='allow'`` (which would emit a different
+    # error class or none at all) trips here.
+    assert any(
+        err.get("type") == "extra_forbidden" for err in excinfo.value.errors()
+    ), excinfo.value.errors()
+
+
+def test_regenerate_request_schema_declares_additional_properties_false() -> None:
+    """Static + runtime ``additionalProperties: false`` parity.
+
+    Codex round-11/12 wanted the parity assertion stated as a
+    standalone test (rather than tucked inside
+    ``test_regenerate_request_schema_forbids_extras``) so a YAML-only
+    or runtime-only drift produces a clearly labelled failure.
+    """
+    import yaml
+
+    contract_path = (
+        Path(__file__).resolve().parent.parent
+        / "docs" / "api" / "openapi.yaml"
+    )
+    contract = yaml.safe_load(contract_path.read_text())
+    static_schema = contract["components"]["schemas"]["RegenerateBriefingRequest"]
+    runtime_schema = RegenerateRequest.model_json_schema()
+    assert static_schema.get("additionalProperties") is False
+    assert runtime_schema.get("additionalProperties") is False

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -1828,7 +1828,7 @@ def test_bootstrap_clears_registry_on_morning_import_failure(
     api_config: PollyPMConfig,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Failed bootstrap import must clear any pre-existing registration.
+    """Failed bootstrap import must replace stale provider with a known-disabled stub.
 
     Codex round-14 on #2059: the ``except`` path used to only log and
     return, leaving a stale provider (from an earlier app instance, a
@@ -1837,15 +1837,25 @@ def test_bootstrap_clears_registry_on_morning_import_failure(
     reporting ``morning.available=true`` against the stale provider
     while the operator saw only the warning in logs.
 
-    This test pre-registers a stub, forces the morning_briefing
-    inbox import to raise during bootstrap, and asserts the registry
-    has been cleared for BOTH the inbox-list provider and the
-    render-provider slot.
+    Codex round-15 on #2059 tightened the contract: instead of clearing
+    the render slot (which makes ``morning`` look like an UNKNOWN
+    briefing type — 404), the except path now installs a stub whose
+    ``is_available`` returns False so the type stays DISCOVERABLE via
+    ``GET /briefings`` (with ``available=false``) and render/regenerate
+    return a typed 503 ``service_unavailable``.
+
+    This test pre-registers a working stub, forces the morning_briefing
+    inbox import to raise during bootstrap, and asserts:
+    - The inbox-list provider slot is cleared (dashboard banner gone).
+    - The render slot holds a replacement provider whose
+      ``is_available`` returns ``False`` (so ``morning`` is known-
+      disabled, not unknown).
     """
     from pollypm import briefings_bootstrap as bb
     from pollypm.briefings_registry import (
         BriefingArtifact,
         get_briefing_render_provider,
+        get_briefing_render_registration,
         is_briefing_provider_registered,
         register_briefing_provider,
         register_briefing_render_provider,
@@ -1873,7 +1883,9 @@ def test_bootstrap_clears_registry_on_morning_import_failure(
 
     try:
         assert is_briefing_provider_registered() is True
-        assert get_briefing_render_provider("morning") is not None
+        prior = get_briefing_render_provider("morning")
+        assert prior is not None
+        assert isinstance(prior, _StubRenderProvider)
 
         # Force the import inside the bootstrap try-block to raise. The
         # try block imports from ``pollypm.plugins_builtin.morning_briefing.inbox``
@@ -1900,22 +1912,145 @@ def test_bootstrap_clears_registry_on_morning_import_failure(
                 inbox_mod.list_briefings = original_list  # type: ignore[attr-defined]
             sys.modules.pop("pollypm.plugins_builtin.morning_briefing.inbox", None)
 
-        # Both registry slots must be empty — the stale stub MUST NOT
-        # survive a failed bootstrap.
+        # The inbox-list provider must be cleared (dashboard banner gone).
         assert is_briefing_provider_registered() is False, (
             "bootstrap import failure left a stale inbox-list provider "
-            "installed; GET /briefings would keep reporting "
-            "morning.available=true against the wrong provider."
+            "installed; the dashboard would keep rendering the banner "
+            "against a stale provider."
         )
-        assert get_briefing_render_provider("morning") is None, (
-            "bootstrap import failure left a stale render provider "
-            "installed; render/regenerate would run against the wrong "
+
+        # The render slot must hold the replacement stub (NOT the
+        # original stale provider, and NOT cleared to None).
+        replacement = get_briefing_render_provider("morning")
+        assert replacement is not None, (
+            "bootstrap import failure cleared the render slot — "
+            "``morning`` will now appear as an UNKNOWN briefing type "
+            "(404) instead of known-but-disabled (Codex round-15)."
+        )
+        assert not isinstance(replacement, _StubRenderProvider), (
+            "bootstrap import failure left the stale stub provider in "
+            "place; render/regenerate would run against the wrong "
             "provider after the operator saw a warning in logs."
+        )
+
+        # The replacement's is_available must return False so the route
+        # layer's discovery / render / regenerate paths all surface
+        # ``morning`` as known-but-unavailable.
+        registration = get_briefing_render_registration("morning")
+        assert registration is not None
+        assert registration.is_available(api_config) is False, (
+            "bootstrap import-failure stub must report "
+            "is_available=False so GET /briefings shows morning as "
+            "known-disabled and render/regenerate return 503."
         )
     finally:
         # Belt-and-suspenders cleanup for the rest of the suite.
         register_briefing_provider(None)
         register_briefing_render_provider("morning", None)
+
+
+# ---------------------------------------------------------------------------
+# Codex round-15 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_morning_still_listed_as_unavailable_via_bootstrap(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+) -> None:
+    """Disabled-startup config keeps ``morning`` discoverable as unavailable.
+
+    Codex round-15 on #2059: when the operator starts ``pm serve`` with
+    ``[plugins].disabled = ["morning_briefing"]`` and no prior provider
+    has been registered, the old bootstrap branch cleared BOTH the
+    inbox-list slot and the render slot. ``GET /briefings`` returned an
+    empty list and ``GET/POST /briefings/morning`` returned 404
+    ``not_found`` — operators could not distinguish "built-in disabled"
+    from "typo in URL", and clients lost the rollback signal entirely.
+
+    The fix registers a known-disabled stub render provider in the
+    disabled branch so ``morning`` stays in the discovery response
+    (``available=false``) and render/regenerate return a typed 503
+    ``service_unavailable``.
+
+    This test reproduces the fresh-disabled-startup path that none of
+    the round-3/13 tests covered (they either pre-seeded
+    ``br._REGISTRY["morning"]`` or flipped the per-request config
+    AFTER bootstrap had wired the enabled provider):
+    1. Clear BOTH ``br._REGISTRY`` and the global render registry so
+       no stale provider can mask the bug.
+    2. Build ``create_app()`` with ``PluginSettings(disabled=("morning_briefing",))``.
+    3. Assert GET /briefings lists morning with available=false.
+    4. Assert GET /briefings/morning -> 503 (NOT 404).
+    5. Assert POST /briefings/morning/regenerate -> 503 (NOT 404).
+    """
+    from pollypm.briefings_registry import (
+        register_briefing_provider,
+        register_briefing_render_provider,
+    )
+
+    # 1) Clear all registry state — fresh process simulation.
+    briefings_routes._REGISTRY.pop("morning", None)
+    register_briefing_provider(None)
+    register_briefing_render_provider("morning", None)
+
+    # 2) Build the app with morning_briefing disabled from the start.
+    api_config.plugins = PluginSettings(disabled=("morning_briefing",))
+    app = create_app(config=api_config, token_path=token_path)
+
+    try:
+        with TestClient(app) as client:
+            # 3) GET /briefings — morning is listed with available=false.
+            response = client.get("/api/v1/briefings", headers=auth_headers)
+            assert response.status_code == 200, response.json()
+            types = response.json()["types"]
+            morning_entries = [t for t in types if t["name"] == "morning"]
+            assert len(morning_entries) == 1, (
+                "disabled-startup bootstrap dropped ``morning`` from the "
+                "discovery response — operators cannot distinguish "
+                "'built-in disabled' from 'typo in URL'. Listed: "
+                f"{[t['name'] for t in types]}"
+            )
+            assert morning_entries[0]["available"] is False, (
+                "disabled-startup bootstrap listed ``morning`` as "
+                "available=true — the per-request plugin-disable gate "
+                "did not fire on the stub registration."
+            )
+            assert morning_entries[0]["description"], (
+                "disabled-startup bootstrap registered ``morning`` with "
+                "an empty description — clients render a blank blurb."
+            )
+
+            # 4) GET /briefings/morning — typed 503, NOT 404.
+            response = client.get(
+                "/api/v1/briefings/morning", headers=auth_headers
+            )
+            assert response.status_code == 503, (
+                f"GET /briefings/morning on a disabled-startup app "
+                f"returned {response.status_code} (expected 503). "
+                f"Body: {response.json()}"
+            )
+            assert response.json()["error"]["code"] == "service_unavailable"
+
+            # 5) POST /briefings/morning/regenerate — typed 503, NOT 404.
+            response = client.post(
+                "/api/v1/briefings/morning/regenerate",
+                json={},
+                headers=auth_headers,
+            )
+            assert response.status_code == 503, (
+                f"POST /briefings/morning/regenerate on a disabled-"
+                f"startup app returned {response.status_code} "
+                f"(expected 503). Body: {response.json()}"
+            )
+            assert response.json()["error"]["code"] == "service_unavailable"
+    finally:
+        # Restore registry state for sibling tests.
+        register_briefing_provider(None)
+        register_briefing_render_provider("morning", None)
+        briefings_routes._REGISTRY.pop("morning", None)
 
 
 def test_regenerate_request_docstring_says_morning_rejects_project() -> None:

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -1074,3 +1074,82 @@ def test_briefings_late_failure_logged(
             f"expected scope + exception repr in log; got: "
             f"{[r.getMessage() for r in late_logs]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Codex round-6 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_briefings_executor_workers_are_daemons(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All briefings-executor worker threads must be daemon threads.
+
+    Codex round-6 P0: the round-5 bounded-shutdown fix made FastAPI
+    lifespan teardown return promptly, but workers were still
+    non-daemon ``threading.Thread`` instances. Any live non-daemon
+    thread keeps the CPython interpreter alive past ``sys.exit``,
+    so a wedged regenerate provider would still block ``pm serve``
+    shutdown / restart even after the route 504'd and the lifespan
+    "leaked" the worker. The fix is :class:`_DaemonThreadPoolExecutor`,
+    which mirrors CPython's ``_adjust_thread_count`` but sets
+    ``t.daemon = True`` before ``t.start()``.
+
+    This test forces the pool to actually spin up a worker (the
+    executor is lazy — ``_threads`` is empty until a future is
+    submitted) by firing a no-op regenerate, then asserts every
+    thread in ``executor._threads`` is a daemon.
+    """
+    from pollypm.web_api.routes import briefings as br
+
+    def _available(_config) -> bool:
+        return True
+
+    def _fast_regenerate(_config, _body: RegenerateRequest) -> BriefingResponse:
+        return _make_response(type_name="morning", markdown="ok")
+
+    monkeypatch.setitem(
+        br._REGISTRY,
+        "morning",
+        _BriefingAdapter(
+            name="morning",
+            description="daemon-thread test",
+            available=_available,
+            render_last=lambda _c: _make_response(
+                type_name="morning", markdown="ok",
+            ),
+            regenerate=_fast_regenerate,
+        ),
+    )
+
+    app = create_app(config=api_config, token_path=token_path)
+
+    with TestClient(app) as client:
+        # Trigger a regenerate so the pool spins up at least one
+        # worker thread. Without this the executor is lazy and
+        # ``_threads`` is empty.
+        response = client.post(
+            "/api/v1/briefings/morning/regenerate?timeout_seconds=5",
+            json={},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200, response.json()
+
+        executor = app.state.briefing_executor
+        threads = list(getattr(executor, "_threads", []) or [])
+        assert threads, (
+            "briefing executor spawned no worker threads even after "
+            "a successful regenerate — test is not exercising the "
+            "daemon-flag code path"
+        )
+        non_daemons = [t for t in threads if not t.daemon]
+        assert not non_daemons, (
+            "briefing executor worker(s) are non-daemon — leaked "
+            "threads will keep pm serve alive past shutdown: "
+            f"{[t.name for t in non_daemons]}"
+        )

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -21,10 +21,12 @@ touch pg, git, or any LLM call.
 
 from __future__ import annotations
 
+import threading
 import time
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -885,3 +887,190 @@ def test_briefings_inflight_isolated_per_app(
         # Poking app_a's in-flight map must not leak into app_b.
         app_a.state.briefing_inflight[("morning", "")] = object()  # type: ignore[assignment]
         assert ("morning", "") not in app_b.state.briefing_inflight
+
+
+# ---------------------------------------------------------------------------
+# Codex round-5 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_briefings_app_teardown_bounded_with_running_worker(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """App teardown returns promptly even with a wedged regenerate worker.
+
+    Codex round-5 P0: previously ``_lifespan`` called
+    ``executor.shutdown(wait=True, cancel_futures=True)`` — but
+    ``cancel_futures=True`` only cancels QUEUED work; a worker already
+    inside ``adapter.regenerate`` cannot be cancelled, so teardown
+    would hang until the slow provider returned. The bounded-shutdown
+    fix caps the wait at ``_BRIEFING_REGEN_SHUTDOWN_DEADLINE_S`` (5 s)
+    and logs a warning if any worker is still alive.
+    """
+    from pollypm.web_api.routes import briefings as br
+
+    # Signal so we know the worker actually started before we exit
+    # the lifespan context (otherwise the test is just measuring queue
+    # cancellation, not the running-worker path).
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def _available(_config) -> bool:
+        return True
+
+    def _slow_regenerate(_config, _body: RegenerateRequest) -> BriefingResponse:
+        worker_started.set()
+        # Block well past the bounded-shutdown deadline so we exercise
+        # the "leak + warn" branch, not the "drained in time" branch.
+        release_worker.wait(timeout=60.0)
+        return _make_response(
+            type_name="morning",
+            markdown="released after deadline",
+        )
+
+    monkeypatch.setitem(
+        br._REGISTRY,
+        "morning",
+        _BriefingAdapter(
+            name="morning",
+            description="bounded-shutdown test",
+            available=_available,
+            render_last=lambda _c: None,
+            regenerate=_slow_regenerate,
+        ),
+    )
+
+    app = create_app(config=api_config, token_path=token_path)
+
+    teardown_start: list[float] = []
+    teardown_end: list[float] = []
+
+    try:
+        with caplog.at_level("WARNING", logger="pollypm.web_api.app"):
+            with TestClient(app) as client:
+                response = client.post(
+                    "/api/v1/briefings/morning/regenerate?timeout_seconds=1",
+                    json={},
+                    headers=auth_headers,
+                )
+                assert response.status_code == 504, response.json()
+
+                # Confirm the worker actually got scheduled and is running
+                # — otherwise we'd be testing the queue-cancel path.
+                assert worker_started.wait(timeout=5.0), (
+                    "slow regenerate worker never started"
+                )
+
+                teardown_start.append(time.monotonic())
+            # TestClient context exit triggered lifespan shutdown.
+            teardown_end.append(time.monotonic())
+
+        # The whole teardown must return within ~10 s — bounded by the
+        # 5 s shutdown deadline plus headroom. Before this fix it would
+        # wait for the full release_worker.wait timeout (60 s).
+        assert teardown_end and teardown_start
+        elapsed = teardown_end[0] - teardown_start[0]
+        assert elapsed < 10.0, (
+            f"app teardown took {elapsed:.2f}s with a running worker; "
+            "expected bounded shutdown to return within ~5s"
+        )
+
+        # And the leak warning should have been logged.
+        leak_logs = [
+            r for r in caplog.records
+            if "still running at shutdown" in r.getMessage()
+        ]
+        assert leak_logs, (
+            "expected lifespan to log a warning about leaked worker(s); "
+            f"got: {[r.getMessage() for r in caplog.records]}"
+        )
+    finally:
+        # Always release the worker so the leaked thread can exit and
+        # not hang test-process teardown.
+        release_worker.set()
+
+
+def test_briefings_late_failure_logged(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Late worker failure after a 504 is observable via the logger.
+
+    Codex round-5 P1: the done callback only popped the in-flight
+    entry; it never inspected ``future.exception()``. If a provider
+    raised after the client already saw 504, operators had no
+    diagnostic. The wired-up ``_on_regenerate_done`` now logs a
+    warning with the scope key + repr of the exception.
+    """
+    from pollypm.web_api.routes import briefings as br
+
+    worker_done = threading.Event()
+
+    def _available(_config) -> bool:
+        return True
+
+    def _failing_regenerate(_config, _body: RegenerateRequest) -> BriefingResponse:
+        try:
+            # Long enough that the HTTP request 504s first.
+            time.sleep(1.5)
+            raise RuntimeError("herald exploded after timeout")
+        finally:
+            worker_done.set()
+
+    monkeypatch.setitem(
+        br._REGISTRY,
+        "morning",
+        _BriefingAdapter(
+            name="morning",
+            description="late-failure test",
+            available=_available,
+            render_last=lambda _c: None,
+            regenerate=_failing_regenerate,
+        ),
+    )
+
+    app = create_app(config=api_config, token_path=token_path)
+
+    with caplog.at_level("WARNING", logger="pollypm.web_api.routes.briefings"):
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/v1/briefings/morning/regenerate?timeout_seconds=1",
+                json={},
+                headers=auth_headers,
+            )
+            assert response.status_code == 504, response.json()
+
+            # Wait for the worker to actually finish (with its raise),
+            # plus a small grace so the done-callback runs on the
+            # executor thread.
+            assert worker_done.wait(timeout=5.0), (
+                "failing regenerate worker never completed"
+            )
+            time.sleep(0.2)
+
+        # Done-callback should have observed the exception and logged it.
+        late_logs = [
+            r for r in caplog.records
+            if "failed after worker completed" in r.getMessage()
+        ]
+        assert late_logs, (
+            "expected late-failure log line; got: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+        # And the scope identifier should appear in the message.
+        assert any(
+            "morning" in r.getMessage() and "herald exploded" in r.getMessage()
+            for r in late_logs
+        ), (
+            f"expected scope + exception repr in log; got: "
+            f"{[r.getMessage() for r in late_logs]}"
+        )

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -980,10 +980,14 @@ def test_briefings_app_teardown_bounded_with_running_worker(
             "expected bounded shutdown to return within ~5s"
         )
 
-        # And the leak warning should have been logged.
+        # And the leak warning should have been logged. The shared
+        # ``_shutdown_daemon_executor`` helper (PR #2059 round-7,
+        # mirroring #2058) emits "still running after Ns grace;
+        # leaking thread(s) past app teardown".
         leak_logs = [
             r for r in caplog.records
-            if "still running at shutdown" in r.getMessage()
+            if "briefing executor" in r.getMessage()
+            and "still running" in r.getMessage()
         ]
         assert leak_logs, (
             "expected lifespan to log a warning about leaked worker(s); "
@@ -1153,3 +1157,145 @@ def test_briefings_executor_workers_are_daemons(
             "threads will keep pm serve alive past shutdown: "
             f"{[t.name for t in non_daemons]}"
         )
+
+
+def test_briefings_pm_serve_process_exits_with_wedged_worker(
+    tmp_path: Path,
+) -> None:
+    """A wedged briefings worker does not keep the ``pm serve`` process alive.
+
+    Codex round-7 on PR #2059: the round-6 daemon-only fix is not
+    process-safe on its own — ``concurrent.futures`` registers an
+    ``atexit`` hook (``_python_exit``) that joins every executor
+    worker via the module-level ``_threads_queues`` dict. That join
+    blocks ``pm serve`` interpreter exit even when the workers are
+    daemon threads. The lifespan finalizer now mirrors #2058's
+    pattern (shared :class:`DaemonThreadPoolExecutor` + atexit
+    eviction) so a wedged regen worker can't keep the process alive.
+
+    Same shape as
+    ``test_doctor_pm_serve_process_exits_with_wedged_worker`` —
+    spawns a child process that:
+
+    1. Builds the app + starts the lifespan.
+    2. Submits a hung job to the briefings executor (no HTTP
+       roundtrip — the daemon/eviction discipline is a property of
+       the executor + lifespan, not the route).
+    3. Exits the lifespan.
+    4. Drops references and lets the interpreter try to exit.
+
+    Pre-fix, the child takes ~60s (waiting on the non-daemon worker
+    via the atexit hook) and we kill it via timeout. Post-fix, the
+    child exits cleanly in well under the 15s budget.
+    """
+    import subprocess
+    import sys
+    import textwrap
+    import time as _time
+
+    child_script = textwrap.dedent(
+        """
+        import sys, time
+        from pathlib import Path
+        from fastapi.testclient import TestClient
+        from pollypm.config import (
+            AccountConfig, MemorySettings, PollyPMConfig,
+            PollyPMSettings, ProjectSettings,
+        )
+        from pollypm.models import (
+            KnownProject, ProjectKind, ProviderKind, RuntimeKind,
+        )
+        from pollypm.web_api import create_app, ensure_token
+
+        workspace = Path(sys.argv[1])
+        token_path = Path(sys.argv[2])
+        ensure_token(token_path)
+
+        base_dir = workspace / ".pollypm"
+        config = PollyPMConfig(
+            project=ProjectSettings(
+                name="PollyPM", root_dir=workspace,
+                tmux_session="pollypm-test",
+                workspace_root=workspace, base_dir=base_dir,
+                logs_dir=base_dir / "logs",
+                snapshots_dir=base_dir / "snapshots",
+                state_db=base_dir / "state.db",
+            ),
+            pollypm=PollyPMSettings(
+                controller_account="codex_primary",
+                open_permissions_by_default=False,
+                failover_enabled=False, failover_accounts=[],
+                heartbeat_backend="local",
+                scheduler_backend="inline",
+                lease_timeout_minutes=30,
+            ),
+            accounts={
+                "codex_primary": AccountConfig(
+                    name="codex_primary",
+                    provider=ProviderKind.CODEX,
+                    email="codex@example.com",
+                    runtime=RuntimeKind.LOCAL,
+                    home=base_dir / "homes" / "codex_primary",
+                ),
+            },
+            sessions={},
+            projects={
+                "myproj": KnownProject(
+                    key="myproj", path=workspace, name="My Project",
+                    tracked=True, kind=ProjectKind.GIT,
+                ),
+            },
+            memory=MemorySettings(backend="file"),
+        )
+
+        app = create_app(config=config, token_path=token_path)
+        with TestClient(app):
+            # Submit a wedged job directly to the executor so the
+            # test doesn't depend on briefings-route plumbing. The
+            # daemon-thread + atexit-eviction invariant is a property
+            # of the executor + lifespan, not the route.
+            app.state.briefing_executor.submit(time.sleep, 60)
+            time.sleep(0.2)
+        # Lifespan has exited; daemon workers + atexit eviction
+        # should let the interpreter exit immediately.
+        print("CHILD EXIT OK", flush=True)
+        """
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".pollypm").mkdir()
+    token_path = tmp_path / "api-token"
+
+    t0 = _time.monotonic()
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", child_script,
+             str(workspace), str(token_path)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired as exc:
+        elapsed = _time.monotonic() - t0
+        pytest.fail(
+            f"child process did not exit within 15s (took {elapsed:.1f}s) — "
+            f"a wedged briefings worker is keeping the interpreter alive. "
+            f"stdout={exc.stdout!r} stderr={exc.stderr!r}"
+        )
+
+    elapsed = _time.monotonic() - t0
+    assert result.returncode == 0, (
+        f"child exited with rc={result.returncode}; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "CHILD EXIT OK" in result.stdout, (
+        f"child did not reach the post-lifespan print; "
+        f"stdout={result.stdout!r}"
+    )
+    # The lifespan grace is 5s and atexit eviction is O(workers),
+    # so even with launcher overhead this should land well under 12s.
+    assert elapsed < 12.0, (
+        f"child took {elapsed:.1f}s; the wedged worker should not "
+        f"have blocked interpreter exit past the lifespan grace."
+    )

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -22,6 +22,7 @@ touch pg, git, or any LLM call.
 from __future__ import annotations
 
 import time
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -178,6 +179,25 @@ class _FakeAdapterState:
 def fake_state() -> _FakeAdapterState:
     """Mutable adapter-control state shared across the test + the fixture."""
     return _FakeAdapterState()
+
+
+@pytest.fixture(autouse=True)
+def _clear_briefing_inflight() -> "Iterator[None]":
+    """Reset the module-level in-flight registry between tests.
+
+    The regenerate endpoint dedupes concurrent runs by `(type, project)`
+    using a module-level dict; a previous test that triggered a 504
+    leaves the background thread running, which would 409 the next
+    request for the same scope. We drop the entry on teardown so each
+    test starts with a clean inflight table.
+    """
+    from pollypm.web_api.routes import briefings as br
+
+    with br._INFLIGHT_LOCK:
+        br._INFLIGHT.clear()
+    yield
+    with br._INFLIGHT_LOCK:
+        br._INFLIGHT.clear()
 
 
 @pytest.fixture
@@ -432,3 +452,181 @@ def test_auth_required_for_all_briefings_routes(
         headers=no_auth,
     )
     assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Codex round-1 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_briefings_uses_injected_config_not_default(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_morning_regenerate` must honor ``config.config_path``, not the
+    global default.
+
+    Asserts the regression for Codex round-1 P0 #1: previously the
+    adapter called ``load_briefing_settings(resolve_config_path(
+    DEFAULT_CONFIG_PATH))`` even when ``pm serve --config /tmp/foo``
+    had loaded a non-default file. We stub ``load_briefing_settings``
+    to record its incoming path and assert it matches the injected
+    config's ``config_path``.
+    """
+    from pollypm.web_api import create_app
+    from pollypm.web_api.routes.briefings import _morning_regenerate
+
+    # Construct a non-default TOML on disk so resolve_config_path can
+    # return a real path. Contents don't matter — the stub intercepts.
+    custom_toml = tmp_path / "custom_pollypm.toml"
+    custom_toml.write_text("# custom config used by test\n")
+    api_config.config_path = custom_toml
+
+    captured_paths: list[Path] = []
+
+    def _fake_load(path: Path):  # noqa: ANN202
+        captured_paths.append(Path(path))
+        # Return whatever default the real impl would; the regenerate
+        # path past this point is mocked by replacing fire_briefing.
+        from pollypm.plugins_builtin.morning_briefing.settings import (
+            BriefingSettings,
+        )
+        return BriefingSettings()
+
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.morning_briefing.settings.load_briefing_settings",
+        _fake_load,
+    )
+    # Short-circuit the heavy regenerate machinery — we only care that
+    # ``load_briefing_settings`` was called with the injected path.
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.morning_briefing.handlers.briefing_tick.fire_briefing",
+        lambda **_kw: {
+            "fired": True,
+            "emitted": False,
+            "draft": {"date_local": "2026-05-22", "mode": "test", "markdown": "x"},
+        },
+    )
+    # Stub state.load_state since we never wrote a real one.
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.morning_briefing.state.load_state",
+        lambda _base: None,
+    )
+
+    # Build a fresh client that uses the real ``_morning_regenerate``
+    # (no patched_registry fixture). The shared executor is module
+    # level, so we don't need to recreate it.
+    app = create_app(config=api_config, token_path=token_path)
+    client = TestClient(app)
+
+    # Mark the morning provider as "available" without the real plugin
+    # tree. Patch only the availability probe — render is unused here.
+    from pollypm.web_api.routes import briefings as br
+
+    monkeypatch.setattr(br, "_morning_available", lambda _c: True)
+    # The registry was built at import time; rebuild it with the new
+    # availability callable so the endpoint trusts the stub.
+    br._REGISTRY["morning"] = br._BriefingAdapter(
+        name="morning",
+        description="real-adapter test",
+        available=lambda _c: True,
+        render_last=lambda _c: None,
+        regenerate=_morning_regenerate,
+    )
+
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        json={},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    # The stub captured at least one path. Crucially it must equal the
+    # *custom* path, not the default ``~/.pollypm/pollypm.toml``.
+    assert captured_paths, "load_briefing_settings was not called"
+    assert captured_paths[0] == custom_toml.resolve()
+
+
+def test_briefings_regenerate_timeout_is_non_blocking(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_registry: dict[str, _BriefingAdapter],  # noqa: ARG001
+    fake_state: _FakeAdapterState,
+) -> None:
+    """504 must return near the timeout, not after the provider sleep.
+
+    Codex round-1 P0 #3: the old code wrapped ``ThreadPoolExecutor`` in
+    a ``with`` block, so context-manager exit blocked on
+    ``shutdown(wait=True)``. A 60 s provider with a 1 s timeout still
+    took ~60 s to respond. With the shared executor, the request
+    should return in roughly ``timeout_seconds`` (plus a small
+    bookkeeping budget).
+    """
+    fake_state.regen_delay = 60.0  # simulate a wedged provider
+    start = time.monotonic()
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate?timeout_seconds=1",
+        json={"project": None},
+        headers=auth_headers,
+    )
+    elapsed = time.monotonic() - start
+    assert response.status_code == 504, response.json()
+    # Give CI a generous ceiling but well under the 60 s sleep — if
+    # the executor still blocks on shutdown, ``elapsed`` would be 60+.
+    assert elapsed < 5.0, (
+        f"timeout response took {elapsed:.2f}s; expected <5s "
+        "(non-blocking executor regression)"
+    )
+
+    # Reset state so the lingering background thread doesn't keep the
+    # in-flight registry full for the next test (it will eventually
+    # clear itself, but be polite).
+    fake_state.regen_delay = 0.0
+
+
+def test_briefings_morning_rejects_project_param(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``project`` on a ``morning`` regenerate is 400, not silently dropped.
+
+    Codex round-1 P1: the request schema documented ``project`` as a
+    scope narrower; the morning adapter ignored it and silently
+    produced a workspace-wide briefing anyway. The new contract is
+    "reject for morning, accept-and-honor for future plugin types".
+    """
+    from pollypm.web_api import create_app
+    from pollypm.web_api.routes.briefings import _morning_regenerate
+    from pollypm.web_api.routes import briefings as br
+
+    api_config.config_path = tmp_path / "pollypm.toml"
+    api_config.config_path.write_text("")
+    monkeypatch.setattr(br, "_morning_available", lambda _c: True)
+    br._REGISTRY["morning"] = br._BriefingAdapter(
+        name="morning",
+        description="real-adapter test",
+        available=lambda _c: True,
+        render_last=lambda _c: None,
+        regenerate=_morning_regenerate,
+    )
+    app = create_app(config=api_config, token_path=token_path)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/briefings/morning/regenerate",
+        json={"project": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400, response.json()
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "morning" in body["error"]["message"].lower() or "project" in body[
+        "error"
+    ]["message"].lower()

--- a/tests/test_briefings_endpoint.py
+++ b/tests/test_briefings_endpoint.py
@@ -630,3 +630,47 @@ def test_briefings_morning_rejects_project_param(
     assert "morning" in body["error"]["message"].lower() or "project" in body[
         "error"
     ]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Codex round-2 regressions (refs #2059)
+# ---------------------------------------------------------------------------
+
+
+def test_briefings_endpoint_available_in_default_create_app(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001 — fixture forces token write
+    auth_headers: dict[str, str],
+) -> None:
+    """`create_app` must wire the morning-briefing provider itself.
+
+    Asserts the regression for Codex round-2 P0 #2: previously
+    ``pm serve`` only called ``load_config`` + ``create_app`` and
+    never bootstrapped the plugin host, so the morning provider stayed
+    ``None`` in the registry. ``GET /api/v1/briefings`` returned
+    ``morning.available=false`` and render/regenerate 503'd in
+    production unless tests monkeypatched ``_REGISTRY`` /
+    ``_morning_available``.
+
+    No fixtures touch the registry here — the app factory itself must
+    populate the provider for the built-in ``morning`` type.
+    """
+    # Clear the registry first so we prove ``create_app`` itself
+    # repopulates it (rather than relying on stale module state from
+    # an earlier test that imported the plugin tree).
+    from pollypm.briefings_registry import register_briefing_provider
+    register_briefing_provider(None)
+
+    app = create_app(config=api_config, token_path=token_path)
+    client = TestClient(app)
+
+    response = client.get("/api/v1/briefings", headers=auth_headers)
+    assert response.status_code == 200, response.json()
+    morning = next(
+        entry for entry in response.json()["types"] if entry["name"] == "morning"
+    )
+    assert morning["available"] is True, (
+        "morning provider was not wired by create_app; "
+        "render/regenerate would 503 in production"
+    )

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -766,3 +766,91 @@ def test_implementation_openapi_validates_as_31() -> None:
     # accepts 3.0 / 3.1 alike.
     assert raw.get("openapi", "").startswith("3.")
     validate_openapi(raw)
+
+
+def test_briefings_runtime_openapi_matches_static_error_codes() -> None:
+    """Pin the briefings route ``responses=`` map against the static YAML.
+
+    Round 8 (Codex) on #2059: the FastAPI route decorators in
+    ``src/pollypm/web_api/routes/briefings.py`` had no ``responses=``
+    map, so the auto-generated ``/openapi.json`` only advertised the
+    success body + FastAPI's default ``422`` validation envelope.
+    ``docs/api/openapi.yaml`` documented the full error surface
+    (401/404/503 on GET, 400/401/404/409/503/504 on regenerate), but
+    generated clients consuming the live spec would not branch on the
+    typed envelopes the handlers actually raise.
+
+    Pin both surfaces so future drift trips CI.
+    """
+    from pollypm.config import (
+        AccountConfig,
+        MemorySettings,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectSettings,
+    )
+    from pollypm.models import ProviderKind, RuntimeKind
+    from pollypm.web_api import create_app
+
+    base = Path(__file__).resolve().parent
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            name="P", root_dir=base, tmux_session="t",
+            workspace_root=base, base_dir=base / ".pollypm",
+            logs_dir=base / ".pollypm/logs",
+            snapshots_dir=base / ".pollypm/snapshots",
+            state_db=base / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={"codex_primary": AccountConfig(
+            name="codex_primary", provider=ProviderKind.CODEX,
+            email="codex@example.com", runtime=RuntimeKind.LOCAL,
+            home=base / ".pollypm/homes/codex_primary",
+        )},
+        sessions={},
+        projects={},
+        memory=MemorySettings(backend="file"),
+    )
+    app = create_app(config=config, token_path=base / "tmp-token")
+    raw = app.openapi()
+    paths = raw["paths"]
+
+    # GET /briefings — 401 only (no typed 4xx / 5xx beyond auth).
+    list_get = paths["/api/v1/briefings"]["get"]["responses"]
+    assert "401" in list_get, (
+        "Implementation OpenAPI for GET /api/v1/briefings is missing "
+        "the 401 response advertised by docs/api/openapi.yaml — keep "
+        "the route's ``responses=`` map in sync (#2059 round-8)."
+    )
+
+    # GET /briefings/{type_name} — 401 / 404 / 503.
+    render_get = paths["/api/v1/briefings/{type_name}"]["get"]["responses"]
+    for code in ("401", "404", "503"):
+        assert code in render_get, (
+            f"Implementation OpenAPI for GET /api/v1/briefings/"
+            f"{{type_name}} is missing the {code} response advertised "
+            "by docs/api/openapi.yaml — keep the route's ``responses=`` "
+            "map in sync (#2059 round-8)."
+        )
+
+    # POST /briefings/{type_name}/regenerate — 400 / 401 / 404 / 409 /
+    # 503 / 504. This is the full typed surface the handler raises
+    # (see ``regenerate_briefing_endpoint`` and the morning adapter).
+    regen_post = (
+        paths["/api/v1/briefings/{type_name}/regenerate"]["post"]["responses"]
+    )
+    for code in ("400", "401", "404", "409", "503", "504"):
+        assert code in regen_post, (
+            f"Implementation OpenAPI for POST /api/v1/briefings/"
+            f"{{type_name}}/regenerate is missing the {code} response "
+            "advertised by docs/api/openapi.yaml — keep the route's "
+            "``responses=`` map in sync (#2059 round-8)."
+        )


### PR DESCRIPTION
## Summary

Adds the Phase 2 §9 briefings surface (per `~/Desktop/pollypm-phase2-endpoints-spec.md`):

- `GET  /api/v1/briefings` — list registered briefing types (with `available` flag)
- `GET  /api/v1/briefings/{type_name}` — render the last cached briefing
- `POST /api/v1/briefings/{type_name}/regenerate` — force regenerate (sync)

Regenerate runs under a thread-pool timeout (default 30 s, configurable via `?timeout_seconds=`, capped at 600 s). Slow providers surface as `504 timeout` per spec §2.7. `?async=true` + a job registry remain deferred to Phase 2.5.

The route uses a small adapter registry: built-in `morning` wraps `pollypm.briefings_registry` + the morning_briefing plugin's `read_briefing` / `fire_briefing` seams. New types plug in by registering an adapter — no route changes required.

## Files

- `src/pollypm/web_api/routes/briefings.py` (new) — router + adapter registry
- `src/pollypm/web_api/app.py` — wire router under `/api/v1`
- `docs/api/openapi.yaml` — Briefings tag + 3 paths + 4 schemas
- `tests/test_briefings_endpoint.py` (new) — 13 cases, fully mocked

## Test plan

- [x] `pytest --noconftest tests/test_briefings_endpoint.py -v --timeout=120` — 13/13 pass
- [x] `pytest --noconftest tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31 tests/web_api/test_openapi_conformance.py::test_implementation_openapi_validates_as_31` — pass
- [ ] Manual: `curl /api/v1/briefings` against a live `pm serve` to confirm `morning.available` reflects plugin state
- [ ] Manual: `curl -XPOST /api/v1/briefings/morning/regenerate` confirms a fresh briefing lands in the inbox