### PR TITLE
feat(api): inbox WRITE endpoints — Phase 2 surface #2

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -877,6 +877,8 @@ paths:
           $ref: "#/components/responses/Conflict"
         "422":
           $ref: "#/components/responses/ValidationError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /inbox/{id}/archive:
     parameters:
@@ -904,6 +906,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /inbox/{id}/snooze:
     parameters:
@@ -937,6 +941,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /inbox/{id}/promote-to-task:
     parameters:
@@ -962,6 +968,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /inbox/{id}/mark-read:
     parameters:
@@ -987,6 +995,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /config:
     get:
@@ -1217,6 +1227,15 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
     Conflict:
       description: Concurrent write conflict; state changed between read and write.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    ServiceUnavailable:
+      description: |
+        Backing store (work-service / pg) unavailable.
+        Returned with error code `service_unavailable`. Retry shortly;
+        check `pm doctor` if the failure persists.
       content:
         application/json:
           schema:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -856,8 +856,6 @@ paths:
       tags: [Inbox]
       operationId: replyInboxItem
       summary: Append a reply to an inbox thread
-      parameters:
-        - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
         required: true
         content:
@@ -887,8 +885,6 @@ paths:
       tags: [Inbox]
       operationId: archiveInboxItem
       summary: Archive (close) an inbox item
-      parameters:
-        - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
         required: false
         content:
@@ -916,8 +912,6 @@ paths:
       tags: [Inbox]
       operationId: snoozeInboxItem
       summary: Snooze an inbox item until a future time
-      parameters:
-        - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
         required: true
         content:
@@ -951,8 +945,6 @@ paths:
       tags: [Inbox]
       operationId: promoteInboxItem
       summary: Promote an inbox item into a new actionable task
-      parameters:
-        - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
         required: false
         content:
@@ -978,8 +970,6 @@ paths:
       tags: [Inbox]
       operationId: markInboxItemRead
       summary: Record a read-marker on an inbox item
-      parameters:
-        - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
         required: false
         content:
@@ -1185,8 +1175,14 @@ components:
       required: false
       schema: { type: string, maxLength: 128 }
       description: |
-        Optional client-supplied key. Server caches the response for
-        24h and replays it on retry with the same key.
+        Optional client-supplied key. **No server-side replay cache is
+        wired today** — the header is accepted on the
+        task-state endpoints (approve / reject / queue) so clients
+        can start sending it from day one, but retries are NOT
+        deduplicated yet. A real replay store is deferred to a later
+        phase. Inbox-write endpoints intentionally do NOT accept this
+        header (their backing operations are not idempotent — sending
+        the header would imply a guarantee we cannot keep — see #2060).
 
   responses:
     Unauthorized:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2234,7 +2234,10 @@ components:
           type: string
           description: |
             Optional operator-supplied reason for archiving; recorded
-            as a context note before the state transition.
+            as a best-effort context note AFTER the strict archive
+            transition succeeds. If the transition fails (e.g.
+            concurrent archive, invalid state, backing-store outage),
+            no note is persisted.
 
     InboxSnoozeRequest:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -854,8 +854,8 @@ paths:
       - $ref: "#/components/parameters/InboxId"
     post:
       tags: [Inbox]
-      operationId: replyInbox
-      summary: Reply to a thread
+      operationId: replyInboxItem
+      summary: Append a reply to an inbox thread
       parameters:
         - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
@@ -865,12 +865,12 @@ paths:
             schema:
               $ref: "#/components/schemas/InboxReplyRequest"
       responses:
-        "201":
-          description: Reply appended to the thread.
+        "200":
+          description: Reply appended; returns the updated task detail.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/InboxMessage"
+                $ref: "#/components/schemas/TaskDetail"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -885,23 +885,118 @@ paths:
       - $ref: "#/components/parameters/InboxId"
     post:
       tags: [Inbox]
-      operationId: archiveInbox
+      operationId: archiveInboxItem
       summary: Archive (close) an inbox item
       parameters:
         - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InboxArchiveRequest"
       responses:
         "200":
-          description: Item moved to `closed/`.
+          description: Item moved to a terminal state; returns the task detail.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ActionResult"
+                $ref: "#/components/schemas/TaskDetail"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+
+  /inbox/{id}/snooze:
+    parameters:
+      - $ref: "#/components/parameters/InboxId"
+    post:
+      tags: [Inbox]
+      operationId: snoozeInboxItem
+      summary: Snooze an inbox item until a future time
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InboxSnoozeRequest"
+      responses:
+        "200":
+          description: Snooze marker recorded; returns the task detail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskDetail"
+        "400":
+          description: Snooze window invalid (missing, in past, or >30d out).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /inbox/{id}/promote-to-task:
+    parameters:
+      - $ref: "#/components/parameters/InboxId"
+    post:
+      tags: [Inbox]
+      operationId: promoteInboxItem
+      summary: Promote an inbox item into a new actionable task
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InboxPromoteRequest"
+      responses:
+        "200":
+          description: New task created; body carries the new TaskDetail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /inbox/{id}/mark-read:
+    parameters:
+      - $ref: "#/components/parameters/InboxId"
+    post:
+      tags: [Inbox]
+      operationId: markInboxItemRead
+      summary: Record a read-marker on an inbox item
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InboxMarkReadRequest"
+      responses:
+        "200":
+          description: Read marker recorded (idempotent); returns the task detail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /config:
     get:
@@ -2109,11 +2204,59 @@ components:
 
     InboxReplyRequest:
       type: object
-      required: [message]
+      required: [body]
       properties:
-        message:
+        body:
           type: string
           minLength: 1
+        owner:
+          $ref: "#/components/schemas/InboxOwner"
+
+    InboxArchiveRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: |
+            Optional operator-supplied reason for archiving; recorded
+            as a context note before the state transition.
+
+    InboxSnoozeRequest:
+      type: object
+      description: |
+        Exactly one of `duration_seconds` or `until` must be supplied.
+        `until` must be < 30 days in the future.
+      properties:
+        duration_seconds:
+          type: integer
+          minimum: 1
+        until:
+          type: string
+          format: date-time
+        reason:
+          type: string
+
+    InboxPromoteRequest:
+      type: object
+      description: |
+        Optional overrides for the new task. ``project`` defaults to
+        the source item's project; ``prompt`` defaults to the source
+        item's description / subject; ``title`` defaults to
+        "From inbox: <source-title>".
+      properties:
+        project:
+          type: string
+        prompt:
+          type: string
+        title:
+          type: string
+
+    InboxMarkReadRequest:
+      type: object
+      properties:
+        actor:
+          type: string
+          description: Actor to record on the read marker (default `api`).
 
     # ---- Events -----------------------------------------------------
     Event:

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -320,6 +320,66 @@ class InboxListResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Inbox write requests (Phase 2 — #1548, spec §4.1)
+# ---------------------------------------------------------------------------
+
+
+class InboxArchiveRequest(BaseModel):
+    """Body for ``POST /inbox/{id}/archive``.
+
+    ``reason`` is optional metadata recorded in the audit trail so the
+    operator can later answer "why did this disappear?". The cockpit
+    archive action doesn't require one.
+    """
+
+    reason: str | None = None
+
+
+class InboxSnoozeRequest(BaseModel):
+    """Body for ``POST /inbox/{id}/snooze``.
+
+    Exactly one of ``duration_seconds`` or ``until`` must be supplied.
+    ``duration_seconds`` is the simpler shape for clients ("snooze for
+    1h"); ``until`` lets the caller pin a wall-clock wake time.
+    """
+
+    duration_seconds: int | None = Field(default=None, ge=1)
+    until: datetime | None = None
+    reason: str | None = None
+
+
+class InboxPromoteRequest(BaseModel):
+    """Body for ``POST /inbox/{id}/promote-to-task``.
+
+    ``project`` overrides the destination project (default: same as
+    source). ``prompt`` becomes the new task's description; if omitted
+    we fall back to the source item's subject + preview.
+    """
+
+    project: str | None = None
+    prompt: str | None = None
+    title: str | None = None
+
+
+class InboxMarkReadRequest(BaseModel):
+    """Body for ``POST /inbox/{id}/mark-read`` (empty body allowed)."""
+
+    actor: str | None = None
+
+
+class InboxReplyRequest(BaseModel):
+    """Body for ``POST /inbox/{id}/reply``.
+
+    Mirrors the spec's snake_case shape; ``body`` carries the reply
+    text. ``owner`` is open metadata so the cockpit can tag who's
+    talking (defaults to ``operator``).
+    """
+
+    body: str = Field(min_length=1)
+    owner: InboxOwnerStr | None = None
+
+
+# ---------------------------------------------------------------------------
 # Events (SSE payload)
 # ---------------------------------------------------------------------------
 
@@ -348,10 +408,15 @@ __all__ = [
     "Event",
     "FlowNodeExecution",
     "HealthResponse",
+    "InboxArchiveRequest",
     "InboxItem",
     "InboxItemDetail",
     "InboxListResponse",
+    "InboxMarkReadRequest",
     "InboxMessage",
+    "InboxPromoteRequest",
+    "InboxReplyRequest",
+    "InboxSnoozeRequest",
     "Plan",
     "PlanJudgmentCall",
     "Project",

--- a/src/pollypm/web_api/routes/inbox.py
+++ b/src/pollypm/web_api/routes/inbox.py
@@ -1,19 +1,41 @@
-"""Inbox read endpoints (Phase 1).
+"""Inbox endpoints (Phase 1 reads + Phase 2 writes).
 
-Implements ``GET /api/v1/inbox`` and ``GET /api/v1/inbox/{id}``.
-Reply / archive ship in Phase 2 (#1548).
+Phase 1 (#1547) shipped ``GET /api/v1/inbox`` and
+``GET /api/v1/inbox/{id}``. Phase 2 (#1548) layers in the write
+surface — archive / snooze / promote-to-task / mark-read / reply —
+all routed through the same canonical work-service writers the
+cockpit uses (#1389). The Web API is never a second writer surface;
+these handlers are thin adapters that translate work-service
+exceptions into the typed error envelope (§6).
 """
 
 from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Header, Query
 
 from pollypm.web_api.errors import not_found
-from pollypm.web_api.models import InboxItemDetail, InboxListResponse
+from pollypm.web_api.models import (
+    InboxArchiveRequest,
+    InboxItemDetail,
+    InboxListResponse,
+    InboxMarkReadRequest,
+    InboxPromoteRequest,
+    InboxReplyRequest,
+    InboxSnoozeRequest,
+    TaskDetail,
+)
 from pollypm.web_api.routes._deps import ConfigDep
-from pollypm.web_api.service import get_inbox_item, list_inbox
+from pollypm.web_api.service import (
+    archive_inbox_item,
+    get_inbox_item,
+    list_inbox,
+    mark_read_inbox_item,
+    promote_inbox_to_task,
+    reply_inbox_item,
+    snooze_inbox_item,
+)
 
 router = APIRouter(tags=["Inbox"])
 
@@ -58,3 +80,139 @@ def get_inbox_item_endpoint(id: str, config: ConfigDep) -> InboxItemDetail:
     if detail is None:
         raise not_found(f"Inbox item not found: {id}")
     return detail
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — inbox write endpoints
+#
+# Each POST handler:
+#   * routes through a service-layer helper that opens
+#     :func:`create_work_service` once per call (mirrors how queue_task
+#     wedge works — same canonical writer the cockpit uses).
+#   * declares the optional ``Idempotency-Key`` header so OpenAPI
+#     consumers see it (the dedup cache itself ships in Phase 3).
+#   * returns the post-mutation task envelope so the client refreshes
+#     UI without a follow-up GET.
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/inbox/{id:path}/archive",
+    response_model=TaskDetail,
+    summary="Archive (close) an inbox item",
+    operation_id="archiveInboxItem",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project or inbox item not found."},
+        "409": {"description": "Item is already in a terminal state."},
+        "503": {"description": "Backing store unavailable."},
+    },
+)
+def archive_inbox_item_endpoint(
+    id: str,
+    config: ConfigDep,
+    body: InboxArchiveRequest | None = None,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+) -> TaskDetail:
+    reason = body.reason if body is not None else None
+    return archive_inbox_item(config, id, reason=reason)
+
+
+@router.post(
+    "/inbox/{id:path}/snooze",
+    response_model=TaskDetail,
+    summary="Snooze an inbox item until a future time",
+    operation_id="snoozeInboxItem",
+    responses={
+        "400": {"description": "Snooze window invalid (missing / past / >30d)."},
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project or inbox item not found."},
+        "409": {"description": "Item is in a terminal state and cannot be snoozed."},
+        "503": {"description": "Backing store unavailable."},
+    },
+)
+def snooze_inbox_item_endpoint(
+    id: str,
+    body: InboxSnoozeRequest,
+    config: ConfigDep,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+) -> TaskDetail:
+    return snooze_inbox_item(
+        config,
+        id,
+        duration_seconds=body.duration_seconds,
+        until=body.until,
+        reason=body.reason,
+    )
+
+
+@router.post(
+    "/inbox/{id:path}/promote-to-task",
+    response_model=TaskDetail,
+    summary="Promote an inbox item into a new actionable task",
+    operation_id="promoteInboxItem",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Source or destination project not found."},
+        "503": {"description": "Backing store unavailable."},
+    },
+)
+def promote_inbox_item_endpoint(
+    id: str,
+    config: ConfigDep,
+    body: InboxPromoteRequest | None = None,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+) -> TaskDetail:
+    if body is None:
+        body = InboxPromoteRequest()
+    return promote_inbox_to_task(
+        config,
+        id,
+        target_project=body.project,
+        prompt=body.prompt,
+        title=body.title,
+    )
+
+
+@router.post(
+    "/inbox/{id:path}/mark-read",
+    response_model=TaskDetail,
+    summary="Record a read-marker on an inbox item",
+    operation_id="markInboxItemRead",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project or inbox item not found."},
+        "503": {"description": "Backing store unavailable."},
+    },
+)
+def mark_read_inbox_item_endpoint(
+    id: str,
+    config: ConfigDep,
+    body: InboxMarkReadRequest | None = None,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+) -> TaskDetail:
+    actor = (body.actor if body is not None else None) or "api"
+    return mark_read_inbox_item(config, id, actor=actor)
+
+
+@router.post(
+    "/inbox/{id:path}/reply",
+    response_model=TaskDetail,
+    summary="Append a reply to an inbox thread",
+    operation_id="replyInboxItem",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project or inbox item not found."},
+        "422": {"description": "Reply body failed validation."},
+        "503": {"description": "Backing store unavailable."},
+    },
+)
+def reply_inbox_item_endpoint(
+    id: str,
+    body: InboxReplyRequest,
+    config: ConfigDep,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+) -> TaskDetail:
+    return reply_inbox_item(
+        config, id, body=body.body, owner=body.owner,
+    )

--- a/src/pollypm/web_api/routes/inbox.py
+++ b/src/pollypm/web_api/routes/inbox.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Header, Query
+from fastapi import APIRouter, Query
 
 from pollypm.web_api.errors import not_found
 from pollypm.web_api.models import (
@@ -89,10 +89,19 @@ def get_inbox_item_endpoint(id: str, config: ConfigDep) -> InboxItemDetail:
 #   * routes through a service-layer helper that opens
 #     :func:`create_work_service` once per call (mirrors how queue_task
 #     wedge works — same canonical writer the cockpit uses).
-#   * declares the optional ``Idempotency-Key`` header so OpenAPI
-#     consumers see it (the dedup cache itself ships in Phase 3).
 #   * returns the post-mutation task envelope so the client refreshes
 #     UI without a follow-up GET.
+#
+# Idempotency: an earlier draft of these handlers advertised an
+# optional ``Idempotency-Key`` request header on every POST. There is
+# no idempotency store wired into the API today (grep for
+# ``idempotency`` returns only docs/comments), so the header would
+# have been silently ignored — a retry after a network drop could
+# create duplicate promoted tasks, replies, and snooze rows while the
+# client reasonably believed the header protected it. The header is
+# intentionally NOT declared here; a real idempotency cache is
+# deferred until a future PR can wire it through every non-idempotent
+# verb (see #2060 review for context).
 # ---------------------------------------------------------------------------
 
 
@@ -112,7 +121,6 @@ def archive_inbox_item_endpoint(
     id: str,
     config: ConfigDep,
     body: InboxArchiveRequest | None = None,
-    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> TaskDetail:
     reason = body.reason if body is not None else None
     return archive_inbox_item(config, id, reason=reason)
@@ -135,7 +143,6 @@ def snooze_inbox_item_endpoint(
     id: str,
     body: InboxSnoozeRequest,
     config: ConfigDep,
-    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> TaskDetail:
     return snooze_inbox_item(
         config,
@@ -161,7 +168,6 @@ def promote_inbox_item_endpoint(
     id: str,
     config: ConfigDep,
     body: InboxPromoteRequest | None = None,
-    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> TaskDetail:
     if body is None:
         body = InboxPromoteRequest()
@@ -189,7 +195,6 @@ def mark_read_inbox_item_endpoint(
     id: str,
     config: ConfigDep,
     body: InboxMarkReadRequest | None = None,
-    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> TaskDetail:
     actor = (body.actor if body is not None else None) or "api"
     return mark_read_inbox_item(config, id, actor=actor)
@@ -211,7 +216,6 @@ def reply_inbox_item_endpoint(
     id: str,
     body: InboxReplyRequest,
     config: ConfigDep,
-    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> TaskDetail:
     return reply_inbox_item(
         config, id, body=body.body, owner=body.owner,

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -644,6 +644,387 @@ def queue_task(
 
 
 # ---------------------------------------------------------------------------
+# Inbox write helpers (Phase 2 — spec §4.1)
+#
+# Each helper opens a fresh work-service via :func:`create_work_service`
+# — the same canonical writer the cockpit uses. The Web API is never a
+# second writer surface; it's a thin adapter that maps inbox-item ids
+# (``project/n``) onto the existing work-service inbox methods and
+# translates the resulting exceptions into typed error envelopes (§6).
+#
+# Why these live next to ``queue_task`` and not under
+# ``pollypm.work.inbox_cli``: the CLI helpers all assume a Typer call
+# graph (they ``raise typer.Exit`` on failure and write to stdout for
+# bulk modes). Routing an HTTP request through Typer is the wrong
+# shape; the helpers below call the same underlying ``PgWorkService``
+# methods (``archive_task``, ``add_reply``, ``mark_read``,
+# ``add_context``, ``create``) the CLI invokes.
+# ---------------------------------------------------------------------------
+
+
+# Statuses we treat as "already archived" for the inbox archive
+# endpoint. ``archive_task`` itself is idempotent (returns the row
+# unchanged when terminal) — but the spec wants a typed 409 so the
+# client can tell "I just archived it" from "someone else already
+# did". We pre-check the status and surface the conflict instead of
+# silently no-op'ing.
+_ALREADY_ARCHIVED_STATUSES: frozenset[str] = frozenset({"done", "cancelled"})
+
+
+def _project_key_from_inbox_id(item_id: str) -> str:
+    """Pull the project key off an inbox item id (``project/n``).
+
+    Inbox ids use the same ``project/task_number`` shape task ids use
+    (see :func:`_task_to_inbox_item`); the first segment is always the
+    project key. We accept ``msg:<n>`` here too so a future router
+    that wants to route those onto the unified messages store can
+    branch on the prefix — for now ``msg:`` ids raise ``not_found``
+    because the Web API only addresses chat-flow tasks.
+    """
+    if "/" not in item_id:
+        raise not_found(
+            f"Inbox item not found: {item_id}",
+            hint=(
+                "Inbox ids look like 'project/n'. Message-store ids "
+                "(``msg:<n>``) are not yet supported on this surface."
+            ),
+        )
+    return item_id.split("/", 1)[0]
+
+
+def _resolve_inbox_project(
+    config: PollyPMConfig, item_id: str
+) -> tuple[str, KnownProject]:
+    """Return ``(project_key, project)`` for an inbox id, or 404.
+
+    Centralizes the "id → registered project" lookup so every inbox
+    write endpoint reports the same error shape on unknown ids.
+    """
+    key = _project_key_from_inbox_id(item_id)
+    project = config.projects.get(key)
+    if project is None:
+        raise not_found(f"Project not registered: {key}")
+    return key, project
+
+
+def archive_inbox_item(
+    config: PollyPMConfig,
+    item_id: str,
+    *,
+    reason: str | None = None,
+    actor: str = "api",
+) -> APITaskDetail:
+    """Archive an inbox item via ``svc.archive_task``.
+
+    Returns the post-transition :class:`TaskDetail` so the client can
+    re-render without a follow-up GET. Returns 409 ``invalid_state``
+    when the item is already terminal (mirrors the spec §4.3 contract:
+    "archive a resolved item → invalid_state").
+    """
+    from pollypm.work.factory import create_work_service
+    from pollypm.work.service_support import TaskNotFoundError
+
+    key, project = _resolve_inbox_project(config, item_id)
+    try:
+        with create_work_service(
+            config=config, project_key=key, project_path=project.path
+        ) as svc:
+            try:
+                current = svc.get(item_id)
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            status = getattr(current.work_status, "value", str(current.work_status))
+            if status in _ALREADY_ARCHIVED_STATUSES:
+                raise APIError(
+                    status_code=409,
+                    code="invalid_state",
+                    message=f"Inbox item {item_id} is already {status}.",
+                    hint="Items in a terminal state cannot be re-archived.",
+                )
+            if reason:
+                # Record the operator-supplied reason before flipping
+                # so the audit trail captures both "why" and "how".
+                try:
+                    svc.add_context(
+                        item_id, actor, f"archive reason: {reason}",
+                        entry_type="note",
+                    )
+                except Exception:  # noqa: BLE001 — non-fatal context-write
+                    logger.debug(
+                        "archive_inbox_item: reason note failed for %s",
+                        item_id, exc_info=True,
+                    )
+            try:
+                svc.archive_task(item_id, actor=actor)
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            task = svc.get(item_id)
+            return _task_to_detail(task)
+    except _BACKING_STORE_ERRORS as exc:
+        logger.warning(
+            "archive_inbox_item: backing store error for %s: %s",
+            item_id, exc, exc_info=True,
+        )
+        raise service_unavailable(
+            f"Backing store unavailable while archiving {item_id}",
+            hint="Retry shortly; check `pm doctor` if the failure persists.",
+        ) from exc
+
+
+def snooze_inbox_item(
+    config: PollyPMConfig,
+    item_id: str,
+    *,
+    duration_seconds: int | None = None,
+    until: datetime | None = None,
+    reason: str | None = None,
+    actor: str = "api",
+) -> APITaskDetail:
+    """Snooze an inbox item until a future time.
+
+    No native ``svc.snooze`` exists on the work-service (#1776 only
+    shipped reply/mark_read/archive). We persist the snooze as a
+    structured ``snooze`` context entry whose text encodes the
+    wake-up time + reason; the cockpit's inbox-curation predicate
+    can later read these to hide snoozed rows from the default view.
+
+    Exactly one of ``duration_seconds`` / ``until`` must be supplied.
+    """
+    from datetime import timedelta, timezone
+    from pollypm.work.factory import create_work_service
+    from pollypm.work.service_support import TaskNotFoundError
+
+    if duration_seconds is None and until is None:
+        raise APIError(
+            status_code=400,
+            code="invalid_request",
+            message="Snooze requires duration_seconds or until.",
+            hint="Pass `duration_seconds` (>=1) or an ISO-8601 `until`.",
+        )
+    if duration_seconds is not None and until is not None:
+        raise APIError(
+            status_code=400,
+            code="invalid_request",
+            message="Pass duration_seconds OR until, not both.",
+        )
+    now = datetime.now(timezone.utc)
+    if until is None:
+        until = now + timedelta(seconds=duration_seconds or 0)
+    # Coerce to tz-aware UTC for a stable comparison.
+    if until.tzinfo is None:
+        until = until.replace(tzinfo=timezone.utc)
+    if until <= now:
+        raise APIError(
+            status_code=400,
+            code="invalid_request",
+            message="Snooze until must be in the future.",
+        )
+    # Spec §4.3: ``until`` > 30 days out is rejected.
+    if (until - now) > timedelta(days=30):
+        raise APIError(
+            status_code=400,
+            code="invalid_request",
+            message="Snooze until is more than 30 days out.",
+            hint="Use a wake-time within 30 days.",
+        )
+
+    key, project = _resolve_inbox_project(config, item_id)
+    try:
+        with create_work_service(
+            config=config, project_key=key, project_path=project.path
+        ) as svc:
+            try:
+                current = svc.get(item_id)
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            status = getattr(current.work_status, "value", str(current.work_status))
+            if status in _ALREADY_ARCHIVED_STATUSES:
+                raise APIError(
+                    status_code=409,
+                    code="invalid_state",
+                    message=f"Inbox item {item_id} is {status}; cannot snooze.",
+                )
+            payload_parts = [f"snoozed until {until.isoformat()}"]
+            if reason:
+                payload_parts.append(f"reason: {reason}")
+            try:
+                svc.add_context(
+                    item_id, actor, "; ".join(payload_parts),
+                    entry_type="snooze",
+                )
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            task = svc.get(item_id)
+            return _task_to_detail(task)
+    except _BACKING_STORE_ERRORS as exc:
+        logger.warning(
+            "snooze_inbox_item: backing store error for %s: %s",
+            item_id, exc, exc_info=True,
+        )
+        raise service_unavailable(
+            f"Backing store unavailable while snoozing {item_id}",
+            hint="Retry shortly; check `pm doctor` if the failure persists.",
+        ) from exc
+
+
+def mark_read_inbox_item(
+    config: PollyPMConfig,
+    item_id: str,
+    *,
+    actor: str = "api",
+) -> APITaskDetail:
+    """Record a read-marker on an inbox item via ``svc.mark_read``.
+
+    Idempotent: re-opening the same item is a no-op (the work-service
+    method itself collapses repeats). Returns the current task detail
+    so the client can refresh its UI without a follow-up GET.
+    """
+    from pollypm.work.factory import create_work_service
+    from pollypm.work.service_support import TaskNotFoundError
+
+    key, project = _resolve_inbox_project(config, item_id)
+    try:
+        with create_work_service(
+            config=config, project_key=key, project_path=project.path
+        ) as svc:
+            try:
+                svc.mark_read(item_id, actor=actor)
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            task = svc.get(item_id)
+            return _task_to_detail(task)
+    except _BACKING_STORE_ERRORS as exc:
+        logger.warning(
+            "mark_read_inbox_item: backing store error for %s: %s",
+            item_id, exc, exc_info=True,
+        )
+        raise service_unavailable(
+            f"Backing store unavailable while marking-read {item_id}",
+            hint="Retry shortly; check `pm doctor` if the failure persists.",
+        ) from exc
+
+
+def reply_inbox_item(
+    config: PollyPMConfig,
+    item_id: str,
+    *,
+    body: str,
+    owner: str | None = None,
+    actor: str = "api",
+) -> APITaskDetail:
+    """Append a reply to an inbox thread via ``svc.add_reply``.
+
+    The work-service strips whitespace and rejects empty bodies via
+    :class:`ValidationError`; we map that to 422 so the client can
+    show the underlying message.
+    """
+    from pollypm.work.factory import create_work_service
+    from pollypm.work.service_support import (
+        TaskNotFoundError,
+        ValidationError as WorkValidationError,
+    )
+
+    key, project = _resolve_inbox_project(config, item_id)
+    actor_name = owner or actor or "operator"
+    try:
+        with create_work_service(
+            config=config, project_key=key, project_path=project.path
+        ) as svc:
+            try:
+                svc.add_reply(item_id, body, actor=actor_name)
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            except WorkValidationError as exc:
+                raise APIError(
+                    status_code=422,
+                    code="validation_error",
+                    message=str(exc) or "Reply body failed validation.",
+                ) from exc
+            task = svc.get(item_id)
+            return _task_to_detail(task)
+    except _BACKING_STORE_ERRORS as exc:
+        logger.warning(
+            "reply_inbox_item: backing store error for %s: %s",
+            item_id, exc, exc_info=True,
+        )
+        raise service_unavailable(
+            f"Backing store unavailable while replying to {item_id}",
+            hint="Retry shortly; check `pm doctor` if the failure persists.",
+        ) from exc
+
+
+def promote_inbox_to_task(
+    config: PollyPMConfig,
+    item_id: str,
+    *,
+    target_project: str | None = None,
+    prompt: str | None = None,
+    title: str | None = None,
+    actor: str = "api",
+) -> APITaskDetail:
+    """Create a new task derived from an inbox item.
+
+    The source item stays open (cockpit operator can archive it
+    separately if they want). The new task lands in the same project
+    by default — pass ``target_project`` to redirect. The new task's
+    description is ``prompt`` when provided, else the source item's
+    description / preview.
+    """
+    from pollypm.work.factory import create_work_service
+    from pollypm.work.service_support import TaskNotFoundError
+
+    src_key, src_project = _resolve_inbox_project(config, item_id)
+    dest_key = target_project or src_key
+    dest_project = config.projects.get(dest_key)
+    if dest_project is None:
+        raise not_found(f"Project not registered: {dest_key}")
+
+    try:
+        with create_work_service(
+            config=config, project_key=src_key, project_path=src_project.path
+        ) as src_svc:
+            try:
+                src_task = src_svc.get(item_id)
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            src_title = title or f"From inbox: {src_task.title}"
+            src_description = (
+                prompt or src_task.description or src_task.title or ""
+            )
+            src_priority = getattr(
+                getattr(src_task, "priority", None), "value", "normal",
+            )
+
+        # Open a fresh service against the destination project so the
+        # write lands on the right per-row ``project`` column even when
+        # cross-project promotion is used.
+        with create_work_service(
+            config=config, project_key=dest_key, project_path=dest_project.path
+        ) as dest_svc:
+            new_task = dest_svc.create(
+                title=src_title,
+                description=src_description,
+                type="task",
+                project=dest_key,
+                flow_template="standard",
+                roles={"requester": actor},
+                priority=src_priority or "normal",
+                created_by=actor,
+                labels=["promoted-from-inbox", f"source:{item_id}"],
+            )
+            return _task_to_detail(dest_svc.get(new_task.task_id))
+    except _BACKING_STORE_ERRORS as exc:
+        logger.warning(
+            "promote_inbox_to_task: backing store error for %s: %s",
+            item_id, exc, exc_info=True,
+        )
+        raise service_unavailable(
+            f"Backing store unavailable while promoting {item_id}",
+            hint="Retry shortly; check `pm doctor` if the failure persists.",
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
 # Plan helpers
 # ---------------------------------------------------------------------------
 
@@ -1225,6 +1606,7 @@ def load_api_config(config_path: Path | None) -> PollyPMConfig:
 
 
 __all__ = [
+    "archive_inbox_item",
     "audit_event_to_api",
     "get_active_plan",
     "get_inbox_item",
@@ -1234,5 +1616,10 @@ __all__ = [
     "list_project_tasks",
     "list_projects",
     "load_api_config",
+    "mark_read_inbox_item",
     "project_drilldown",
+    "promote_inbox_to_task",
+    "queue_task",
+    "reply_inbox_item",
+    "snooze_inbox_item",
 ]

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -18,7 +18,7 @@ import logging
 import os
 import re
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -722,28 +722,32 @@ def archive_inbox_item(
     "archive a resolved item → invalid_state").
     """
     from pollypm.work.factory import create_work_service
-    from pollypm.work.service_support import TaskNotFoundError
+    from pollypm.work.service_support import (
+        InvalidTransitionError,
+        TaskNotFoundError,
+    )
 
     key, project = _resolve_inbox_project(config, item_id)
     try:
         with create_work_service(
             config=config, project_key=key, project_path=project.path
         ) as svc:
+            # Quick existence/auth probe so unknown ids surface as 404
+            # before we attempt the (atomic) transition. The terminal
+            # check is intentionally NOT here: ``archive_task`` with
+            # ``strict=True`` performs that check atomically inside
+            # the canonical transition, so two concurrent archivers
+            # see exactly one 200 and one 409 (closes the race the
+            # earlier pre-check version exposed — #2060).
             try:
-                current = svc.get(item_id)
+                svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
-            status = getattr(current.work_status, "value", str(current.work_status))
-            if status in _ALREADY_ARCHIVED_STATUSES:
-                raise APIError(
-                    status_code=409,
-                    code="invalid_state",
-                    message=f"Inbox item {item_id} is already {status}.",
-                    hint="Items in a terminal state cannot be re-archived.",
-                )
             if reason:
                 # Record the operator-supplied reason before flipping
                 # so the audit trail captures both "why" and "how".
+                # Best-effort: a failed note must not block the
+                # archive (and must not race the strict transition).
                 try:
                     svc.add_context(
                         item_id, actor, f"archive reason: {reason}",
@@ -755,9 +759,20 @@ def archive_inbox_item(
                         item_id, exc_info=True,
                     )
             try:
-                svc.archive_task(item_id, actor=actor)
+                svc.archive_task(item_id, actor=actor, strict=True)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
+            except InvalidTransitionError as exc:
+                # The atomic UPDATE asserted the row was non-terminal;
+                # losing the race means another caller archived first.
+                raise APIError(
+                    status_code=409,
+                    code="invalid_state",
+                    message=str(exc) or (
+                        f"Inbox item {item_id} is already terminal."
+                    ),
+                    hint="Items in a terminal state cannot be re-archived.",
+                ) from exc
             task = svc.get(item_id)
             return _task_to_detail(task)
     except _BACKING_STORE_ERRORS as exc:
@@ -844,7 +859,15 @@ def snooze_inbox_item(
                     code="invalid_state",
                     message=f"Inbox item {item_id} is {status}; cannot snooze.",
                 )
-            payload_parts = [f"snoozed until {until.isoformat()}"]
+            # Persist the wake time as a structured ``until_iso=...``
+            # marker so the inbox-list predicate (_snoozed_until_for)
+            # can parse it back without regex-guessing on free-form
+            # text. Older entries that only carried "snoozed until
+            # <iso>" still parse via the fallback path in the reader.
+            payload_parts = [
+                f"until_iso={until.isoformat()}",
+                f"snoozed until {until.isoformat()}",
+            ]
             if reason:
                 payload_parts.append(f"reason: {reason}")
             try:
@@ -1448,6 +1471,7 @@ def _collect_inbox_items(
     else:
         keys = config.projects.keys()
 
+    now = datetime.now(timezone.utc)
     for key in keys:
         proj = config.projects[key]
         try:
@@ -1455,6 +1479,16 @@ def _collect_inbox_items(
                 config=config, project_key=key, project_path=proj.path
             ) as svc:
                 tasks = svc.list_tasks(project=key)
+                # Snooze visibility (#2060): the snooze write helper
+                # persists ``entry_type='snooze'`` rows whose text
+                # encodes the wake-up time. Items whose latest snooze
+                # is still in the future must NOT appear in the
+                # default inbox view (otherwise the endpoint returns
+                # 200 while the row stays actionable). We compute the
+                # active-snooze set once per project — the same
+                # readonly service handle stays open so we don't
+                # double-pay for connection setup.
+                snoozed_ids = _active_snoozed_ids(svc, tasks, now=now)
         except _BACKING_STORE_ERRORS as exc:
             # Backing-store failure on a single project: log loudly,
             # skip that project but keep building the aggregate. We
@@ -1470,10 +1504,86 @@ def _collect_inbox_items(
             )
             continue
         for task in tasks:
+            if task.task_id in snoozed_ids:
+                continue
             entry = _task_to_inbox_item(task)
             if entry is not None:
                 out.append(entry)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Snooze visibility helpers (#2060)
+#
+# The POST /inbox/{id}/snooze endpoint persists an ``entry_type='snooze'``
+# row whose text starts with ``until_iso=<ISO>; snoozed until <ISO>``.
+# These helpers parse that wake-time back so the inbox list filters
+# out items whose snooze hasn't expired.  Kept private to this module
+# because the cockpit-side inbox panel has its own (unrelated) curation
+# predicate — wiring snooze through that surface is out of scope for
+# this PR and tracked separately.
+# ---------------------------------------------------------------------------
+
+
+def _parse_snooze_until(text: str) -> datetime | None:
+    """Pull a tz-aware wake-time out of a snooze context-entry text.
+
+    Accepts both the canonical ``until_iso=<ISO>`` marker the snooze
+    writer emits and the older ``snoozed until <ISO>`` shape so rows
+    written before the structured marker landed still parse. Returns
+    ``None`` when no recognisable timestamp is present.
+    """
+    if not text:
+        return None
+    candidates: list[str] = []
+    for part in text.split(";"):
+        chunk = part.strip()
+        if chunk.startswith("until_iso="):
+            candidates.append(chunk[len("until_iso="):].strip())
+        elif chunk.lower().startswith("snoozed until "):
+            candidates.append(chunk[len("snoozed until "):].strip())
+    for raw in candidates:
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    return None
+
+
+def _active_snoozed_ids(
+    svc, tasks, *, now: datetime,
+) -> set[str]:
+    """Return task_ids whose latest snooze entry is still in the future.
+
+    Per-task ``get_context(entry_type='snooze', limit=1)`` query; the
+    work-service returns rows ``ORDER BY id DESC`` so the first row is
+    the most recent snooze. Items without a snooze row, or whose latest
+    snooze has expired, are NOT in the returned set (the inbox shows
+    them as actionable, matching cockpit semantics).
+    """
+    snoozed: set[str] = set()
+    for task in tasks:
+        try:
+            entries = svc.get_context(
+                task.task_id, entry_type="snooze", limit=1,
+            )
+        except Exception:  # noqa: BLE001 — readonly view degrades open
+            logger.debug(
+                "inbox: snooze lookup failed for %s",
+                task.task_id, exc_info=True,
+            )
+            continue
+        if not entries:
+            continue
+        wake = _parse_snooze_until(entries[0].text)
+        if wake is None:
+            continue
+        if wake > now:
+            snoozed.add(task.task_id)
+    return snoozed
 
 
 def _task_to_inbox_item(task) -> APIInboxItem | None:

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -740,9 +740,17 @@ def archive_inbox_item(
             # see exactly one 200 and one 409 (closes the race the
             # earlier pre-check version exposed — #2060).
             try:
-                svc.get(item_id)
+                src_task = svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
+            # Membership guard (#2060 round-3): the bare ``svc.get`` above
+            # returns ANY task with that id, including non-inbox work
+            # rows that the GET /inbox surface would never expose. A
+            # caller could otherwise POST /inbox/<id>/archive against a
+            # plain-task flow row and close it via this endpoint. We
+            # short-circuit with the same 404 the read surface returns.
+            if not _is_inbox_member(src_task):
+                raise not_found(f"Inbox item not found: {item_id}")
             if reason:
                 # Record the operator-supplied reason before flipping
                 # so the audit trail captures both "why" and "how".
@@ -852,6 +860,11 @@ def snooze_inbox_item(
                 current = svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
+            # Membership guard (#2060 round-3): see archive_inbox_item.
+            # A caller could otherwise snooze a non-inbox work task that
+            # the read surface would 404.
+            if not _is_inbox_member(current):
+                raise not_found(f"Inbox item not found: {item_id}")
             status = getattr(current.work_status, "value", str(current.work_status))
             if status in _ALREADY_ARCHIVED_STATUSES:
                 raise APIError(
@@ -910,6 +923,17 @@ def mark_read_inbox_item(
         with create_work_service(
             config=config, project_key=key, project_path=project.path
         ) as svc:
+            # Membership guard (#2060 round-3): fetch the task first so
+            # a non-inbox work row can't be silently mark-read'd through
+            # this endpoint. Without this, ``svc.mark_read`` only checks
+            # existence and would happily write a ``read`` context row
+            # against any task id.
+            try:
+                src_task = svc.get(item_id)
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            if not _is_inbox_member(src_task):
+                raise not_found(f"Inbox item not found: {item_id}")
             try:
                 svc.mark_read(item_id, actor=actor)
             except TaskNotFoundError as exc:
@@ -953,6 +977,15 @@ def reply_inbox_item(
         with create_work_service(
             config=config, project_key=key, project_path=project.path
         ) as svc:
+            # Membership guard (#2060 round-3): without this a reply to
+            # a non-inbox work task would be persisted as a reply row
+            # the GET /inbox surface would never expose.
+            try:
+                src_task = svc.get(item_id)
+            except TaskNotFoundError as exc:
+                raise not_found(f"Inbox item not found: {item_id}") from exc
+            if not _is_inbox_member(src_task):
+                raise not_found(f"Inbox item not found: {item_id}")
             try:
                 svc.add_reply(item_id, body, actor=actor_name)
             except TaskNotFoundError as exc:
@@ -1010,6 +1043,12 @@ def promote_inbox_to_task(
                 src_task = src_svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
+            # Membership guard (#2060 round-3): the GET /inbox surface
+            # would 404 a non-inbox task id, so promote-to-task must
+            # too — otherwise a caller can derive a new task from an
+            # arbitrary work row by addressing it through this verb.
+            if not _is_inbox_member(src_task):
+                raise not_found(f"Inbox item not found: {item_id}")
             src_title = title or f"From inbox: {src_task.title}"
             src_description = (
                 prompt or src_task.description or src_task.title or ""
@@ -1610,13 +1649,43 @@ def _active_snoozed_ids(
     return snoozed
 
 
-def _task_to_inbox_item(task) -> APIInboxItem | None:
+def _is_inbox_member(task) -> bool:
+    """Return True iff ``task`` belongs to the API inbox surface.
+
+    Canonical predicate shared by the read (``GET /inbox`` via
+    :func:`_collect_inbox_items` / :func:`_task_to_inbox_item`) and
+    write (archive / snooze / mark-read / reply / promote) paths so a
+    POST cannot mutate a non-inbox work task — Codex round-3 blocker
+    #1 on #2060 (the old write helpers only probed ``svc.get()``,
+    which returns ANY task with that id and let a caller close a
+    plain "task" flow row via ``POST /inbox/<id>/archive``).
+
+    Mirrors :func:`_task_to_inbox_item` exactly: chat-flow rows OR
+    plan-review rows (label ``plan_review`` or
+    :func:`_is_plan_task`). The terminal-state check stays on the
+    read side because mutating write helpers each have their own
+    typed conflict path (archive's strict UPDATE, snooze's
+    pre-check) — including ``state == 'closed'`` here would
+    incorrectly 404 a request that should 409.
+    """
     flow = (getattr(task, "flow_template_id", "") or "").lower()
     labels = [str(lbl) for lbl in (getattr(task, "labels", []) or [])]
-    is_plan_review = any("plan_review" in lbl for lbl in labels) or _is_plan_task(task)
+    is_plan_review = (
+        any("plan_review" in lbl for lbl in labels) or _is_plan_task(task)
+    )
     is_chat = flow == "chat"
-    if not (is_chat or is_plan_review):
+    return bool(is_chat or is_plan_review)
+
+
+def _task_to_inbox_item(task) -> APIInboxItem | None:
+    if not _is_inbox_member(task):
         return None
+    flow = (getattr(task, "flow_template_id", "") or "").lower()
+    labels = [str(lbl) for lbl in (getattr(task, "labels", []) or [])]
+    is_plan_review = (
+        any("plan_review" in lbl for lbl in labels) or _is_plan_task(task)
+    )
+    is_chat = flow == "chat"
     item_type = "plan_review" if is_plan_review and not is_chat else "message"
     state = _inbox_state_from_task(task)
     if state == "closed":

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -24,6 +24,9 @@ from typing import Any
 
 import sqlite3
 
+import psycopg
+import psycopg_pool
+
 from pollypm.audit.log import AuditEvent, read_events
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.models import KnownProject
@@ -69,10 +72,22 @@ _DISABLE_WORK_DB_OPENED_AUDIT_ENV = "POLLYPM_DISABLE_WORK_DB_OPENED_AUDIT"
 # retry. Anything outside this tuple bubbles up to the FastAPI
 # unhandled-exception handler (500 ``internal_error``) so we don't
 # silently swallow real bugs.
+#
+# Pg-only backend (``pollypm.work.factory`` post #1971): a real pg
+# outage / pool exhaustion raises ``psycopg.OperationalError`` /
+# ``psycopg_pool.PoolTimeout``, neither of which subclasses
+# ``OSError`` — without them in the tuple the documented 503
+# envelope is bypassed and the new inbox write endpoints return 500
+# on a real outage. Codex round-6 blocker 1 on PR #2060.
+# ``sqlite3.*`` entries are kept for the legacy sqlite-flavoured
+# integration tests that still construct fakes raising those types;
+# the production path will never see them.
 _BACKING_STORE_ERRORS: tuple[type[BaseException], ...] = (
     sqlite3.OperationalError,
     sqlite3.DatabaseError,
     OSError,
+    psycopg.OperationalError,
+    psycopg_pool.PoolTimeout,
 )
 
 
@@ -1551,10 +1566,20 @@ def _collect_inbox_items(
                 # inbox predicate (Codex round-5 on #2060) can call
                 # ``svc.get_flow(...)`` for its current-node-human
                 # branch while the readonly handle is still open.
+                #
+                # One shared ``flow_cache`` per project scan: the
+                # canonical predicate falls back to ``svc.get_flow``
+                # for the current-node-human branch, and a page of N
+                # tasks on the same flow would otherwise pay N
+                # lookups. Matches the cockpit / rail / dashboard
+                # path in :func:`pollypm.work.inbox_view.inbox_tasks`
+                # (one cache, threaded through every call). Codex
+                # round-6 blocker 2 on PR #2060.
+                flow_cache: dict = {}
                 for task in tasks:
                     if task.task_id in snoozed_ids:
                         continue
-                    entry = _task_to_inbox_item(task, svc)
+                    entry = _task_to_inbox_item(task, svc, flow_cache=flow_cache)
                     if entry is not None:
                         out.append(entry)
         except _BACKING_STORE_ERRORS as exc:
@@ -1672,7 +1697,7 @@ def _active_snoozed_ids(
     return snoozed
 
 
-def _is_inbox_member(task, svc=None) -> bool:
+def _is_inbox_member(task, svc=None, flow_cache=None) -> bool:
     """Return True iff ``task`` belongs to the API inbox surface.
 
     Thin delegate to :func:`pollypm.work.inbox_view.is_inbox_task` —
@@ -1691,9 +1716,18 @@ def _is_inbox_member(task, svc=None) -> bool:
     when it falls back to the human-actor check. When ``svc`` is
     omitted we hand the predicate a no-flow shim so it degrades to
     the role / label branches only.
+
+    ``flow_cache`` is an optional ``{(name, version): FlowTemplate}``
+    dict — the same shape :mod:`pollypm.work.inbox_view` uses to make
+    sure scanning N tasks on a shared flow runs ``svc.get_flow(...)``
+    once, not N times. ``_collect_inbox_items`` builds one cache per
+    request and threads it through; single-shot callers (write helpers
+    resolving one task) can leave it ``None`` and pay one lookup —
+    that's still an improvement over the per-call fresh cache the
+    previous shape created. Codex round-6 blocker 2 on PR #2060.
     """
     flow_lookup = svc if svc is not None else _NoFlowLookup()
-    return bool(is_inbox_task(task, flow_lookup))
+    return bool(is_inbox_task(task, flow_lookup, flow_cache=flow_cache))
 
 
 class _NoFlowLookup:
@@ -1710,14 +1744,17 @@ class _NoFlowLookup:
         return None
 
 
-def _task_to_inbox_item(task, svc=None) -> APIInboxItem | None:
-    if not _is_inbox_member(task, svc):
+def _task_to_inbox_item(task, svc=None, flow_cache=None) -> APIInboxItem | None:
+    if not _is_inbox_member(task, svc, flow_cache=flow_cache):
         return None
     flow = (getattr(task, "flow_template_id", "") or "").lower()
     labels = [str(lbl) for lbl in (getattr(task, "labels", []) or [])]
-    is_plan_review = (
-        any("plan_review" in lbl for lbl in labels) or _is_plan_task(task)
-    )
+    # Exact-equality on ``plan_review`` (NOT substring) so labels like
+    # ``not_plan_review`` / ``planning`` cannot get classified as
+    # ``type=plan_review`` items. Mirrors the canonical
+    # :func:`pollypm.work.inbox_view._is_plan_review_label` predicate
+    # the write gate uses — Codex round-6 blocker 3 on PR #2060.
+    is_plan_review = any(lbl == "plan_review" for lbl in labels)
     is_chat = flow == "chat"
     item_type = "plan_review" if is_plan_review and not is_chat else "message"
     state = _inbox_state_from_task(task)

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -27,6 +27,7 @@ import sqlite3
 from pollypm.audit.log import AuditEvent, read_events
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.models import KnownProject
+from pollypm.work.inbox_view import is_inbox_task
 from pollypm.web_api.errors import (
     APIError,
     not_found,
@@ -743,13 +744,15 @@ def archive_inbox_item(
                 src_task = svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
-            # Membership guard (#2060 round-3): the bare ``svc.get`` above
-            # returns ANY task with that id, including non-inbox work
-            # rows that the GET /inbox surface would never expose. A
-            # caller could otherwise POST /inbox/<id>/archive against a
-            # plain-task flow row and close it via this endpoint. We
-            # short-circuit with the same 404 the read surface returns.
-            if not _is_inbox_member(src_task):
+            # Membership guard (#2060 round-3/round-5): the bare
+            # ``svc.get`` above returns ANY task with that id,
+            # including non-inbox work rows that the GET /inbox
+            # surface would never expose. We route resolution through
+            # the canonical :func:`pollypm.work.inbox_view.is_inbox_task`
+            # used by cockpit / rail / dashboard so the write surface
+            # cannot drift open relative to the read surface (Codex
+            # round-5 blocker on #2060).
+            if not is_inbox_task(src_task, svc):
                 raise not_found(f"Inbox item not found: {item_id}")
             # Run the strict transition FIRST so the reason note is
             # only persisted on a successful archive (#2060 round-4
@@ -870,10 +873,11 @@ def snooze_inbox_item(
                 current = svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
-            # Membership guard (#2060 round-3): see archive_inbox_item.
-            # A caller could otherwise snooze a non-inbox work task that
-            # the read surface would 404.
-            if not _is_inbox_member(current):
+            # Membership guard (#2060 round-3/round-5): canonical
+            # predicate (see archive_inbox_item). A caller could
+            # otherwise snooze a non-inbox work task that GET /inbox
+            # would 404.
+            if not is_inbox_task(current, svc):
                 raise not_found(f"Inbox item not found: {item_id}")
             status = getattr(current.work_status, "value", str(current.work_status))
             if status in _ALREADY_ARCHIVED_STATUSES:
@@ -933,16 +937,18 @@ def mark_read_inbox_item(
         with create_work_service(
             config=config, project_key=key, project_path=project.path
         ) as svc:
-            # Membership guard (#2060 round-3): fetch the task first so
-            # a non-inbox work row can't be silently mark-read'd through
-            # this endpoint. Without this, ``svc.mark_read`` only checks
-            # existence and would happily write a ``read`` context row
-            # against any task id.
+            # Membership guard (#2060 round-3/round-5): fetch the
+            # task first so a non-inbox work row can't be silently
+            # mark-read'd through this endpoint. Without this,
+            # ``svc.mark_read`` only checks existence and would
+            # happily write a ``read`` context row against any task
+            # id. Canonical inbox predicate so writes can't drift
+            # past what cockpit / rail / dashboard surface.
             try:
                 src_task = svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
-            if not _is_inbox_member(src_task):
+            if not is_inbox_task(src_task, svc):
                 raise not_found(f"Inbox item not found: {item_id}")
             try:
                 svc.mark_read(item_id, actor=actor)
@@ -987,14 +993,15 @@ def reply_inbox_item(
         with create_work_service(
             config=config, project_key=key, project_path=project.path
         ) as svc:
-            # Membership guard (#2060 round-3): without this a reply to
-            # a non-inbox work task would be persisted as a reply row
-            # the GET /inbox surface would never expose.
+            # Membership guard (#2060 round-3/round-5): canonical
+            # inbox predicate; without this a reply to a non-inbox
+            # work task would be persisted as a reply row the GET
+            # /inbox surface would never expose.
             try:
                 src_task = svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
-            if not _is_inbox_member(src_task):
+            if not is_inbox_task(src_task, svc):
                 raise not_found(f"Inbox item not found: {item_id}")
             try:
                 svc.add_reply(item_id, body, actor=actor_name)
@@ -1053,11 +1060,13 @@ def promote_inbox_to_task(
                 src_task = src_svc.get(item_id)
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
-            # Membership guard (#2060 round-3): the GET /inbox surface
-            # would 404 a non-inbox task id, so promote-to-task must
-            # too — otherwise a caller can derive a new task from an
-            # arbitrary work row by addressing it through this verb.
-            if not _is_inbox_member(src_task):
+            # Membership guard (#2060 round-3/round-5): the GET
+            # /inbox surface would 404 a non-inbox task id, so
+            # promote-to-task must too — otherwise a caller can
+            # derive a new task from an arbitrary work row by
+            # addressing it through this verb. Canonical predicate
+            # so writes don't widen past cockpit / rail / dashboard.
+            if not is_inbox_task(src_task, src_svc):
                 raise not_found(f"Inbox item not found: {item_id}")
             src_title = title or f"From inbox: {src_task.title}"
             src_description = (
@@ -1538,6 +1547,16 @@ def _collect_inbox_items(
                 # readonly service handle stays open so we don't
                 # double-pay for connection setup.
                 snoozed_ids = _active_snoozed_ids(svc, tasks, now=now)
+                # Iterate inside the ``with`` block so the canonical
+                # inbox predicate (Codex round-5 on #2060) can call
+                # ``svc.get_flow(...)`` for its current-node-human
+                # branch while the readonly handle is still open.
+                for task in tasks:
+                    if task.task_id in snoozed_ids:
+                        continue
+                    entry = _task_to_inbox_item(task, svc)
+                    if entry is not None:
+                        out.append(entry)
         except _BACKING_STORE_ERRORS as exc:
             # Backing-store failure on a single project: log loudly,
             # skip that project but keep building the aggregate. We
@@ -1552,12 +1571,6 @@ def _collect_inbox_items(
                 exc_info=True,
             )
             continue
-        for task in tasks:
-            if task.task_id in snoozed_ids:
-                continue
-            entry = _task_to_inbox_item(task)
-            if entry is not None:
-                out.append(entry)
     return out
 
 
@@ -1659,36 +1672,46 @@ def _active_snoozed_ids(
     return snoozed
 
 
-def _is_inbox_member(task) -> bool:
+def _is_inbox_member(task, svc=None) -> bool:
     """Return True iff ``task`` belongs to the API inbox surface.
 
-    Canonical predicate shared by the read (``GET /inbox`` via
-    :func:`_collect_inbox_items` / :func:`_task_to_inbox_item`) and
-    write (archive / snooze / mark-read / reply / promote) paths so a
-    POST cannot mutate a non-inbox work task — Codex round-3 blocker
-    #1 on #2060 (the old write helpers only probed ``svc.get()``,
-    which returns ANY task with that id and let a caller close a
-    plain "task" flow row via ``POST /inbox/<id>/archive``).
+    Thin delegate to :func:`pollypm.work.inbox_view.is_inbox_task` —
+    the canonical predicate used by the cockpit inbox panel, the
+    dashboard inbox count, and the rail badge. Routing the API
+    write resolution through the same predicate closes Codex round-5
+    blocker on #2060: the previous web-layer predicate accepted any
+    ``flow_template_id == 'chat'`` plus substring plan labels (so
+    ``not_plan_review`` / ``planning`` matched), widening the write
+    surface beyond what GET /inbox / cockpit ever surfaces.
 
-    Mirrors :func:`_task_to_inbox_item` exactly: chat-flow rows OR
-    plan-review rows (label ``plan_review`` or
-    :func:`_is_plan_task`). The terminal-state check stays on the
-    read side because mutating write helpers each have their own
-    typed conflict path (archive's strict UPDATE, snooze's
-    pre-check) — including ``state == 'closed'`` here would
-    incorrectly 404 a request that should 409.
+    ``svc`` is optional only so legacy callers without a flow-lookup
+    handle (e.g. unit tests that construct stubs by hand) can still
+    reach the helper; production callers always pass the live work
+    service so the canonical predicate can resolve the current node
+    when it falls back to the human-actor check. When ``svc`` is
+    omitted we hand the predicate a no-flow shim so it degrades to
+    the role / label branches only.
     """
-    flow = (getattr(task, "flow_template_id", "") or "").lower()
-    labels = [str(lbl) for lbl in (getattr(task, "labels", []) or [])]
-    is_plan_review = (
-        any("plan_review" in lbl for lbl in labels) or _is_plan_task(task)
-    )
-    is_chat = flow == "chat"
-    return bool(is_chat or is_plan_review)
+    flow_lookup = svc if svc is not None else _NoFlowLookup()
+    return bool(is_inbox_task(task, flow_lookup))
 
 
-def _task_to_inbox_item(task) -> APIInboxItem | None:
-    if not _is_inbox_member(task):
+class _NoFlowLookup:
+    """Flow-lookup shim used when no work service handle is on hand.
+
+    ``is_inbox_task`` falls back to ``service.get_flow(...)`` for its
+    "current node is human" branch. When the caller has no service
+    (rare; legacy tests) we return ``None`` so the canonical
+    predicate's existing ``try/except`` short-circuits that branch
+    cleanly. Roles and exact ``plan_review`` label checks still run.
+    """
+
+    def get_flow(self, name, project=None):  # noqa: D401 - protocol shim
+        return None
+
+
+def _task_to_inbox_item(task, svc=None) -> APIInboxItem | None:
+    if not _is_inbox_member(task, svc):
         return None
     flow = (getattr(task, "flow_template_id", "") or "").lower()
     labels = [str(lbl) for lbl in (getattr(task, "labels", []) or [])]

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -1517,40 +1517,35 @@ def _collect_inbox_items(
 #
 # The POST /inbox/{id}/snooze endpoint persists an ``entry_type='snooze'``
 # row whose text starts with ``until_iso=<ISO>; snoozed until <ISO>``.
-# These helpers parse that wake-time back so the inbox list filters
-# out items whose snooze hasn't expired.  Kept private to this module
-# because the cockpit-side inbox panel has its own (unrelated) curation
-# predicate — wiring snooze through that surface is out of scope for
-# this PR and tracked separately.
+# The wake-time parser + "still snoozed?" predicate live in
+# ``pollypm.work.inbox_snooze`` so cockpit can adopt them WITHOUT
+# duplicating regex logic (Codex round-2 ask on PR #2060). The
+# module-private aliases here keep the existing import sites + tests
+# working unchanged.
+#
+# ``_active_snoozed_ids`` calls ``svc.latest_snoozes_bulk(...)``
+# (single SQL on pg) instead of the original per-task
+# ``svc.get_context(entry_type='snooze', limit=1)`` loop — the
+# inbox-list path is user-facing and a 50-task page was paying N
+# round-trips to the work-service per request.
 # ---------------------------------------------------------------------------
 
+from pollypm.work.inbox_snooze import (
+    is_snooze_active as _is_snooze_active,
+    parse_snooze_until as _parse_snooze_until,
+)
 
-def _parse_snooze_until(text: str) -> datetime | None:
-    """Pull a tz-aware wake-time out of a snooze context-entry text.
 
-    Accepts both the canonical ``until_iso=<ISO>`` marker the snooze
-    writer emits and the older ``snoozed until <ISO>`` shape so rows
-    written before the structured marker landed still parse. Returns
-    ``None`` when no recognisable timestamp is present.
+def _task_key(task_id: str) -> tuple[str, int]:
+    """Split ``project/n`` into a ``(project, number)`` tuple.
+
+    The bulk snooze helper keys by ``(project, task_number)`` (mirrors
+    the underlying ``work_context_entries`` PK shape); this just
+    centralises the parse so the call site doesn't sprout an ad-hoc
+    splitter.
     """
-    if not text:
-        return None
-    candidates: list[str] = []
-    for part in text.split(";"):
-        chunk = part.strip()
-        if chunk.startswith("until_iso="):
-            candidates.append(chunk[len("until_iso="):].strip())
-        elif chunk.lower().startswith("snoozed until "):
-            candidates.append(chunk[len("snoozed until "):].strip())
-    for raw in candidates:
-        try:
-            parsed = datetime.fromisoformat(raw)
-        except ValueError:
-            continue
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return parsed
-    return None
+    project, num = task_id.split("/", 1)
+    return project, int(num)
 
 
 def _active_snoozed_ids(
@@ -1558,13 +1553,45 @@ def _active_snoozed_ids(
 ) -> set[str]:
     """Return task_ids whose latest snooze entry is still in the future.
 
-    Per-task ``get_context(entry_type='snooze', limit=1)`` query; the
-    work-service returns rows ``ORDER BY id DESC`` so the first row is
-    the most recent snooze. Items without a snooze row, or whose latest
+    Uses :meth:`WorkService.latest_snoozes_bulk` — one SQL query
+    regardless of task count — instead of the per-task
+    ``get_context(entry_type='snooze', limit=1)`` loop the round-1
+    implementation shipped. Inbox listing is a user-facing scan path;
+    a 50-row page was paying 50 round-trips before this lands
+    (#2060 round-2). Items without a snooze row, or whose latest
     snooze has expired, are NOT in the returned set (the inbox shows
     them as actionable, matching cockpit semantics).
+
+    Falls back to the per-task loop when the backing service lacks
+    the bulk method (older mocks, alternate backends) so this stays
+    safe to land before every implementation grows the helper.
     """
-    snoozed: set[str] = set()
+    if not tasks:
+        return set()
+    bulk = getattr(svc, "latest_snoozes_bulk", None)
+    if bulk is not None:
+        try:
+            keys = [_task_key(t.task_id) for t in tasks]
+            latest = bulk(keys)
+        except Exception:  # noqa: BLE001 — readonly view degrades open
+            logger.debug(
+                "inbox: bulk snooze lookup failed; falling back to per-task",
+                exc_info=True,
+            )
+            latest = None
+        if latest is not None:
+            snoozed: set[str] = set()
+            for task in tasks:
+                key = _task_key(task.task_id)
+                entry = latest.get(key)
+                if entry is None:
+                    continue
+                if _is_snooze_active(entry.text, now=now):
+                    snoozed.add(task.task_id)
+            return snoozed
+    # Fallback: per-task loop (legacy path, kept for backends without
+    # the bulk helper). This branch should not run against pg.
+    snoozed = set()
     for task in tasks:
         try:
             entries = svc.get_context(
@@ -1578,10 +1605,7 @@ def _active_snoozed_ids(
             continue
         if not entries:
             continue
-        wake = _parse_snooze_until(entries[0].text)
-        if wake is None:
-            continue
-        if wake > now:
+        if _is_snooze_active(entries[0].text, now=now):
             snoozed.add(task.task_id)
     return snoozed
 

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -751,21 +751,14 @@ def archive_inbox_item(
             # short-circuit with the same 404 the read surface returns.
             if not _is_inbox_member(src_task):
                 raise not_found(f"Inbox item not found: {item_id}")
-            if reason:
-                # Record the operator-supplied reason before flipping
-                # so the audit trail captures both "why" and "how".
-                # Best-effort: a failed note must not block the
-                # archive (and must not race the strict transition).
-                try:
-                    svc.add_context(
-                        item_id, actor, f"archive reason: {reason}",
-                        entry_type="note",
-                    )
-                except Exception:  # noqa: BLE001 — non-fatal context-write
-                    logger.debug(
-                        "archive_inbox_item: reason note failed for %s",
-                        item_id, exc_info=True,
-                    )
+            # Run the strict transition FIRST so the reason note is
+            # only persisted on a successful archive (#2060 round-4
+            # blocker 2). The earlier ordering wrote the note before
+            # the transition; a losing concurrent archiver returned
+            # 409 with the reason already attached to a task that
+            # this caller had not, in fact, archived — leaving stray
+            # ``archive reason:`` notes on terminal items and a
+            # confusing audit trail.
             try:
                 svc.archive_task(item_id, actor=actor, strict=True)
             except TaskNotFoundError as exc:
@@ -781,6 +774,23 @@ def archive_inbox_item(
                     ),
                     hint="Items in a terminal state cannot be re-archived.",
                 ) from exc
+            if reason:
+                # Record the operator-supplied reason AFTER the strict
+                # transition succeeds so failed archives leave no
+                # note. Best-effort: a failed context-write must not
+                # roll back the (already-committed) archive — the
+                # transition itself is the source of truth, the note
+                # is supplementary audit context.
+                try:
+                    svc.add_context(
+                        item_id, actor, f"archive reason: {reason}",
+                        entry_type="note",
+                    )
+                except Exception:  # noqa: BLE001 — non-fatal context-write
+                    logger.debug(
+                        "archive_inbox_item: reason note failed for %s",
+                        item_id, exc_info=True,
+                    )
             task = svc.get(item_id)
             return _task_to_detail(task)
     except _BACKING_STORE_ERRORS as exc:

--- a/src/pollypm/work/inbox_snooze.py
+++ b/src/pollypm/work/inbox_snooze.py
@@ -1,0 +1,76 @@
+"""Shared snooze-marker predicate for inbox surfaces (#2060).
+
+The POST ``/api/v1/inbox/{id}/snooze`` writer persists snooze state as
+an ``entry_type='snooze'`` row whose text starts with a structured
+``until_iso=<ISO>`` marker. Multiple consumers (the API list path
+today, the cockpit inbox panel tomorrow) need to filter "still
+snoozed" items out of the default view. Without a shared parser the
+two surfaces would drift on what counts as snoozed and a future regex
+tweak in one place would silently desync the other.
+
+This module owns the two small helpers both surfaces rely on:
+
+- :func:`parse_snooze_until` — pull a tz-aware wake time out of a
+  snooze context entry's text (handles both the canonical
+  ``until_iso=`` marker and the older ``snoozed until <iso>`` shape
+  so legacy rows still parse).
+- :func:`is_snooze_active` — given an entry text and a reference
+  ``now``, return whether the wake time is still in the future.
+
+Lives in ``pollypm.work`` rather than ``pollypm.web_api`` so cockpit
+code (which must not depend on the web layer) can import it without
+pulling FastAPI into its dependency closure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+__all__ = ["parse_snooze_until", "is_snooze_active"]
+
+
+def parse_snooze_until(text: str) -> datetime | None:
+    """Pull a tz-aware wake time out of a snooze context-entry text.
+
+    Accepts both the canonical ``until_iso=<ISO>`` marker the snooze
+    writer emits and the older ``snoozed until <ISO>`` shape so rows
+    written before the structured marker landed still parse. Returns
+    ``None`` when no recognisable timestamp is present.
+    """
+    if not text:
+        return None
+    candidates: list[str] = []
+    for part in text.split(";"):
+        chunk = part.strip()
+        if chunk.startswith("until_iso="):
+            candidates.append(chunk[len("until_iso="):].strip())
+        elif chunk.lower().startswith("snoozed until "):
+            candidates.append(chunk[len("snoozed until "):].strip())
+    for raw in candidates:
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    return None
+
+
+def is_snooze_active(text: str, *, now: datetime) -> bool:
+    """Return True when ``text`` carries a wake time still in the future.
+
+    Convenience wrapper around :func:`parse_snooze_until` for the
+    common predicate "should this inbox row be hidden?" — keeps both
+    surfaces from re-implementing the wake-time comparison.
+    """
+    wake = parse_snooze_until(text)
+    if wake is None:
+        return False
+    # ``now`` should already be tz-aware (UTC); be defensive in case a
+    # caller passes a naive datetime so the comparison doesn't blow up
+    # on a single misuse.
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return wake > now

--- a/src/pollypm/work/inbox_view.py
+++ b/src/pollypm/work/inbox_view.py
@@ -20,8 +20,10 @@ autoreview), then by priority descending, then by ``updated_at`` descending.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Iterable, Protocol
 
+from pollypm.work.inbox_snooze import is_snooze_active
 from pollypm.work.models import (
     ActorType,
     FlowTemplate,
@@ -182,15 +184,82 @@ def is_inbox_task(
 # ---------------------------------------------------------------------------
 
 
+def _filter_active_snoozes(
+    service, tasks: list[Task], *, now: datetime | None = None,
+) -> list[Task]:
+    """Drop tasks whose latest snooze marker is still in the future.
+
+    The HTTP ``GET /api/v1/inbox`` surface already filters snoozed
+    items via :func:`pollypm.web_api.service._active_snoozed_ids` (uses
+    :meth:`PgWorkService.latest_snoozes_bulk` + the shared
+    :func:`pollypm.work.inbox_snooze.is_snooze_active` predicate). The
+    cockpit / dashboard / rail path went through
+    :func:`inbox_tasks` and never consulted snooze state, so a row
+    snoozed via the API would vanish from ``/api/v1/inbox`` while
+    still showing up in the cockpit inbox panel and dashboard count.
+    Codex round-3 blocker #2 on #2060 — fix is to share the same
+    membership + snooze predicate here so every surface agrees.
+
+    Pg path uses the bulk SQL when available; degrades gracefully
+    (no filter) when neither the bulk helper nor ``get_context`` is
+    on the service. Callers using a mock ``_FakeService`` without
+    snooze state see no behavioural change.
+    """
+    if not tasks:
+        return tasks
+    reference = now if now is not None else datetime.now(timezone.utc)
+    bulk = getattr(service, "latest_snoozes_bulk", None)
+    snoozed: set[str] = set()
+    if callable(bulk):
+        try:
+            keys = [(t.project, t.task_number) for t in tasks]
+            latest = bulk(keys)
+        except Exception:  # noqa: BLE001 — readonly view degrades open
+            latest = None
+        if latest is not None:
+            for task in tasks:
+                entry = latest.get((task.project, task.task_number))
+                if entry is None:
+                    continue
+                if is_snooze_active(getattr(entry, "text", "") or "", now=reference):
+                    snoozed.add(task.task_id)
+            if snoozed:
+                return [t for t in tasks if t.task_id not in snoozed]
+            return tasks
+    # Fallback: per-task ``get_context`` loop. Kept for mock services
+    # (test fakes) and backends without the bulk helper. Pg always has
+    # the bulk helper so this branch should not run in production.
+    get_context = getattr(service, "get_context", None)
+    if not callable(get_context):
+        return tasks
+    for task in tasks:
+        try:
+            entries = get_context(task.task_id, entry_type="snooze", limit=1)
+        except Exception:  # noqa: BLE001 — readonly view degrades open
+            continue
+        if not entries:
+            continue
+        text = getattr(entries[0], "text", "") or ""
+        if is_snooze_active(text, now=reference):
+            snoozed.add(task.task_id)
+    if snoozed:
+        return [t for t in tasks if t.task_id not in snoozed]
+    return tasks
+
+
 def inbox_tasks(
     service,
     *,
     project: str | None = None,
+    now: datetime | None = None,
 ) -> list[Task]:
     """Return all inbox tasks, sorted user-review first within review rows.
 
     ``service`` must satisfy the WorkService protocol. In particular it must
     provide ``list_tasks(project=...)`` and ``get_flow(name, project=...)``.
+    Snoozed rows (latest ``entry_type='snooze'`` context whose wake
+    time is still in the future) are filtered out so the cockpit
+    inbox panel agrees with ``GET /api/v1/inbox`` (#2060 round-3).
     """
     list_nonterminal = getattr(service, "list_nonterminal_tasks", None)
     if callable(list_nonterminal):
@@ -213,6 +282,7 @@ def inbox_tasks(
         task for task in candidates
         if is_inbox_task(task, service, flow_cache=flow_cache)
     ]
+    matches = _filter_active_snoozes(service, matches, now=now)
     # Stable-sort twice so both keys descend: updated_at first (least
     # significant), priority second, then review owner split for rows in review.
     matches.sort(key=_updated_at_key, reverse=True)

--- a/src/pollypm/work/inbox_view.py
+++ b/src/pollypm/work/inbox_view.py
@@ -127,8 +127,11 @@ def _roles_match_user(task: Task) -> bool:
     """True if the task has a 'user' role assignment.
 
     Matches both ``roles["user"] = <anything>`` and ``roles[<key>] = "user"``.
+    Uses ``getattr`` so duck-typed test stubs without a ``roles``
+    attribute degrade to "no user role" instead of ``AttributeError``
+    — real ``Task`` instances always carry the field.
     """
-    roles = task.roles or {}
+    roles = getattr(task, "roles", None) or {}
     if "user" in roles:
         return True
     return any(value == "user" for value in roles.values())
@@ -137,8 +140,14 @@ def _roles_match_user(task: Task) -> bool:
 def _current_node_is_human(
     task: Task, service: _FlowLookup, *, flow_cache: dict[tuple[str, int], FlowTemplate]
 ) -> bool:
-    """True if the task's current flow node has actor_type == HUMAN."""
-    if task.current_node_id is None:
+    """True if the task's current flow node has actor_type == HUMAN.
+
+    ``getattr`` on ``current_node_id`` so duck-typed test stubs that
+    only carry ``flow_template_id`` + ``labels`` (the chat-flow /
+    plan-review write tests) degrade to "no current node" cleanly.
+    Real ``Task`` instances always carry the field.
+    """
+    if getattr(task, "current_node_id", None) is None:
         return False
     flow = _flow_for_task(task, service, flow_cache=flow_cache)
     if flow is None:
@@ -157,8 +166,12 @@ def _is_plan_review_label(task: Task) -> bool:
     test above would drop them. They still need to appear in the
     shared cockpit inbox (reviewed by Sam or by Polly on Sam's
     behalf), so we accept the label itself as a membership signal.
+
+    Exact-match check on ``plan_review`` (not substring) so labels
+    like ``not_plan_review`` / ``planning`` cannot widen the inbox
+    write surface by accident — Codex round-5 blocker on PR #2060.
     """
-    labels = task.labels or []
+    labels = getattr(task, "labels", None) or []
     return any(label == "plan_review" for label in labels)
 
 
@@ -168,8 +181,17 @@ def is_inbox_task(
     *,
     flow_cache: dict[tuple[str, int], FlowTemplate] | None = None,
 ) -> bool:
-    """Return True if ``task`` belongs in the user's inbox."""
-    if task.work_status in TERMINAL_STATUSES:
+    """Return True if ``task`` belongs in the user's inbox.
+
+    Canonical predicate shared by the cockpit inbox panel, the
+    dashboard inbox count, the rail badge, AND (since #2060 round-5)
+    the API ``GET /inbox`` + write resolution helpers. Centralising
+    here prevents write-side drift past the read surface: a chat-flow
+    task lacking a user role / human current node cannot be archived,
+    snoozed, mark-read, replied to, or promoted via the API if it
+    would not have appeared in the cockpit inbox.
+    """
+    if getattr(task, "work_status", None) in TERMINAL_STATUSES:
         return False
     if _roles_match_user(task):
         return True

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -2796,24 +2796,75 @@ class PgWorkService:
             conn.commit()
         return True
 
-    def archive_task(self, task_id: str, actor: str = "user") -> Task:
+    def archive_task(
+        self, task_id: str, actor: str = "user", *, strict: bool = False,
+    ) -> Task:
         """Flip an inbox task to the chat-flow terminal state.
 
-        Idempotent: archiving an already-terminal task is a no-op and
-        returns the current record unchanged. Uses the same underlying
-        transition shape as :meth:`mark_done` (audit row + auto-unblock
-        cascade) so dashboard counts and dependency unblocking stay
-        consistent.
+        By default this is idempotent: archiving an already-terminal
+        task is a no-op and returns the current record unchanged. Uses
+        the same underlying transition shape as :meth:`mark_done`
+        (audit row + auto-unblock cascade) so dashboard counts and
+        dependency unblocking stay consistent.
+
+        When ``strict=True`` is passed, the state transition is
+        performed atomically (single conditional UPDATE that asserts
+        the row is still non-terminal) and the method raises
+        :class:`InvalidTransitionError` if the row was already
+        terminal when the write executed. This closes the
+        concurrent-archive race the Web API exposes — two simultaneous
+        ``POST /inbox/{id}/archive`` calls now produce exactly one 200
+        and one 409 ``invalid_state`` (see #2060 Codex review).
         """
         task = self.get(task_id)
-        if task.work_status in TERMINAL_STATUSES:
+        if not strict and task.work_status in TERMINAL_STATUSES:
             return task
         project, task_number = task.project, task.task_number
         now = _now_iso()
         from_status = task.work_status
+        terminal_values = sorted(s.value for s in TERMINAL_STATUSES)
+        # Inline the terminal-status placeholders — psycopg binds
+        # tuples positionally to %s and NOT IN expects an explicit
+        # list expression. The values come from the WorkStatus enum
+        # so there's no injection surface.
+        placeholders = ",".join(["%s"] * len(terminal_values))
         with self._pool.connection() as conn:
             conn.autocommit = False
             with conn.cursor() as cur:
+                # Atomically claim the transition: the WHERE guard
+                # asserts the row is still non-terminal at write time,
+                # so concurrent archivers race on this single UPDATE
+                # rather than on a stale read. Postgres serialises
+                # row-level writes, so exactly one caller sees
+                # rowcount==1; the loser sees rowcount==0 and (under
+                # ``strict``) raises InvalidTransitionError instead of
+                # silently returning the terminal record.
+                cur.execute(
+                    "UPDATE work_tasks SET work_status = %s, updated_at = %s "
+                    "WHERE project = %s AND task_number = %s "
+                    f"AND work_status NOT IN ({placeholders}) "
+                    "RETURNING work_status",
+                    (
+                        WorkStatus.DONE.value,
+                        now,
+                        project,
+                        task_number,
+                        *terminal_values,
+                    ),
+                )
+                claimed = cur.fetchone() is not None
+                if not claimed:
+                    conn.rollback()
+                    if strict:
+                        current = self.get(task_id)
+                        raise InvalidTransitionError(
+                            f"Task {task_id} is already "
+                            f"{current.work_status.value}; cannot archive."
+                        )
+                    # Non-strict fallthrough: row raced to terminal
+                    # between the pre-read and the UPDATE. Return the
+                    # current record (idempotent contract).
+                    return self.get(task_id)
                 cur.execute(
                     "INSERT INTO work_transitions ("
                     "task_project, task_number, from_state, to_state, "
@@ -2828,11 +2879,6 @@ class PgWorkService:
                         "inbox.archive",
                         now,
                     ),
-                )
-                cur.execute(
-                    "UPDATE work_tasks SET work_status = %s, updated_at = %s "
-                    "WHERE project = %s AND task_number = %s",
-                    (WorkStatus.DONE.value, now, project, task_number),
                 )
             conn.commit()
         # #1787: audit emit after commit so the JSONL trail tracks this

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -2950,6 +2950,62 @@ class PgWorkService:
             out.setdefault(int(r[0]), []).append(entry)
         return out
 
+    def latest_snoozes_bulk(
+        self, task_keys: list[tuple[str, int]],
+    ) -> dict[tuple[str, int], ContextEntry]:
+        """Return ``{(project, task_number): latest_snooze_entry}`` (#2060).
+
+        SINGLE SQL query — replaces the per-task
+        ``get_context(entry_type='snooze', limit=1)`` loop the inbox
+        list path was running for every visible task (Codex round-2
+        blocker on PR #2060). The inbox-list helper uses this to
+        decide which items are still snoozed (wake time in the
+        future) without paying for N round-trips on a user-facing
+        scan path.
+
+        Mirrors the existing :meth:`bulk_list_replies` /
+        :meth:`task_numbers_with_context_entry` pattern: one
+        statement, bucketed in Python, the "latest" row per task is
+        picked via ``DISTINCT ON`` + ``ORDER BY id DESC`` so it
+        matches what ``get_context(..., limit=1)`` returns per-row.
+
+        ``task_keys`` is the list of ``(project, task_number)`` pairs
+        the caller wants snooze state for; an empty list short-
+        circuits to ``{}`` without hitting the DB. Tasks with no
+        snooze rows are simply absent from the result mapping.
+        """
+        if not task_keys:
+            return {}
+        # ``task_key`` ANY-array filter keeps the statement to one
+        # bind regardless of N — psycopg adapts the list of tuples
+        # into a row-comparison array. DISTINCT ON (project, num) +
+        # ORDER (project, num, id DESC) picks the most-recent row per
+        # task, matching ``get_context(..., limit=1)`` semantics.
+        projects = [k[0] for k in task_keys]
+        numbers = [k[1] for k in task_keys]
+        sql = (
+            "SELECT DISTINCT ON (task_project, task_number) "
+            "task_project, task_number, actor, created_at, text, entry_type "
+            "FROM work_context_entries "
+            "WHERE entry_type = 'snooze' "
+            "AND (task_project, task_number) IN ("
+            "SELECT UNNEST(%s::text[]), UNNEST(%s::int[])) "
+            "ORDER BY task_project, task_number, id DESC"
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (projects, numbers))
+            rows = cur.fetchall()
+        out: dict[tuple[str, int], ContextEntry] = {}
+        for r in rows:
+            entry = ContextEntry(
+                actor=str(r[2]),
+                timestamp=r[3],
+                text=str(r[4]),
+                entry_type=str(r[5] or "snooze"),
+            )
+            out[(str(r[0]), int(r[1]))] = entry
+        return out
+
     # ------------------------------------------------------------------
     # Dependencies
     # ------------------------------------------------------------------

--- a/src/pollypm/work/service.py
+++ b/src/pollypm/work/service.py
@@ -280,6 +280,23 @@ class WorkService(Protocol):
         """
         ...
 
+    def latest_snoozes_bulk(
+        self, task_keys: list[tuple[str, int]],
+    ) -> dict[tuple[str, int], ContextEntry]:
+        """Return ``{(project, task_number): latest_snooze_entry}`` (#2060).
+
+        Single-query bulk fetch of the most-recent ``entry_type='snooze'``
+        row per task. Replaces the per-task
+        ``get_context(entry_type='snooze', limit=1)`` loop the inbox
+        list path was running on a user-facing scan. Tasks with no
+        snooze rows are absent from the returned mapping. An empty
+        ``task_keys`` short-circuits without a query.
+
+        Pinned on the protocol so the bulk path is part of the
+        contract (not a backend-specific optimisation that drifts).
+        """
+        ...
+
     # ------------------------------------------------------------------
     # Relationships
     # ------------------------------------------------------------------

--- a/tests/test_inbox_view_snooze.py
+++ b/tests/test_inbox_view_snooze.py
@@ -1,0 +1,212 @@
+"""Snooze-filter regression for the cockpit/dashboard inbox path (#2060).
+
+Codex round-3 blocker #2 on PR #2060: snooze visibility was split
+across surfaces. ``GET /api/v1/inbox`` filtered active snoozes via
+``pollypm.web_api.service._active_snoozed_ids``, but the cockpit
+inbox panel + dashboard + rail count went through
+``pollypm.work.inbox_view.inbox_tasks()`` which never consulted
+snooze state. A snoozed item would vanish from the API while still
+showing up everywhere the cockpit looked.
+
+These tests pin the cockpit-path filter at the inbox-view layer so
+both surfaces agree on what's visible.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pollypm.work.inbox_view import inbox_tasks
+from pollypm.work.models import (
+    ActorType,
+    FlowNode,
+    FlowTemplate,
+    NodeType,
+    Priority,
+    Task,
+    TaskType,
+    WorkStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests/test_inbox_review_ordering.py shape)
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    number: int,
+    *,
+    title: str = "Inbox item",
+    flow_template_id: str = "chat",
+    current_node_id: str = "human_review",
+    priority: Priority = Priority.NORMAL,
+    roles: dict[str, str] | None = None,
+) -> Task:
+    return Task(
+        project="demo",
+        task_number=number,
+        title=title,
+        type=TaskType.TASK,
+        work_status=WorkStatus.IN_PROGRESS,
+        priority=priority,
+        flow_template_id=flow_template_id,
+        current_node_id=current_node_id,
+        roles=roles or {"requester": "user"},
+        updated_at=datetime(2026, 5, 22, 12, 0, tzinfo=UTC),
+    )
+
+
+def _chat_flow() -> FlowTemplate:
+    return FlowTemplate(
+        name="chat",
+        description="",
+        start_node="human_review",
+        nodes={
+            "human_review": FlowNode(
+                name="human_review",
+                type=NodeType.REVIEW,
+                actor_type=ActorType.HUMAN,
+            ),
+        },
+    )
+
+
+class _ContextEntry:
+    """Mimics :class:`pollypm.work.models.ContextEntry` for the snooze field."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _BulkSnoozeService:
+    """Inbox-view stub with the pg-shape bulk snooze helper.
+
+    Mirrors the pg backend (which is what cockpit/dashboard go
+    through) — exposes ``list_tasks``, ``get_flow``, and
+    ``latest_snoozes_bulk``. The bulk helper returns one entry per
+    snoozed task keyed by ``(project, task_number)`` (matching
+    :meth:`PgWorkService.latest_snoozes_bulk`).
+    """
+
+    def __init__(
+        self,
+        tasks: list[Task],
+        *,
+        snoozes: dict[tuple[str, int], str] | None = None,
+    ) -> None:
+        self.tasks = list(tasks)
+        self.snoozes = dict(snoozes or {})
+        self.bulk_calls = 0
+        self.flows = {"chat": _chat_flow()}
+
+    def list_tasks(self, *, project: str | None = None, work_status=None):
+        out = list(self.tasks)
+        if project is not None:
+            out = [t for t in out if t.project == project]
+        if work_status is not None:
+            out = [
+                t for t in out
+                if getattr(t.work_status, "value", str(t.work_status)) == work_status
+            ]
+        return out
+
+    def get_flow(self, name: str, project: str | None = None) -> FlowTemplate:
+        return self.flows[name]
+
+    def latest_snoozes_bulk(self, keys):
+        self.bulk_calls += 1
+        return {
+            key: _ContextEntry(text)
+            for key, text in self.snoozes.items()
+            if key in set(keys)
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_inbox_tasks_excludes_actively_snoozed_row() -> None:
+    """A row with a future snooze must NOT appear in cockpit inbox.
+
+    This is the broken-feature case from Codex round-3: snooze hid
+    the row from ``GET /api/v1/inbox`` but the cockpit / dashboard
+    panel still surfaced it because ``inbox_tasks`` never consulted
+    the snooze state.
+    """
+    now = datetime(2026, 5, 22, 12, 0, tzinfo=UTC)
+    future = (now + timedelta(hours=2)).isoformat()
+
+    visible = _task(1, title="visible")
+    snoozed = _task(2, title="snoozed")
+
+    svc = _BulkSnoozeService(
+        [visible, snoozed],
+        snoozes={("demo", 2): f"until_iso={future}"},
+    )
+    result = inbox_tasks(svc, project="demo", now=now)
+    ids = [t.task_id for t in result]
+    assert "demo/1" in ids
+    assert "demo/2" not in ids, (
+        "snoozed item still surfaced via inbox_tasks — cockpit / "
+        "dashboard would show it even though /api/v1/inbox hides it"
+    )
+
+
+def test_inbox_tasks_re_surfaces_expired_snooze() -> None:
+    """A snooze marker whose wake time is in the past must NOT hide the row."""
+    now = datetime(2026, 5, 22, 12, 0, tzinfo=UTC)
+    past = (now - timedelta(hours=1)).isoformat()
+
+    task = _task(1, title="re-emerged")
+    svc = _BulkSnoozeService(
+        [task],
+        snoozes={("demo", 1): f"until_iso={past}"},
+    )
+    result = inbox_tasks(svc, project="demo", now=now)
+    assert [t.task_id for t in result] == ["demo/1"]
+
+
+def test_inbox_tasks_uses_bulk_helper_when_available() -> None:
+    """One bulk call regardless of page size — no N+1 on cockpit refresh."""
+    now = datetime(2026, 5, 22, 12, 0, tzinfo=UTC)
+    future = (now + timedelta(hours=2)).isoformat()
+
+    tasks = [_task(i, title=f"item-{i}") for i in range(1, 6)]
+    svc = _BulkSnoozeService(
+        tasks,
+        snoozes={("demo", 3): f"until_iso={future}"},
+    )
+    result = inbox_tasks(svc, project="demo", now=now)
+    assert svc.bulk_calls == 1, (
+        f"cockpit path must call latest_snoozes_bulk once; saw {svc.bulk_calls}"
+    )
+    ids = sorted(t.task_id for t in result)
+    assert ids == ["demo/1", "demo/2", "demo/4", "demo/5"]
+
+
+def test_inbox_tasks_without_bulk_helper_returns_all_rows() -> None:
+    """Backends without bulk OR get_context (legacy mocks) degrade open.
+
+    The snooze filter must not blow up on a service that lacks both
+    helpers — that's the shape of the existing fakes in
+    ``tests/test_inbox_review_ordering.py``. Without snooze state we
+    can't decide; the safe default is "show the row" (matches
+    pre-#2060 behaviour everywhere except pg).
+    """
+
+    class _LegacyService:
+        def list_tasks(self, *, project=None, work_status=None):
+            # Only return when filtered to IN_PROGRESS so the per-
+            # status fanout in inbox_tasks doesn't dupe the row.
+            if work_status not in (None, "in_progress"):
+                return []
+            return [_task(1)]
+
+        def get_flow(self, name, project=None):
+            return _chat_flow()
+
+    result = inbox_tasks(_LegacyService(), project="demo")
+    assert [t.task_id for t in result] == ["demo/1"]

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -1151,3 +1151,186 @@ def test_membership_helper_accepts_chat_and_plan_review() -> None:
     assert _is_inbox_member(_PlanReviewLabel()) is True
     assert _is_inbox_member(_PlanReviewFlow()) is True
     assert _is_inbox_member(_NonInbox()) is False
+
+
+# ---------------------------------------------------------------------------
+# Archive reason ordering (#2060 round-4, blocker 2)
+#
+# Round-3 wrote the ``archive reason:`` context note BEFORE calling
+# the strict archive. If the strict archive lost a concurrent race
+# (rowcount == 0 → InvalidTransitionError) the API surfaced 409 to
+# the caller, but the reason note had already been persisted —
+# stamping a "this is why I archived" annotation onto a task this
+# caller never actually archived. Round-4 reorders: strict archive
+# first, then (only on success) the reason note. These tests pin the
+# ordering so the regression can't slip back in.
+# ---------------------------------------------------------------------------
+
+
+class _ConcurrentLoserStubTask:
+    """Looks like an inbox item (chat-flow) so the membership guard
+    accepts it; the conflict is raised by ``archive_task``, not by
+    the predicate."""
+
+    task_id = "myproj/1"
+    project = "myproj"
+    task_number = 1
+    title = "Inbox item"
+    description = "ping"
+    flow_template_id = "chat"  # Passes _is_inbox_member.
+    labels: list[str] = []
+
+    @property
+    def work_status(self):  # noqa: D401
+        from pollypm.work.models import WorkStatus
+        return WorkStatus.IN_PROGRESS
+
+
+class _ArchiveRaceLoserSvc:
+    """Records every mutation and raises on ``archive_task``.
+
+    Mirrors the pg ``strict=True`` rowcount==0 path: the conditional
+    UPDATE returned zero rows because a concurrent archiver beat us,
+    so the canonical writer raises ``InvalidTransitionError``. The
+    test asserts the reason note was NOT persisted before that raise.
+    """
+
+    def __init__(self) -> None:
+        self.archive_calls = 0
+        self.add_context_calls: list[tuple] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, item_id):
+        return _ConcurrentLoserStubTask()
+
+    def archive_task(self, item_id, *, actor, strict=False):
+        self.archive_calls += 1
+        from pollypm.work.service_support import InvalidTransitionError
+        raise InvalidTransitionError(
+            f"Inbox item {item_id} already terminal (concurrent race loser)."
+        )
+
+    def add_context(self, *args, **kwargs):
+        # Record the call so the test can assert it never happened.
+        self.add_context_calls.append((args, kwargs))
+
+
+def test_archive_strict_loser_does_not_persist_reason_note(
+    config, monkeypatch,
+) -> None:
+    """Concurrent archive loser must not stamp a reason note.
+
+    Reproduces #2060 round-4 blocker 2: when ``archive_task(strict=True)``
+    raises ``InvalidTransitionError`` (rowcount==0 because another
+    writer won the race), the API surfaces 409. Before the fix, the
+    handler had already persisted ``archive reason: <text>`` as a
+    context note — falsely attributing an archive to a caller whose
+    transition lost. The fix reorders so the note is only written
+    after the strict transition succeeds.
+
+    This test fails on the broken ordering (note persisted) and
+    passes after the fix (note skipped).
+    """
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    svc = _ArchiveRaceLoserSvc()
+
+    def fake_factory(*, config, project_key, project_path):
+        return svc
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+
+    with pytest.raises(APIError) as excinfo:
+        web_service.archive_inbox_item(
+            config, "myproj/1", reason="testing", actor="api",
+        )
+    # 1. Loser sees the documented 409 invalid_state envelope.
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.code == "invalid_state"
+    # 2. Strict archive WAS attempted (otherwise we wouldn't have
+    #    raised, and the ordering question would be moot).
+    assert svc.archive_calls == 1
+    # 3. Critical: reason note was NOT persisted. A failed archive
+    #    must leave no ``archive reason:`` audit row.
+    assert svc.add_context_calls == [], (
+        "archive_inbox_item persisted a reason note for a 409-loser "
+        "concurrent archive. The reason write must happen AFTER the "
+        "strict transition succeeds (#2060 round-4)."
+    )
+
+
+def test_archive_strict_success_persists_reason_note_after_transition(
+    config, monkeypatch,
+) -> None:
+    """Happy path still records the reason — but only after archive.
+
+    The fix must not regress the existing behaviour: on a successful
+    archive, the reason note IS persisted. This guards against a
+    too-aggressive fix that drops the note entirely.
+    """
+    from pollypm.web_api import service as web_service
+
+    class _SuccessSvc:
+        def __init__(self) -> None:
+            self.archive_calls = 0
+            self.add_context_calls: list[tuple] = []
+            self.call_order: list[str] = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get(self, item_id):
+            return _ConcurrentLoserStubTask()
+
+        def archive_task(self, item_id, *, actor, strict=False):
+            self.archive_calls += 1
+            self.call_order.append("archive_task")
+            return None
+
+        def add_context(self, *args, **kwargs):
+            self.add_context_calls.append((args, kwargs))
+            self.call_order.append("add_context")
+
+    svc = _SuccessSvc()
+
+    def fake_factory(*, config, project_key, project_path):
+        return svc
+
+    # Bypass the final ``_task_to_detail`` since the stub task does
+    # not carry every relationship attribute — this test cares only
+    # about the call ordering of archive_task vs add_context, not
+    # the response envelope shape (that's pinned elsewhere).
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+    monkeypatch.setattr(
+        web_service, "_task_to_detail", lambda task, plan=None: None,
+    )
+    web_service.archive_inbox_item(
+        config, "myproj/1", reason="testing", actor="api",
+    )
+    # Both ran, and archive_task ran FIRST (the ordering is the fix).
+    assert svc.archive_calls == 1
+    assert len(svc.add_context_calls) == 1
+    assert svc.call_order.index("archive_task") < svc.call_order.index(
+        "add_context"
+    ), (
+        "Reason note was written before archive_task — the round-4 "
+        "ordering fix has regressed (#2060)."
+    )
+    # Reason payload is intact.
+    args, kwargs = svc.add_context_calls[0]
+    # Positional shape: (item_id, actor, text, entry_type=...).
+    assert args[0] == "myproj/1"
+    assert "archive reason: testing" in args[2]

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -1626,3 +1626,303 @@ def test_archive_strict_success_persists_reason_note_after_transition(
     # Positional shape: (item_id, actor, text, entry_type=...).
     assert args[0] == "myproj/1"
     assert "archive reason: testing" in args[2]
+
+
+# ---------------------------------------------------------------------------
+# Round-6 backing-store error classification (#2060, Codex 16:07 UTC).
+#
+# pg is the only supported backend post #1971 (``pollypm.work.factory``).
+# Before round-6, ``_BACKING_STORE_ERRORS`` only listed sqlite3 +
+# OSError — neither covers ``psycopg.OperationalError`` nor
+# ``psycopg_pool.PoolTimeout``, so a real pg outage / pool exhaustion
+# raised through the inbox write helpers as an unhandled exception and
+# the route mapped it to 500 ``internal_error`` instead of the
+# documented 503 ``service_unavailable`` envelope. These tests pin the
+# classification so a regression that drops either class trips CI.
+# ---------------------------------------------------------------------------
+
+
+def _install_raising_factory(monkeypatch, exc: BaseException) -> None:
+    """Patch ``create_work_service`` to raise ``exc`` at construction.
+
+    Mirrors the production failure mode for a real pg outage / pool
+    exhaustion: the helper opens a work-service handle inside a
+    ``with`` block, and the pg/pool layer raises before we ever get a
+    chance to ``svc.get(...)``. That raise must hit the central
+    ``_BACKING_STORE_ERRORS`` ``except`` and surface as 503.
+    """
+
+    def fake_factory(*, config, project_key, project_path):
+        raise exc
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+
+
+def test_archive_returns_503_on_psycopg_operational_error(
+    config, monkeypatch,
+) -> None:
+    """A real pg outage must surface as ``503 service_unavailable``.
+
+    Before round-6 this fell through ``_BACKING_STORE_ERRORS`` and
+    became an unhandled exception → 500 ``internal_error``. Codex
+    round-6 blocker 1 on PR #2060.
+    """
+    import psycopg
+
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    _install_raising_factory(
+        monkeypatch, psycopg.OperationalError("pg pool dead"),
+    )
+    with pytest.raises(APIError) as excinfo:
+        web_service.archive_inbox_item(config, "myproj/1", reason="x")
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.code == "service_unavailable"
+
+
+def test_archive_returns_503_on_pool_timeout(config, monkeypatch) -> None:
+    """Pool exhaustion (``psycopg_pool.PoolTimeout``) must surface 503."""
+    import psycopg_pool
+
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    _install_raising_factory(
+        monkeypatch, psycopg_pool.PoolTimeout("pool exhausted"),
+    )
+    with pytest.raises(APIError) as excinfo:
+        web_service.archive_inbox_item(config, "myproj/1", reason="x")
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.code == "service_unavailable"
+
+
+def test_snooze_returns_503_on_psycopg_operational_error(
+    config, monkeypatch,
+) -> None:
+    """Snooze writer shares the central classifier; confirm coverage."""
+    import psycopg
+
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    _install_raising_factory(
+        monkeypatch, psycopg.OperationalError("pg pool dead"),
+    )
+    with pytest.raises(APIError) as excinfo:
+        web_service.snooze_inbox_item(
+            config, "myproj/1", duration_seconds=3600,
+        )
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.code == "service_unavailable"
+
+
+def test_promote_returns_503_on_pool_timeout(config, monkeypatch) -> None:
+    """Promote writer shares the central classifier; confirm coverage."""
+    import psycopg_pool
+
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    _install_raising_factory(
+        monkeypatch, psycopg_pool.PoolTimeout("pool exhausted"),
+    )
+    with pytest.raises(APIError) as excinfo:
+        web_service.promote_inbox_to_task(config, "myproj/1")
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.code == "service_unavailable"
+
+
+def test_backing_store_errors_includes_psycopg_classes() -> None:
+    """The central tuple must list both pg failure classes.
+
+    Direct introspection so a refactor that splits / renames the
+    tuple without re-adding the pg entries trips here even if no
+    integration test exercises the specific exception.
+    """
+    import psycopg
+    import psycopg_pool
+
+    from pollypm.web_api.service import _BACKING_STORE_ERRORS
+
+    assert psycopg.OperationalError in _BACKING_STORE_ERRORS, (
+        "pg outages must map to the typed 503 envelope; add "
+        "psycopg.OperationalError to _BACKING_STORE_ERRORS "
+        "(#2060 round-6 blocker 1)."
+    )
+    assert psycopg_pool.PoolTimeout in _BACKING_STORE_ERRORS, (
+        "Pool exhaustion must map to the typed 503 envelope; add "
+        "psycopg_pool.PoolTimeout to _BACKING_STORE_ERRORS "
+        "(#2060 round-6 blocker 1)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-6 shared flow_cache (#2060, Codex 16:07 UTC).
+#
+# Before round-6, ``_collect_inbox_items`` looped over tasks and called
+# ``_task_to_inbox_item(task, svc)`` per task. ``_task_to_inbox_item``
+# fell through to ``_is_inbox_member`` → ``is_inbox_task`` with a
+# FRESH flow_cache per call, so N tasks on the same flow paid N
+# ``svc.get_flow()`` lookups on a user-facing scan. The shared
+# cockpit / rail / dashboard path in ``pollypm.work.inbox_view``
+# already threads ONE cache through every call. Round-6 fixes the
+# API list to do the same. This test pins the one-lookup behaviour
+# so a refactor that resets the cache per-task trips CI.
+# ---------------------------------------------------------------------------
+
+
+def test_inbox_list_resolves_flow_once_per_unique_flow_id(
+    client, auth_headers, monkeypatch, config,
+) -> None:
+    """N tasks on the same flow must trigger ONE ``get_flow`` call.
+
+    Constructs 5 tasks all on the same flow with no user role and no
+    plan_review label, so the canonical predicate must fall back to
+    the current-human-node branch — the branch that calls
+    ``svc.get_flow``. With the shared cache, that branch runs once
+    and caches the FlowTemplate; without it, it runs N times.
+    """
+    from pollypm.work.models import (
+        ActorType,
+        FlowNode,
+        FlowTemplate,
+        NodeType,
+        WorkStatus,
+    )
+
+    # Build a fake flow whose current node is human, so the canonical
+    # predicate's flow-lookup branch is exercised (and gets a hit).
+    fake_flow = FlowTemplate(
+        name="chat",
+        version=1,
+        description="test flow",
+        nodes={
+            "n0": FlowNode(
+                name="n0",
+                type=NodeType.WORK,
+                actor_type=ActorType.HUMAN,
+                actor_role=None,
+            ),
+        },
+        start_node="n0",
+    )
+
+    class _Task:
+        def __init__(self, n: int) -> None:
+            self.task_id = f"myproj/{n}"
+            self.project = "myproj"
+            self.task_number = n
+            self.title = f"task {n}"
+            self.description = "body"
+            self.flow_template_id = "chat"
+            self.flow_template_version = 1
+            self.labels: list[str] = []  # no plan_review label
+            self.roles: dict = {}  # no user role -> falls through
+            self.current_node_id = "n0"
+            self.work_status = WorkStatus.IN_PROGRESS
+            self.created_at = datetime(2026, 5, 22, 12, 0, tzinfo=timezone.utc)
+            self.updated_at = self.created_at
+
+    tasks = [_Task(i) for i in range(1, 6)]
+
+    class _CountingSvc:
+        def __init__(self) -> None:
+            self.get_flow_calls = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def list_tasks(self, project=None, work_status=None):
+            return list(tasks)
+
+        def get_flow(self, name, project=None):
+            self.get_flow_calls += 1
+            return fake_flow
+
+        def latest_snoozes_bulk(self, keys):
+            return {}
+
+    svc = _CountingSvc()
+
+    def fake_factory(*, config, project_key, project_path):
+        return svc
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+
+    response = client.get("/api/v1/inbox", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # All 5 tasks should surface (canonical predicate accepts via the
+    # current-human-node branch).
+    assert len(body["items"]) == 5, body
+    # The critical assertion: ONE flow lookup for 5 tasks sharing the
+    # same flow, not 5. Without the shared cache this would be 5.
+    assert svc.get_flow_calls == 1, (
+        f"inbox list path called get_flow {svc.get_flow_calls} times "
+        "for 5 tasks on a shared flow; expected exactly 1 (shared "
+        "flow_cache, #2060 round-6 blocker 2)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-6 exact plan-review classifier (#2060, Codex 16:07 UTC).
+#
+# ``_task_to_inbox_item`` previously used ``"plan_review" in lbl``
+# (substring match), so a task labeled ``not_plan_review`` was
+# classified as ``type="plan_review"`` even though the shared
+# membership predicate treats ``plan_review`` as exact-match. Round-6
+# tightens to exact equality, matching the canonical
+# :func:`pollypm.work.inbox_view._is_plan_review_label`.
+# ---------------------------------------------------------------------------
+
+
+def test_inbox_item_type_uses_exact_plan_review_label() -> None:
+    """A canonical inbox row labeled ``not_plan_review`` is not
+    classified as ``type="plan_review"``.
+
+    The substring ``"plan_review" in lbl`` matched ``not_plan_review``
+    and silently widened the API's type classification past the
+    canonical exact-match predicate. Codex round-6 blocker 3 on
+    PR #2060.
+    """
+    from pollypm.web_api.service import _task_to_inbox_item
+    from pollypm.work.models import WorkStatus
+
+    class _NearMissLabelInboxTask:
+        """Standard-flow task with a user role (so the canonical
+        predicate accepts it as an inbox member) carrying the
+        substring-but-not-equal label ``not_plan_review``."""
+        task_id = "myproj/7"
+        project = "myproj"
+        task_number = 7
+        title = "near-miss label"
+        description = "body"
+        flow_template_id = "standard"  # NOT 'chat'
+        flow_template_version = 1
+        labels = ["not_plan_review", "planning"]
+        roles = {"requester": "user"}  # accepted as inbox member
+        current_node_id = None
+        work_status = WorkStatus.IN_PROGRESS
+        created_at = datetime(2026, 5, 22, 12, 0, tzinfo=timezone.utc)
+        updated_at = created_at
+
+    entry = _task_to_inbox_item(_NearMissLabelInboxTask())
+    assert entry is not None, (
+        "near-miss labelled task with user role must still be an "
+        "inbox member (canonical predicate accepts via role) — only "
+        "the type classification should change."
+    )
+    assert entry.type != "plan_review", (
+        "type=plan_review classification was triggered by substring "
+        "match on ``not_plan_review`` — round-6 fix requires exact "
+        "equality (#2060)."
+    )
+    assert entry.type == "message"

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -1,0 +1,577 @@
+"""Integration tests for the Phase 2 inbox write endpoints.
+
+Covers ``POST /api/v1/inbox/{id}/{archive,snooze,promote-to-task,
+mark-read,reply}`` per the Phase 2 endpoints spec §4
+(``~/Desktop/pollypm-phase2-endpoints-spec.md``).
+
+The repo's full conftest spins up a Postgres testcontainer for every
+work-service test; that's too slow for endpoint-level coverage. We
+take the same approach the chat-send / chat-messages endpoint suites
+take: ``--noconftest`` to skip the heavy fixtures, then monkeypatch
+the service-layer write helpers so the FastAPI route ↔ handler ↔
+error-envelope plumbing is exercised end-to-end without touching
+Postgres. The underlying work-service writers themselves are
+exercised by ``tests/test_pg_inbox_actions.py``.
+
+Run with ``pytest --noconftest tests/test_inbox_writes_endpoint.py -v``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.errors import APIError
+from pollypm.web_api.models import (
+    TaskDetail,
+    TaskRelationships,
+)
+from pollypm.web_api.routes import inbox as inbox_routes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (self-contained — do not rely on tests/web_api/conftest.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def config(workspace: Path, project_root: Path) -> PollyPMConfig:
+    base_dir = workspace / ".pollypm"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def token(tmp_path: Path) -> tuple[Path, str]:
+    token_path = tmp_path / "api-token"
+    value, _ = ensure_token(token_path)
+    return token_path, value
+
+
+@pytest.fixture
+def auth_headers(token: tuple[Path, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token[1]}"}
+
+
+@pytest.fixture
+def app(config, token):
+    token_path, _ = token
+    return create_app(config=config, token_path=token_path)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+def _make_task_detail(
+    *,
+    task_id: str = "myproj/1",
+    title: str = "Inbox item",
+    work_status: str = "in_progress",
+    description: str = "hello from the inbox",
+) -> TaskDetail:
+    project, num = task_id.split("/", 1)
+    return TaskDetail(
+        task_id=task_id,
+        project=project,
+        task_number=int(num),
+        title=title,
+        work_status=work_status,
+        type="task",
+        priority="normal",
+        assignee=None,
+        current_node_id=None,
+        plan_version=1,
+        updated_at=datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc),
+        description=description,
+        acceptance_criteria=None,
+        constraints=None,
+        labels=[],
+        relevant_files=[],
+        relationships=TaskRelationships(),
+        flow_template_id="chat",
+        flow_template_version=1,
+        requires_human_review=False,
+        predecessor_task_id=None,
+        transitions=[],
+        executions=[],
+        context=[],
+        external_refs={},
+        total_input_tokens=0,
+        total_output_tokens=0,
+        session_count=0,
+        created_at=datetime(2026, 5, 20, 9, 0, 0, tzinfo=timezone.utc),
+        created_by="tester",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+
+def test_archive_happy_path_returns_task_detail(
+    client, auth_headers, monkeypatch,
+) -> None:
+    """Archive flips the source row to ``done`` via the work-service.
+
+    The handler should call ``archive_inbox_item`` with the path id
+    and the optional ``reason``, returning the post-transition
+    ``TaskDetail`` so the client can re-render.
+    """
+    captured: dict[str, object] = {}
+
+    def fake_archive(config, item_id, *, reason=None, actor="api"):
+        captured["item_id"] = item_id
+        captured["reason"] = reason
+        return _make_task_detail(task_id=item_id, work_status="done")
+
+    monkeypatch.setattr(inbox_routes, "archive_inbox_item", fake_archive)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/archive",
+        headers=auth_headers,
+        json={"reason": "no longer relevant"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["task_id"] == "myproj/1"
+    assert body["work_status"] == "done"
+    assert captured == {"item_id": "myproj/1", "reason": "no longer relevant"}
+
+
+def test_archive_accepts_empty_body(client, auth_headers, monkeypatch) -> None:
+    """The ``reason`` field is optional — empty body must work."""
+
+    def fake_archive(config, item_id, *, reason=None, actor="api"):
+        assert reason is None
+        return _make_task_detail(task_id=item_id, work_status="done")
+
+    monkeypatch.setattr(inbox_routes, "archive_inbox_item", fake_archive)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/archive", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_archive_409_when_already_archived(
+    client, auth_headers, monkeypatch,
+) -> None:
+    """Spec §4.3: archiving a terminal item returns 409 invalid_state."""
+
+    def fake_archive(config, item_id, *, reason=None, actor="api"):
+        raise APIError(
+            status_code=409,
+            code="invalid_state",
+            message=f"Inbox item {item_id} is already done.",
+        )
+
+    monkeypatch.setattr(inbox_routes, "archive_inbox_item", fake_archive)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/archive", headers=auth_headers,
+    )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "invalid_state"
+
+
+def test_archive_404_for_unknown_item(client, auth_headers, monkeypatch) -> None:
+    """Unknown ids surface as 404 ``not_found``."""
+    from pollypm.web_api.errors import not_found
+
+    def fake_archive(config, item_id, **kwargs):
+        raise not_found(f"Inbox item not found: {item_id}")
+
+    monkeypatch.setattr(inbox_routes, "archive_inbox_item", fake_archive)
+    response = client.post(
+        "/api/v1/inbox/myproj/9999/archive", headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_archive_requires_auth(client) -> None:
+    response = client.post("/api/v1/inbox/myproj/1/archive")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] in {"unauthorized", "invalid_token"}
+
+
+# ---------------------------------------------------------------------------
+# Snooze
+# ---------------------------------------------------------------------------
+
+
+def test_snooze_with_duration_seconds(
+    client, auth_headers, monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_snooze(
+        config, item_id, *, duration_seconds=None, until=None, reason=None,
+        actor="api",
+    ):
+        captured["duration_seconds"] = duration_seconds
+        captured["until"] = until
+        captured["reason"] = reason
+        return _make_task_detail(task_id=item_id)
+
+    monkeypatch.setattr(inbox_routes, "snooze_inbox_item", fake_snooze)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/snooze",
+        headers=auth_headers,
+        json={"duration_seconds": 3600, "reason": "later"},
+    )
+    assert response.status_code == 200, response.text
+    assert captured["duration_seconds"] == 3600
+    assert captured["until"] is None
+    assert captured["reason"] == "later"
+
+
+def test_snooze_with_until_timestamp(
+    client, auth_headers, monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_snooze(
+        config, item_id, *, duration_seconds=None, until=None, reason=None,
+        actor="api",
+    ):
+        captured["until"] = until
+        captured["duration_seconds"] = duration_seconds
+        return _make_task_detail(task_id=item_id)
+
+    monkeypatch.setattr(inbox_routes, "snooze_inbox_item", fake_snooze)
+    target = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
+    response = client.post(
+        "/api/v1/inbox/myproj/1/snooze",
+        headers=auth_headers,
+        json={"until": target},
+    )
+    assert response.status_code == 200, response.text
+    assert captured["duration_seconds"] is None
+    # FastAPI / Pydantic deserialises the iso string to a datetime.
+    assert isinstance(captured["until"], datetime)
+
+
+def test_snooze_requires_body(client, auth_headers) -> None:
+    """Spec: snooze must carry duration_seconds or until."""
+    response = client.post(
+        "/api/v1/inbox/myproj/1/snooze",
+        headers=auth_headers,
+    )
+    # Missing body fails Pydantic body validation → 422.
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
+def test_snooze_400_for_invalid_window(
+    client, auth_headers, monkeypatch,
+) -> None:
+    """Spec §4.3: 400 invalid_request when window is empty / past / >30d."""
+
+    def fake_snooze(config, item_id, **kwargs):
+        raise APIError(
+            status_code=400,
+            code="invalid_request",
+            message="Snooze until must be in the future.",
+        )
+
+    monkeypatch.setattr(inbox_routes, "snooze_inbox_item", fake_snooze)
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    response = client.post(
+        "/api/v1/inbox/myproj/1/snooze",
+        headers=auth_headers,
+        json={"until": past},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+# ---------------------------------------------------------------------------
+# Promote
+# ---------------------------------------------------------------------------
+
+
+def test_promote_creates_new_task(client, auth_headers, monkeypatch) -> None:
+    """``promote-to-task`` returns the new TaskDetail, not the source's."""
+    captured: dict[str, object] = {}
+
+    def fake_promote(
+        config, item_id, *, target_project=None, prompt=None, title=None,
+        actor="api",
+    ):
+        captured["item_id"] = item_id
+        captured["target_project"] = target_project
+        captured["prompt"] = prompt
+        captured["title"] = title
+        # Return a new id to mimic "create": myproj/1 → myproj/2.
+        return _make_task_detail(
+            task_id="myproj/2", title=title or "From inbox: Source",
+        )
+
+    monkeypatch.setattr(inbox_routes, "promote_inbox_to_task", fake_promote)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/promote-to-task",
+        headers=auth_headers,
+        json={"title": "Ship the feature", "prompt": "Description body"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["task_id"] == "myproj/2"
+    assert captured["title"] == "Ship the feature"
+    assert captured["prompt"] == "Description body"
+
+
+def test_promote_accepts_empty_body(client, auth_headers, monkeypatch) -> None:
+    """All overrides are optional — empty body falls through to defaults."""
+    captured: dict[str, object] = {}
+
+    def fake_promote(
+        config, item_id, *, target_project=None, prompt=None, title=None,
+        actor="api",
+    ):
+        captured.update(
+            target_project=target_project, prompt=prompt, title=title,
+        )
+        return _make_task_detail(task_id="myproj/2")
+
+    monkeypatch.setattr(inbox_routes, "promote_inbox_to_task", fake_promote)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/promote-to-task", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert captured == {"target_project": None, "prompt": None, "title": None}
+
+
+# ---------------------------------------------------------------------------
+# Mark read
+# ---------------------------------------------------------------------------
+
+
+def test_mark_read_updates_state(client, auth_headers, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_mark(config, item_id, *, actor="api"):
+        captured["item_id"] = item_id
+        captured["actor"] = actor
+        return _make_task_detail(task_id=item_id)
+
+    monkeypatch.setattr(inbox_routes, "mark_read_inbox_item", fake_mark)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/mark-read", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["task_id"] == "myproj/1"
+    assert captured["item_id"] == "myproj/1"
+    # Default actor falls through to "api" when body is omitted.
+    assert captured["actor"] == "api"
+
+
+def test_mark_read_honors_actor_override(
+    client, auth_headers, monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_mark(config, item_id, *, actor="api"):
+        captured["actor"] = actor
+        return _make_task_detail(task_id=item_id)
+
+    monkeypatch.setattr(inbox_routes, "mark_read_inbox_item", fake_mark)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/mark-read",
+        headers=auth_headers,
+        json={"actor": "operator"},
+    )
+    assert response.status_code == 200, response.text
+    assert captured["actor"] == "operator"
+
+
+# ---------------------------------------------------------------------------
+# Reply
+# ---------------------------------------------------------------------------
+
+
+def test_reply_happy_path(client, auth_headers, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_reply(config, item_id, *, body, owner=None, actor="api"):
+        captured["item_id"] = item_id
+        captured["body"] = body
+        captured["owner"] = owner
+        return _make_task_detail(task_id=item_id)
+
+    monkeypatch.setattr(inbox_routes, "reply_inbox_item", fake_reply)
+    response = client.post(
+        "/api/v1/inbox/myproj/1/reply",
+        headers=auth_headers,
+        json={"body": "thanks for the update", "owner": "pm"},
+    )
+    assert response.status_code == 200, response.text
+    assert captured["body"] == "thanks for the update"
+    assert captured["owner"] == "pm"
+
+
+def test_reply_422_on_empty_body(client, auth_headers) -> None:
+    """``body`` is min_length=1; Pydantic surfaces a 422."""
+    response = client.post(
+        "/api/v1/inbox/myproj/1/reply",
+        headers=auth_headers,
+        json={"body": ""},
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: 404 propagation, auth, slashes in ids
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_item_returns_404_across_endpoints(
+    client, auth_headers, monkeypatch,
+) -> None:
+    """Every write endpoint should surface a not_found error verbatim."""
+    from pollypm.web_api.errors import not_found
+
+    def boom(config, item_id, **kwargs):
+        raise not_found(f"Inbox item not found: {item_id}")
+
+    monkeypatch.setattr(inbox_routes, "archive_inbox_item", boom)
+    monkeypatch.setattr(inbox_routes, "snooze_inbox_item", boom)
+    monkeypatch.setattr(inbox_routes, "promote_inbox_to_task", boom)
+    monkeypatch.setattr(inbox_routes, "mark_read_inbox_item", boom)
+    monkeypatch.setattr(inbox_routes, "reply_inbox_item", boom)
+
+    # snooze + reply require a body; supply minimal valid ones.
+    cases = [
+        ("archive", {}),
+        ("snooze", {"duration_seconds": 60}),
+        ("promote-to-task", {}),
+        ("mark-read", {}),
+        ("reply", {"body": "x"}),
+    ]
+    for verb, payload in cases:
+        r = client.post(
+            f"/api/v1/inbox/myproj/9999/{verb}",
+            headers=auth_headers,
+            json=payload,
+        )
+        assert r.status_code == 404, (verb, r.text)
+        assert r.json()["error"]["code"] == "not_found", verb
+
+
+def test_id_with_slash_round_trips_for_all_write_verbs(
+    client, auth_headers, monkeypatch,
+) -> None:
+    """Inbox IDs carry a slash (``project/n``). The ``{id:path}`` mount
+    must accept them on every POST verb."""
+    seen_ids: list[str] = []
+
+    def capture(config, item_id, **kwargs):
+        seen_ids.append(item_id)
+        return _make_task_detail(task_id=item_id)
+
+    monkeypatch.setattr(inbox_routes, "archive_inbox_item", capture)
+    monkeypatch.setattr(inbox_routes, "snooze_inbox_item", capture)
+    monkeypatch.setattr(inbox_routes, "promote_inbox_to_task", capture)
+    monkeypatch.setattr(inbox_routes, "mark_read_inbox_item", capture)
+    monkeypatch.setattr(inbox_routes, "reply_inbox_item", capture)
+
+    cases = [
+        ("archive", {}),
+        ("snooze", {"duration_seconds": 60}),
+        ("promote-to-task", {}),
+        ("mark-read", {}),
+        ("reply", {"body": "hi"}),
+    ]
+    for verb, payload in cases:
+        r = client.post(
+            f"/api/v1/inbox/myproj/7/{verb}",
+            headers=auth_headers,
+            json=payload,
+        )
+        assert r.status_code == 200, (verb, r.text)
+    assert seen_ids == ["myproj/7"] * len(cases)
+
+
+def test_all_write_endpoints_require_auth(client) -> None:
+    """No Authorization header → 401 across every write endpoint."""
+    cases = [
+        ("archive", {}),
+        ("snooze", {"duration_seconds": 60}),
+        ("promote-to-task", {}),
+        ("mark-read", {}),
+        ("reply", {"body": "hi"}),
+    ]
+    for verb, payload in cases:
+        r = client.post(f"/api/v1/inbox/myproj/1/{verb}", json=payload)
+        assert r.status_code == 401, verb
+        assert r.json()["error"]["code"] in {"unauthorized", "invalid_token"}, verb

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -799,3 +799,151 @@ def test_snooze_writer_persists_structured_until_iso_marker(
     parsed = web_service._parse_snooze_until(text)
     assert parsed is not None
     assert parsed > datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Inbox list bulk snooze path (#2060 round-2)
+#
+# Round 1 of #2060 shipped ``_active_snoozed_ids`` as a per-task
+# ``svc.get_context(entry_type='snooze', limit=1)`` loop. Codex's
+# round-2 review flagged the N+1: for a 10-task inbox page that
+# means 10 round-trips to the work-service just to decide visibility.
+# Round 2 routes the call through ``svc.latest_snoozes_bulk`` (one
+# SQL on pg) and falls back to the per-task loop only when the
+# backing service lacks the bulk method. These tests pin both
+# behaviours so a refactor can't silently regress to N+1.
+# ---------------------------------------------------------------------------
+
+
+def test_active_snoozed_ids_uses_bulk_helper_when_available() -> None:
+    """A backing service with ``latest_snoozes_bulk`` is called ONCE.
+
+    Mocks both ``latest_snoozes_bulk`` and ``get_context`` on the
+    same stub; the bulk-aware path must call the bulk helper exactly
+    once and must NOT touch ``get_context`` (the per-task fallback).
+    """
+    from pollypm.web_api.service import _active_snoozed_ids
+
+    now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    future = (now + timedelta(hours=2)).isoformat()
+    past = (now - timedelta(hours=2)).isoformat()
+
+    class _StubEntry:
+        def __init__(self, text: str) -> None:
+            self.text = text
+            self.actor = "api"
+            self.entry_type = "snooze"
+
+    class _StubTask:
+        def __init__(self, tid: str) -> None:
+            self.task_id = tid
+
+    class _BulkSvc:
+        def __init__(self) -> None:
+            self.bulk_calls = 0
+            self.bulk_keys: list = []
+            self.per_task_calls = 0
+
+        def latest_snoozes_bulk(self, keys):
+            self.bulk_calls += 1
+            self.bulk_keys = list(keys)
+            # Half the tasks are snoozed (future), half expired (past),
+            # rest absent. Mirrors the round-1 unit tests but at the
+            # bulk boundary.
+            return {
+                ("myproj", 1): _StubEntry(f"until_iso={future}"),
+                ("myproj", 2): _StubEntry(f"until_iso={past}"),
+                ("myproj", 3): _StubEntry(f"until_iso={future}"),
+                ("myproj", 4): _StubEntry(f"until_iso={past}"),
+                ("myproj", 5): _StubEntry(f"until_iso={future}"),
+                # ids 6..10 absent (not snoozed).
+            }
+
+        def get_context(self, *a, **kw):  # pragma: no cover
+            self.per_task_calls += 1
+            raise AssertionError(
+                "bulk-aware backend must not fall back to per-task "
+                "get_context (#2060 round-2)"
+            )
+
+    tasks = [_StubTask(f"myproj/{i}") for i in range(1, 11)]
+    svc = _BulkSvc()
+    snoozed = _active_snoozed_ids(svc, tasks, now=now)
+    assert svc.bulk_calls == 1, (
+        "inbox list path must call latest_snoozes_bulk exactly once; "
+        f"saw {svc.bulk_calls}"
+    )
+    assert svc.per_task_calls == 0
+    # Bulk call received all 10 keys so the helper has the full set
+    # to scan in one shot, not N calls of one key each.
+    assert len(svc.bulk_keys) == 10
+    # Active set is the future-wake ids only.
+    assert snoozed == {"myproj/1", "myproj/3", "myproj/5"}
+
+
+def test_active_snoozed_ids_falls_back_to_per_task_when_bulk_missing() -> None:
+    """A backend without the bulk helper still works (legacy path).
+
+    This protects the mock-service / sqlite shape: bulk is a pg
+    optimisation, but the predicate must still return correct data
+    when the method is absent. Falls through to the round-1 loop.
+    """
+    from pollypm.web_api.service import _active_snoozed_ids
+
+    now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    future = (now + timedelta(hours=2)).isoformat()
+
+    class _StubEntry:
+        def __init__(self, text: str) -> None:
+            self.text = text
+            self.actor = "api"
+            self.entry_type = "snooze"
+
+    class _StubTask:
+        def __init__(self, tid: str) -> None:
+            self.task_id = tid
+
+    class _LegacySvc:
+        # NB: no ``latest_snoozes_bulk`` attribute.
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get_context(self, task_id, *, entry_type=None, limit=None):
+            self.calls += 1
+            assert entry_type == "snooze"
+            if task_id == "myproj/1":
+                return [_StubEntry(f"until_iso={future}")]
+            return []
+
+    svc = _LegacySvc()
+    tasks = [_StubTask("myproj/1"), _StubTask("myproj/2")]
+    snoozed = _active_snoozed_ids(svc, tasks, now=now)
+    assert snoozed == {"myproj/1"}
+    # One call per task — the documented legacy behaviour.
+    assert svc.calls == 2
+
+
+def test_shared_snooze_predicate_lives_in_work_module() -> None:
+    """The parser + ``is_snooze_active`` predicate live in
+    ``pollypm.work.inbox_snooze`` so cockpit can adopt them without
+    pulling in the web layer (#2060 round-2).
+
+    This test exists to keep the module from being silently moved
+    back into ``pollypm.web_api.service`` — the whole point of the
+    extraction is shareability with cockpit code that must not
+    depend on FastAPI.
+    """
+    from pollypm.work import inbox_snooze
+
+    now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    future = (now + timedelta(hours=2)).isoformat()
+    past = (now - timedelta(hours=2)).isoformat()
+    assert inbox_snooze.is_snooze_active(
+        f"until_iso={future}", now=now,
+    ) is True
+    assert inbox_snooze.is_snooze_active(
+        f"until_iso={past}", now=now,
+    ) is False
+    assert inbox_snooze.parse_snooze_until(
+        f"until_iso={future}"
+    ) is not None

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -756,11 +756,14 @@ def test_snooze_writer_persists_structured_until_iso_marker(
         task_number = 1
         title = "Inbox item"
         description = "body"
-        # Membership guard (#2060 round-3) requires chat-flow OR
-        # plan-review label; the snooze writer rejects with 404
-        # otherwise.
+        # Canonical inbox predicate (#2060 round-5) requires a user
+        # role / plan_review label / current human node — chat-flow
+        # alone is not sufficient. Give this stub a ``requester=user``
+        # so ``_roles_match_user`` accepts it as an inbox member.
         flow_template_id = "chat"
         labels: list[str] = []
+        roles: dict = {"requester": "user"}
+        current_node_id = None
 
     captured: dict[str, object] = {}
 
@@ -972,7 +975,14 @@ def test_shared_snooze_predicate_lives_in_work_module() -> None:
 
 
 class _NonInboxStubTask:
-    """Pretends to be a regular work task (not chat / not plan_review)."""
+    """Pretends to be a regular work task (not an inbox row).
+
+    Post-#2060 round-5 the membership predicate is the canonical
+    :func:`pollypm.work.inbox_view.is_inbox_task` (cockpit / rail /
+    dashboard). That requires a ``user`` role, exact ``plan_review``
+    label, or a current human flow node — none of which this stub
+    carries — so the write helpers must reject it.
+    """
 
     task_id = "myproj/1"
     project = "myproj"
@@ -981,6 +991,8 @@ class _NonInboxStubTask:
     description = "not an inbox row"
     flow_template_id = "standard"  # NOT 'chat'
     labels: list[str] = []  # NO plan_review label
+    roles: dict = {}  # NO user role
+    current_node_id = None  # NO current human node
 
     @property
     def work_status(self):  # noqa: D401
@@ -1125,32 +1137,306 @@ def test_promote_rejects_non_inbox_task(config, monkeypatch) -> None:
     assert svc.create_calls == 0
 
 
-def test_membership_helper_accepts_chat_and_plan_review() -> None:
-    """Sanity-check the predicate's positive cases so the guard
-    can't silently reject everything (which would also "pass" the
-    rejection tests above)."""
+def test_membership_helper_matches_canonical_inbox_predicate() -> None:
+    """The API membership helper must mirror the canonical predicate.
+
+    Post-#2060 round-5 the web layer routes through
+    :func:`pollypm.work.inbox_view.is_inbox_task` — the same predicate
+    cockpit, the rail, and the dashboard use. The contract is:
+
+    * Chat-flow with a ``user`` role -> inbox member.
+    * Exact ``plan_review`` label -> inbox member.
+    * Plain task with no user role / no exact plan_review label /
+      no current human node -> NOT a member, even if the flow_id
+      contains the substring ``plan``.
+
+    Substring matches on ``plan_review`` (e.g. ``not_plan_review``,
+    ``planning``) MUST be rejected — the round-3 web helper's
+    ``"plan_review" in lbl`` widening is what Codex round-5 caught.
+    """
     from pollypm.web_api.service import _is_inbox_member
 
-    class _Chat:
+    class _ChatWithUserRole:
         flow_template_id = "chat"
         labels: list[str] = []
+        roles = {"requester": "user"}
+        current_node_id = None
 
     class _PlanReviewLabel:
         flow_template_id = "standard"
         labels = ["plan_review"]
+        roles: dict = {}
+        current_node_id = None
 
-    class _PlanReviewFlow:
-        flow_template_id = "plan_review_flow"
+    class _ChatNoUserRole:
+        # Chat-flow but no user role + no current node — would have
+        # been accepted by the old web-layer predicate, must now be
+        # rejected (canonical contract).
+        flow_template_id = "chat"
         labels: list[str] = []
+        roles: dict = {}
+        current_node_id = None
+
+    class _NearMissPlanLabel:
+        # Substring would have matched the old helper; canonical
+        # predicate requires exact ``plan_review``.
+        flow_template_id = "standard"
+        labels = ["not_plan_review"]
+        roles: dict = {}
+        current_node_id = None
 
     class _NonInbox:
         flow_template_id = "standard"
         labels: list[str] = []
+        roles: dict = {}
+        current_node_id = None
 
-    assert _is_inbox_member(_Chat()) is True
+    assert _is_inbox_member(_ChatWithUserRole()) is True
     assert _is_inbox_member(_PlanReviewLabel()) is True
-    assert _is_inbox_member(_PlanReviewFlow()) is True
+    assert _is_inbox_member(_ChatNoUserRole()) is False
+    assert _is_inbox_member(_NearMissPlanLabel()) is False
     assert _is_inbox_member(_NonInbox()) is False
+
+
+# ---------------------------------------------------------------------------
+# Round-5 canonical-predicate negative coverage (#2060, Codex 15:41 UTC).
+#
+# Round-3 added a web-layer ``_is_inbox_member`` that accepted any
+# chat-flow task plus substring plan labels. Codex round-5 caught the
+# drift: cockpit / rail / dashboard use the stricter
+# ``pollypm.work.inbox_view.is_inbox_task`` (user role / exact
+# plan_review / human current node), so a chat task that the read
+# surface 404s could still be mutated through the write endpoints.
+#
+# Codex's ask, verbatim:
+#   "at minimum, add negative tests for a chat-flow task with no user
+#    role/current human node and for near-miss plan labels so the
+#    write surface cannot widen by substring accident."
+#
+# These tests are designed to FAIL on the round-3 predicate (chat
+# alone passes; ``not_plan_review`` substring-matches) and PASS once
+# the write helpers route through ``is_inbox_task``.
+# ---------------------------------------------------------------------------
+
+
+class _ChatNoUserRoleStubTask:
+    """Chat-flow task with no user role / no human current node.
+
+    Old (round-3) predicate: ``flow_template_id == 'chat'`` -> accept.
+    Canonical predicate: chat alone is insufficient; needs a ``user``
+    role / exact ``plan_review`` label / current human node.
+    """
+
+    task_id = "myproj/1"
+    project = "myproj"
+    task_number = 1
+    title = "Headless chat-flow row"
+    description = "should not be mutable via /inbox writes"
+    flow_template_id = "chat"
+    labels: list[str] = []
+    roles: dict = {}  # no user role
+    current_node_id = None  # no current human node
+
+    @property
+    def work_status(self):
+        from pollypm.work.models import WorkStatus
+        return WorkStatus.IN_PROGRESS
+
+
+class _NearMissPlanLabelStubTask:
+    """Task whose only ``plan``-flavoured label substring-matches
+    ``plan_review`` but is not exactly that label.
+
+    Old (round-3) predicate: ``"plan_review" in lbl`` -> accept on
+    ``not_plan_review``. Canonical predicate: exact match only.
+    """
+
+    task_id = "myproj/1"
+    project = "myproj"
+    task_number = 1
+    title = "Near-miss plan label"
+    description = "label is not_plan_review, not plan_review"
+    flow_template_id = "standard"
+    labels = ["not_plan_review", "planning"]
+    roles: dict = {}
+    current_node_id = None
+
+    @property
+    def work_status(self):
+        from pollypm.work.models import WorkStatus
+        return WorkStatus.IN_PROGRESS
+
+
+class _CanonicalRejectingSvc:
+    """Recording stub whose ``get`` returns a configurable task.
+
+    Like ``_MembershipRecordingSvc`` but parameterised on which fake
+    task to return, so the round-5 negative tests can exercise the
+    two specific shapes Codex called out without duplicating the
+    fake-factory wiring.
+    """
+
+    def __init__(self, task) -> None:
+        self._task = task
+        self.archive_calls = 0
+        self.add_context_calls = 0
+        self.add_reply_calls = 0
+        self.mark_read_calls = 0
+        self.create_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, item_id):
+        return self._task
+
+    def archive_task(self, *a, **kw):
+        self.archive_calls += 1
+        raise AssertionError(
+            "canonical predicate must block archive on non-inbox row"
+        )
+
+    def add_context(self, *a, **kw):
+        self.add_context_calls += 1
+        raise AssertionError(
+            "canonical predicate must block add_context on non-inbox row"
+        )
+
+    def add_reply(self, *a, **kw):
+        self.add_reply_calls += 1
+        raise AssertionError(
+            "canonical predicate must block add_reply on non-inbox row"
+        )
+
+    def mark_read(self, *a, **kw):
+        self.mark_read_calls += 1
+        raise AssertionError(
+            "canonical predicate must block mark_read on non-inbox row"
+        )
+
+    def create(self, *a, **kw):
+        self.create_calls += 1
+        raise AssertionError(
+            "canonical predicate must block create on non-inbox row"
+        )
+
+
+def _install_canonical_stub(monkeypatch, task) -> _CanonicalRejectingSvc:
+    svc = _CanonicalRejectingSvc(task)
+
+    def fake_factory(*, config, project_key, project_path):
+        return svc
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+    return svc
+
+
+def test_archive_rejects_chat_flow_task_with_no_user_role(
+    config, monkeypatch,
+) -> None:
+    """Chat-flow without a user role is NOT an inbox member.
+
+    The old round-3 predicate accepted any ``flow_template_id ==
+    'chat'`` and would have allowed this archive to proceed —
+    write-side drift past the cockpit / rail / dashboard inbox
+    surface. The canonical :func:`is_inbox_task` requires a user
+    role / exact plan_review label / current human node.
+    """
+    from pollypm.web_api import service as web_service
+
+    svc = _install_canonical_stub(monkeypatch, _ChatNoUserRoleStubTask())
+    with pytest.raises(APIError) as excinfo:
+        web_service.archive_inbox_item(config, "myproj/1", reason="oops")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.archive_calls == 0
+    assert svc.add_context_calls == 0
+
+
+def test_archive_rejects_near_miss_plan_label(
+    config, monkeypatch,
+) -> None:
+    """Labels like ``not_plan_review`` / ``planning`` MUST NOT widen
+    the write surface. Round-3 used ``"plan_review" in lbl`` which
+    matched both; canonical predicate is exact equality."""
+    from pollypm.web_api import service as web_service
+
+    svc = _install_canonical_stub(monkeypatch, _NearMissPlanLabelStubTask())
+    with pytest.raises(APIError) as excinfo:
+        web_service.archive_inbox_item(config, "myproj/1", reason="oops")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.archive_calls == 0
+    assert svc.add_context_calls == 0
+
+
+def test_snooze_rejects_chat_flow_task_with_no_user_role(
+    config, monkeypatch,
+) -> None:
+    """Snooze must agree with archive's canonical predicate.
+
+    Otherwise a caller could snooze a row the cockpit never surfaces
+    — the row gets a future ``until_iso`` marker that nothing reads.
+    """
+    from pollypm.web_api import service as web_service
+
+    svc = _install_canonical_stub(monkeypatch, _ChatNoUserRoleStubTask())
+    with pytest.raises(APIError) as excinfo:
+        web_service.snooze_inbox_item(
+            config, "myproj/1", duration_seconds=3600,
+        )
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.add_context_calls == 0
+
+
+def test_snooze_rejects_near_miss_plan_label(
+    config, monkeypatch,
+) -> None:
+    from pollypm.web_api import service as web_service
+
+    svc = _install_canonical_stub(monkeypatch, _NearMissPlanLabelStubTask())
+    with pytest.raises(APIError) as excinfo:
+        web_service.snooze_inbox_item(
+            config, "myproj/1", duration_seconds=3600,
+        )
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.add_context_calls == 0
+
+
+def test_promote_rejects_chat_flow_task_with_no_user_role(
+    config, monkeypatch,
+) -> None:
+    """Promote is the most damaging widening surface: it derives a
+    new task from the source. Canonical predicate must reject so
+    the API cannot mint tasks from rows cockpit never surfaced."""
+    from pollypm.web_api import service as web_service
+
+    svc = _install_canonical_stub(monkeypatch, _ChatNoUserRoleStubTask())
+    with pytest.raises(APIError) as excinfo:
+        web_service.promote_inbox_to_task(config, "myproj/1")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.create_calls == 0
+
+
+def test_promote_rejects_near_miss_plan_label(
+    config, monkeypatch,
+) -> None:
+    from pollypm.web_api import service as web_service
+
+    svc = _install_canonical_stub(monkeypatch, _NearMissPlanLabelStubTask())
+    with pytest.raises(APIError) as excinfo:
+        web_service.promote_inbox_to_task(config, "myproj/1")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.create_calls == 0
 
 
 # ---------------------------------------------------------------------------
@@ -1168,17 +1454,23 @@ def test_membership_helper_accepts_chat_and_plan_review() -> None:
 
 
 class _ConcurrentLoserStubTask:
-    """Looks like an inbox item (chat-flow) so the membership guard
-    accepts it; the conflict is raised by ``archive_task``, not by
-    the predicate."""
+    """Looks like an inbox item so the membership guard accepts it;
+    the conflict is raised by ``archive_task``, not by the predicate.
+
+    Canonical inbox predicate (#2060 round-5) requires a user role
+    in addition to chat-flow, so include ``requester=user`` to mimic
+    a real chat thread surfaced via cockpit / GET /inbox.
+    """
 
     task_id = "myproj/1"
     project = "myproj"
     task_number = 1
     title = "Inbox item"
     description = "ping"
-    flow_template_id = "chat"  # Passes _is_inbox_member.
+    flow_template_id = "chat"
     labels: list[str] = []
+    roles: dict = {"requester": "user"}
+    current_node_id = None
 
     @property
     def work_status(self):  # noqa: D401

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -756,6 +756,11 @@ def test_snooze_writer_persists_structured_until_iso_marker(
         task_number = 1
         title = "Inbox item"
         description = "body"
+        # Membership guard (#2060 round-3) requires chat-flow OR
+        # plan-review label; the snooze writer rejects with 404
+        # otherwise.
+        flow_template_id = "chat"
+        labels: list[str] = []
 
     captured: dict[str, object] = {}
 
@@ -947,3 +952,202 @@ def test_shared_snooze_predicate_lives_in_work_module() -> None:
     assert inbox_snooze.parse_snooze_until(
         f"until_iso={future}"
     ) is not None
+
+
+# ---------------------------------------------------------------------------
+# Inbox membership guard (#2060 round-3, blocker 1)
+#
+# Round-2 left every write helper probing ``svc.get(...)`` alone before
+# mutating. That returns ANY task with the id, not just inbox rows —
+# so a caller could POST /inbox/<id>/{archive,snooze,reply,mark-read,
+# promote-to-task} against a plain-task flow row and close / mutate
+# it via this endpoint even though GET /inbox would 404 the same id.
+# The fix is a small ``_is_inbox_member`` predicate (chat-flow OR
+# plan-review label / flow, matching ``_task_to_inbox_item``) that
+# every write helper consults right after the existence probe and
+# raises ``not_found`` for non-members. These tests pin the gate so
+# a refactor can't drop it silently. Codex round-3 explicitly named
+# archive + snooze; we cover all five for symmetry.
+# ---------------------------------------------------------------------------
+
+
+class _NonInboxStubTask:
+    """Pretends to be a regular work task (not chat / not plan_review)."""
+
+    task_id = "myproj/1"
+    project = "myproj"
+    task_number = 1
+    title = "Regular work task"
+    description = "not an inbox row"
+    flow_template_id = "standard"  # NOT 'chat'
+    labels: list[str] = []  # NO plan_review label
+
+    @property
+    def work_status(self):  # noqa: D401
+        from pollypm.work.models import WorkStatus
+        return WorkStatus.IN_PROGRESS
+
+
+class _MembershipRecordingSvc:
+    """Records whether any mutating method was called.
+
+    Membership guard must reject the request BEFORE any of these run.
+    Each ``raise AssertionError`` would surface in pytest if the
+    write helper slipped past the guard.
+    """
+
+    def __init__(self) -> None:
+        self.archive_calls = 0
+        self.add_context_calls = 0
+        self.add_reply_calls = 0
+        self.mark_read_calls = 0
+        self.create_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, item_id):
+        return _NonInboxStubTask()
+
+    def archive_task(self, *a, **kw):
+        self.archive_calls += 1
+        raise AssertionError(
+            "membership guard must block archive_task on a non-inbox row"
+        )
+
+    def add_context(self, *a, **kw):
+        self.add_context_calls += 1
+        raise AssertionError(
+            "membership guard must block add_context on a non-inbox row"
+        )
+
+    def add_reply(self, *a, **kw):
+        self.add_reply_calls += 1
+        raise AssertionError(
+            "membership guard must block add_reply on a non-inbox row"
+        )
+
+    def mark_read(self, *a, **kw):
+        self.mark_read_calls += 1
+        raise AssertionError(
+            "membership guard must block mark_read on a non-inbox row"
+        )
+
+    def create(self, *a, **kw):
+        self.create_calls += 1
+        raise AssertionError(
+            "membership guard must block create on a non-inbox row"
+        )
+
+
+def _install_membership_stub(monkeypatch) -> _MembershipRecordingSvc:
+    """Patch ``create_work_service`` to return the recording stub."""
+    svc = _MembershipRecordingSvc()
+
+    def fake_factory(*, config, project_key, project_path):
+        return svc
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+    return svc
+
+
+def test_archive_rejects_non_inbox_task(config, monkeypatch) -> None:
+    """``POST /inbox/<id>/archive`` on a non-inbox row must 404 cleanly."""
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    svc = _install_membership_stub(monkeypatch)
+    with pytest.raises(APIError) as excinfo:
+        web_service.archive_inbox_item(config, "myproj/1", reason="oops")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    # Critical: NEITHER the canonical archive transition NOR the
+    # archive-reason context note ran. The stub asserts on either.
+    assert svc.archive_calls == 0
+    assert svc.add_context_calls == 0
+
+
+def test_snooze_rejects_non_inbox_task(config, monkeypatch) -> None:
+    """``POST /inbox/<id>/snooze`` on a non-inbox row must 404 cleanly."""
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    svc = _install_membership_stub(monkeypatch)
+    with pytest.raises(APIError) as excinfo:
+        web_service.snooze_inbox_item(
+            config, "myproj/1", duration_seconds=3600,
+        )
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    # Snooze-row write (entry_type='snooze') must not be persisted.
+    assert svc.add_context_calls == 0
+
+
+def test_mark_read_rejects_non_inbox_task(config, monkeypatch) -> None:
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    svc = _install_membership_stub(monkeypatch)
+    with pytest.raises(APIError) as excinfo:
+        web_service.mark_read_inbox_item(config, "myproj/1")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.mark_read_calls == 0
+
+
+def test_reply_rejects_non_inbox_task(config, monkeypatch) -> None:
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    svc = _install_membership_stub(monkeypatch)
+    with pytest.raises(APIError) as excinfo:
+        web_service.reply_inbox_item(config, "myproj/1", body="ping")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.add_reply_calls == 0
+
+
+def test_promote_rejects_non_inbox_task(config, monkeypatch) -> None:
+    from pollypm.web_api import service as web_service
+    from pollypm.web_api.errors import APIError
+
+    svc = _install_membership_stub(monkeypatch)
+    with pytest.raises(APIError) as excinfo:
+        web_service.promote_inbox_to_task(config, "myproj/1")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    # Most damaging side effect: a derived task gets created.
+    assert svc.create_calls == 0
+
+
+def test_membership_helper_accepts_chat_and_plan_review() -> None:
+    """Sanity-check the predicate's positive cases so the guard
+    can't silently reject everything (which would also "pass" the
+    rejection tests above)."""
+    from pollypm.web_api.service import _is_inbox_member
+
+    class _Chat:
+        flow_template_id = "chat"
+        labels: list[str] = []
+
+    class _PlanReviewLabel:
+        flow_template_id = "standard"
+        labels = ["plan_review"]
+
+    class _PlanReviewFlow:
+        flow_template_id = "plan_review_flow"
+        labels: list[str] = []
+
+    class _NonInbox:
+        flow_template_id = "standard"
+        labels: list[str] = []
+
+    assert _is_inbox_member(_Chat()) is True
+    assert _is_inbox_member(_PlanReviewLabel()) is True
+    assert _is_inbox_member(_PlanReviewFlow()) is True
+    assert _is_inbox_member(_NonInbox()) is False

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -575,3 +575,227 @@ def test_all_write_endpoints_require_auth(client) -> None:
         r = client.post(f"/api/v1/inbox/myproj/1/{verb}", json=payload)
         assert r.status_code == 401, verb
         assert r.json()["error"]["code"] in {"unauthorized", "invalid_token"}, verb
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI contract — Idempotency-Key header is NOT advertised (#2060 P0 #1)
+#
+# An earlier draft of these handlers declared an ``Idempotency-Key``
+# request header on every POST. There is no idempotency store wired
+# into the API today, so retries duplicated promoted tasks / replies
+# / snooze rows while the client reasonably believed the header
+# protected it. The header was stripped from the contract; this test
+# locks that decision so a future refactor can't silently re-introduce
+# it without also implementing the dedup cache.
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_does_not_advertise_idempotency_key_header(app) -> None:
+    schema = app.openapi()
+    write_paths = [
+        "/api/v1/inbox/{id}/archive",
+        "/api/v1/inbox/{id}/snooze",
+        "/api/v1/inbox/{id}/promote-to-task",
+        "/api/v1/inbox/{id}/mark-read",
+        "/api/v1/inbox/{id}/reply",
+    ]
+    for path in write_paths:
+        op = schema["paths"][path]["post"]
+        header_params = [
+            p for p in op.get("parameters", [])
+            if p.get("in") == "header"
+        ]
+        names = [p.get("name") for p in header_params]
+        assert "Idempotency-Key" not in names, (
+            f"{path} re-introduced the Idempotency-Key header "
+            "without an idempotency store — strip it or wire the "
+            "real dedup cache first (#2060)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Snooze visibility regression (#2060 P0 #2)
+#
+# The snooze write helper persists ``entry_type='snooze'`` rows whose
+# text starts with the structured marker ``until_iso=<ISO>``. The
+# inbox-list predicate (``_active_snoozed_ids`` /
+# ``_parse_snooze_until``) reads that marker and filters out items
+# whose snooze hasn't expired. Without this, the endpoint returned
+# 200 while the row stayed visible — a pure broken feature.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_snooze_until_reads_structured_marker() -> None:
+    from pollypm.web_api.service import _parse_snooze_until
+
+    text = "until_iso=2026-06-01T12:00:00+00:00; snoozed until 2026-06-01T12:00:00+00:00; reason: later"
+    parsed = _parse_snooze_until(text)
+    assert parsed is not None
+    assert parsed == datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_snooze_until_falls_back_to_legacy_shape() -> None:
+    """Rows written before the structured marker landed still parse."""
+    from pollypm.web_api.service import _parse_snooze_until
+
+    text = "snoozed until 2026-06-01T12:00:00+00:00"
+    parsed = _parse_snooze_until(text)
+    assert parsed == datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_snooze_until_returns_none_when_no_timestamp() -> None:
+    from pollypm.web_api.service import _parse_snooze_until
+
+    assert _parse_snooze_until("reason: later") is None
+    assert _parse_snooze_until("") is None
+    assert _parse_snooze_until("until_iso=not-a-date") is None
+
+
+class _StubContextEntry:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.actor = "api"
+        self.entry_type = "snooze"
+
+
+class _StubTask:
+    def __init__(self, task_id: str) -> None:
+        self.task_id = task_id
+
+
+class _StubSvc:
+    """Minimal stand-in for ``PgWorkService.get_context`` semantics."""
+
+    def __init__(self, entries_by_id: dict[str, list[str]]) -> None:
+        self._entries = entries_by_id
+
+    def get_context(self, task_id, *, entry_type=None, limit=None):
+        assert entry_type == "snooze"
+        texts = self._entries.get(task_id, [])
+        # Real svc returns DESC (most recent first); ``limit=1`` picks
+        # the latest. Mirror that ordering so the helper sees the same
+        # shape it does in production.
+        rows = [_StubContextEntry(t) for t in reversed(texts)]
+        if limit is not None:
+            rows = rows[: int(limit)]
+        return rows
+
+
+def test_active_snoozed_ids_excludes_expired_snooze() -> None:
+    from pollypm.web_api.service import _active_snoozed_ids
+
+    now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    past = (now - timedelta(hours=1)).isoformat()
+    svc = _StubSvc({"myproj/1": [f"until_iso={past}"]})
+    snoozed = _active_snoozed_ids(svc, [_StubTask("myproj/1")], now=now)
+    assert snoozed == set()
+
+
+def test_active_snoozed_ids_hides_future_snooze() -> None:
+    """Regression for the original bug: the row stayed visible."""
+    from pollypm.web_api.service import _active_snoozed_ids
+
+    now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    future = (now + timedelta(hours=2)).isoformat()
+    svc = _StubSvc({"myproj/1": [f"until_iso={future}"]})
+    snoozed = _active_snoozed_ids(svc, [_StubTask("myproj/1")], now=now)
+    assert snoozed == {"myproj/1"}
+
+
+def test_active_snoozed_ids_uses_latest_snooze_entry() -> None:
+    """When an item is snoozed multiple times, the latest one wins.
+
+    The reader sorts by ``id DESC`` (most-recent first) and takes
+    ``limit=1``; so an item snoozed for an hour and then re-snoozed
+    for ten seconds (now expired) must NOT be hidden.
+    """
+    from pollypm.web_api.service import _active_snoozed_ids
+
+    now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    old_future = (now + timedelta(hours=2)).isoformat()
+    new_past = (now - timedelta(minutes=5)).isoformat()
+    svc = _StubSvc({
+        # Order = insertion order; the stub reverses it to mimic
+        # ``ORDER BY id DESC``. So the second entry is "newer".
+        "myproj/1": [
+            f"until_iso={old_future}",
+            f"until_iso={new_past}",
+        ],
+    })
+    snoozed = _active_snoozed_ids(svc, [_StubTask("myproj/1")], now=now)
+    assert snoozed == set(), (
+        "An item whose latest snooze has expired must be visible "
+        "again — the older still-future snooze should not mask it."
+    )
+
+
+def test_active_snoozed_ids_skips_items_with_no_snooze() -> None:
+    from pollypm.web_api.service import _active_snoozed_ids
+
+    now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    svc = _StubSvc({})
+    snoozed = _active_snoozed_ids(svc, [_StubTask("myproj/1")], now=now)
+    assert snoozed == set()
+
+
+def test_snooze_writer_persists_structured_until_iso_marker(
+    config, monkeypatch,
+) -> None:
+    """The snooze helper must persist ``until_iso=...`` so the reader
+    can parse the wake-time back without regex-guessing on free-form
+    text. Regression for the original P0: the writer encoded the wake
+    time only inside the human ``snoozed until <iso>`` blob, which
+    the reader never honored."""
+    from pollypm.web_api import service as web_service
+    from pollypm.work.models import WorkStatus
+
+    class _StubInboxTask:
+        task_id = "myproj/1"
+        work_status = WorkStatus.IN_PROGRESS
+        project = "myproj"
+        task_number = 1
+        title = "Inbox item"
+        description = "body"
+
+    captured: dict[str, object] = {}
+
+    class _RecordingSvc:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get(self, item_id):
+            return _StubInboxTask()
+
+        def add_context(self, item_id, actor, text, *, entry_type):
+            captured["text"] = text
+            captured["entry_type"] = entry_type
+
+    def fake_factory(*, config, project_key, project_path):
+        return _RecordingSvc()
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+    # The service-layer helper calls ``_task_to_detail(svc.get(...))``
+    # at the tail; the StubInboxTask isn't a full Task so short-circuit
+    # by patching the detail builder too.
+    monkeypatch.setattr(
+        web_service, "_task_to_detail",
+        lambda task: _make_task_detail(task_id="myproj/1"),
+    )
+
+    web_service.snooze_inbox_item(
+        config, "myproj/1", duration_seconds=3600, reason="later",
+    )
+    text = str(captured.get("text", ""))
+    assert captured.get("entry_type") == "snooze"
+    assert text.startswith("until_iso="), (
+        f"snooze row must lead with the parseable marker; got {text!r}"
+    )
+    # And the reader is happy with it round-trip.
+    parsed = web_service._parse_snooze_until(text)
+    assert parsed is not None
+    assert parsed > datetime.now(timezone.utc)

--- a/tests/test_pg_inbox_actions.py
+++ b/tests/test_pg_inbox_actions.py
@@ -283,3 +283,102 @@ class TestArchiveTask:
             and (tr.reason or "").startswith("inbox.archive")
         ]
         assert len(archive_transitions) == 1
+
+
+# ---------------------------------------------------------------------------
+# latest_snoozes_bulk (#2060 round-2) — single-query snooze lookup for the
+# inbox-list scan path. Replaces the per-task
+# ``get_context(entry_type='snooze', limit=1)`` loop in
+# ``_active_snoozed_ids`` (Codex round-2 blocker #2 on PR #2060).
+# ---------------------------------------------------------------------------
+
+
+class TestLatestSnoozesBulk:
+    """Bulk snooze fetch — one SQL for N tasks, latest row per task.
+
+    The helper's docstring promises a single statement; verifying the
+    actual statement count would require monkeypatching the pool, but
+    we can lock the contract behaviour (correct latest row per task,
+    absent when no snooze, no leakage of other entry_types) so a
+    regression that splits into N queries still ships obviously
+    correct data while the bulk-path test in
+    ``tests/test_inbox_writes_endpoint.py`` pins the call-count
+    behaviour at the API integration layer.
+    """
+
+    def test_empty_input_short_circuits(self, pg_work_service):
+        # ``[]`` returns ``{}`` without hitting the DB (the helper
+        # branches early). Asserting the result shape is enough — a
+        # regression that hits the DB with an empty IN-list would
+        # raise on the bind, not silently misbehave.
+        assert pg_work_service.latest_snoozes_bulk([]) == {}
+
+    def test_returns_latest_snooze_per_task(self, pg_work_service):
+        svc = pg_work_service
+        t1 = _inbox_task(svc, title="task one")
+        t2 = _inbox_task(svc, title="task two")
+        # t1: two snoozes — bulk must return the SECOND (latest by id).
+        svc.add_context(t1, "api", "until_iso=2026-06-01T00:00:00+00:00",
+                        entry_type="snooze")
+        svc.add_context(t1, "api", "until_iso=2026-07-01T00:00:00+00:00",
+                        entry_type="snooze")
+        # t2: one snooze.
+        svc.add_context(t2, "api", "until_iso=2026-08-01T00:00:00+00:00",
+                        entry_type="snooze")
+        keys = [
+            (t1.split("/")[0], int(t1.split("/")[1])),
+            (t2.split("/")[0], int(t2.split("/")[1])),
+        ]
+        out = svc.latest_snoozes_bulk(keys)
+        assert set(out.keys()) == set(keys)
+        # t1's latest is the July snooze.
+        assert "2026-07-01" in out[keys[0]].text
+        assert "2026-08-01" in out[keys[1]].text
+
+    def test_absent_when_task_has_no_snooze(self, pg_work_service):
+        svc = pg_work_service
+        t1 = _inbox_task(svc, title="snoozed")
+        t2 = _inbox_task(svc, title="not snoozed")
+        svc.add_context(t1, "api", "until_iso=2026-06-01T00:00:00+00:00",
+                        entry_type="snooze")
+        keys = [
+            (t1.split("/")[0], int(t1.split("/")[1])),
+            (t2.split("/")[0], int(t2.split("/")[1])),
+        ]
+        out = svc.latest_snoozes_bulk(keys)
+        # Only t1 appears; t2 has no snooze row so it's absent.
+        assert (t1.split("/")[0], int(t1.split("/")[1])) in out
+        assert (t2.split("/")[0], int(t2.split("/")[1])) not in out
+
+    def test_ignores_non_snooze_entry_types(self, pg_work_service):
+        """A ``reply`` or ``read`` row must not leak into the result."""
+        svc = pg_work_service
+        t1 = _inbox_task(svc, title="mixed")
+        svc.add_reply(t1, "hi", actor="user")
+        svc.add_context(t1, "api", "read", entry_type="read")
+        keys = [(t1.split("/")[0], int(t1.split("/")[1]))]
+        out = svc.latest_snoozes_bulk(keys)
+        # No snooze row exists, so the helper returns ``{}`` — proving
+        # the WHERE filter is on entry_type='snooze', not "any context
+        # row".
+        assert out == {}
+
+    def test_legacy_snoozed_until_text_round_trips(self, pg_work_service):
+        """Rows written before the structured marker landed still load.
+
+        The bulk helper returns the raw ``ContextEntry``; the snooze
+        text parser (``pollypm.work.inbox_snooze.parse_snooze_until``)
+        accepts both shapes. This test just confirms the bulk path
+        doesn't filter or mangle the legacy text.
+        """
+        svc = pg_work_service
+        t1 = _inbox_task(svc, title="legacy")
+        svc.add_context(
+            t1, "api",
+            "snoozed until 2026-06-01T12:00:00+00:00",
+            entry_type="snooze",
+        )
+        keys = [(t1.split("/")[0], int(t1.split("/")[1]))]
+        out = svc.latest_snoozes_bulk(keys)
+        assert keys[0] in out
+        assert "snoozed until 2026-06-01" in out[keys[0]].text

--- a/tests/test_pg_inbox_actions.py
+++ b/tests/test_pg_inbox_actions.py
@@ -26,6 +26,7 @@ import pytest
 
 from pollypm.work.models import WorkStatus
 from pollypm.work.service_support import (
+    InvalidTransitionError,
     TaskNotFoundError,
     ValidationError,
 )
@@ -209,3 +210,76 @@ class TestArchiveTask:
         svc = pg_work_service
         with pytest.raises(TaskNotFoundError):
             svc.archive_task("demo/777", actor="user")
+
+    # ------------------------------------------------------------------
+    # strict=True (#2060) — atomic concurrent-archive contract
+    # ------------------------------------------------------------------
+
+    def test_archive_strict_flips_status(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        archived = svc.archive_task(task_id, actor="user", strict=True)
+        assert archived.work_status == WorkStatus.DONE
+
+    def test_archive_strict_raises_when_already_terminal(
+        self, pg_work_service,
+    ):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        svc.archive_task(task_id, actor="user")
+        # Second archiver under strict mode must NOT silently succeed
+        # — that was the race surfaced by #2060 (Codex P0 #3).
+        with pytest.raises(InvalidTransitionError):
+            svc.archive_task(task_id, actor="user", strict=True)
+
+    def test_archive_strict_concurrent_only_one_winner(self, pg_work_service):
+        """Two threads race the same archive; exactly one wins.
+
+        Regression test for the #2060 race: under the old pre-check
+        version both threads observed the row in ``in_progress``, both
+        called the idempotent ``archive_task``, and both returned 200
+        — losing the documented ``invalid_state`` contract. With
+        ``strict=True`` the conditional UPDATE serialises the writers
+        so the loser sees rowcount==0 and raises
+        ``InvalidTransitionError``.
+        """
+        import threading
+
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        barrier = threading.Barrier(2)
+        results: list[object] = []
+        errors: list[Exception] = []
+        lock = threading.Lock()
+
+        def attempt() -> None:
+            try:
+                barrier.wait(timeout=5)
+                outcome = svc.archive_task(task_id, actor="racer", strict=True)
+                with lock:
+                    results.append(outcome)
+            except Exception as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=attempt) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        # Exactly one winner, one InvalidTransitionError loser.
+        assert len(results) == 1, (results, errors)
+        assert len(errors) == 1, (results, errors)
+        assert isinstance(errors[0], InvalidTransitionError)
+
+        # And the canonical writer only appended ONE archive
+        # transition row, matching the contract for idempotent /
+        # serialised archivers.
+        task = svc.get(task_id)
+        archive_transitions = [
+            tr for tr in task.transitions
+            if tr.to_state == WorkStatus.DONE.value
+            and (tr.reason or "").startswith("inbox.archive")
+        ]
+        assert len(archive_transitions) == 1

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -223,6 +223,45 @@ def test_static_yaml_declares_503_on_inbox_write_paths() -> None:
         )
 
 
+def test_inbox_archive_reason_documented_as_post_transition() -> None:
+    """Pin the reason-note ordering contract.
+
+    Round 4 of #2060 reordered ``archive_inbox_item`` to write the
+    reason note ONLY after ``archive_task(strict=True)`` succeeds, so
+    a losing concurrent archiver no longer leaves a stray
+    ``archive reason:`` note on a task it never archived. Round 7
+    (Codex) caught that ``docs/api/openapi.yaml`` still described the
+    old pre-transition order in the ``InboxArchiveRequest.reason``
+    schema, advertising a contract the implementation no longer
+    honors.
+
+    This test fails if anyone rewrites the schema description back to
+    a pre-transition contract.
+    """
+    contract = _load_contract()
+    description = (
+        contract["components"]["schemas"]["InboxArchiveRequest"]
+        ["properties"]["reason"]["description"]
+    )
+    lowered = description.lower()
+    assert "after" in lowered, (
+        "InboxArchiveRequest.reason description must say the note is "
+        "recorded AFTER the archive transition (#2060 round-4 / "
+        "round-7). Got: " + description
+    )
+    assert "transition" in lowered, (
+        "InboxArchiveRequest.reason description must reference the "
+        "archive transition explicitly so the ordering contract is "
+        "unambiguous. Got: " + description
+    )
+    assert "before the state transition" not in lowered, (
+        "InboxArchiveRequest.reason description reverted to the old "
+        "pre-transition contract. The implementation writes the note "
+        "AFTER archive_task(strict=True) succeeds — see "
+        "src/pollypm/web_api/service.py archive_inbox_item."
+    )
+
+
 def test_implementation_openapi_validates_as_31() -> None:
     """The auto-generated doc must itself be a valid OpenAPI 3.x doc."""
     # Re-read straight off the FastAPI app so we don't depend on the

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -185,6 +185,44 @@ def test_static_yaml_does_not_advertise_idempotency_on_inbox_writes() -> None:
         )
 
 
+def test_static_yaml_declares_503_on_inbox_write_paths() -> None:
+    """Static contract must declare 503 on every inbox-write path.
+
+    Round 4 of #2060: the FastAPI route decorators in
+    ``src/pollypm/web_api/routes/inbox.py`` list ``503`` for archive /
+    snooze / promote-to-task / mark-read / reply, and the service
+    helpers map ``_BACKING_STORE_ERRORS`` to the
+    ``service_unavailable`` typed error envelope. The static
+    ``docs/api/openapi.yaml`` was missing 503 entries on those paths,
+    so a generated client would not know to handle a backing-store
+    outage with the same error shape it sees from the live server.
+
+    This test pins the contract: every inbox-write path must declare
+    503 under its ``responses:`` block (either inline or via a shared
+    ``$ref`` to ``#/components/responses/ServiceUnavailable``).
+    """
+    contract = _load_contract()
+    inbox_write_paths = [
+        "/inbox/{id}/reply",
+        "/inbox/{id}/archive",
+        "/inbox/{id}/snooze",
+        "/inbox/{id}/promote-to-task",
+        "/inbox/{id}/mark-read",
+    ]
+    paths = contract.get("paths", {})
+    for path in inbox_write_paths:
+        ops = paths.get(path, {})
+        post = ops.get("post", {})
+        responses = post.get("responses", {}) or {}
+        # OpenAPI status codes are stringly-typed in YAML.
+        assert "503" in responses, (
+            f"{path} POST missing 503 response in static contract "
+            "(#2060 round-4). The FastAPI handler maps backing-store "
+            "errors to a 503 with the service_unavailable envelope; "
+            "the YAML must say so too."
+        )
+
+
 def test_implementation_openapi_validates_as_31() -> None:
     """The auto-generated doc must itself be a valid OpenAPI 3.x doc."""
     # Re-read straight off the FastAPI app so we don't depend on the

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -122,6 +122,69 @@ def test_chat_message_type_enum_matches_runtime() -> None:
     )
 
 
+def test_static_yaml_does_not_advertise_idempotency_on_inbox_writes() -> None:
+    """Static contract must match the implementation: no Idempotency-Key
+    on inbox-write paths.
+
+    Round 1 of #2060 stripped the header from the FastAPI handlers
+    because no replay cache exists; round 2 (Codex blocker #1) caught
+    that the static YAML still advertised it on every inbox-write
+    path AND that the shared component description still claimed
+    "server caches/replays responses for 24h". This test pins both
+    fixes:
+
+    - None of the 5 inbox-write paths reference
+      ``#/components/parameters/IdempotencyKey``.
+    - If the ``IdempotencyKey`` component still exists (the task
+      endpoints — ``/approve``, ``/reject``, ``/queue`` — still
+      accept the header for forward-compat with a future store) its
+      description must be honest about NOT replaying responses
+      today. The old "Server caches the response for 24h" string is
+      the smoking gun and is forbidden.
+    """
+    contract = _load_contract()
+    inbox_write_paths = [
+        "/inbox/{id}/reply",
+        "/inbox/{id}/archive",
+        "/inbox/{id}/snooze",
+        "/inbox/{id}/promote-to-task",
+        "/inbox/{id}/mark-read",
+    ]
+    paths = contract.get("paths", {})
+    for path in inbox_write_paths:
+        ops = paths.get(path, {})
+        post = ops.get("post", {})
+        params = post.get("parameters", []) or []
+        refs = [
+            p.get("$ref", "") for p in params if isinstance(p, dict)
+        ]
+        assert not any(
+            "IdempotencyKey" in ref for ref in refs
+        ), (
+            f"{path} static contract still advertises Idempotency-Key "
+            "but the handler does not implement it (#2060). Strip the "
+            "$ref or wire a real replay cache first."
+        )
+
+    # If the component still exists, its description must NOT claim
+    # caching/replay (that promise was the actual contract bug).
+    component = (
+        contract.get("components", {}).get("parameters", {}).get(
+            "IdempotencyKey"
+        )
+    )
+    if component is not None:
+        description = (component.get("description") or "").lower()
+        assert "caches the response" not in description, (
+            "IdempotencyKey component still promises a 24h replay "
+            "cache that the server does not implement (#2060)."
+        )
+        assert "replays it on retry" not in description, (
+            "IdempotencyKey component still promises retry replay "
+            "that the server does not implement (#2060)."
+        )
+
+
 def test_implementation_openapi_validates_as_31() -> None:
     """The auto-generated doc must itself be a valid OpenAPI 3.x doc."""
     # Re-read straight off the FastAPI app so we don't depend on the


### PR DESCRIPTION
## Summary

Phase 2 surface #2 — inbox WRITE endpoints, per the Phase 2 endpoints spec §4.

Adds five POST endpoints under `/api/v1/inbox/{id}/...`:

- `archive` — close an inbox item (returns 409 invalid_state when already terminal)
- `snooze` — record a future wake-time (`duration_seconds` xor `until`; <=30d window)
- `promote-to-task` — create a new actionable task from the inbox item
- `mark-read` — idempotent read marker
- `reply` — append a reply to the thread

Every handler routes through a new service-layer helper (`archive_inbox_item`, `snooze_inbox_item`, `promote_inbox_to_task`, `mark_read_inbox_item`, `reply_inbox_item`) that opens `create_work_service` once per call. Same canonical writer the cockpit uses — Web API stays a thin adapter, not a second writer.

## Reused writers

- `svc.archive_task` (#1776) for archive
- `svc.add_reply` for reply
- `svc.mark_read` for mark-read
- `svc.add_context(entry_type="snooze")` for snooze (no native snooze on the work service yet)
- `svc.create(flow_template="standard", labels=["promoted-from-inbox", ...])` for promote

## Tests

`tests/test_inbox_writes_endpoint.py` — 18 cases. Uses the chat-endpoints pattern (`--noconftest` + service-layer monkeypatching) so the FastAPI routing + error envelope are exercised end-to-end without spinning up the pg testcontainer.

Run: `pytest --noconftest tests/test_inbox_writes_endpoint.py -v --timeout=120` (all 18 pass locally).

## OpenAPI

Spec entries under `/inbox/{id}/{archive,snooze,promote-to-task,mark-read,reply}` updated; the `replyInbox` / `archiveInbox` operations were renamed to match the implementation operationIds (`replyInboxItem` / `archiveInboxItem`) and their return shape switched from `ActionResult`/`InboxMessage` to `TaskDetail` so the client can refresh UI without a follow-up GET. New schemas: `InboxArchiveRequest`, `InboxSnoozeRequest`, `InboxPromoteRequest`, `InboxMarkReadRequest`; `InboxReplyRequest` now carries `body` + `owner` (was `message`-only). `tests/web_api/test_openapi_conformance.py` still passes.

## Test plan

- [x] `pytest --noconftest tests/test_inbox_writes_endpoint.py -v --timeout=120` — 18/18 pass
- [x] `pytest tests/web_api/test_openapi_conformance.py -v` — 5/5 pass (yaml validity, Phase 1 coverage)
- [ ] Manual: `curl -X POST /api/v1/inbox/<id>/archive` against a live `pm serve` instance
- [ ] Manual: cockpit sees the archive reflected within 5s (spec Q2.1)
- [ ] Manual: snooze with `duration_seconds=3600` records a `snooze` context entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)