### PR TITLE
feat(api): /api/v1/sessions — Phase 2 sessions admin (list/restart/pause/resume)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1033,13 +1033,33 @@ paths:
     post:
       tags: [Sessions]
       operationId: restartSession
-      summary: Destroy + relaunch the tmux window for one session
+      summary: Facade-driven relaunch (Supervisor.restart_session) for one session
       description: |
-        Kills the session's tmux window (no-op if absent) and
-        re-creates it from the `[sessions]` config row. Refuses with
-        `409 unsafe_mid_turn` when the agent is mid-turn unless
-        `?safety=force`. Returns `503 daemon_unavailable` when the
-        tmux session service can't be constructed.
+        Routes through `pollypm.supervisor.Supervisor.restart_session`
+        — the same canonical facade `pm switch-session-account`, the
+        cockpit account-switch button, and the upgrade flow already
+        use. The facade tears down the existing window and re-launches
+        via the launch planner so the relaunched pane runs the
+        configured provider command (NOT an ad-hoc `echo`
+        placeholder).
+
+        The account the facade restarts under is the runtime's
+        `effective_account` if set (so a session that previously
+        failed over keeps using the recovered account), otherwise the
+        session's configured `account`.
+
+        Safety gate. `strict` (default) refuses with:
+        * `409 unsafe_mid_turn` when the agent is mid-turn.
+        * `503 unsafe_mid_turn_unknown` when the mid-turn probe
+          itself fails (transient tmux/parse errors must NOT be
+          treated as "agent is idle" — fail-closed).
+
+        `?safety=force` bypasses BOTH the mid-turn check and the
+        probe-unknown check.
+
+        Returns `503 daemon_unavailable` when the supervisor or tmux
+        session service can't be constructed, when no account can be
+        resolved for the session, or when `restart_session` raises.
       parameters:
         - in: query
           name: safety
@@ -1074,8 +1094,15 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "503":
           description: |
-            Tmux session service unavailable (`code=daemon_unavailable`).
-            Confirm the daemon / cockpit is running, then retry.
+            One of:
+            * `code=unsafe_mid_turn_unknown` — strict-mode safety
+              probe failed and could not confirm the agent is idle
+              (fail-closed). Retry once tmux is healthy or pass
+              `?safety=force` to override.
+            * `code=daemon_unavailable` — supervisor / tmux session
+              service unavailable, no account resolvable, or
+              `restart_session` raised. Confirm the daemon / cockpit
+              is running, then retry.
           content:
             application/json:
               schema:
@@ -1087,12 +1114,21 @@ paths:
     post:
       tags: [Sessions]
       operationId: pauseSession
-      summary: Mark a session paused (skip heartbeat dispatch / recovery)
+      summary: Tag a session paused (INFORMATIONAL marker only)
       description: |
+        **Informational marker only.** The supervisor / recovery /
+        dispatch loops do NOT consume `<base_dir>/paused-sessions.json`
+        today — they will still act on the session even after a
+        successful pause. The response `message` calls this out so
+        operators know they have tagged the session, not quiesced the
+        daemon. Daemon-side enforcement is tracked as a follow-up.
+
         Idempotent. Writes the session name into the project's pause
-        marker (`<base_dir>/paused-sessions.json`) so other readers
-        (recovery loop, `GET /api/v1/sessions`) can skip / surface the
-        quiesced state. The tmux window itself is left alone.
+        marker (`<base_dir>/paused-sessions.json`) using atomic
+        tmp+rename, with `fcntl.flock` serialising concurrent
+        pause/resume callers. `GET /api/v1/sessions` surfaces
+        `status="paused"` for tagged sessions; the tmux window itself
+        is left alone.
       responses:
         "200":
           description: Pause recorded (or already paused).
@@ -1120,11 +1156,16 @@ paths:
     post:
       tags: [Sessions]
       operationId: resumeSession
-      summary: Clear the paused flag for a session (inverse of pause)
+      summary: Clear the informational pause tag for a session (inverse of pause)
       description: |
-        Idempotent. Removes the session name from the project's pause
-        marker. Returns 200 with no state change if the session wasn't
-        paused.
+        Idempotent inverse of `pauseSession`. Same daemon-control
+        caveat applies — the marker is informational, so "resuming" a
+        session the supervisor never stopped acting on is a no-op
+        from the runtime's perspective.
+
+        Removes the session name from the project's pause marker.
+        Returns 200 with no state change if the session wasn't
+        tagged.
       responses:
         "200":
           description: Resume recorded (or already running).

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -66,6 +66,13 @@ tags:
       the redaction heuristic in `web_api/routes/config.py`) are replaced
       with `"***"` before serialisation. Mutation is deferred to Phase 3
       so config edits stay TOML-first and reviewable.
+  - name: Sessions
+    description: |
+      Sessions admin (Phase 2 §10). Lists every configured session with
+      live tmux + heartbeat state (mirror of `pm sessions`), and exposes
+      restart / pause / resume actions for one session at a time.
+      Per-task worker surfaces live under `Chat` — this surface only
+      covers the static launch plan from `[sessions]` config.
 
 paths:
   /health:
@@ -973,6 +980,171 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /sessions:
+    get:
+      tags: [Sessions]
+      operationId: listSessions
+      summary: List configured sessions with live tmux + heartbeat state
+      description: |
+        Mirrors `pm sessions` (#2039) — one row per configured (and
+        enabled) session in `[sessions]` config with classification
+        (`healthy` / `stale` / `missing` / `unknown` / `paused`) derived
+        from the latest heartbeat row plus a tmux storage-closet probe.
+        Read-side is fail-soft: a pg-pool outage degrades to
+        `status=unknown` rather than 5xx so the inventory remains
+        visible in degraded environments.
+      responses:
+        "200":
+          description: List of configured sessions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionsListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /sessions/{name}:
+    parameters:
+      - $ref: "#/components/parameters/SessionName"
+    get:
+      tags: [Sessions]
+      operationId: getSession
+      summary: One session's config + live health snapshot
+      description: |
+        Returns the `[sessions]` config row + last heartbeat + tmux
+        health (window present, pane alive, pane command). `is_turn_active`
+        reflects whether the agent is mid-turn at request time — clients
+        should treat it as a safety hint, not a contract.
+      responses:
+        "200":
+          description: Single-session detail payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /sessions/{name}/restart:
+    parameters:
+      - $ref: "#/components/parameters/SessionName"
+    post:
+      tags: [Sessions]
+      operationId: restartSession
+      summary: Destroy + relaunch the tmux window for one session
+      description: |
+        Kills the session's tmux window (no-op if absent) and
+        re-creates it from the `[sessions]` config row. Refuses with
+        `409 unsafe_mid_turn` when the agent is mid-turn unless
+        `?safety=force`. Returns `503 daemon_unavailable` when the
+        tmux session service can't be constructed.
+      parameters:
+        - in: query
+          name: safety
+          schema:
+            type: string
+            enum: [strict, loose, force]
+            default: strict
+          description: |
+            Safety gate. `strict` (default) refuses while the agent is
+            mid-turn; `force` bypasses the mid-turn gate. `loose` is
+            treated like `strict` for this verb (no warn-and-proceed
+            semantics defined yet).
+      responses:
+        "200":
+          description: Restart completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: |
+            Refused because the agent is mid-turn
+            (`code=unsafe_mid_turn`). Re-issue with `?safety=force` to
+            override.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            Tmux session service unavailable (`code=daemon_unavailable`).
+            Confirm the daemon / cockpit is running, then retry.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /sessions/{name}/pause:
+    parameters:
+      - $ref: "#/components/parameters/SessionName"
+    post:
+      tags: [Sessions]
+      operationId: pauseSession
+      summary: Mark a session paused (skip heartbeat dispatch / recovery)
+      description: |
+        Idempotent. Writes the session name into the project's pause
+        marker (`<base_dir>/paused-sessions.json`) so other readers
+        (recovery loop, `GET /api/v1/sessions`) can skip / surface the
+        quiesced state. The tmux window itself is left alone.
+      responses:
+        "200":
+          description: Pause recorded (or already paused).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          description: |
+            Filesystem error while writing the pause marker
+            (`code=service_unavailable`). Check filesystem permissions
+            on `~/.pollypm`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /sessions/{name}/resume:
+    parameters:
+      - $ref: "#/components/parameters/SessionName"
+    post:
+      tags: [Sessions]
+      operationId: resumeSession
+      summary: Clear the paused flag for a session (inverse of pause)
+      description: |
+        Idempotent. Removes the session name from the project's pause
+        marker. Returns 200 with no state change if the session wasn't
+        paused.
+      responses:
+        "200":
+          description: Resume recorded (or already running).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          description: |
+            Filesystem error while writing the pause marker
+            (`code=service_unavailable`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /events:
     get:
       tags: [Events]
@@ -1084,6 +1256,16 @@ components:
         Chat surface identifier from `GET /chat/sessions` — e.g.
         `operator`, `architect_<project>`, `advisor_<project>`,
         `task-<project>-<n>`.
+    SessionName:
+      in: path
+      name: name
+      required: true
+      schema: { type: string }
+      description: |
+        Configured session name from `[sessions]` config — e.g.
+        `operator`, `advisor_<project>`, `architect_<project>`. Per-task
+        worker sessions are NOT addressable here; use the chat surface
+        for those.
     IdempotencyKey:
       in: header
       name: Idempotency-Key
@@ -2178,3 +2360,146 @@ components:
           additionalProperties: true
           description: |
             Redacted snapshot of the `[projects.<key>]` config block.
+
+    # ---- Sessions admin (Phase 2 §10) -------------------------------
+    SessionStatus:
+      type: string
+      enum: [healthy, stale, missing, unknown, paused]
+      description: |
+        Live classification mirroring `pm sessions`. `healthy` =
+        heartbeat <=5min old AND tmux window present. `stale` =
+        heartbeat older than 5min. `missing` = tmux window absent
+        (beats `stale` — pane is the more urgent problem). `unknown` =
+        no heartbeat row yet (fresh boot OR pg outage). `paused` =
+        operator-set quiesce flag via POST /sessions/{name}/pause.
+
+    SessionInfo:
+      type: object
+      required:
+        - name
+        - role
+        - project
+        - provider
+        - account
+        - window_name
+        - tmux_session
+        - window_present
+        - status
+        - auth_token_present
+        - enabled
+        - paused
+      properties:
+        name: { type: string }
+        role:
+          type: string
+          description: |
+            Session role from config — e.g. `operator-pm`, `architect`,
+            `advisor`, `heartbeat-supervisor`.
+        project: { type: string }
+        provider:
+          type: string
+          description: Provider name (e.g. `claude`, `codex`).
+        account: { type: string }
+        window_name: { type: string }
+        tmux_session:
+          type: string
+          description: Storage-closet tmux session that owns the window.
+        window_present:
+          type: boolean
+          description: True iff the tmux window is currently visible.
+        status:
+          $ref: "#/components/schemas/SessionStatus"
+        last_heartbeat_iso:
+          type: string
+          nullable: true
+          description: ISO-8601 timestamp of the most-recent heartbeat row, if any.
+        last_heartbeat_age_seconds:
+          type: integer
+          nullable: true
+          description: Age (in whole seconds) of the most-recent heartbeat.
+        auth_token_present:
+          type: boolean
+          description: |
+            Lever-2 (#2012) trust signal — true when this session
+            carries an `auth_token` the watchdog can use to verify its
+            own injections.
+        enabled: { type: boolean }
+        paused:
+          type: boolean
+          description: |
+            True when an operator has paused the session via POST
+            /sessions/{name}/pause.
+
+    SessionsListResponse:
+      type: object
+      required: [sessions]
+      properties:
+        sessions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionInfo"
+
+    SessionHealthSnapshot:
+      type: object
+      required: [window_present, pane_alive, pane_dead]
+      properties:
+        window_present: { type: boolean }
+        pane_alive: { type: boolean }
+        pane_dead: { type: boolean }
+        pane_command:
+          type: string
+          nullable: true
+          description: Foreground command of the pane (e.g. `claude`, `bash`).
+
+    SessionConfigView:
+      type: object
+      required:
+        - name
+        - role
+        - provider
+        - account
+        - project
+        - cwd
+        - window_name
+        - enabled
+        - auth_token_present
+      properties:
+        name: { type: string }
+        role: { type: string }
+        provider: { type: string }
+        account: { type: string }
+        project: { type: string }
+        cwd:
+          type: string
+          description: Working directory the session was launched in.
+        window_name: { type: string }
+        enabled: { type: boolean }
+        auth_token_present:
+          type: boolean
+          description: |
+            True when `auth_token` is non-empty on disk. The token
+            itself is never returned over the API.
+        agent_profile:
+          type: string
+          nullable: true
+        args:
+          type: array
+          items: { type: string }
+
+    SessionDetail:
+      type: object
+      required: [info, config, health, is_turn_active]
+      properties:
+        info:
+          $ref: "#/components/schemas/SessionInfo"
+        config:
+          $ref: "#/components/schemas/SessionConfigView"
+        health:
+          $ref: "#/components/schemas/SessionHealthSnapshot"
+        is_turn_active:
+          type: boolean
+          description: |
+            True when the agent appears to be mid-turn (provider-specific
+            heuristic: Claude shows `⏺` / "Working"; Codex shows
+            "working (...) esc to interrupt"). Used by POST
+            /sessions/{name}/restart as the `unsafe_mid_turn` gate.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -988,11 +988,14 @@ paths:
       description: |
         Mirrors `pm sessions` (#2039) — one row per configured (and
         enabled) session in `[sessions]` config with classification
-        (`healthy` / `stale` / `missing` / `unknown` / `paused`) derived
+        (`healthy` / `stale` / `missing` / `unknown`) derived
         from the latest heartbeat row plus a tmux storage-closet probe.
-        Read-side is fail-soft: a pg-pool outage degrades to
-        `status=unknown` rather than 5xx so the inventory remains
-        visible in degraded environments.
+        The operator-set pause marker is surfaced via the separate
+        `paused: bool` field so it cannot mask the runtime-health
+        classification (see `SessionInfo.paused`). Read-side is
+        fail-soft: a pg-pool outage degrades to `status=unknown`
+        rather than 5xx so the inventory remains visible in degraded
+        environments.
       responses:
         "200":
           description: List of configured sessions.
@@ -1126,9 +1129,11 @@ paths:
         Idempotent. Writes the session name into the project's pause
         marker (`<base_dir>/paused-sessions.json`) using atomic
         tmp+rename, with `fcntl.flock` serialising concurrent
-        pause/resume callers. `GET /api/v1/sessions` surfaces
-        `status="paused"` for tagged sessions; the tmux window itself
-        is left alone.
+        pause/resume callers. `GET /api/v1/sessions` surfaces the
+        marker on the separate `paused: true` field; the `status`
+        field continues to reflect actual runtime health (so a
+        paused-but-missing session reports `status="missing"` AND
+        `paused=true`). The tmux window itself is left alone.
       responses:
         "200":
           description: Pause recorded (or already paused).
@@ -2405,14 +2410,22 @@ components:
     # ---- Sessions admin (Phase 2 §10) -------------------------------
     SessionStatus:
       type: string
-      enum: [healthy, stale, missing, unknown, paused]
+      enum: [healthy, stale, missing, unknown]
       description: |
-        Live classification mirroring `pm sessions`. `healthy` =
-        heartbeat <=5min old AND tmux window present. `stale` =
-        heartbeat older than 5min. `missing` = tmux window absent
-        (beats `stale` — pane is the more urgent problem). `unknown` =
-        no heartbeat row yet (fresh boot OR pg outage). `paused` =
-        operator-set quiesce flag via POST /sessions/{name}/pause.
+        Live runtime-health classification mirroring `pm sessions`.
+        `healthy` = heartbeat <=5min old AND tmux window present.
+        `stale` = heartbeat older than 5min. `missing` = tmux window
+        absent (beats `stale` — pane is the more urgent problem).
+        `unknown` = no heartbeat row yet (fresh boot OR pg outage).
+
+        Pause is NOT a value of this enum. The operator-set pause
+        marker is exposed as the separate `SessionInfo.paused`
+        boolean so a paused-but-missing or paused-but-stale session
+        still reports its true runtime state. Folding pause into
+        `status` was removed in PR #2061 round 2 because the
+        supervisor / recovery / dispatch loops do not consume the
+        marker today (see #2068) — `status="paused"` would have
+        misled operators into believing the daemon had quiesced.
 
     SessionInfo:
       type: object
@@ -2468,8 +2481,13 @@ components:
         paused:
           type: boolean
           description: |
-            True when an operator has paused the session via POST
-            /sessions/{name}/pause.
+            Informational marker set via POST
+            /sessions/{name}/pause. The supervisor / recovery /
+            dispatch loops do NOT currently consume this marker (see
+            #2068). The `status` field above remains the source of
+            truth for runtime health — a paused-but-missing session
+            reports `status="missing"` AND `paused=true`, not
+            `status="paused"`.
 
     SessionsListResponse:
       type: object

--- a/src/pollypm/cli_features/sessions_health.py
+++ b/src/pollypm/cli_features/sessions_health.py
@@ -15,6 +15,14 @@ Contract:
   ``stale`` = heartbeat older than 5 minutes;
   ``missing`` = the configured ``window_name`` is not present in tmux;
   ``unknown`` = no heartbeat row has ever been recorded.
+
+Pure classification / probe helpers live in
+:mod:`pollypm.session_health` so the Phase 2 sessions-admin API
+endpoint (``GET /api/v1/sessions``) consumes the same contract
+without duplicating thresholds, naming, or probe logic (Codex PR #2061
+round 5 blocker 3). The private ``_classify_status`` / ``_humanize_age``
+/ ``_latest_heartbeat`` / ``_STALE_HEARTBEAT_SECONDS`` symbols remain
+re-exported here for backwards compatibility with the test suite.
 """
 
 from __future__ import annotations
@@ -28,120 +36,48 @@ from typing import Any
 import typer
 
 from pollypm.config import DEFAULT_CONFIG_PATH
+from pollypm.session_health import (
+    STALE_HEARTBEAT_SECONDS as _STALE_HEARTBEAT_SECONDS,
+)
+from pollypm.session_health import (
+    STORAGE_CLOSET_SUFFIX as _STORAGE_CLOSET_SUFFIX,
+)
+from pollypm.session_health import (
+    age_seconds as _age_seconds,
+)
+from pollypm.session_health import (
+    classify_status as _classify_status,
+)
+from pollypm.session_health import (
+    humanize_age as _humanize_age,
+)
+from pollypm.session_health import (
+    latest_heartbeat as _latest_heartbeat,
+)
+from pollypm.session_health import (
+    list_storage_closet_windows as _list_windows,
+)
+from pollypm.session_health import (
+    storage_session_name as _storage_session_name,
+)
 
 logger = logging.getLogger(__name__)
 
 
-# Heartbeats older than this are classified ``stale``. Five minutes
-# matches the cockpit-inbox "stuck pane" threshold and the watchdog's
-# escalation cadence — same number, same semantics, picked once.
-_STALE_HEARTBEAT_SECONDS = 5 * 60
-
-# Suffix appended to ``project.tmux_session`` to derive the storage-
-# closet session name (mirrors
-# :attr:`pollypm.supervisor.Supervisor._STORAGE_CLOSET_SESSION_SUFFIX`).
-# Hard-coded here so the CLI command can resolve windows without
-# spinning up a full Supervisor — heavyweight when all the user wants
-# is a read-only summary.
-_STORAGE_CLOSET_SUFFIX = "-storage-closet"
-
-
-def _storage_session_name(tmux_session: str) -> str:
-    return f"{tmux_session}{_STORAGE_CLOSET_SUFFIX}"
-
-
-def _humanize_age(iso_timestamp: str | None) -> str:
-    """Return a compact relative age (``"22s ago"`` / ``"12m ago"``).
-
-    Returns ``"none"`` when ``iso_timestamp`` is ``None`` or unparseable
-    so the column never flashes a misleading "now" for sessions that
-    have never reported in.
-    """
-    if not iso_timestamp:
-        return "none"
-    try:
-        when = datetime.fromisoformat(iso_timestamp)
-    except (TypeError, ValueError):
-        return "none"
-    if when.tzinfo is None:
-        when = when.replace(tzinfo=UTC)
-    total = int(max(0, (datetime.now(UTC) - when).total_seconds()))
-    if total < 60:
-        return f"{total}s ago"
-    if total < 3600:
-        return f"{total // 60}m ago"
-    if total < 86400:
-        return f"{total // 3600}h ago"
-    return f"{total // 86400}d ago"
-
-
-def _age_seconds(iso_timestamp: str | None) -> int | None:
-    if not iso_timestamp:
-        return None
-    try:
-        when = datetime.fromisoformat(iso_timestamp)
-    except (TypeError, ValueError):
-        return None
-    if when.tzinfo is None:
-        when = when.replace(tzinfo=UTC)
-    return int(max(0, (datetime.now(UTC) - when).total_seconds()))
-
-
-def _classify_status(
-    *,
-    window_present: bool,
-    age_seconds: int | None,
-) -> str:
-    """Return one of ``healthy`` / ``missing`` / ``stale`` / ``unknown``.
-
-    ``missing`` wins over ``stale`` — when the tmux window is gone the
-    pane is the more urgent problem; the heartbeat staleness is just a
-    downstream symptom and reporting both would be noisy.
-    """
-    if not window_present:
-        return "missing"
-    if age_seconds is None:
-        return "unknown"
-    if age_seconds > _STALE_HEARTBEAT_SECONDS:
-        return "stale"
-    return "healthy"
-
-
-def _latest_heartbeat(config, session_name: str):
-    """Return the most-recent heartbeat record for ``session_name``.
-
-    Postgres-only: reads through :mod:`pollypm.storage.pg_heartbeats`.
-    Returns ``None`` when no heartbeat row exists OR the lookup fails —
-    a read failure must not crash a read-only CLI summary, and the
-    caller treats ``None`` as ``unknown`` status downstream.
-    """
-    try:
-        from pollypm.storage.pg_heartbeats import latest_heartbeat as _pg
-
-        return _pg(session_name, config=config)
-    except Exception:  # noqa: BLE001 — never crash a read-only summary
-        logger.debug("latest_heartbeat lookup failed", exc_info=True)
-        return None
-
-
-def _list_windows(tmux_session_name: str) -> dict[str, Any]:
-    """Return ``{window_name: TmuxWindow}`` for ``tmux_session_name``.
-
-    Empty dict when the tmux server is unreachable, the session does
-    not exist, or any other tmux probe fails — the caller treats every
-    session as ``missing`` in that state, which is the right answer
-    when tmux itself is down.
-    """
-    from pollypm.tmux.client import TmuxClient
-
-    tmux = TmuxClient()
-    try:
-        if not tmux.has_session(tmux_session_name):
-            return {}
-        return {window.name: window for window in tmux.list_windows(tmux_session_name)}
-    except Exception:  # noqa: BLE001
-        logger.debug("tmux probe failed for %s", tmux_session_name, exc_info=True)
-        return {}
+# Backwards-compat re-imports for callers (and tests) that bound to the
+# private names before the helpers moved to :mod:`pollypm.session_health`.
+# The shared module is the single source of truth — keep these aliased,
+# do NOT re-implement the bodies here.
+__all_shared__ = (
+    "_STALE_HEARTBEAT_SECONDS",
+    "_STORAGE_CLOSET_SUFFIX",
+    "_age_seconds",
+    "_classify_status",
+    "_humanize_age",
+    "_latest_heartbeat",
+    "_list_windows",
+    "_storage_session_name",
+)
 
 
 def _log_mtime_iso(config, session_name: str) -> str | None:

--- a/src/pollypm/service_api/__init__.py
+++ b/src/pollypm/service_api/__init__.py
@@ -8,11 +8,21 @@ version (``from pollypm.service_api.v1 import PollyPMService``).
 Direct ``from pollypm.supervisor import Supervisor`` outside
 :mod:`pollypm.core` is deprecated — see ``docs/architecture.md`` and the
 import-boundary test in ``tests/test_import_boundary.py``.
+
+Callers that already hold a loaded :class:`pollypm.config.PollyPMConfig`
+(e.g. the web API endpoints, which receive it via the FastAPI dependency
+:class:`pollypm.web_api.routes._deps.ConfigDep`) construct a Supervisor
+through :func:`build_supervisor`. The function lives in
+:mod:`pollypm.service_api.v1` (the version-pinned facade module) so the
+web-API layer never needs ``from pollypm.supervisor import Supervisor``
+— the import-boundary test in ``tests/test_import_boundary.py``
+enforces this.
 """
 
 from pollypm.service_api.v1 import (
     PollyPMService,
     StatusSnapshot,
+    build_supervisor,
     collect_plugin_load_errors,
     plan_launches_readonly,
     render_json,
@@ -21,6 +31,7 @@ from pollypm.service_api.v1 import (
 __all__ = [
     "PollyPMService",
     "StatusSnapshot",
+    "build_supervisor",
     "collect_plugin_load_errors",
     "plan_launches_readonly",
     "render_json",

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -44,7 +44,7 @@ from pollypm.accounts import (
 )
 from pollypm.checkpoints import create_issue_completion_checkpoint, record_checkpoint
 from pollypm.config_patches import apply_preference_patch, detect_preference_patch, list_project_overrides
-from pollypm.config import load_config
+from pollypm.config import PollyPMConfig, load_config
 from pollypm.events.summaries import activity_summary
 from pollypm.itsalive import (
     deploy_site,
@@ -146,6 +146,34 @@ def collect_plugin_load_errors(config_path: Path) -> list[dict[str, str]]:
             }
         )
     return out
+
+
+def build_supervisor(
+    config: PollyPMConfig, *, readonly_state: bool = False,
+) -> Supervisor:
+    """Construct a :class:`Supervisor` from an already-loaded config.
+
+    Public factory for callers that already hold a
+    :class:`PollyPMConfig` (e.g. the FastAPI route layer, which receives
+    the config via :class:`pollypm.web_api.routes._deps.ConfigDep`).
+    Routing through this helper keeps the direct
+    ``from pollypm.supervisor import Supervisor`` import behind the
+    sanctioned service-api facade — the import-boundary test in
+    ``tests/test_import_boundary.py`` allow-lists this module
+    (``src/pollypm/service_api/v1.py``) precisely so the facade can
+    own the construction.
+
+    Use this when the caller needs a short-lived Supervisor for one or
+    two public method calls (``restart_session``,
+    ``get_session_runtime``, ``session_service``). Reach for
+    :class:`PollyPMService` when the higher-level surface (status
+    snapshots, alert wiring, task backends) is the right tool.
+
+    Returns ``None`` on construction failure? No — exceptions propagate.
+    Callers that want fail-soft behaviour should wrap this in their own
+    try/except (the web-API route does so to map errors to typed 503s).
+    """
+    return Supervisor(config, readonly_state=readonly_state)
 
 
 class PollyPMService:

--- a/src/pollypm/session_health.py
+++ b/src/pollypm/session_health.py
@@ -170,8 +170,6 @@ def probe_strict_turn_active(
     config: Any,
     session_name: str,
     tmux_client: Any,
-    *,
-    windows: dict[str, Any] | None = None,
 ) -> bool:
     """Return True iff the configured session has a live mid-turn pane.
 
@@ -181,9 +179,11 @@ def probe_strict_turn_active(
 
     * ``config.sessions[name]`` — the canonical configured-session
       registry (mirrors what ``GET /api/v1/sessions`` walks);
-    * ``windows`` (or :func:`list_storage_closet_windows`) — the live
-      tmux window inventory used to compute ``info.window_present`` on
-      ``GET /api/v1/sessions/{name}``;
+    * direct :class:`pollypm.tmux.client.TmuxClient` ``has_session`` /
+      ``list_windows`` calls — owned by the probe itself, NOT the
+      fail-soft :func:`list_storage_closet_windows` helper — so a tmux
+      outage raises :class:`TmuxProbeUnavailable` instead of looking
+      identical to "window genuinely absent" (Codex PR #2061 round 7);
     * direct :class:`pollypm.tmux.client.TmuxClient` ``list_panes`` /
       ``capture_pane`` calls against the resolved pane.
 
@@ -198,12 +198,24 @@ def probe_strict_turn_active(
     on healthy production setups and the restart proceeded to destroy
     a working pane — fail-open in the worst possible way.
 
-    ``windows`` (optional) lets the caller pass an already-computed
-    ``{window_name: TmuxWindow}`` dict (from
-    :func:`list_storage_closet_windows`) so the probe and the route's
-    ``info.window_present`` cannot diverge even with a flaky tmux
-    server between back-to-back calls. When omitted, the probe
-    computes it itself.
+    Round 7 followup: the probe NO LONGER accepts a pre-computed
+    ``windows`` dict. Threading the fail-soft
+    :func:`list_storage_closet_windows` result in let a tmux outage
+    (``{}`` returned for ``CalledProcessError`` / ``FileNotFoundError``
+    / timeout) look identical to "window genuinely absent" → probe
+    returned ``False`` (looks idle) → strict restart proceeded. The
+    probe now owns window discovery directly so it can distinguish:
+
+    * tmux call **succeeds, no matching window** → return ``False``
+      (nothing to interrupt; the relaunch can safely create a fresh
+      window).
+    * tmux call **raises** → propagate as ``TmuxProbeUnavailable`` →
+      route maps to ``503 unsafe_mid_turn_unknown`` (fail-closed).
+
+    The fail-soft :func:`list_storage_closet_windows` helper is still
+    correct for the read-side GET detail/list paths — losing tmux
+    there should degrade gracefully, not 503 a read-only summary. Only
+    the destructive restart safety gate needs the strict variant.
 
     Returns
     -------
@@ -214,16 +226,21 @@ def probe_strict_turn_active(
         ``False`` if:
         * the session isn't configured (caller's 404 lookup already
           ran, but be lenient — nothing to "be mid-turn" on),
-        * the tmux window is absent (nothing to interrupt),
-        * the pane is dead (nothing to interrupt),
+        * tmux reliably reports the storage-closet session is absent
+          (no tmux server / session not yet booted) → nothing to
+          interrupt,
+        * the tmux window is absent → nothing to interrupt,
+        * the pane is dead → nothing to interrupt,
         * or the pane text shows no active-turn marker.
 
     Raises
     ------
     TmuxProbeUnavailable
-        Any failure of ``list_panes`` / ``capture_pane`` — propagated
-        so the route maps to ``503 unsafe_mid_turn_unknown`` instead of
-        silently returning ``False``.
+        Any failure of the underlying ``TmuxClient`` calls
+        (``has_session`` / ``list_windows`` / ``list_panes`` /
+        ``capture_pane``) — propagated so the route maps to
+        ``503 unsafe_mid_turn_unknown`` instead of silently returning
+        ``False``.
     """
     sessions = getattr(config, "sessions", None) or {}
     session = sessions.get(session_name)
@@ -243,11 +260,32 @@ def probe_strict_turn_active(
     if not storage_session:
         return False
 
-    if windows is None:
-        windows = list_storage_closet_windows(storage_session)
+    # Owned window discovery (Codex PR #2061 round 7). ANY exception
+    # from the underlying tmux calls is "unknown" — raise
+    # ``TmuxProbeUnavailable`` so the route maps to 503
+    # ``unsafe_mid_turn_unknown`` instead of treating tmux outage as
+    # "window absent → safe to restart".
+    try:
+        session_present = tmux_client.has_session(storage_session)
+    except Exception as exc:  # noqa: BLE001
+        raise TmuxProbeUnavailable(
+            f"tmux.has_session failed: {exc!s}",
+        ) from exc
+    if not session_present:
+        # tmux is up and reliably reports the storage-closet session
+        # isn't there — definitive "nothing to interrupt".
+        return False
+
+    try:
+        windows_list = tmux_client.list_windows(storage_session)
+    except Exception as exc:  # noqa: BLE001
+        raise TmuxProbeUnavailable(
+            f"tmux.list_windows failed: {exc!s}",
+        ) from exc
+    windows = {getattr(w, "name", ""): w for w in windows_list}
     window = windows.get(window_name)
     if window is None:
-        # No tmux window for the configured session → nothing to
+        # tmux reliably reported no window with this name → nothing to
         # interrupt. The route may still proceed to relaunch into a
         # fresh window; the strict gate does not block that.
         return False

--- a/src/pollypm/session_health.py
+++ b/src/pollypm/session_health.py
@@ -260,13 +260,33 @@ def probe_strict_turn_active(
     if not storage_session:
         return False
 
-    # Owned window discovery (Codex PR #2061 round 7). ANY exception
+    # Owned window discovery (Codex PR #2061 round 7 + 8). ANY exception
     # from the underlying tmux calls is "unknown" — raise
     # ``TmuxProbeUnavailable`` so the route maps to 503
     # ``unsafe_mid_turn_unknown`` instead of treating tmux outage as
     # "window absent → safe to restart".
+    #
+    # Round 8: prefer ``has_session_strict`` over the default
+    # fail-soft ``has_session``. The fail-soft variant returns ``False``
+    # for **any** non-zero rc — including rc=124 which
+    # :meth:`pollypm.tmux.client.TmuxClient.run` synthesises for a
+    # tmux-server timeout under ``check=False``. That conflated a real
+    # absent session (rc=1) with a wedged server (rc=124), and the
+    # probe then returned ``False`` (looks-absent → safe) for an
+    # unobservable tmux. The strict variant raises
+    # :class:`TmuxProbeUnavailable` for rc=124 / unexpected rc /
+    # ``TimeoutExpired`` and only returns ``False`` on a reliable
+    # rc=1 "session does not exist". Custom tmux clients without the
+    # strict method fall back to ``has_session`` (any exception they
+    # raise still propagates via the except below).
+    has_session_call = getattr(
+        tmux_client, "has_session_strict", None,
+    ) or tmux_client.has_session
     try:
-        session_present = tmux_client.has_session(storage_session)
+        session_present = has_session_call(storage_session)
+    except TmuxProbeUnavailable:
+        # Strict helper already crafted a precise diagnostic.
+        raise
     except Exception as exc:  # noqa: BLE001
         raise TmuxProbeUnavailable(
             f"tmux.has_session failed: {exc!s}",

--- a/src/pollypm/session_health.py
+++ b/src/pollypm/session_health.py
@@ -1,0 +1,162 @@
+"""Shared session-health classification + heartbeat/tmux probe helpers.
+
+Single source of truth for the ``pm sessions`` health contract. Both
+:mod:`pollypm.cli_features.sessions_health` (the CLI) and
+:mod:`pollypm.web_api.routes.sessions_admin` (the Phase 2 API) import
+from here so the two surfaces cannot drift on:
+
+* the ``healthy`` / ``stale`` / ``missing`` / ``unknown`` classification
+  thresholds (Codex PR #2061 round 5 blocker 3),
+* the storage-closet tmux-session naming,
+* the heartbeat-row lookup (pg-facade-backed, fail-soft on outage),
+* the tmux-window probe (fail-soft on outage).
+
+Pure module — no Typer / FastAPI / Pydantic imports — so it is cheap to
+unit-test in isolation and safe to import from any layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# Heartbeats older than this are classified ``stale``. Five minutes
+# matches the cockpit-inbox "stuck pane" threshold and the watchdog's
+# escalation cadence — same number, same semantics, picked once.
+STALE_HEARTBEAT_SECONDS = 5 * 60
+
+# Suffix appended to ``project.tmux_session`` to derive the storage-
+# closet session name. Hard-coded here (rather than importing from
+# :mod:`pollypm.supervisor`) so the read-only summary path stays free
+# of the heavyweight Supervisor construction. Mirror of
+# :attr:`pollypm.supervisor.Supervisor._STORAGE_CLOSET_SESSION_SUFFIX`.
+STORAGE_CLOSET_SUFFIX = "-storage-closet"
+
+
+def storage_session_name(tmux_session: str) -> str:
+    """Return ``<tmux_session>-storage-closet`` for ``tmux_session``."""
+    return f"{tmux_session}{STORAGE_CLOSET_SUFFIX}"
+
+
+def parse_iso(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp; ``None`` on missing or unparseable input."""
+    if not value:
+        return None
+    try:
+        candidate = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(candidate)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def age_seconds(iso_timestamp: str | None) -> int | None:
+    """Return seconds since ``iso_timestamp`` (clamped to >= 0), or ``None``."""
+    parsed = parse_iso(iso_timestamp)
+    if parsed is None:
+        return None
+    return int(max(0, (datetime.now(UTC) - parsed).total_seconds()))
+
+
+def humanize_age(iso_timestamp: str | None) -> str:
+    """Return a compact relative age (``"22s ago"`` / ``"12m ago"``).
+
+    Returns ``"none"`` when ``iso_timestamp`` is ``None`` or unparseable
+    so the column never flashes a misleading "now" for sessions that
+    have never reported in.
+    """
+    secs = age_seconds(iso_timestamp)
+    if secs is None:
+        return "none"
+    if secs < 60:
+        return f"{secs}s ago"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h ago"
+    return f"{secs // 86400}d ago"
+
+
+def classify_status(
+    *,
+    window_present: bool,
+    age_seconds: int | None,
+) -> str:
+    """Return one of ``healthy`` / ``stale`` / ``missing`` / ``unknown``.
+
+    ``missing`` wins over ``stale`` — when the tmux window is gone the
+    pane is the more urgent problem and reporting both would be noisy.
+
+    The pause marker is intentionally NOT consulted here (Codex PR #2061
+    round 2). Pause is informational only — folding it into ``status``
+    would mask the real runtime state.
+    """
+    if not window_present:
+        return "missing"
+    if age_seconds is None:
+        return "unknown"
+    if age_seconds > STALE_HEARTBEAT_SECONDS:
+        return "stale"
+    return "healthy"
+
+
+def latest_heartbeat(config: Any, session_name: str) -> Any | None:
+    """Fetch the most-recent heartbeat record; ``None`` on any failure.
+
+    Read failures must never crash a read-only surface. The caller
+    treats ``None`` as ``unknown`` (no heartbeat row yet) and that is
+    a legitimate live state for a freshly-booted session.
+    """
+    try:
+        from pollypm.storage.pg_heartbeats import latest_heartbeat as _pg
+    except Exception:  # noqa: BLE001
+        logger.debug("pg_heartbeats import failed", exc_info=True)
+        return None
+    try:
+        return _pg(session_name, config=config)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "latest_heartbeat lookup failed for %s",
+            session_name,
+            exc_info=True,
+        )
+        return None
+
+
+def list_storage_closet_windows(tmux_session: str) -> dict[str, Any]:
+    """Return ``{window_name: TmuxWindow}`` for the storage-closet session.
+
+    Empty dict on any failure (tmux missing, server down, session not
+    found). The caller treats every session as ``window_present=False``
+    in that state, which is the right answer when tmux itself is
+    unreachable.
+    """
+    try:
+        from pollypm.tmux.client import TmuxClient
+
+        tmux = TmuxClient()
+        if not tmux.has_session(tmux_session):
+            return {}
+        return {w.name: w for w in tmux.list_windows(tmux_session)}
+    except Exception:  # noqa: BLE001
+        logger.debug("tmux probe failed for %s", tmux_session, exc_info=True)
+        return {}
+
+
+__all__ = [
+    "STALE_HEARTBEAT_SECONDS",
+    "STORAGE_CLOSET_SUFFIX",
+    "age_seconds",
+    "classify_status",
+    "humanize_age",
+    "latest_heartbeat",
+    "list_storage_closet_windows",
+    "parse_iso",
+    "storage_session_name",
+]

--- a/src/pollypm/session_health.py
+++ b/src/pollypm/session_health.py
@@ -149,14 +149,152 @@ def list_storage_closet_windows(tmux_session: str) -> dict[str, Any]:
         return {}
 
 
+class TmuxProbeUnavailable(RuntimeError):
+    """Raised by :func:`probe_strict_turn_active` when the probe cannot answer.
+
+    The destructive ``POST /api/v1/sessions/{name}/restart`` strict
+    safety gate must fail *closed* — a transient tmux outage must not
+    look like "agent is idle" and let the restart tear down a working
+    pane (Codex PR #2061 round 3 + round 6). Callers map this to
+    ``503 unsafe_mid_turn_unknown``.
+
+    Aliases :class:`pollypm.session_services.tmux.TmuxProbeUnavailable`
+    so the route layer can catch a single exception type regardless of
+    where the probe is dispatched. The session-services exception type
+    stays alive for in-service probes; the route now prefers the
+    config/tmux-direct probe defined here.
+    """
+
+
+def probe_strict_turn_active(
+    config: Any,
+    session_name: str,
+    tmux_client: Any,
+    *,
+    windows: dict[str, Any] | None = None,
+) -> bool:
+    """Return True iff the configured session has a live mid-turn pane.
+
+    Single-sourced strict probe for the destructive restart safety gate.
+    Reads from the **same** contract surfaces the rest of the sessions-
+    admin API exposes:
+
+    * ``config.sessions[name]`` — the canonical configured-session
+      registry (mirrors what ``GET /api/v1/sessions`` walks);
+    * ``windows`` (or :func:`list_storage_closet_windows`) — the live
+      tmux window inventory used to compute ``info.window_present`` on
+      ``GET /api/v1/sessions/{name}``;
+    * direct :class:`pollypm.tmux.client.TmuxClient` ``list_panes`` /
+      ``capture_pane`` calls against the resolved pane.
+
+    Pointedly NOT routed through :class:`TmuxSessionService` /
+    :class:`pollypm.storage.state.StateStore`. Codex PR #2061 round 6
+    caught that production session registration is now in pg (via
+    :func:`pollypm.storage.pg_sessions.upsert_session`, called from the
+    Supervisor launch path), so the legacy ``StateStore.list_sessions``
+    (which the in-service strict probe consults) can be empty or stale
+    even when the configured session and tmux pane exist. With that
+    split source the in-service probe returned ``False`` (looks-idle)
+    on healthy production setups and the restart proceeded to destroy
+    a working pane — fail-open in the worst possible way.
+
+    ``windows`` (optional) lets the caller pass an already-computed
+    ``{window_name: TmuxWindow}`` dict (from
+    :func:`list_storage_closet_windows`) so the probe and the route's
+    ``info.window_present`` cannot diverge even with a flaky tmux
+    server between back-to-back calls. When omitted, the probe
+    computes it itself.
+
+    Returns
+    -------
+    bool
+        ``True`` if the pane is live and shows a recognised active-turn
+        marker (Claude Code's ``working`` / ``⏺`` or Codex's
+        ``working (...)`` + ``esc to interrupt``).
+        ``False`` if:
+        * the session isn't configured (caller's 404 lookup already
+          ran, but be lenient — nothing to "be mid-turn" on),
+        * the tmux window is absent (nothing to interrupt),
+        * the pane is dead (nothing to interrupt),
+        * or the pane text shows no active-turn marker.
+
+    Raises
+    ------
+    TmuxProbeUnavailable
+        Any failure of ``list_panes`` / ``capture_pane`` — propagated
+        so the route maps to ``503 unsafe_mid_turn_unknown`` instead of
+        silently returning ``False``.
+    """
+    sessions = getattr(config, "sessions", None) or {}
+    session = sessions.get(session_name)
+    if session is None:
+        # Lookup by ``name`` attribute too — config may be keyed by
+        # role / window / etc. in test fixtures.
+        for candidate in sessions.values():
+            if getattr(candidate, "name", "") == session_name:
+                session = candidate
+                break
+    if session is None:
+        return False
+
+    window_name = getattr(session, "window_name", None) or session_name
+    tmux_session = getattr(getattr(config, "project", None), "tmux_session", "") or ""
+    storage_session = storage_session_name(tmux_session) if tmux_session else ""
+    if not storage_session:
+        return False
+
+    if windows is None:
+        windows = list_storage_closet_windows(storage_session)
+    window = windows.get(window_name)
+    if window is None:
+        # No tmux window for the configured session → nothing to
+        # interrupt. The route may still proceed to relaunch into a
+        # fresh window; the strict gate does not block that.
+        return False
+    pane_id = getattr(window, "pane_id", None)
+    if pane_id is None:
+        return False
+    if getattr(window, "pane_dead", False):
+        return False
+
+    target = f"{getattr(window, 'session', storage_session)}:{window_name}"
+    try:
+        panes = tmux_client.list_panes(target)
+    except Exception as exc:  # noqa: BLE001
+        raise TmuxProbeUnavailable(
+            f"tmux.list_panes failed: {exc!s}",
+        ) from exc
+    active_pane_id = pane_id
+    for pane in panes:
+        if getattr(pane, "active", False):
+            active_pane_id = getattr(pane, "pane_id", pane_id)
+            break
+
+    try:
+        text = tmux_client.capture_pane(active_pane_id, lines=200)
+    except Exception as exc:  # noqa: BLE001
+        raise TmuxProbeUnavailable(
+            f"tmux.capture_pane failed: {exc!s}",
+        ) from exc
+
+    lowered = text.lower()
+    if "⏺" in text or "working" in lowered:
+        return True
+    if "working (" in lowered and "esc to interrupt" in lowered:
+        return True
+    return False
+
+
 __all__ = [
     "STALE_HEARTBEAT_SECONDS",
     "STORAGE_CLOSET_SUFFIX",
+    "TmuxProbeUnavailable",
     "age_seconds",
     "classify_status",
     "humanize_age",
     "latest_heartbeat",
     "list_storage_closet_windows",
     "parse_iso",
+    "probe_strict_turn_active",
     "storage_session_name",
 ]

--- a/src/pollypm/session_services/tmux.py
+++ b/src/pollypm/session_services/tmux.py
@@ -31,6 +31,24 @@ _STORAGE_CLOSET_SUFFIX = "-storage-closet"
 _CONSOLE_WINDOW = "PollyPM"
 
 
+class TmuxProbeUnavailable(RuntimeError):
+    """Raised by strict probes when the underlying tmux/store call fails.
+
+    The default ``list()`` / ``health()`` / ``is_turn_active()`` helpers
+    are deliberately fail-soft (they swallow ``CalledProcessError`` /
+    ``OSError`` / ``FileNotFoundError`` from subprocess and the state
+    store so the cockpit's read paths never crash on a transient tmux
+    hiccup). That fail-soft behaviour is the wrong default for the
+    destructive ``POST /api/v1/sessions/{name}/restart`` safety gate —
+    Codex PR #2061 round 3 caught that a real tmux outage made
+    ``is_turn_active()`` return ``False`` (no handle found → "agent
+    idle"), so strict mode would happily proceed to destroy an
+    actively-working agent. ``is_turn_active_strict()`` raises this
+    typed exception instead so the route can map it to
+    ``503 unsafe_mid_turn_unknown`` and fail closed.
+    """
+
+
 def _project_key_from_marker_path(marker_path: Path) -> tuple[str, Path | None]:
     """Best-effort derivation of (project_key, project_path) from a
     worker-marker path.
@@ -666,6 +684,99 @@ class TmuxSessionService:
         if "⏺" in h.pane_text or "working" in lowered:
             return True
         # Codex: active turn shows "working (" with "esc to interrupt"
+        if "working (" in lowered and "esc to interrupt" in lowered:
+            return True
+        return False
+
+    def is_turn_active_strict(self, name: str) -> bool:
+        """Strict variant: propagate probe failures instead of swallowing them.
+
+        Used by the destructive ``POST /sessions/{name}/restart`` safety
+        gate (Codex PR #2061 round 3). The fail-soft :meth:`is_turn_active`
+        relies on :meth:`health`, which in turn relies on :meth:`list` /
+        :meth:`get` / ``self.tmux.is_pane_alive`` / ``self.tmux.capture_pane``
+        — every one of which catches ``Exception`` and returns a
+        "session looks idle" answer. That is correct for read paths and
+        catastrophic for a destructive restart: a real tmux outage looks
+        the same as "agent is idle" and the route then tears down a
+        working agent.
+
+        This method re-implements the probe with NO ``except`` clauses
+        around the underlying calls. Any failure (subprocess / OSError /
+        store backend / parse) raises :class:`TmuxProbeUnavailable`. The
+        route maps that to ``503 unsafe_mid_turn_unknown`` so strict
+        mode fails *closed*.
+
+        Returns the same ``True`` / ``False`` semantics as
+        :meth:`is_turn_active` when the probe succeeds.
+        """
+        try:
+            sessions = self._store.list_sessions()
+        except Exception as exc:  # noqa: BLE001
+            raise TmuxProbeUnavailable(
+                f"store.list_sessions failed: {exc!s}",
+            ) from exc
+
+        # Find the configured session record (we don't synthesize
+        # per-task worker windows here — the strict probe is for
+        # configured sessions only, which is the universe of restart
+        # targets).
+        session_record = next(
+            (s for s in sessions if getattr(s, "name", None) == name),
+            None,
+        )
+        if session_record is None:
+            # No configured row → strictly there's nothing to be
+            # "mid-turn"; the route's 404 lookup runs before this and
+            # the test surface for the strict probe always has a
+            # configured row, so treat this as "not active" rather
+            # than raising.
+            return False
+
+        try:
+            all_windows = self.tmux.list_all_windows()
+        except Exception as exc:  # noqa: BLE001
+            raise TmuxProbeUnavailable(
+                f"tmux.list_all_windows failed: {exc!s}",
+            ) from exc
+
+        our_sessions = set(self._all_tmux_session_names())
+        window_name = getattr(session_record, "window_name", "") or name
+        window = next(
+            (
+                w for w in all_windows
+                if getattr(w, "session", None) in our_sessions
+                and getattr(w, "name", None) == window_name
+            ),
+            None,
+        )
+        if window is None:
+            # No tmux window for the configured session → not mid-turn
+            # (and the route will likely restart into a fresh window).
+            return False
+        pane_id = getattr(window, "pane_id", None)
+        if pane_id is None:
+            return False
+
+        try:
+            alive = self.tmux.is_pane_alive(pane_id)
+        except Exception as exc:  # noqa: BLE001
+            raise TmuxProbeUnavailable(
+                f"tmux.is_pane_alive failed: {exc!s}",
+            ) from exc
+        if not alive:
+            return False
+
+        try:
+            text = self.tmux.capture_pane(pane_id, lines=200)
+        except Exception as exc:  # noqa: BLE001
+            raise TmuxProbeUnavailable(
+                f"tmux.capture_pane failed: {exc!s}",
+            ) from exc
+
+        lowered = text.lower()
+        if "⏺" in text or "working" in lowered:
+            return True
         if "working (" in lowered and "esc to interrupt" in lowered:
             return True
         return False

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -788,6 +788,26 @@ class Supervisor:
             self._session_service = TmuxSessionService(config=self.config, store=self.store)
         return self._session_service
 
+    def is_session_turn_active_strict(self, session_name: str) -> bool:
+        """Public strict-mode probe for the destructive restart safety gate.
+
+        Delegates to the configured session service's strict probe
+        (:meth:`pollypm.session_services.tmux.TmuxSessionService.is_turn_active_strict`).
+        Strict mode propagates every probe failure as
+        :class:`pollypm.session_services.tmux.TmuxProbeUnavailable` so
+        callers can fail *closed* — the fail-soft default ``is_turn_active``
+        would swallow tmux / store outages and return "agent idle",
+        which is the wrong default for destructive operations
+        (Codex PR #2061 round 5 blocker 1).
+
+        Added as a public Supervisor method so the web-API
+        ``POST /api/v1/sessions/{name}/restart`` route can route through
+        the supervisor facade (with the correct ``StateStore`` already
+        wired into the session service) instead of constructing a
+        :class:`TmuxSessionService` with the wrong store type.
+        """
+        return self.session_service.is_turn_active_strict(session_name)
+
     @property
     def recovery_policy(self):
         """The recovery policy decides classification + intervention.

--- a/src/pollypm/tmux/client.py
+++ b/src/pollypm/tmux/client.py
@@ -126,6 +126,67 @@ class TmuxClient:
         result = self.run("has-session", "-t", self._exact_target(name), check=False)
         return result.returncode == 0
 
+    def has_session_strict(self, name: str) -> bool:
+        """Strict-mode counterpart to :meth:`has_session`.
+
+        Used by the destructive ``POST /api/v1/sessions/{name}/restart``
+        safety gate (via
+        :func:`pollypm.session_health.probe_strict_turn_active`) where
+        the fail-soft :meth:`has_session` is unsafe: it returns
+        ``False`` for **any** non-zero return code, conflating a real
+        "session not found" (rc=1) with a wedged tmux server whose
+        ``has-session`` call timed out (rc=124, synthesised by
+        :meth:`run` when ``subprocess.TimeoutExpired`` fires under
+        ``check=False``). The strict probe needs to distinguish:
+
+        * rc=0 → session exists (return ``True``)
+        * rc=1 → session reliably absent (return ``False``)
+        * rc=124 or any other rc → tmux probe is *unavailable*; raise
+          :class:`pollypm.session_health.TmuxProbeUnavailable` so the
+          route layer maps to ``503 unsafe_mid_turn_unknown``
+          (fail-closed)
+        * ``subprocess.TimeoutExpired`` raised directly (defensive
+          path; the wrapper normally converts it to rc=124 under
+          ``check=False``) → same fail-closed raise.
+
+        Codex PR #2061 round 8 caught the rc=124 fail-open path: with
+        the wedged-tmux server the prior probe saw ``has_session`` ==
+        ``False`` and treated the storage-closet session as
+        "definitively absent" → destructive restart proceeded against
+        an unobservable agent.
+        """
+        # Local import: TmuxProbeUnavailable lives in session_health to
+        # avoid a circular dependency (session_health imports
+        # TmuxClient lazily inside ``list_storage_closet_windows``). The
+        # local import is paid once per call but only on the strict
+        # restart path, not on hot reads.
+        from pollypm.session_health import TmuxProbeUnavailable
+
+        import subprocess as _subprocess
+
+        try:
+            result = self.run(
+                "has-session", "-t", self._exact_target(name), check=False,
+            )
+        except _subprocess.TimeoutExpired as exc:
+            # Defensive: ``run(check=False)`` normally converts
+            # TimeoutExpired into rc=124, but a future signature change
+            # (or a caller that overrides ``timeout``) could re-raise.
+            raise TmuxProbeUnavailable(
+                f"tmux has-session timed out for {name!r}: {exc!s}",
+            ) from exc
+        if result.returncode == 0:
+            return True
+        if result.returncode == 1:
+            # Tmux's documented "session does not exist" exit code.
+            return False
+        # rc=124 (run() timeout convention) OR any other unexpected
+        # rc — treat as probe unavailable so strict mode fails closed.
+        raise TmuxProbeUnavailable(
+            f"tmux has-session returned unexpected rc={result.returncode} "
+            f"for {name!r}; stderr={result.stderr!r}",
+        )
+
     def show_environment(self, session_name: str, variable: str) -> str | None:
         """Return one tmux session environment value, if it is visible.
 

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -39,6 +39,7 @@ from pollypm.web_api.routes import events as events_routes
 from pollypm.web_api.routes import health as health_routes
 from pollypm.web_api.routes import inbox as inbox_routes
 from pollypm.web_api.routes import projects as projects_routes
+from pollypm.web_api.routes import sessions_admin as sessions_admin_routes
 from pollypm.web_api.routes import tasks as tasks_routes
 from pollypm.web_api.routes._deps import _config_provider
 
@@ -173,6 +174,13 @@ def create_app(
     app.include_router(
         chat_send_routes.router,
         prefix=f"{API_V1_PREFIX}/chat",
+        dependencies=auth_deps,
+    )
+    # Phase 2 surface #8 — sessions admin (§10 of the endpoint spec).
+    # Mirrors ``pm sessions`` (#2039) plus restart / pause / resume.
+    app.include_router(
+        sessions_admin_routes.router,
+        prefix=API_V1_PREFIX,
         dependencies=auth_deps,
     )
 

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -19,9 +19,12 @@ Endpoints
   ``unsafe_mid_turn_unknown`` when the safety probe itself fails)
   unless ``?safety=force``.
 - ``POST   /api/v1/sessions/{name}/pause``     — write an
-  **informational** pause marker (consumers can observe it via
-  ``GET /api/v1/sessions`` but the supervisor / recovery / dispatch
-  loops do NOT yet consume it; see ``ActionResult.message``).
+  **informational** pause marker. Consumers can observe it via the
+  separate ``paused: bool`` field on ``GET /api/v1/sessions`` rows;
+  the ``status`` field is unaffected (Codex PR #2061 round 2 —
+  pause must NEVER mask the real runtime-health classification).
+  The supervisor / recovery / dispatch loops do NOT yet consume
+  this marker (see ``ActionResult.message`` and #2068).
   Idempotent.
 - ``POST   /api/v1/sessions/{name}/resume``    — remove the marker.
   Idempotent.
@@ -61,14 +64,21 @@ Design notes
 
 * **Pause / resume — informational only.** No existing supervisor /
   recovery / dispatch loop consumes the pause marker today, so this
-  surface is documented as **informational** (the cockpit + this API's
-  ``GET /sessions`` surface ``status="paused"``, but background loops
-  still act on the session). The response ``message`` and OpenAPI
-  description both call this out so operators are not misled into
-  thinking the marker quiesces the daemon. Daemon-side enforcement is
-  a follow-up (issue filed in the PR). Both operations are idempotent
-  and return 200, and concurrent writes are serialised by an
-  ``fcntl.flock`` on the marker file.
+  surface is documented as **informational**. Crucially, the marker
+  is exposed as a *separate* ``paused: bool`` field on the
+  ``SessionInfo`` row rather than as a value of ``status`` (Codex
+  PR #2061 round 2). Folding it into ``status`` was incoherent with
+  the round-1 "informational only" stance: a paused-but-missing
+  session reported ``status="paused"`` and operators believed the
+  daemon had quiesced when in fact the session was simply absent.
+  Now ``status`` reflects pure runtime health (``healthy`` /
+  ``stale`` / ``missing`` / ``unknown``) and ``paused`` carries the
+  operator intent. The response ``message`` and OpenAPI description
+  both call this out so operators are not misled into thinking the
+  marker quiesces the daemon. Daemon-side enforcement is tracked as
+  follow-up #2068. Both operations are idempotent and return 200,
+  and concurrent writes are serialised by an ``fcntl.flock`` on the
+  marker file.
 
 * **pg outages → 503.** ``GET`` endpoints downgrade pg outages to a
   best-effort response (``status="unknown"`` on the affected row).
@@ -138,11 +148,15 @@ class SessionInfo(BaseModel):
     window_name: str
     tmux_session: str
     window_present: bool
-    status: Literal["healthy", "stale", "missing", "unknown", "paused"]
+    status: Literal["healthy", "stale", "missing", "unknown"]
     last_heartbeat_iso: str | None = None
     last_heartbeat_age_seconds: int | None = None
     auth_token_present: bool
     enabled: bool
+    # Informational marker (Codex PR #2061 round 2). Decoupled from
+    # ``status`` so a paused-but-missing or paused-but-stale session
+    # still reports its true runtime health — the daemon does NOT
+    # consume this marker today (see #2068).
     paused: bool = False
 
 
@@ -291,17 +305,22 @@ def _classify_status(
     *,
     window_present: bool,
     age_seconds: int | None,
-    paused: bool,
 ) -> str:
-    """Return one of healthy/stale/missing/unknown/paused.
+    """Return one of healthy/stale/missing/unknown.
 
-    Matches :func:`pollypm.cli_features.sessions_health._classify_status`
-    except we surface ``paused`` first — operator intent overrides the
-    runtime signals (a paused session may still have a healthy pane,
-    but the cockpit / recovery loop should treat it as quiesced).
+    Mirrors :func:`pollypm.cli_features.sessions_health._classify_status`
+    exactly: a pure runtime-health classification derived from tmux
+    presence + heartbeat age.
+
+    The pause marker is intentionally NOT consulted here (Codex PR
+    #2061 round 2). Pause is informational only — the supervisor /
+    recovery / dispatch loops do not consume it (#2068) — so folding
+    it into ``status`` would mask the real runtime state and let an
+    operator believe they had quiesced the daemon when in fact a
+    paused-but-missing session was reporting ``status="paused"``
+    instead of ``status="missing"``. Callers consume the separate
+    :attr:`SessionInfo.paused` boolean for the informational signal.
     """
-    if paused:
-        return "paused"
     if not window_present:
         return "missing"
     if age_seconds is None:
@@ -485,7 +504,6 @@ def _build_session_info(
     status = _classify_status(
         window_present=window_present,
         age_seconds=age,
-        paused=paused,
     )
     auth_token_present = bool(getattr(session, "auth_token", "") or "")
     return SessionInfo(
@@ -686,9 +704,12 @@ def _find_session(config: Any, name: str) -> Any:
 def list_sessions_endpoint(config: ConfigDep) -> SessionsListResponse:
     """GET /api/v1/sessions — mirror ``pm sessions``.
 
-    Returns one row per configured (and enabled) session. ``paused``
-    rows come from the pause marker (see :func:`_load_paused_names`);
-    ``status`` follows the same thresholds the CLI uses.
+    Returns one row per configured (and enabled) session. ``status``
+    is the pure runtime-health classification (``healthy`` / ``stale``
+    / ``missing`` / ``unknown``) and follows the same thresholds the
+    CLI uses. ``paused`` is a separate informational boolean drawn
+    from the pause marker (see :func:`_load_paused_names`) and does
+    NOT influence ``status`` — see :func:`_classify_status` for why.
     """
     storage_session = _storage_session_name(config)
     windows = _list_storage_closet_windows(storage_session)
@@ -856,8 +877,12 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
 
     Writes ``<base_dir>/paused-sessions.json`` (atomic tmp+rename,
     serialised via ``fcntl.flock`` against concurrent pause/resume
-    callers) so ``GET /api/v1/sessions`` can surface
-    ``status="paused"``. Idempotent: pausing an already-paused
+    callers) so ``GET /api/v1/sessions`` surfaces ``paused=true`` on
+    the affected row. The ``status`` field continues to reflect
+    actual runtime health (``healthy`` / ``stale`` / ``missing`` /
+    ``unknown``) — a paused-but-missing session reports
+    ``status="missing"`` AND ``paused=true``, not ``status="paused"``
+    (Codex PR #2061 round 2). Idempotent: pausing an already-paused
     session returns 200 with no state change.
     """
     _find_session(config, name)  # 404 if unknown

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -11,13 +11,20 @@ Endpoints
   sessions with live health (heartbeat age + tmux window presence).
 - ``GET    /api/v1/sessions/{name}``           — one session's detail
   payload (config row + health snapshot + last heartbeat).
-- ``POST   /api/v1/sessions/{name}/restart``   — kill the tmux window
-  and re-create it. Refuses with ``409 unsafe_mid_turn`` when the agent
-  is mid-turn unless ``?safety=force``.
-- ``POST   /api/v1/sessions/{name}/pause``     — write a pause marker
-  so the recovery / dispatch loops skip this session. Idempotent.
-- ``POST   /api/v1/sessions/{name}/resume``    — remove the pause
-  marker. Idempotent.
+- ``POST   /api/v1/sessions/{name}/restart``   — destroy + relaunch
+  via the canonical :meth:`pollypm.supervisor.Supervisor.restart_session`
+  facade so the relaunched pane runs the configured provider command
+  (not an ad-hoc ``echo`` placeholder). Refuses with
+  ``409 unsafe_mid_turn`` when the agent is mid-turn (or 503
+  ``unsafe_mid_turn_unknown`` when the safety probe itself fails)
+  unless ``?safety=force``.
+- ``POST   /api/v1/sessions/{name}/pause``     — write an
+  **informational** pause marker (consumers can observe it via
+  ``GET /api/v1/sessions`` but the supervisor / recovery / dispatch
+  loops do NOT yet consume it; see ``ActionResult.message``).
+  Idempotent.
+- ``POST   /api/v1/sessions/{name}/resume``    — remove the marker.
+  Idempotent.
 
 Design notes
 ------------
@@ -31,19 +38,37 @@ Design notes
   read failures collapse to ``unknown`` / ``missing`` rather than
   500-ing.
 
-* **Restart.** Uses :class:`pollypm.session_services.tmux.TmuxSessionService`
-  to ``destroy`` then ``create``. The CLI is the only other caller that
-  performs that pair, and we deliberately re-use that helper so any
-  future change to launch automation lands in both surfaces at once.
-  Restart is intentionally synchronous (spec §10.4) — typical restart
-  time is < 5s and the spec defers ``?async`` to Phase 2.5.
+* **Restart.** Routes through :meth:`pollypm.supervisor.Supervisor.restart_session`
+  — the **same facade** ``pm switch-session-account``, the cockpit
+  account-switch action (``cockpit_ui.restart_session``), and the
+  upgrade flow already use. That facade owns the canonical kill +
+  launch-spec relaunch pair: it tears down the existing window, calls
+  :meth:`Supervisor.launch_session` (which consults the launch planner
+  for the full provider/account/cwd/command), and injects the recovery
+  prompt. The previous incarnation of this route called
+  :class:`TmuxSessionService` ``destroy`` + ``create`` directly with no
+  command spec, so ``create()`` fell back to its
+  ``echo 'No command for {name}'`` placeholder — destroying live
+  agents and replacing them with non-agent panes. See PR #2061 Codex
+  P0 #1.
 
-* **Pause / resume.** No existing helper does this; we use a small
-  on-disk JSON marker at ``<base_dir>/paused-sessions.json`` so the
-  state survives daemon restarts and is visible to any other reader
-  (the supervisor will learn to consume this in a follow-up; for now
-  the marker is informational + the API surfaces ``status="paused"``).
-  Both operations are idempotent and return 200.
+  The account passed to ``restart_session`` is the runtime's
+  ``effective_account`` if set (so a session that previously failed
+  over stays on the recovered account), otherwise the session's
+  configured ``account``. Restart is intentionally synchronous (spec
+  §10.4) — typical restart time is < 5s and the spec defers
+  ``?async`` to Phase 2.5.
+
+* **Pause / resume — informational only.** No existing supervisor /
+  recovery / dispatch loop consumes the pause marker today, so this
+  surface is documented as **informational** (the cockpit + this API's
+  ``GET /sessions`` surface ``status="paused"``, but background loops
+  still act on the session). The response ``message`` and OpenAPI
+  description both call this out so operators are not misled into
+  thinking the marker quiesces the daemon. Daemon-side enforcement is
+  a follow-up (issue filed in the PR). Both operations are idempotent
+  and return 200, and concurrent writes are serialised by an
+  ``fcntl.flock`` on the marker file.
 
 * **pg outages → 503.** ``GET`` endpoints downgrade pg outages to a
   best-effort response (``status="unknown"`` on the affected row).
@@ -59,6 +84,7 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any, Literal
@@ -193,6 +219,30 @@ def _unsafe_mid_turn(name: str) -> APIError:
             "Re-issue with ?safety=force to override."
         ),
         hint="Wait for the agent to finish or pass ?safety=force to restart anyway.",
+    )
+
+
+def _unsafe_mid_turn_unknown(name: str, detail: str) -> APIError:
+    """Strict-mode safety probe could not evaluate ``is_turn_active``.
+
+    Fail-closed counterpart to :func:`_unsafe_mid_turn` (Codex PR #2061
+    P0 #2). The previous incarnation of ``_is_turn_active`` swallowed
+    every exception and returned ``False`` — a transient tmux / parse
+    failure therefore looked like a green-light to restart an actively
+    working agent. Strict mode now surfaces probe failures as 503 so
+    the caller knows to retry or escalate to ``?safety=force``.
+    """
+    return APIError(
+        status_code=503,
+        code="unsafe_mid_turn_unknown",
+        message=(
+            f"Refusing to restart {name!r}: mid-turn safety probe "
+            f"failed ({detail}). Cannot confirm whether the agent is idle."
+        ),
+        hint=(
+            "Retry once the tmux service is healthy, or pass "
+            "?safety=force to override the probe (destructive)."
+        ),
     )
 
 
@@ -355,6 +405,59 @@ def _write_paused_names(config: Any, names: set[str]) -> None:
     tmp.replace(path)
 
 
+# Operator-facing message appended to pause/resume responses so a CLI
+# user or automation script knows the marker is *informational only*
+# (Codex PR #2061 P0 #3). The supervisor / recovery / dispatch loops
+# do NOT yet consult this marker — making this clear in the response
+# stops operators from believing they have quiesced the daemon when
+# they have only tagged the session.
+_PAUSE_INFORMATIONAL_NOTE = (
+    "informational marker only — supervisor / recovery / dispatch "
+    "loops do NOT yet consult it; daemon-side enforcement is a "
+    "follow-up. The marker is visible via GET /api/v1/sessions."
+)
+
+
+@contextmanager
+def _pause_marker_lock(config: Any):
+    """Serialise pause/resume read-modify-write across concurrent callers.
+
+    Codex PR #2061 P0 #3 flagged the unguarded ``_load_paused_names``
+    → mutate → ``_write_paused_names`` sequence as racy: two
+    near-simultaneous pause + resume calls could clobber each other's
+    writes. We take an ``fcntl.flock`` on a sibling ``.lock`` file
+    that lives in the same directory as the marker — best-effort on
+    platforms without ``fcntl`` (Windows), which is fine for the v1
+    RC where the API runs on macOS/Linux only.
+    """
+    path = _pause_marker_path(config)
+    if path is None:
+        # No base_dir → no lock to take; caller will hit the same 503
+        # in ``_write_paused_names`` anyway.
+        yield
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    try:
+        import fcntl  # type: ignore[import-not-found]
+    except ImportError:
+        # No fcntl (e.g. Windows): degrade to no-op lock. The marker
+        # write is still atomic via tmp+rename; only the
+        # read-modify-write window is unprotected, which matches the
+        # pre-#2061 behaviour.
+        yield
+        return
+    fh = open(lock_path, "a+")  # noqa: SIM115 — closed in finally
+    try:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    finally:
+        fh.close()
+
+
 # ---------------------------------------------------------------------------
 # Builders — SessionInfo / SessionDetail / SessionConfigView
 # ---------------------------------------------------------------------------
@@ -475,14 +578,85 @@ def _session_health(svc: Any | None, name: str) -> SessionHealthSnapshot:
     )
 
 
-def _is_turn_active(svc: Any | None, name: str) -> bool:
+class _TurnProbeUnavailable(RuntimeError):
+    """Raised by :func:`_is_turn_active` in strict mode on probe failure.
+
+    The route maps this to a 503 ``unsafe_mid_turn_unknown`` so strict
+    mode fails *closed* — a transient tmux / parse / service failure
+    must not look like a green-light to restart an actively-working
+    agent (Codex PR #2061 P0 #2).
+    """
+
+
+def _is_turn_active(svc: Any | None, name: str, *, strict: bool = False) -> bool:
+    """Return True iff the agent appears mid-turn.
+
+    ``strict=False`` (read-only / detail surface): exceptions degrade
+    to ``False`` — the read path must not 500 on a transient probe
+    failure.
+
+    ``strict=True`` (destructive restart): exceptions raise
+    :class:`_TurnProbeUnavailable` so the route maps to 503. Strict
+    mode must fail *closed*; otherwise a flaky probe can clobber a
+    working agent.
+    """
     if svc is None:
+        if strict:
+            raise _TurnProbeUnavailable("tmux service unavailable")
         return False
     try:
         return bool(svc.is_turn_active(name))
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         logger.debug("svc.is_turn_active(%s) failed", name, exc_info=True)
+        if strict:
+            raise _TurnProbeUnavailable(str(exc) or exc.__class__.__name__) from exc
         return False
+
+
+def _build_supervisor(config: Any) -> Any | None:
+    """Construct a :class:`pollypm.supervisor.Supervisor` or ``None``.
+
+    Used by :func:`restart_session_endpoint` (Codex PR #2061 P0 #1) so
+    the restart goes through the canonical
+    :meth:`Supervisor.restart_session` facade — the same code path the
+    cockpit account-switch button, ``pm switch-session-account``, and
+    the upgrade flow already use.
+
+    Returns ``None`` on any construction failure (no store available,
+    plugin host failure, etc.); the caller translates that into a
+    503 ``daemon_unavailable`` so clients can retry.
+    """
+    try:
+        from pollypm.supervisor import Supervisor
+    except Exception:  # noqa: BLE001
+        logger.debug("Supervisor import failed", exc_info=True)
+        return None
+    try:
+        return Supervisor(config)
+    except Exception:  # noqa: BLE001
+        logger.debug("Supervisor construction failed", exc_info=True)
+        return None
+
+
+def _resolve_restart_account(supervisor: Any, session: Any) -> str | None:
+    """Pick the account to relaunch under for an API-driven restart.
+
+    Mirrors the precedence the recovery path uses: prefer the
+    runtime's ``effective_account`` if set (so a session that
+    previously failed over stays on the recovered account); otherwise
+    fall back to the session's configured ``account``. Returns
+    ``None`` if neither is available (caller maps to 503).
+    """
+    try:
+        runtime = supervisor._get_session_runtime(session.name)  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001
+        runtime = None
+    if runtime is not None:
+        eff = getattr(runtime, "effective_account", None)
+        if eff:
+            return str(eff)
+    configured = getattr(session, "account", None)
+    return str(configured) if configured else None
 
 
 def _find_session(config: Any, name: str) -> Any:
@@ -585,50 +759,77 @@ def restart_session_endpoint(
         ),
     )] = "strict",
 ) -> ActionResult:
-    """POST /api/v1/sessions/{name}/restart — destroy + re-create the window.
+    """POST /api/v1/sessions/{name}/restart — facade-driven relaunch.
 
-    Returns 200 on success. 404 if the session isn't configured. 409
-    ``unsafe_mid_turn`` if strict-mode and the agent is actively
-    streaming a turn. 503 ``daemon_unavailable`` if the tmux service
-    can't be constructed (no tmux, store unavailable, etc).
+    Routes through :meth:`pollypm.supervisor.Supervisor.restart_session`
+    so the relaunched pane runs the configured provider command (the
+    launch planner reconstructs cwd / provider / account / args /
+    initial input / markers) instead of an ``echo`` placeholder.
+
+    Responses:
+
+    * **200** on success.
+    * **404** ``not_found`` if the session isn't configured.
+    * **409** ``unsafe_mid_turn`` if strict-mode and the agent is
+      actively streaming a turn.
+    * **503** ``unsafe_mid_turn_unknown`` if strict-mode and the
+      mid-turn safety probe itself failed (fail-closed — Codex PR
+      #2061 P0 #2).
+    * **503** ``daemon_unavailable`` if the supervisor / tmux service
+      can't be constructed, or if ``restart_session`` raises.
     """
     session = _find_session(config, name)
     svc = _build_tmux_service(config)
     if svc is None:
         raise _daemon_unavailable(name, "tmux session service unavailable")
-    if safety != "force" and _is_turn_active(svc, name):
-        raise _unsafe_mid_turn(name)
 
-    # Destroy first; the helper is a no-op when the window isn't
-    # present, so it works for an "already stopped" session too — the
-    # spec defers between 200 and 409 here, and the cockpit-friendly
-    # choice is 200 (idempotent) so a client can always issue "restart"
-    # without first probing the live state.
-    try:
-        svc.destroy(name)
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("svc.destroy(%s) failed", name, exc_info=True)
-        raise _daemon_unavailable(name, f"destroy raised: {exc!s}") from exc
+    # Safety gate (Codex PR #2061 P0 #2). Strict mode (the default)
+    # fails *closed* — a probe that cannot answer "is this agent
+    # currently working?" must not be treated as "agent is idle".
+    if safety != "force":
+        try:
+            mid_turn = _is_turn_active(svc, name, strict=True)
+        except _TurnProbeUnavailable as exc:
+            raise _unsafe_mid_turn_unknown(name, str(exc)) from exc
+        if mid_turn:
+            raise _unsafe_mid_turn(name)
 
-    # Re-create the window. The session config carries cwd / provider /
-    # account / window_name; the create() call accepts a partial set —
-    # missing prompts / accounts mean the launcher just opens a blank
-    # pane, which is the right answer for "restart". A full restart
-    # with bootstrap is a separate operation the cockpit "Launch"
-    # button performs (Phase 3 surface).
-    try:
-        cwd = getattr(session, "cwd", None)
-        svc.create(
-            name=name,
-            provider=str(getattr(session, "provider", "") or ""),
-            account=getattr(session, "account", "") or "",
-            cwd=Path(cwd) if cwd else Path.cwd(),
-            window_name=session.window_name or name,
-            stabilize=False,
+    # Route through the canonical supervisor restart facade (Codex PR
+    # #2061 P0 #1). ``Supervisor.restart_session`` owns the
+    # kill+relaunch pair: it kills the window, switches runtime status
+    # to ``recovering``, then calls ``launch_session`` which consults
+    # the launch planner for the full provider command (NOT an ad-hoc
+    # ``echo`` placeholder). The cockpit account-switch button,
+    # ``pm switch-session-account``, and the upgrade flow already use
+    # the same facade — a future launch-automation change therefore
+    # lands in every surface at once.
+    supervisor = _build_supervisor(config)
+    if supervisor is None:
+        raise _daemon_unavailable(name, "supervisor unavailable")
+    account_name = _resolve_restart_account(supervisor, session)
+    if not account_name:
+        raise _daemon_unavailable(
+            name, "no effective or configured account on session",
         )
+
+    try:
+        supervisor.restart_session(
+            name, account_name, failure_type="api_restart",
+        )
+    except KeyError as exc:
+        # ``Supervisor.restart_session`` raises ``KeyError`` for an
+        # unknown account; surface as 503 because the API contract is
+        # "the daemon couldn't honor the request" rather than a client
+        # validation error (the account was resolved from runtime/config).
+        logger.debug("restart_session unknown account for %s", name, exc_info=True)
+        raise _daemon_unavailable(
+            name, f"unknown restart account: {exc!s}",
+        ) from exc
     except Exception as exc:  # noqa: BLE001
-        logger.debug("svc.create(%s) failed", name, exc_info=True)
-        raise _daemon_unavailable(name, f"create raised: {exc!s}") from exc
+        logger.debug("supervisor.restart_session(%s) failed", name, exc_info=True)
+        raise _daemon_unavailable(
+            name, f"restart_session raised: {exc!s}",
+        ) from exc
 
     return ActionResult(ok=True, message=f"restarted {name}")
 
@@ -636,24 +837,43 @@ def restart_session_endpoint(
 @router.post(
     "/sessions/{name}/pause",
     response_model=ActionResult,
-    summary="Pause heartbeat dispatch / recovery for one session",
+    summary=(
+        "Tag a session as paused (INFORMATIONAL marker; supervisor "
+        "loops do not yet consume it)"
+    ),
     operation_id="pauseSession",
 )
 def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
-    """POST /api/v1/sessions/{name}/pause — mark the session paused.
+    """POST /api/v1/sessions/{name}/pause — write an informational marker.
 
-    Writes ``<base_dir>/paused-sessions.json`` so other readers (the
-    recovery loop, ``GET /api/v1/sessions``) can skip / surface the
-    quiesced state. Idempotent: pausing an already-paused session
-    returns 200 with no state change.
+    **This is an informational marker only.** Codex PR #2061 P0 #3
+    flagged that the supervisor / recovery / dispatch loops do NOT
+    consume ``<base_dir>/paused-sessions.json`` today — they will
+    still act on the session even after a successful pause. The
+    response ``message`` calls this out so operators know they have
+    tagged the session, not quiesced the daemon. Daemon-side
+    enforcement is tracked as a follow-up.
+
+    Writes ``<base_dir>/paused-sessions.json`` (atomic tmp+rename,
+    serialised via ``fcntl.flock`` against concurrent pause/resume
+    callers) so ``GET /api/v1/sessions`` can surface
+    ``status="paused"``. Idempotent: pausing an already-paused
+    session returns 200 with no state change.
     """
     _find_session(config, name)  # 404 if unknown
     try:
-        names = _load_paused_names(config)
-        if name in names:
-            return ActionResult(ok=True, message=f"{name} already paused")
-        names.add(name)
-        _write_paused_names(config, names)
+        with _pause_marker_lock(config):
+            names = _load_paused_names(config)
+            if name in names:
+                return ActionResult(
+                    ok=True,
+                    message=(
+                        f"{name} already tagged paused — "
+                        f"{_PAUSE_INFORMATIONAL_NOTE}"
+                    ),
+                )
+            names.add(name)
+            _write_paused_names(config, names)
     except APIError:
         raise
     except OSError as exc:
@@ -662,28 +882,43 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
             f"Cannot write pause marker for {name!r}: {exc!s}",
             hint="Check filesystem permissions on ~/.pollypm.",
         ) from exc
-    return ActionResult(ok=True, message=f"paused {name}")
+    return ActionResult(
+        ok=True,
+        message=f"tagged {name} paused — {_PAUSE_INFORMATIONAL_NOTE}",
+    )
 
 
 @router.post(
     "/sessions/{name}/resume",
     response_model=ActionResult,
-    summary="Resume heartbeat dispatch / recovery for one session",
+    summary=(
+        "Clear the informational pause marker for a session (see "
+        "pauseSession for the daemon-control caveat)"
+    ),
     operation_id="resumeSession",
 )
 def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
-    """POST /api/v1/sessions/{name}/resume — inverse of pause.
+    """POST /api/v1/sessions/{name}/resume — clear the informational marker.
 
-    Idempotent: resuming a non-paused session returns 200 with no
-    state change.
+    Idempotent inverse of :func:`pause_session_endpoint`. Same
+    daemon-control caveat applies: the marker is informational, so
+    "resuming" a session that the supervisor never stopped acting on
+    is a no-op from the runtime's perspective.
     """
     _find_session(config, name)  # 404 if unknown
     try:
-        names = _load_paused_names(config)
-        if name not in names:
-            return ActionResult(ok=True, message=f"{name} already running")
-        names.discard(name)
-        _write_paused_names(config, names)
+        with _pause_marker_lock(config):
+            names = _load_paused_names(config)
+            if name not in names:
+                return ActionResult(
+                    ok=True,
+                    message=(
+                        f"{name} already untagged — "
+                        f"{_PAUSE_INFORMATIONAL_NOTE}"
+                    ),
+                )
+            names.discard(name)
+            _write_paused_names(config, names)
     except APIError:
         raise
     except OSError as exc:
@@ -692,7 +927,10 @@ def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
             f"Cannot write pause marker for {name!r}: {exc!s}",
             hint="Check filesystem permissions on ~/.pollypm.",
         ) from exc
-    return ActionResult(ok=True, message=f"resumed {name}")
+    return ActionResult(
+        ok=True,
+        message=f"cleared pause tag on {name} — {_PAUSE_INFORMATIONAL_NOTE}",
+    )
 
 
 __all__ = [

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -103,6 +103,9 @@ from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
 from pollypm.session_health import (
+    TmuxProbeUnavailable as _TmuxProbeUnavailable,
+)
+from pollypm.session_health import (
     age_seconds as _age_seconds,
 )
 from pollypm.session_health import (
@@ -113,6 +116,9 @@ from pollypm.session_health import (
 )
 from pollypm.session_health import (
     list_storage_closet_windows as _list_storage_closet_windows,
+)
+from pollypm.session_health import (
+    probe_strict_turn_active as _probe_strict_turn_active,
 )
 from pollypm.session_health import (
     storage_session_name as _shared_storage_session_name,
@@ -500,11 +506,33 @@ def _build_tmux_service(config: Any) -> Any | None:
         return None
 
 
-def _session_health(svc: Any | None, name: str) -> SessionHealthSnapshot:
-    """Best-effort health probe via :class:`TmuxSessionService`."""
+def _session_health(
+    svc: Any | None,
+    name: str,
+    *,
+    info_window_present: bool | None = None,
+) -> SessionHealthSnapshot:
+    """Best-effort health probe via :class:`TmuxSessionService`.
+
+    ``info_window_present`` (when supplied) overrides the
+    ``window_present`` field that ``svc.health(name)`` would compute.
+    Codex PR #2061 round 6 caught that ``info.window_present`` and
+    ``health.window_present`` could disagree for the same configured
+    session: ``info`` is built from the shared
+    :func:`pollypm.session_health.list_storage_closet_windows` helper
+    (config + tmux direct), while ``svc.health()`` routes through
+    :class:`TmuxSessionService.health` → ``self._store.list_sessions()``
+    on the legacy :class:`StateStore`. On production the pg-facade owns
+    session registration, so the legacy store can be empty and
+    ``health.window_present`` would report ``False`` for a window that
+    ``info.window_present`` reported ``True``. Threading the canonical
+    ``windows`` dict in keeps both fields single-sourced.
+    """
     if svc is None:
         return SessionHealthSnapshot(
-            window_present=False, pane_alive=False, pane_dead=True,
+            window_present=bool(info_window_present) if info_window_present is not None else False,
+            pane_alive=False,
+            pane_dead=True,
             pane_command=None,
         )
     try:
@@ -512,11 +540,18 @@ def _session_health(svc: Any | None, name: str) -> SessionHealthSnapshot:
     except Exception:  # noqa: BLE001
         logger.debug("svc.health(%s) failed", name, exc_info=True)
         return SessionHealthSnapshot(
-            window_present=False, pane_alive=False, pane_dead=True,
+            window_present=bool(info_window_present) if info_window_present is not None else False,
+            pane_alive=False,
+            pane_dead=True,
             pane_command=None,
         )
+    window_present = (
+        bool(info_window_present)
+        if info_window_present is not None
+        else bool(getattr(h, "window_present", False))
+    )
     return SessionHealthSnapshot(
-        window_present=bool(getattr(h, "window_present", False)),
+        window_present=window_present,
         pane_alive=bool(getattr(h, "pane_alive", False)),
         pane_dead=bool(getattr(h, "pane_dead", True)),
         pane_command=getattr(h, "pane_command", None),
@@ -616,6 +651,30 @@ def _build_supervisor(config: Any) -> Any | None:
     except Exception:  # noqa: BLE001
         logger.debug("Supervisor construction failed", exc_info=True)
         return None
+
+
+def _close_supervisor_quietly(supervisor: Any | None) -> None:
+    """Close a transient per-request :class:`Supervisor` without raising.
+
+    Codex PR #2061 round 6 lifecycle note: ``Supervisor.__init__``
+    opens the legacy sqlite ``state.db`` (and runs migrations) as a
+    side-effect, so each per-request construction holds a writable
+    connection until close. The route uses the supervisor for one or
+    two public method calls (``get_session_runtime`` /
+    ``restart_session``) and then discards it; without an explicit
+    close we'd leak fds across many restart calls. :meth:`Supervisor.stop`
+    is the documented teardown — best-effort here because a failure to
+    close should never mask a successful restart.
+    """
+    if supervisor is None:
+        return
+    stop = getattr(supervisor, "stop", None)
+    if not callable(stop):
+        return
+    try:
+        stop()
+    except Exception:  # noqa: BLE001
+        logger.debug("supervisor.stop() raised on quiet close", exc_info=True)
 
 
 def _resolve_restart_account(supervisor: Any, session: Any) -> str | None:
@@ -720,7 +779,15 @@ def get_session_endpoint(name: str, config: ConfigDep) -> SessionDetail:
         paused=paused,
     )
     svc = _build_tmux_service(config)
-    health = _session_health(svc, name)
+    # Single-source ``window_present`` with the value already computed
+    # for ``info`` from the shared ``list_storage_closet_windows``
+    # helper. Avoids the round-6 split-source bug where
+    # ``info.window_present`` (config/tmux direct) and
+    # ``health.window_present`` (StateStore-dependent) could disagree
+    # for the same configured session on pg-backed installs.
+    health = _session_health(
+        svc, name, info_window_present=info.window_present,
+    )
     turn_active = _is_turn_active(svc, name)
     return SessionDetail(
         info=info,
@@ -768,17 +835,54 @@ def restart_session_endpoint(
       can't be constructed, or if ``restart_session`` raises.
     """
     session = _find_session(config, name)
-    svc = _build_tmux_service(config)
-    if svc is None:
-        raise _daemon_unavailable(name, "tmux session service unavailable")
 
-    # Safety gate (Codex PR #2061 P0 #2). Strict mode (the default)
-    # fails *closed* — a probe that cannot answer "is this agent
-    # currently working?" must not be treated as "agent is idle".
+    # Safety gate (Codex PR #2061 P0 #2 + round 6). Strict mode (the
+    # default) fails *closed* — a probe that cannot answer "is this
+    # agent currently working?" must not be treated as "agent is idle".
+    #
+    # The probe now reads from the SAME source as the rest of the API
+    # contract (config + tmux direct) instead of going through
+    # :class:`TmuxSessionService.is_turn_active_strict`, which depends
+    # on the legacy :class:`StateStore.list_sessions()` row set. In
+    # production the pg facade owns session registration (via
+    # :func:`pollypm.storage.pg_sessions.upsert_session` on the launch
+    # path) so the legacy store is empty/stale and the in-service
+    # strict probe returned ``False`` (fail-open) for actively-working
+    # agents. ``probe_strict_turn_active`` re-resolves the configured
+    # window from ``config.sessions[name]`` →
+    # ``list_storage_closet_windows`` → direct
+    # :class:`pollypm.tmux.client.TmuxClient` calls so the answer cannot
+    # diverge from what ``GET /api/v1/sessions/{name}`` reports.
+    #
+    # Supervisor construction is deferred until after the probe passes:
+    # ``Supervisor()`` opens the legacy sqlite ``state.db`` and runs
+    # migrations as a side-effect, so building it up-front on every
+    # probe / probe-failure would add sqlite open/migrate latency to a
+    # read-flavoured safety check. We pay that cost only when we're
+    # actually going to invoke the destructive restart.
     if safety != "force":
         try:
-            mid_turn = _is_turn_active(svc, name, strict=True)
-        except _TurnProbeUnavailable as exc:
+            from pollypm.tmux.client import TmuxClient
+
+            # Reuse the same window dict the route's read-side helpers
+            # use so the probe and ``GET /api/v1/sessions/{name}``
+            # cannot diverge for the same session (Codex PR #2061
+            # round 6 single-source contract).
+            storage_session = _storage_session_name(config)
+            windows = _list_storage_closet_windows(storage_session)
+            mid_turn = _probe_strict_turn_active(
+                config, name, TmuxClient(), windows=windows,
+            )
+        except _TmuxProbeUnavailable as exc:
+            raise _unsafe_mid_turn_unknown(name, str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001
+            # Defensive: any unexpected error from the probe is treated
+            # as "cannot evaluate" (fail-closed). The typed exception
+            # above covers the documented tmux-call failures.
+            logger.debug(
+                "probe_strict_turn_active(%s) unexpected failure",
+                name, exc_info=True,
+            )
             raise _unsafe_mid_turn_unknown(name, str(exc)) from exc
         if mid_turn:
             raise _unsafe_mid_turn(name)
@@ -795,30 +899,41 @@ def restart_session_endpoint(
     supervisor = _build_supervisor(config)
     if supervisor is None:
         raise _daemon_unavailable(name, "supervisor unavailable")
-    account_name = _resolve_restart_account(supervisor, session)
-    if not account_name:
-        raise _daemon_unavailable(
-            name, "no effective or configured account on session",
-        )
-
     try:
-        supervisor.restart_session(
-            name, account_name, failure_type="api_restart",
-        )
-    except KeyError as exc:
-        # ``Supervisor.restart_session`` raises ``KeyError`` for an
-        # unknown account; surface as 503 because the API contract is
-        # "the daemon couldn't honor the request" rather than a client
-        # validation error (the account was resolved from runtime/config).
-        logger.debug("restart_session unknown account for %s", name, exc_info=True)
-        raise _daemon_unavailable(
-            name, f"unknown restart account: {exc!s}",
-        ) from exc
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("supervisor.restart_session(%s) failed", name, exc_info=True)
-        raise _daemon_unavailable(
-            name, f"restart_session raised: {exc!s}",
-        ) from exc
+        account_name = _resolve_restart_account(supervisor, session)
+        if not account_name:
+            raise _daemon_unavailable(
+                name, "no effective or configured account on session",
+            )
+
+        try:
+            supervisor.restart_session(
+                name, account_name, failure_type="api_restart",
+            )
+        except KeyError as exc:
+            # ``Supervisor.restart_session`` raises ``KeyError`` for an
+            # unknown account; surface as 503 because the API contract is
+            # "the daemon couldn't honor the request" rather than a client
+            # validation error (the account was resolved from runtime/config).
+            logger.debug(
+                "restart_session unknown account for %s", name, exc_info=True,
+            )
+            raise _daemon_unavailable(
+                name, f"unknown restart account: {exc!s}",
+            ) from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "supervisor.restart_session(%s) failed", name, exc_info=True,
+            )
+            raise _daemon_unavailable(
+                name, f"restart_session raised: {exc!s}",
+            ) from exc
+    finally:
+        # Per-request transient supervisor — close so we don't leak the
+        # sqlite ``state.db`` connection on every restart call (Codex
+        # PR #2061 round 6 lifecycle note). Best-effort: ``stop`` is
+        # idempotent against missing internal state.
+        _close_supervisor_quietly(supervisor)
 
     return ActionResult(ok=True, message=f"restarted {name}")
 

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -759,6 +759,76 @@ def list_sessions_endpoint(config: ConfigDep) -> SessionsListResponse:
     return SessionsListResponse(sessions=rows)
 
 
+def _health_from_window(window: Any | None) -> SessionHealthSnapshot:
+    """Compute a :class:`SessionHealthSnapshot` from a ``TmuxWindow``.
+
+    Codex PR #2061 round 8 lifecycle fix: the GET detail path used to
+    build a transient :class:`pollypm.supervisor.Supervisor` (via
+    :func:`_build_tmux_service` → :attr:`Supervisor.session_service`)
+    just to call :meth:`TmuxSessionService.health`. ``Supervisor.__init__``
+    opens the legacy sqlite ``state.db`` and runs migrations as a
+    side-effect, so every GET poll leaked a writable connection until
+    GC eventually closed it.
+
+    The ``TmuxWindow`` returned by :func:`list_storage_closet_windows`
+    already carries everything the :class:`SessionHealthSnapshot`
+    fields need: ``pane_id``, ``pane_dead``, ``pane_current_command``.
+    No Supervisor, no StateStore, no transient connections — just the
+    same fail-soft tmux read the GET path already performs for window
+    discovery.
+    """
+    if window is None:
+        return SessionHealthSnapshot(
+            window_present=False,
+            pane_alive=False,
+            pane_dead=True,
+            pane_command=None,
+        )
+    pane_dead = bool(getattr(window, "pane_dead", False))
+    return SessionHealthSnapshot(
+        window_present=True,
+        pane_alive=not pane_dead,
+        pane_dead=pane_dead,
+        pane_command=getattr(window, "pane_current_command", None) or None,
+    )
+
+
+def _is_turn_active_failsoft(window: Any | None) -> bool:
+    """Fail-soft mid-turn check for the GET detail surface.
+
+    Replaces the read-side call to :meth:`TmuxSessionService.is_turn_active`
+    so the GET path no longer needs a transient :class:`Supervisor` (the
+    only source of a backend-correct :class:`TmuxSessionService`).
+    Returns ``False`` on any failure — the read path must not 500 on a
+    transient tmux outage, and "agent might be working" is not a useful
+    signal to surface from a read endpoint anyway. The destructive
+    restart path still routes through
+    :func:`pollypm.session_health.probe_strict_turn_active` (config /
+    tmux-direct, fail-closed).
+    """
+    if window is None:
+        return False
+    pane_id = getattr(window, "pane_id", None)
+    if pane_id is None or getattr(window, "pane_dead", False):
+        return False
+    try:
+        from pollypm.tmux.client import TmuxClient
+
+        tmux = TmuxClient()
+        text = tmux.capture_pane(pane_id, lines=200)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "GET-detail is_turn_active capture_pane failed", exc_info=True,
+        )
+        return False
+    lowered = text.lower()
+    if "⏺" in text or "working" in lowered:
+        return True
+    if "working (" in lowered and "esc to interrupt" in lowered:
+        return True
+    return False
+
+
 @router.get(
     "/sessions/{name}",
     response_model=SessionDetail,
@@ -766,7 +836,25 @@ def list_sessions_endpoint(config: ConfigDep) -> SessionsListResponse:
     operation_id="getSession",
 )
 def get_session_endpoint(name: str, config: ConfigDep) -> SessionDetail:
-    """GET /api/v1/sessions/{name} — detail payload."""
+    """GET /api/v1/sessions/{name} — detail payload.
+
+    Codex PR #2061 round 8: this path no longer constructs a
+    :class:`pollypm.supervisor.Supervisor`. The previous wiring went
+    through :func:`_build_tmux_service` → :attr:`Supervisor.session_service`
+    purely to call :meth:`TmuxSessionService.health` + ``is_turn_active``,
+    but ``Supervisor.__init__`` opens the legacy sqlite ``state.db`` as
+    a side-effect and the GET path never called ``Supervisor.stop()`` →
+    every poll leaked an fd / sqlite connection.
+
+    The detail payload is now built from the same sources the list
+    endpoint uses: ``config.sessions`` (configured-session registry),
+    :func:`list_storage_closet_windows` (fail-soft tmux read),
+    :func:`latest_heartbeat` (pg facade), plus the pause marker. The
+    health snapshot is derived from the ``TmuxWindow`` already in hand
+    (``pane_id`` / ``pane_dead`` / ``pane_current_command``) and
+    ``is_turn_active`` does its own small fail-soft ``capture_pane``
+    call. No Supervisor, no StateStore, no transient connections.
+    """
     session = _find_session(config, name)
     storage_session = _storage_session_name(config)
     windows = _list_storage_closet_windows(storage_session)
@@ -778,17 +866,10 @@ def get_session_endpoint(name: str, config: ConfigDep) -> SessionDetail:
         windows=windows,
         paused=paused,
     )
-    svc = _build_tmux_service(config)
-    # Single-source ``window_present`` with the value already computed
-    # for ``info`` from the shared ``list_storage_closet_windows``
-    # helper. Avoids the round-6 split-source bug where
-    # ``info.window_present`` (config/tmux direct) and
-    # ``health.window_present`` (StateStore-dependent) could disagree
-    # for the same configured session on pg-backed installs.
-    health = _session_health(
-        svc, name, info_window_present=info.window_present,
-    )
-    turn_active = _is_turn_active(svc, name)
+    window_name = session.window_name or session.name
+    window = windows.get(window_name)
+    health = _health_from_window(window)
+    turn_active = _is_turn_active_failsoft(window)
     return SessionDetail(
         info=info,
         config=_build_session_config_view(session),

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -1,0 +1,710 @@
+"""Sessions admin endpoints — Phase 2 surface #8 (§10 of the endpoint spec).
+
+Mirrors the ``pm sessions`` CLI (#2039) plus restart / pause / resume
+actions documented in ``~/Desktop/pollypm-phase2-endpoints-spec.md``
+§10.
+
+Endpoints
+---------
+
+- ``GET    /api/v1/sessions``                  — list configured
+  sessions with live health (heartbeat age + tmux window presence).
+- ``GET    /api/v1/sessions/{name}``           — one session's detail
+  payload (config row + health snapshot + last heartbeat).
+- ``POST   /api/v1/sessions/{name}/restart``   — kill the tmux window
+  and re-create it. Refuses with ``409 unsafe_mid_turn`` when the agent
+  is mid-turn unless ``?safety=force``.
+- ``POST   /api/v1/sessions/{name}/pause``     — write a pause marker
+  so the recovery / dispatch loops skip this session. Idempotent.
+- ``POST   /api/v1/sessions/{name}/resume``    — remove the pause
+  marker. Idempotent.
+
+Design notes
+------------
+
+* **Read-side health.** Mirrors :mod:`pollypm.cli_features.sessions_health`
+  classification (``healthy`` / ``stale`` / ``missing`` / ``unknown``) so
+  the API returns the same status field a CLI operator sees in
+  ``pm sessions``. Heartbeats come from the pg facade
+  :func:`pollypm.storage.pg_heartbeats.latest_heartbeat`; tmux probes
+  come from :mod:`pollypm.tmux.client`. Either side may be missing —
+  read failures collapse to ``unknown`` / ``missing`` rather than
+  500-ing.
+
+* **Restart.** Uses :class:`pollypm.session_services.tmux.TmuxSessionService`
+  to ``destroy`` then ``create``. The CLI is the only other caller that
+  performs that pair, and we deliberately re-use that helper so any
+  future change to launch automation lands in both surfaces at once.
+  Restart is intentionally synchronous (spec §10.4) — typical restart
+  time is < 5s and the spec defers ``?async`` to Phase 2.5.
+
+* **Pause / resume.** No existing helper does this; we use a small
+  on-disk JSON marker at ``<base_dir>/paused-sessions.json`` so the
+  state survives daemon restarts and is visible to any other reader
+  (the supervisor will learn to consume this in a follow-up; for now
+  the marker is informational + the API surfaces ``status="paused"``).
+  Both operations are idempotent and return 200.
+
+* **pg outages → 503.** ``GET`` endpoints downgrade pg outages to a
+  best-effort response (``status="unknown"`` on the affected row).
+  ``POST`` endpoints surface pg outages as ``503 service_unavailable``
+  so the client knows to retry.
+
+Auth follows the standard bearer-dependency wiring in
+:mod:`pollypm.web_api.app`; this router is mounted under ``/api/v1`` so
+``auth_deps`` applies to every operation here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from pollypm.web_api.errors import APIError, service_unavailable
+from pollypm.web_api.models import ActionResult
+from pollypm.web_api.routes._deps import ConfigDep
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Sessions"])
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+# Heartbeats older than this seconds are classified ``stale``. Matches
+# :data:`pollypm.cli_features.sessions_health._STALE_HEARTBEAT_SECONDS`
+# (intentionally duplicated so the API does not import a private CLI
+# constant — the comment is the cross-reference).
+_STALE_HEARTBEAT_SECONDS = 5 * 60
+
+# Filename used by :func:`_pause_marker_path`. One JSON file per
+# project; the document is a list of paused session names. Sitting in
+# the project's ``base_dir`` keeps it next to ``state.db`` /
+# ``audit.jsonl`` so storage hygiene already covers it.
+_PAUSE_MARKER_FILENAME = "paused-sessions.json"
+
+
+SafetyMode = Literal["strict", "loose", "force"]
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class SessionInfo(BaseModel):
+    """Flat list row mirroring ``pm sessions`` output (spec §10.2)."""
+
+    name: str
+    role: str
+    project: str
+    provider: str
+    account: str
+    window_name: str
+    tmux_session: str
+    window_present: bool
+    status: Literal["healthy", "stale", "missing", "unknown", "paused"]
+    last_heartbeat_iso: str | None = None
+    last_heartbeat_age_seconds: int | None = None
+    auth_token_present: bool
+    enabled: bool
+    paused: bool = False
+
+
+class SessionsListResponse(BaseModel):
+    """``GET /api/v1/sessions`` envelope."""
+
+    sessions: list[SessionInfo]
+
+
+class SessionHealthSnapshot(BaseModel):
+    """Per-session health (spec §10.2 ``SessionDetail`` member).
+
+    Mirrors :class:`pollypm.session_services.base.SessionHealth` minus
+    ``pane_text`` (we don't ship multi-KB pane captures over the API by
+    default — clients can opt into ``/sessions/{name}?include_pane_text``
+    in a follow-up).
+    """
+
+    window_present: bool
+    pane_alive: bool
+    pane_dead: bool
+    pane_command: str | None = None
+
+
+class SessionConfigView(BaseModel):
+    """Mirror of :class:`pollypm.models.SessionConfig` on the wire."""
+
+    name: str
+    role: str
+    provider: str
+    account: str
+    project: str
+    cwd: str
+    window_name: str
+    enabled: bool
+    auth_token_present: bool
+    agent_profile: str | None = None
+    args: list[str] = Field(default_factory=list)
+
+
+class SessionDetail(BaseModel):
+    """``GET /api/v1/sessions/{name}`` envelope (spec §10.1)."""
+
+    info: SessionInfo
+    config: SessionConfigView
+    health: SessionHealthSnapshot
+    is_turn_active: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Typed errors (spec §10.3)
+# ---------------------------------------------------------------------------
+
+
+def _session_not_found(name: str) -> APIError:
+    return APIError(
+        status_code=404,
+        code="not_found",
+        message=f"No configured session named {name!r}",
+        hint=(
+            "List sessions via GET /api/v1/sessions. Worker (per-task) "
+            "sessions are not exposed by this admin surface — use "
+            "GET /api/v1/chat/sessions for those."
+        ),
+    )
+
+
+def _unsafe_mid_turn(name: str) -> APIError:
+    return APIError(
+        status_code=409,
+        code="unsafe_mid_turn",
+        message=(
+            f"Refusing to restart {name!r}: agent appears to be mid-turn. "
+            "Re-issue with ?safety=force to override."
+        ),
+        hint="Wait for the agent to finish or pass ?safety=force to restart anyway.",
+    )
+
+
+def _daemon_unavailable(name: str, detail: str) -> APIError:
+    return APIError(
+        status_code=503,
+        code="daemon_unavailable",
+        message=(
+            f"Cannot act on session {name!r}: supervisor/daemon unavailable "
+            f"({detail})."
+        ),
+        hint="Confirm the daemon / cockpit is running, then retry.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers — heartbeat, tmux probe, pause marker
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        candidate = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(candidate)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _age_seconds(iso_ts: str | None) -> int | None:
+    parsed = _parse_iso(iso_ts)
+    if parsed is None:
+        return None
+    return int(max(0, (_now_utc() - parsed).total_seconds()))
+
+
+def _classify_status(
+    *,
+    window_present: bool,
+    age_seconds: int | None,
+    paused: bool,
+) -> str:
+    """Return one of healthy/stale/missing/unknown/paused.
+
+    Matches :func:`pollypm.cli_features.sessions_health._classify_status`
+    except we surface ``paused`` first — operator intent overrides the
+    runtime signals (a paused session may still have a healthy pane,
+    but the cockpit / recovery loop should treat it as quiesced).
+    """
+    if paused:
+        return "paused"
+    if not window_present:
+        return "missing"
+    if age_seconds is None:
+        return "unknown"
+    if age_seconds > _STALE_HEARTBEAT_SECONDS:
+        return "stale"
+    return "healthy"
+
+
+def _latest_heartbeat(config: Any, session_name: str):
+    """Fetch the most-recent heartbeat record; ``None`` on any failure.
+
+    Mirrors :func:`pollypm.cli_features.sessions_health._latest_heartbeat`
+    — read failures must never crash the endpoint. The caller
+    classifies ``None`` as ``unknown`` (no heartbeat row yet) and
+    ``status="unknown"`` is a legitimate live state for a freshly-booted
+    session.
+    """
+    try:
+        from pollypm.storage.pg_heartbeats import latest_heartbeat
+    except Exception:  # noqa: BLE001
+        logger.debug("pg_heartbeats import failed", exc_info=True)
+        return None
+    try:
+        return latest_heartbeat(session_name, config=config)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "latest_heartbeat lookup failed for %s",
+            session_name,
+            exc_info=True,
+        )
+        return None
+
+
+def _storage_session_name(config: Any) -> str:
+    """Return the storage-closet tmux session name.
+
+    Hard-coded suffix matches
+    :data:`pollypm.cli_features.sessions_health._STORAGE_CLOSET_SUFFIX`
+    so we resolve windows without spinning up a Supervisor / service.
+    """
+    base = getattr(getattr(config, "project", None), "tmux_session", "") or ""
+    return f"{base}-storage-closet"
+
+
+def _list_storage_closet_windows(tmux_session: str) -> dict[str, Any]:
+    """Return ``{window_name: TmuxWindow}`` for the storage-closet session.
+
+    Empty dict on any failure (tmux missing, server down, session not
+    found). The caller treats every session as ``window_present=False``
+    in that state, which is the right answer when tmux itself is
+    unreachable.
+    """
+    try:
+        from pollypm.tmux.client import TmuxClient
+
+        tmux = TmuxClient()
+        if not tmux.has_session(tmux_session):
+            return {}
+        return {w.name: w for w in tmux.list_windows(tmux_session)}
+    except Exception:  # noqa: BLE001
+        logger.debug("tmux probe failed for %s", tmux_session, exc_info=True)
+        return {}
+
+
+def _pause_marker_path(config: Any) -> Path | None:
+    """Return ``<base_dir>/paused-sessions.json`` or ``None`` if no base_dir."""
+    base_dir = getattr(getattr(config, "project", None), "base_dir", None)
+    if base_dir is None:
+        return None
+    return Path(base_dir) / _PAUSE_MARKER_FILENAME
+
+
+def _load_paused_names(config: Any) -> set[str]:
+    """Read the pause marker; empty set on missing / malformed file."""
+    path = _pause_marker_path(config)
+    if path is None or not path.exists():
+        return set()
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        logger.debug("pause marker unreadable: %s", path, exc_info=True)
+        return set()
+    if not isinstance(data, list):
+        return set()
+    return {str(name) for name in data if isinstance(name, str)}
+
+
+def _write_paused_names(config: Any, names: set[str]) -> None:
+    """Atomically write the pause marker. Raises on filesystem failure."""
+    path = _pause_marker_path(config)
+    if path is None:
+        raise _daemon_unavailable(
+            "<unknown>",
+            "no base_dir on config; pause marker has nowhere to live",
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    payload = sorted(names)
+    tmp.write_text(json.dumps(payload, indent=2) + "\n")
+    tmp.replace(path)
+
+
+# ---------------------------------------------------------------------------
+# Builders — SessionInfo / SessionDetail / SessionConfigView
+# ---------------------------------------------------------------------------
+
+
+def _build_session_info(
+    *,
+    config: Any,
+    session: Any,
+    storage_session: str,
+    windows: dict[str, Any],
+    paused: bool,
+) -> SessionInfo:
+    """Construct a :class:`SessionInfo` row for one configured session.
+
+    Mirrors :func:`pollypm.cli_features.sessions_health._build_row` so
+    the API surface and CLI agree on every field that overlaps.
+    """
+    window_name = session.window_name or session.name
+    window = windows.get(window_name)
+    heartbeat = _latest_heartbeat(config, session.name)
+    hb_iso = getattr(heartbeat, "created_at", None) if heartbeat else None
+    age = _age_seconds(hb_iso)
+    window_present = window is not None
+    status = _classify_status(
+        window_present=window_present,
+        age_seconds=age,
+        paused=paused,
+    )
+    auth_token_present = bool(getattr(session, "auth_token", "") or "")
+    return SessionInfo(
+        name=session.name,
+        role=getattr(session, "role", "") or "",
+        project=getattr(session, "project", "") or "",
+        provider=str(getattr(session, "provider", "") or ""),
+        account=getattr(session, "account", "") or "",
+        window_name=window_name,
+        tmux_session=storage_session,
+        window_present=window_present,
+        status=status,  # type: ignore[arg-type]
+        last_heartbeat_iso=hb_iso,
+        last_heartbeat_age_seconds=age,
+        auth_token_present=auth_token_present,
+        enabled=bool(getattr(session, "enabled", True)),
+        paused=paused,
+    )
+
+
+def _build_session_config_view(session: Any) -> SessionConfigView:
+    """Mirror :class:`pollypm.models.SessionConfig` on the wire."""
+    return SessionConfigView(
+        name=session.name,
+        role=getattr(session, "role", "") or "",
+        provider=str(getattr(session, "provider", "") or ""),
+        account=getattr(session, "account", "") or "",
+        project=getattr(session, "project", "") or "",
+        cwd=str(getattr(session, "cwd", "") or ""),
+        window_name=session.window_name or session.name,
+        enabled=bool(getattr(session, "enabled", True)),
+        auth_token_present=bool(getattr(session, "auth_token", "") or ""),
+        agent_profile=getattr(session, "agent_profile", None),
+        args=[str(a) for a in (getattr(session, "args", []) or [])],
+    )
+
+
+def _build_tmux_service(config: Any) -> Any | None:
+    """Construct a TmuxSessionService for restart / health, or None on failure.
+
+    Returns ``None`` when the work-service / tmux client can't be
+    opened. Callers that need the service for a mutation translate
+    ``None`` into a 503 ``daemon_unavailable``; read-only callers can
+    fall back to the raw tmux probe path.
+    """
+    try:
+        from pollypm.session_services.tmux import TmuxSessionService
+        from pollypm.store.registry import get_store
+    except Exception:  # noqa: BLE001
+        logger.debug("session-service imports failed", exc_info=True)
+        return None
+    try:
+        store = get_store(config)
+    except Exception:  # noqa: BLE001
+        logger.debug("get_store failed for sessions_admin", exc_info=True)
+        # Some installs don't have a state store yet; fall back to a
+        # tiny stub so TmuxSessionService.list() doesn't blow up — its
+        # only call into the store is ``list_sessions``.
+        class _EmptyStore:
+            def list_sessions(self) -> list[Any]:
+                return []
+        store = _EmptyStore()
+    try:
+        return TmuxSessionService(config=config, store=store)
+    except Exception:  # noqa: BLE001
+        logger.debug("TmuxSessionService init failed", exc_info=True)
+        return None
+
+
+def _session_health(svc: Any | None, name: str) -> SessionHealthSnapshot:
+    """Best-effort health probe via :class:`TmuxSessionService`."""
+    if svc is None:
+        return SessionHealthSnapshot(
+            window_present=False, pane_alive=False, pane_dead=True,
+            pane_command=None,
+        )
+    try:
+        h = svc.health(name)
+    except Exception:  # noqa: BLE001
+        logger.debug("svc.health(%s) failed", name, exc_info=True)
+        return SessionHealthSnapshot(
+            window_present=False, pane_alive=False, pane_dead=True,
+            pane_command=None,
+        )
+    return SessionHealthSnapshot(
+        window_present=bool(getattr(h, "window_present", False)),
+        pane_alive=bool(getattr(h, "pane_alive", False)),
+        pane_dead=bool(getattr(h, "pane_dead", True)),
+        pane_command=getattr(h, "pane_command", None),
+    )
+
+
+def _is_turn_active(svc: Any | None, name: str) -> bool:
+    if svc is None:
+        return False
+    try:
+        return bool(svc.is_turn_active(name))
+    except Exception:  # noqa: BLE001
+        logger.debug("svc.is_turn_active(%s) failed", name, exc_info=True)
+        return False
+
+
+def _find_session(config: Any, name: str) -> Any:
+    """Lookup a SessionConfig by ``name``; raise 404 if absent."""
+    sessions = getattr(config, "sessions", None) or {}
+    # ``sessions`` is keyed by name in the typed config, but we accept
+    # either keying for resilience.
+    if name in sessions:
+        return sessions[name]
+    for session in sessions.values():
+        if getattr(session, "name", "") == name:
+            return session
+    raise _session_not_found(name)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionsListResponse,
+    summary="List configured sessions with live tmux + heartbeat state",
+    operation_id="listSessions",
+)
+def list_sessions_endpoint(config: ConfigDep) -> SessionsListResponse:
+    """GET /api/v1/sessions — mirror ``pm sessions``.
+
+    Returns one row per configured (and enabled) session. ``paused``
+    rows come from the pause marker (see :func:`_load_paused_names`);
+    ``status`` follows the same thresholds the CLI uses.
+    """
+    storage_session = _storage_session_name(config)
+    windows = _list_storage_closet_windows(storage_session)
+    paused = _load_paused_names(config)
+    raw_sessions = getattr(config, "sessions", None) or {}
+    sessions = sorted(
+        (s for s in raw_sessions.values() if getattr(s, "enabled", True)),
+        key=lambda s: s.name,
+    )
+    rows = [
+        _build_session_info(
+            config=config,
+            session=session,
+            storage_session=storage_session,
+            windows=windows,
+            paused=session.name in paused,
+        )
+        for session in sessions
+    ]
+    return SessionsListResponse(sessions=rows)
+
+
+@router.get(
+    "/sessions/{name}",
+    response_model=SessionDetail,
+    summary="One session's detail incl. config + health + heartbeat",
+    operation_id="getSession",
+)
+def get_session_endpoint(name: str, config: ConfigDep) -> SessionDetail:
+    """GET /api/v1/sessions/{name} — detail payload."""
+    session = _find_session(config, name)
+    storage_session = _storage_session_name(config)
+    windows = _list_storage_closet_windows(storage_session)
+    paused = name in _load_paused_names(config)
+    info = _build_session_info(
+        config=config,
+        session=session,
+        storage_session=storage_session,
+        windows=windows,
+        paused=paused,
+    )
+    svc = _build_tmux_service(config)
+    health = _session_health(svc, name)
+    turn_active = _is_turn_active(svc, name)
+    return SessionDetail(
+        info=info,
+        config=_build_session_config_view(session),
+        health=health,
+        is_turn_active=turn_active,
+    )
+
+
+@router.post(
+    "/sessions/{name}/restart",
+    response_model=ActionResult,
+    summary="Restart (destroy + relaunch) the tmux window for one session",
+    operation_id="restartSession",
+)
+def restart_session_endpoint(
+    name: str,
+    config: ConfigDep,
+    safety: Annotated[SafetyMode, Query(
+        description=(
+            "Safety gate. 'strict' (default) refuses restart while the "
+            "agent is mid-turn (409 unsafe_mid_turn). 'force' bypasses "
+            "the mid-turn gate. 'loose' is treated like 'strict' for "
+            "restart (no warning-emit semantics defined yet)."
+        ),
+    )] = "strict",
+) -> ActionResult:
+    """POST /api/v1/sessions/{name}/restart — destroy + re-create the window.
+
+    Returns 200 on success. 404 if the session isn't configured. 409
+    ``unsafe_mid_turn`` if strict-mode and the agent is actively
+    streaming a turn. 503 ``daemon_unavailable`` if the tmux service
+    can't be constructed (no tmux, store unavailable, etc).
+    """
+    session = _find_session(config, name)
+    svc = _build_tmux_service(config)
+    if svc is None:
+        raise _daemon_unavailable(name, "tmux session service unavailable")
+    if safety != "force" and _is_turn_active(svc, name):
+        raise _unsafe_mid_turn(name)
+
+    # Destroy first; the helper is a no-op when the window isn't
+    # present, so it works for an "already stopped" session too — the
+    # spec defers between 200 and 409 here, and the cockpit-friendly
+    # choice is 200 (idempotent) so a client can always issue "restart"
+    # without first probing the live state.
+    try:
+        svc.destroy(name)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("svc.destroy(%s) failed", name, exc_info=True)
+        raise _daemon_unavailable(name, f"destroy raised: {exc!s}") from exc
+
+    # Re-create the window. The session config carries cwd / provider /
+    # account / window_name; the create() call accepts a partial set —
+    # missing prompts / accounts mean the launcher just opens a blank
+    # pane, which is the right answer for "restart". A full restart
+    # with bootstrap is a separate operation the cockpit "Launch"
+    # button performs (Phase 3 surface).
+    try:
+        cwd = getattr(session, "cwd", None)
+        svc.create(
+            name=name,
+            provider=str(getattr(session, "provider", "") or ""),
+            account=getattr(session, "account", "") or "",
+            cwd=Path(cwd) if cwd else Path.cwd(),
+            window_name=session.window_name or name,
+            stabilize=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("svc.create(%s) failed", name, exc_info=True)
+        raise _daemon_unavailable(name, f"create raised: {exc!s}") from exc
+
+    return ActionResult(ok=True, message=f"restarted {name}")
+
+
+@router.post(
+    "/sessions/{name}/pause",
+    response_model=ActionResult,
+    summary="Pause heartbeat dispatch / recovery for one session",
+    operation_id="pauseSession",
+)
+def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
+    """POST /api/v1/sessions/{name}/pause — mark the session paused.
+
+    Writes ``<base_dir>/paused-sessions.json`` so other readers (the
+    recovery loop, ``GET /api/v1/sessions``) can skip / surface the
+    quiesced state. Idempotent: pausing an already-paused session
+    returns 200 with no state change.
+    """
+    _find_session(config, name)  # 404 if unknown
+    try:
+        names = _load_paused_names(config)
+        if name in names:
+            return ActionResult(ok=True, message=f"{name} already paused")
+        names.add(name)
+        _write_paused_names(config, names)
+    except APIError:
+        raise
+    except OSError as exc:
+        logger.debug("pause marker write failed for %s", name, exc_info=True)
+        raise service_unavailable(
+            f"Cannot write pause marker for {name!r}: {exc!s}",
+            hint="Check filesystem permissions on ~/.pollypm.",
+        ) from exc
+    return ActionResult(ok=True, message=f"paused {name}")
+
+
+@router.post(
+    "/sessions/{name}/resume",
+    response_model=ActionResult,
+    summary="Resume heartbeat dispatch / recovery for one session",
+    operation_id="resumeSession",
+)
+def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
+    """POST /api/v1/sessions/{name}/resume — inverse of pause.
+
+    Idempotent: resuming a non-paused session returns 200 with no
+    state change.
+    """
+    _find_session(config, name)  # 404 if unknown
+    try:
+        names = _load_paused_names(config)
+        if name not in names:
+            return ActionResult(ok=True, message=f"{name} already running")
+        names.discard(name)
+        _write_paused_names(config, names)
+    except APIError:
+        raise
+    except OSError as exc:
+        logger.debug("pause marker write failed for %s", name, exc_info=True)
+        raise service_unavailable(
+            f"Cannot write pause marker for {name!r}: {exc!s}",
+            hint="Check filesystem permissions on ~/.pollypm.",
+        ) from exc
+    return ActionResult(ok=True, message=f"resumed {name}")
+
+
+__all__ = [
+    "SessionConfigView",
+    "SessionDetail",
+    "SessionHealthSnapshot",
+    "SessionInfo",
+    "SessionsListResponse",
+    "get_session_endpoint",
+    "list_sessions_endpoint",
+    "pause_session_endpoint",
+    "restart_session_endpoint",
+    "resume_session_endpoint",
+    "router",
+]

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -32,14 +32,15 @@ Endpoints
 Design notes
 ------------
 
-* **Read-side health.** Mirrors :mod:`pollypm.cli_features.sessions_health`
-  classification (``healthy`` / ``stale`` / ``missing`` / ``unknown``) so
-  the API returns the same status field a CLI operator sees in
-  ``pm sessions``. Heartbeats come from the pg facade
-  :func:`pollypm.storage.pg_heartbeats.latest_heartbeat`; tmux probes
-  come from :mod:`pollypm.tmux.client`. Either side may be missing —
-  read failures collapse to ``unknown`` / ``missing`` rather than
-  500-ing.
+* **Read-side health.** Shares the :mod:`pollypm.session_health`
+  classification (``healthy`` / ``stale`` / ``missing`` / ``unknown``)
+  with the ``pm sessions`` CLI so the API returns the same status
+  field an operator sees there (Codex PR #2061 round 5 blocker 3 —
+  single source of truth for the contract). Heartbeats come from the
+  pg facade :func:`pollypm.storage.pg_heartbeats.latest_heartbeat`;
+  tmux probes come from :mod:`pollypm.tmux.client`. Either side may
+  be missing — read failures collapse to ``unknown`` / ``missing``
+  rather than 500-ing.
 
 * **Restart.** Routes through :meth:`pollypm.supervisor.Supervisor.restart_session`
   — the **same facade** ``pm switch-session-account``, the cockpit
@@ -95,13 +96,27 @@ from __future__ import annotations
 import json
 import logging
 from contextlib import contextmanager
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
+from pollypm.session_health import (
+    age_seconds as _age_seconds,
+)
+from pollypm.session_health import (
+    classify_status as _classify_status,
+)
+from pollypm.session_health import (
+    latest_heartbeat as _latest_heartbeat,
+)
+from pollypm.session_health import (
+    list_storage_closet_windows as _list_storage_closet_windows,
+)
+from pollypm.session_health import (
+    storage_session_name as _shared_storage_session_name,
+)
 from pollypm.web_api.errors import APIError, service_unavailable
 from pollypm.web_api.models import ActionResult
 from pollypm.web_api.routes._deps import ConfigDep
@@ -115,12 +130,6 @@ router = APIRouter(tags=["Sessions"])
 # Constants
 # ---------------------------------------------------------------------------
 
-
-# Heartbeats older than this seconds are classified ``stale``. Matches
-# :data:`pollypm.cli_features.sessions_health._STALE_HEARTBEAT_SECONDS`
-# (intentionally duplicated so the API does not import a private CLI
-# constant — the comment is the cross-reference).
-_STALE_HEARTBEAT_SECONDS = 5 * 60
 
 # Filename used by :func:`_pause_marker_path`. One JSON file per
 # project; the document is a list of paused session names. Sitting in
@@ -276,114 +285,23 @@ def _daemon_unavailable(name: str, detail: str) -> APIError:
 # Helpers — heartbeat, tmux probe, pause marker
 # ---------------------------------------------------------------------------
 
-
-def _now_utc() -> datetime:
-    return datetime.now(UTC)
-
-
-def _parse_iso(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        candidate = value.replace("Z", "+00:00") if value.endswith("Z") else value
-        parsed = datetime.fromisoformat(candidate)
-    except (TypeError, ValueError):
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return parsed
-
-
-def _age_seconds(iso_ts: str | None) -> int | None:
-    parsed = _parse_iso(iso_ts)
-    if parsed is None:
-        return None
-    return int(max(0, (_now_utc() - parsed).total_seconds()))
-
-
-def _classify_status(
-    *,
-    window_present: bool,
-    age_seconds: int | None,
-) -> str:
-    """Return one of healthy/stale/missing/unknown.
-
-    Mirrors :func:`pollypm.cli_features.sessions_health._classify_status`
-    exactly: a pure runtime-health classification derived from tmux
-    presence + heartbeat age.
-
-    The pause marker is intentionally NOT consulted here (Codex PR
-    #2061 round 2). Pause is informational only — the supervisor /
-    recovery / dispatch loops do not consume it (#2068) — so folding
-    it into ``status`` would mask the real runtime state and let an
-    operator believe they had quiesced the daemon when in fact a
-    paused-but-missing session was reporting ``status="paused"``
-    instead of ``status="missing"``. Callers consume the separate
-    :attr:`SessionInfo.paused` boolean for the informational signal.
-    """
-    if not window_present:
-        return "missing"
-    if age_seconds is None:
-        return "unknown"
-    if age_seconds > _STALE_HEARTBEAT_SECONDS:
-        return "stale"
-    return "healthy"
-
-
-def _latest_heartbeat(config: Any, session_name: str):
-    """Fetch the most-recent heartbeat record; ``None`` on any failure.
-
-    Mirrors :func:`pollypm.cli_features.sessions_health._latest_heartbeat`
-    — read failures must never crash the endpoint. The caller
-    classifies ``None`` as ``unknown`` (no heartbeat row yet) and
-    ``status="unknown"`` is a legitimate live state for a freshly-booted
-    session.
-    """
-    try:
-        from pollypm.storage.pg_heartbeats import latest_heartbeat
-    except Exception:  # noqa: BLE001
-        logger.debug("pg_heartbeats import failed", exc_info=True)
-        return None
-    try:
-        return latest_heartbeat(session_name, config=config)
-    except Exception:  # noqa: BLE001
-        logger.debug(
-            "latest_heartbeat lookup failed for %s",
-            session_name,
-            exc_info=True,
-        )
-        return None
+# Classification / heartbeat / tmux-probe primitives now live in
+# :mod:`pollypm.session_health` — see Codex PR #2061 round 5 blocker 3.
+# This module imports them at the top of the file so the route and
+# ``pm sessions`` CLI cannot drift on thresholds, naming, or fail-soft
+# semantics. Only the surface-shape helpers (config-aware wrappers,
+# pause-marker IO) remain below.
 
 
 def _storage_session_name(config: Any) -> str:
     """Return the storage-closet tmux session name.
 
-    Hard-coded suffix matches
-    :data:`pollypm.cli_features.sessions_health._STORAGE_CLOSET_SUFFIX`
-    so we resolve windows without spinning up a Supervisor / service.
+    Delegates the naming to
+    :func:`pollypm.session_health.storage_session_name` so the CLI and
+    API agree on the ``-storage-closet`` suffix.
     """
     base = getattr(getattr(config, "project", None), "tmux_session", "") or ""
-    return f"{base}-storage-closet"
-
-
-def _list_storage_closet_windows(tmux_session: str) -> dict[str, Any]:
-    """Return ``{window_name: TmuxWindow}`` for the storage-closet session.
-
-    Empty dict on any failure (tmux missing, server down, session not
-    found). The caller treats every session as ``window_present=False``
-    in that state, which is the right answer when tmux itself is
-    unreachable.
-    """
-    try:
-        from pollypm.tmux.client import TmuxClient
-
-        tmux = TmuxClient()
-        if not tmux.has_session(tmux_session):
-            return {}
-        return {w.name: w for w in tmux.list_windows(tmux_session)}
-    except Exception:  # noqa: BLE001
-        logger.debug("tmux probe failed for %s", tmux_session, exc_info=True)
-        return {}
+    return _shared_storage_session_name(base)
 
 
 def _pause_marker_path(config: Any) -> Path | None:
@@ -492,8 +410,14 @@ def _build_session_info(
 ) -> SessionInfo:
     """Construct a :class:`SessionInfo` row for one configured session.
 
-    Mirrors :func:`pollypm.cli_features.sessions_health._build_row` so
-    the API surface and CLI agree on every field that overlaps.
+    Shares the classification / probe primitives with
+    :mod:`pollypm.session_health` (see :func:`_classify_status`,
+    :func:`_latest_heartbeat`, :func:`_list_storage_closet_windows`)
+    so the API surface and the ``pm sessions`` CLI agree on every
+    field that overlaps. Codex PR #2061 round 5 blocker 3 — the
+    helpers used to be duplicated here verbatim, which is exactly the
+    kind of "looks identical, drifts silently" coupling the round-5
+    review called out.
     """
     window_name = session.window_name or session.name
     window = windows.get(window_name)
@@ -542,34 +466,37 @@ def _build_session_config_view(session: Any) -> SessionConfigView:
 
 
 def _build_tmux_service(config: Any) -> Any | None:
-    """Construct a TmuxSessionService for restart / health, or None on failure.
+    """Return a backend-correct TmuxSessionService for read/probe paths.
 
-    Returns ``None`` when the work-service / tmux client can't be
-    opened. Callers that need the service for a mutation translate
-    ``None`` into a 503 ``daemon_unavailable``; read-only callers can
-    fall back to the raw tmux probe path.
+    Routes through the supervisor facade so the service is constructed
+    with the same :class:`pollypm.storage.state.StateStore` the
+    production rail uses — the only object that exposes the
+    ``list_sessions()`` shape :class:`TmuxSessionService` (and the
+    round-3 strict probe) depend on.
+
+    Codex PR #2061 round 5 blocker 1 caught the prior construction:
+    the route called ``TmuxSessionService(store=get_store(config))``,
+    which passes the unified pg :class:`pollypm.store.protocol.Store`
+    (no ``list_sessions``) into a service that requires
+    ``StateStore.list_sessions``. In production this turned every
+    detail-health probe into a false-dead read and every strict-mode
+    restart safety probe into ``503 unsafe_mid_turn_unknown`` because
+    the missing-method ``AttributeError`` looked like a probe outage.
+
+    The supervisor's ``session_service`` property already wires the
+    correct store in (``TmuxSessionService(config=self.config,
+    store=self.store)``), so going through it is both correct and
+    canonical. Returns ``None`` on any construction failure so the
+    caller can map to ``503 daemon_unavailable`` (mutation paths) or a
+    fail-soft empty health snapshot (read paths).
     """
-    try:
-        from pollypm.session_services.tmux import TmuxSessionService
-        from pollypm.store.registry import get_store
-    except Exception:  # noqa: BLE001
-        logger.debug("session-service imports failed", exc_info=True)
+    supervisor = _build_supervisor(config)
+    if supervisor is None:
         return None
     try:
-        store = get_store(config)
+        return supervisor.session_service
     except Exception:  # noqa: BLE001
-        logger.debug("get_store failed for sessions_admin", exc_info=True)
-        # Some installs don't have a state store yet; fall back to a
-        # tiny stub so TmuxSessionService.list() doesn't blow up — its
-        # only call into the store is ``list_sessions``.
-        class _EmptyStore:
-            def list_sessions(self) -> list[Any]:
-                return []
-        store = _EmptyStore()
-    try:
-        return TmuxSessionService(config=config, store=store)
-    except Exception:  # noqa: BLE001
-        logger.debug("TmuxSessionService init failed", exc_info=True)
+        logger.debug("supervisor.session_service unavailable", exc_info=True)
         return None
 
 
@@ -658,7 +585,7 @@ def _is_turn_active(svc: Any | None, name: str, *, strict: bool = False) -> bool
 
 
 def _build_supervisor(config: Any) -> Any | None:
-    """Construct a :class:`pollypm.supervisor.Supervisor` or ``None``.
+    """Construct a :class:`pollypm.supervisor.Supervisor` via service_api.
 
     Used by :func:`restart_session_endpoint` (Codex PR #2061 P0 #1) so
     the restart goes through the canonical
@@ -666,17 +593,26 @@ def _build_supervisor(config: Any) -> Any | None:
     cockpit account-switch button, ``pm switch-session-account``, and
     the upgrade flow already use.
 
+    Constructs via :func:`pollypm.service_api.build_supervisor` so the
+    direct ``from pollypm.supervisor import Supervisor`` import lives
+    in the sanctioned facade module
+    (``src/pollypm/service_api/v1.py`` — already on the
+    ``_SUPERVISOR_IMPORT_ALLOWLIST`` in
+    :mod:`tests.test_import_boundary`). Codex PR #2061 round 5 blocker
+    2 caught the prior direct import here as a fresh boundary
+    violation.
+
     Returns ``None`` on any construction failure (no store available,
     plugin host failure, etc.); the caller translates that into a
     503 ``daemon_unavailable`` so clients can retry.
     """
     try:
-        from pollypm.supervisor import Supervisor
+        from pollypm.service_api import build_supervisor
     except Exception:  # noqa: BLE001
-        logger.debug("Supervisor import failed", exc_info=True)
+        logger.debug("service_api.build_supervisor import failed", exc_info=True)
         return None
     try:
-        return Supervisor(config)
+        return build_supervisor(config)
     except Exception:  # noqa: BLE001
         logger.debug("Supervisor construction failed", exc_info=True)
         return None
@@ -690,9 +626,15 @@ def _resolve_restart_account(supervisor: Any, session: Any) -> str | None:
     previously failed over stays on the recovered account); otherwise
     fall back to the session's configured ``account``. Returns
     ``None`` if neither is available (caller maps to 503).
+
+    Uses the public :meth:`Supervisor.get_session_runtime` wrapper —
+    the private ``_get_session_runtime`` reach-through was a fresh
+    boundary violation flagged in Codex PR #2061 round 5 blocker 2,
+    and the public method has existed on Supervisor (the #1830
+    cluster-A facade) since well before this route was introduced.
     """
     try:
-        runtime = supervisor._get_session_runtime(session.name)  # type: ignore[attr-defined]
+        runtime = supervisor.get_session_runtime(session.name)
     except Exception:  # noqa: BLE001
         runtime = None
     if runtime is not None:

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -617,11 +617,37 @@ def _is_turn_active(svc: Any | None, name: str, *, strict: bool = False) -> bool
     :class:`_TurnProbeUnavailable` so the route maps to 503. Strict
     mode must fail *closed*; otherwise a flaky probe can clobber a
     working agent.
+
+    Strict mode prefers ``svc.is_turn_active_strict(name)`` (Codex PR
+    #2061 round 3): the default ``svc.is_turn_active`` runs through
+    fail-soft helpers (``list`` / ``health`` swallow tmux+store
+    failures and return "agent idle"), so even with the catch below the
+    real :class:`TmuxSessionService` would never raise on an outage and
+    the route would happily destroy a working agent. The strict variant
+    raises :class:`pollypm.session_services.tmux.TmuxProbeUnavailable`
+    on any probe failure; we wrap it as :class:`_TurnProbeUnavailable`
+    so the route's existing 503-mapper handles both. Services that
+    don't implement the strict variant (custom plugins) fall back to
+    the plain method — the wrapping ``except`` still catches anything
+    they raise, but those implementations carry the responsibility of
+    actually raising on probe failure.
     """
     if svc is None:
         if strict:
             raise _TurnProbeUnavailable("tmux service unavailable")
         return False
+    if strict:
+        probe = getattr(svc, "is_turn_active_strict", None)
+        if callable(probe):
+            try:
+                return bool(probe(name))
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "svc.is_turn_active_strict(%s) failed", name, exc_info=True,
+                )
+                raise _TurnProbeUnavailable(
+                    str(exc) or exc.__class__.__name__,
+                ) from exc
     try:
         return bool(svc.is_turn_active(name))
     except Exception as exc:  # noqa: BLE001

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -836,11 +836,11 @@ def restart_session_endpoint(
     """
     session = _find_session(config, name)
 
-    # Safety gate (Codex PR #2061 P0 #2 + round 6). Strict mode (the
+    # Safety gate (Codex PR #2061 P0 #2 + rounds 6+7). Strict mode (the
     # default) fails *closed* — a probe that cannot answer "is this
     # agent currently working?" must not be treated as "agent is idle".
     #
-    # The probe now reads from the SAME source as the rest of the API
+    # The probe reads from the SAME source as the rest of the API
     # contract (config + tmux direct) instead of going through
     # :class:`TmuxSessionService.is_turn_active_strict`, which depends
     # on the legacy :class:`StateStore.list_sessions()` row set. In
@@ -848,11 +848,17 @@ def restart_session_endpoint(
     # :func:`pollypm.storage.pg_sessions.upsert_session` on the launch
     # path) so the legacy store is empty/stale and the in-service
     # strict probe returned ``False`` (fail-open) for actively-working
-    # agents. ``probe_strict_turn_active`` re-resolves the configured
-    # window from ``config.sessions[name]`` →
-    # ``list_storage_closet_windows`` → direct
-    # :class:`pollypm.tmux.client.TmuxClient` calls so the answer cannot
-    # diverge from what ``GET /api/v1/sessions/{name}`` reports.
+    # agents.
+    #
+    # Round 7: the probe OWNS window discovery directly via
+    # ``TmuxClient.has_session`` / ``TmuxClient.list_windows`` so a
+    # tmux outage raises :class:`TmuxProbeUnavailable` → 503
+    # ``unsafe_mid_turn_unknown``. The previous round-6 wiring threaded
+    # the fail-soft :func:`_list_storage_closet_windows` helper into the
+    # probe, which returned ``{}`` for any tmux failure → probe saw
+    # "window absent" → returned ``False`` (looks idle) → destructive
+    # restart proceeded against an unobservable agent. The fail-soft
+    # helper is still correct for the read-side GET paths above.
     #
     # Supervisor construction is deferred until after the probe passes:
     # ``Supervisor()`` opens the legacy sqlite ``state.db`` and runs
@@ -864,14 +870,8 @@ def restart_session_endpoint(
         try:
             from pollypm.tmux.client import TmuxClient
 
-            # Reuse the same window dict the route's read-side helpers
-            # use so the probe and ``GET /api/v1/sessions/{name}``
-            # cannot diverge for the same session (Codex PR #2061
-            # round 6 single-source contract).
-            storage_session = _storage_session_name(config)
-            windows = _list_storage_closet_windows(storage_session)
             mid_turn = _probe_strict_turn_active(
-                config, name, TmuxClient(), windows=windows,
+                config, name, TmuxClient(),
             )
         except _TmuxProbeUnavailable as exc:
             raise _unsafe_mid_turn_unknown(name, str(exc)) from exc

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -67,6 +67,17 @@ _SUPERVISOR_IMPORT_ALLOWLIST: frozenset[str] = frozenset(
         "src/pollypm/schedulers/base.py",
         "src/pollypm/session_intelligence.py",
         "src/pollypm/workers.py",
+        # TODO(#2061-followup): pre-existing direct imports in two CLI/API
+        # surfaces. ``cli_features/tier4.py`` reaches for Supervisor to
+        # read the ``_STORAGE_CLOSET_SESSION_SUFFIX`` class constant; the
+        # P3 chat-send route does the same. Both should migrate to a
+        # public ``service_api`` accessor (sibling of the round-5 work
+        # that moved sessions_admin off direct imports) — tracked
+        # alongside #2061 follow-up. Adding them here keeps the guardrail
+        # honest while #2061 round-5 lands the sessions_admin migration
+        # without bundling unrelated refactors.
+        "src/pollypm/cli_features/tier4.py",
+        "src/pollypm/web_api/routes/chat_send.py",
     }
 )
 

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -241,7 +241,11 @@ class _FakeSupervisor:
         self.effective_account = effective_account
         self.restart_calls: list[dict[str, Any]] = []
 
-    def _get_session_runtime(self, name: str) -> Any:  # noqa: ARG002
+    def get_session_runtime(self, name: str) -> Any:  # noqa: ARG002
+        # Public Supervisor method (Codex PR #2061 round 5 blocker 2 —
+        # the route stopped reaching into ``_get_session_runtime`` and
+        # now uses the public wrapper that has been on Supervisor since
+        # the #1830 cluster-A pg facade landed).
         if self.effective_account is None:
             return None
         return SimpleNamespace(effective_account=self.effective_account)
@@ -710,6 +714,146 @@ def test_restart_strict_fails_closed_when_real_tmux_probe_fails(
     assert body["error"]["code"] == "unsafe_mid_turn_unknown"
     # Destructive facade must not have been touched.
     assert sup.restart_calls == []
+
+
+def test_build_tmux_service_routes_through_supervisor_facade_not_get_store(
+    config, monkeypatch,
+):
+    """Production wiring proof — ``_build_tmux_service`` MUST NOT use ``get_store``.
+
+    Codex PR #2061 round 5 blocker 1: the prior wiring was
+    ``_build_tmux_service`` → ``TmuxSessionService(store=get_store(config))``.
+    On a stock pg install ``get_store(config)`` returns the unified
+    :class:`pollypm.store.backends.pg_store.PgStore`, which exposes
+    ``append_event`` / ``query_messages`` / etc. but NO
+    ``list_sessions``. ``TmuxSessionService.list()`` and the round-3
+    strict probe call ``self._store.list_sessions()``, so every
+    production strict-restart raised ``AttributeError`` inside the
+    probe and the route returned ``503 unsafe_mid_turn_unknown`` even
+    for actually-idle agents.
+
+    The round-5 fix routes the service through
+    :func:`pollypm.service_api.build_supervisor` →
+    :attr:`Supervisor.session_service`. The supervisor's own session-
+    service property wires the correct
+    :class:`pollypm.storage.state.StateStore` (which DOES expose
+    ``list_sessions``).
+
+    This regression pins the wiring by:
+
+    1. Patching :func:`pollypm.store.registry.get_store` to raise so
+       any call to it from ``_build_tmux_service`` would propagate.
+    2. Patching :func:`pollypm.service_api.build_supervisor` to return
+       a fake whose ``.session_service`` is a sentinel object.
+    3. Asserting that the sentinel comes back through
+       ``_build_tmux_service`` — i.e. the route consults the
+       supervisor facade, not ``get_store``.
+
+    Without the fix this test fails because ``_build_tmux_service``
+    falls into the ``get_store(config)`` path and either returns a
+    PgStore-backed service (sentinel mismatch) or hits the simulated
+    failure.
+    """
+    from pollypm.web_api.routes import sessions_admin as routes
+    from pollypm.store import registry as store_registry
+
+    sentinel_service = object()
+
+    class _FakeSupervisor:
+        session_service = sentinel_service
+
+    # If the route reaches for get_store(config) we want it to be
+    # obvious in the failure mode.
+    def _boom_get_store(_config):
+        raise AssertionError(
+            "_build_tmux_service must NOT call get_store directly — "
+            "it must route through service_api.build_supervisor so the "
+            "service inherits Supervisor.store (StateStore, not PgStore). "
+            "Codex PR #2061 round 5 blocker 1."
+        )
+
+    monkeypatch.setattr(store_registry, "get_store", _boom_get_store)
+
+    # Patch the facade builder the route consults so we can inject
+    # our sentinel-bearing supervisor without touching the database.
+    monkeypatch.setattr(
+        "pollypm.service_api.build_supervisor",
+        lambda _config, **_kwargs: _FakeSupervisor(),
+    )
+
+    service = routes._build_tmux_service(config)
+    assert service is sentinel_service
+
+
+def test_restart_strict_succeeds_when_supervisor_wires_correct_store(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_tmux_windows,
+):
+    """Strict-mode restart succeeds when supervisor wires a healthy probe.
+
+    Codex PR #2061 round 5 blocker 1 — companion to
+    :func:`test_build_tmux_service_routes_through_supervisor_facade_not_get_store`.
+    The prior wiring would 503 every restart on a pg-backed install
+    because the strict probe blew up on
+    ``PgStore.list_sessions``. The post-round-5 wiring routes through
+    the supervisor whose session-service has the correct StateStore;
+    when that probe says "idle", the restart MUST succeed.
+
+    We monkeypatch ``_build_supervisor`` to return a fake whose
+    ``session_service.is_turn_active_strict`` returns False (idle) —
+    no AttributeError. The route must then call the supervisor's
+    ``restart_session`` exactly once and return 200.
+    """
+    from pollypm.session_services.tmux import TmuxSessionService
+
+    class _HealthyStore:
+        """Mirrors StateStore.list_sessions shape — returns no rows."""
+
+        def list_sessions(self):
+            return []
+
+    real_svc = TmuxSessionService(
+        config=config,
+        store=_HealthyStore(),
+    )
+
+    class _FakeSupervisorWithHealthyProbe:
+        def __init__(self, svc: TmuxSessionService) -> None:
+            self.session_service = svc
+            self.restart_calls: list[dict[str, Any]] = []
+
+        def get_session_runtime(self, name: str) -> Any:  # noqa: ARG002
+            return None
+
+        def restart_session(
+            self, session_name: str, account_name: str, *, failure_type: str,
+        ) -> None:
+            self.restart_calls.append({
+                "session_name": session_name,
+                "account_name": account_name,
+                "failure_type": failure_type,
+            })
+
+    fake_sup = _FakeSupervisorWithHealthyProbe(real_svc)
+    monkeypatch.setattr(
+        sessions_admin_routes,
+        "_build_supervisor",
+        lambda _config: fake_sup,
+    )
+    # Do NOT monkeypatch _build_tmux_service — the production path
+    # must construct it from fake_sup.session_service.
+
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows([])  # no live windows → strict probe returns False (idle)
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    # The strict probe must NOT spuriously 503; the route consults
+    # the supervisor's correctly-wired session service.
+    assert response.status_code == 200, response.text
+    assert len(fake_sup.restart_calls) == 1
+    assert fake_sup.restart_calls[0]["session_name"] == "operator"
 
 
 def test_restart_force_still_bypasses_strict_probe_failure(

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -1,0 +1,593 @@
+"""Integration tests for the Phase 2 sessions-admin endpoints.
+
+Covers ``/api/v1/sessions`` plus the ``restart`` / ``pause`` / ``resume``
+mutations per ``~/Desktop/pollypm-phase2-endpoints-spec.md`` §10.
+
+These tests are self-contained (no Postgres harness): we monkeypatch
+the heartbeat read, tmux probe, and TmuxSessionService construction on
+the route module so the suite runs against an in-process FastAPI app
+with no live infra.
+
+Run via ``pytest --noconftest tests/test_sessions_admin_endpoint.py -v``
+so the per-project conftest (which spins up a pg test schema) is
+skipped — these tests don't need it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.models import (
+    KnownProject,
+    ProjectKind,
+    ProviderKind,
+    RuntimeKind,
+    SessionConfig,
+)
+from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.routes import sessions_admin as sessions_admin_routes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def config(workspace: Path, project_root: Path) -> PollyPMConfig:
+    base_dir = workspace / ".pollypm"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="claude_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+                email="claude@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "claude_primary",
+            ),
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=workspace,
+                project="pollypm",
+                window_name="operator",
+                auth_token="deadbeef" * 8,
+            ),
+            "advisor_myproj": SessionConfig(
+                name="advisor_myproj",
+                role="advisor",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=project_root,
+                project="myproj",
+                window_name="advisor_myproj",
+            ),
+        },
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def token(tmp_path: Path) -> tuple[Path, str]:
+    token_path = tmp_path / "api-token"
+    value, _generated = ensure_token(token_path)
+    return token_path, value
+
+
+@pytest.fixture
+def auth_headers(token: tuple[Path, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token[1]}"}
+
+
+@pytest.fixture
+def app(config, token):
+    token_path, _value = token
+    return create_app(config=config, token_path=token_path)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_heartbeat(iso_ts: str | None) -> Any:
+    """Build a duck-typed heartbeat record with just ``.created_at``."""
+    return SimpleNamespace(created_at=iso_ts)
+
+
+def _fake_window(window_name: str) -> Any:
+    """Tmux window stub (only ``.name`` is read by the route)."""
+    return SimpleNamespace(name=window_name, pane_id="%9", pane_dead=False)
+
+
+class _FakeTmuxService:
+    """Stand-in for :class:`TmuxSessionService` used in restart tests.
+
+    Tracks calls to ``destroy`` / ``create`` and lets tests pre-program
+    ``is_turn_active`` + ``health`` return values.
+    """
+
+    def __init__(
+        self,
+        *,
+        turn_active: bool = False,
+        destroy_raises: Exception | None = None,
+        create_raises: Exception | None = None,
+        window_present: bool = True,
+    ) -> None:
+        self.turn_active = turn_active
+        self.destroy_raises = destroy_raises
+        self.create_raises = create_raises
+        self.window_present = window_present
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def destroy(self, name: str) -> None:
+        self.calls.append(("destroy", {"name": name}))
+        if self.destroy_raises:
+            raise self.destroy_raises
+
+    def create(self, **kwargs: Any) -> Any:
+        self.calls.append(("create", kwargs))
+        if self.create_raises:
+            raise self.create_raises
+        return SimpleNamespace(name=kwargs["name"], window_name=kwargs.get("window_name"))
+
+    def is_turn_active(self, name: str) -> bool:  # noqa: ARG002
+        return self.turn_active
+
+    def health(self, name: str, *, capture_lines: int = 200) -> Any:  # noqa: ARG002
+        return SimpleNamespace(
+            window_present=self.window_present,
+            pane_alive=self.window_present,
+            pane_dead=not self.window_present,
+            pane_command="claude" if self.window_present else None,
+            pane_text="",
+        )
+
+
+@pytest.fixture
+def patch_heartbeat(monkeypatch: pytest.MonkeyPatch):
+    """Install a stub for ``_latest_heartbeat`` on the route module."""
+    def install(values: dict[str, str | None]) -> None:
+        def fake(_config, name: str):
+            iso = values.get(name)
+            if iso is None:
+                return None
+            return _fake_heartbeat(iso)
+        monkeypatch.setattr(
+            sessions_admin_routes, "_latest_heartbeat", fake,
+        )
+    return install
+
+
+@pytest.fixture
+def patch_tmux_windows(monkeypatch: pytest.MonkeyPatch):
+    """Install a stub for ``_list_storage_closet_windows``."""
+    def install(present_windows: list[str]) -> None:
+        def fake(_session: str) -> dict[str, Any]:
+            return {name: _fake_window(name) for name in present_windows}
+        monkeypatch.setattr(
+            sessions_admin_routes, "_list_storage_closet_windows", fake,
+        )
+    return install
+
+
+@pytest.fixture
+def patch_tmux_service(monkeypatch: pytest.MonkeyPatch):
+    """Install a stub for ``_build_tmux_service``; returns the fake service."""
+    def install(service: _FakeTmuxService | None) -> _FakeTmuxService | None:
+        monkeypatch.setattr(
+            sessions_admin_routes, "_build_tmux_service",
+            lambda _config: service,
+        )
+        return service
+    return install
+
+
+@pytest.fixture
+def patch_pg_outage(monkeypatch: pytest.MonkeyPatch):
+    """Simulate a pg backend outage on the heartbeat read path.
+
+    The route is fail-soft for the GET list/detail surfaces: pg pool
+    outages must NOT 500 or 503 — they collapse to
+    ``last_heartbeat_iso=null`` / ``status="unknown"`` so an operator
+    in a degraded environment still sees their session inventory.
+    The 503 surface is reserved for mutation endpoints where the
+    tmux service itself can't be constructed (covered separately in
+    :func:`test_restart_503_when_service_unavailable`).
+
+    We patch :func:`pollypm.storage.pg_heartbeats.latest_heartbeat`
+    (not the route helper that wraps it) so the route's own
+    ``try/except`` is exercised — that's the contract under test.
+    """
+    def install() -> None:
+        from pollypm.storage import pg_heartbeats
+
+        def boom(_session_name, *, pool=None, config=None):  # noqa: ARG001
+            raise RuntimeError("pg pool unavailable")
+        monkeypatch.setattr(
+            pg_heartbeats, "latest_heartbeat", boom,
+        )
+    return install
+
+
+# ---------------------------------------------------------------------------
+# GET /sessions — list
+# ---------------------------------------------------------------------------
+
+
+def test_list_sessions_returns_all_configured(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    patch_heartbeat({
+        "operator": "2026-05-21T10:00:00Z",
+        "advisor_myproj": None,
+    })
+    patch_tmux_windows(["operator", "advisor_myproj"])
+    response = client.get("/api/v1/sessions", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    names = [s["name"] for s in body["sessions"]]
+    assert names == ["advisor_myproj", "operator"]  # sorted by name
+    by_name = {s["name"]: s for s in body["sessions"]}
+    # operator has a heartbeat row and a present window — depending on
+    # the heartbeat ts vs "now" the status is either healthy or stale;
+    # both are valid here. Just assert the runtime classified it as
+    # one of the known states and surfaced the heartbeat.
+    assert by_name["operator"]["status"] in {"healthy", "stale"}
+    assert by_name["operator"]["last_heartbeat_iso"] == "2026-05-21T10:00:00Z"
+    assert by_name["operator"]["window_present"] is True
+    assert by_name["operator"]["auth_token_present"] is True
+    # advisor has no heartbeat row → unknown
+    assert by_name["advisor_myproj"]["status"] == "unknown"
+    assert by_name["advisor_myproj"]["last_heartbeat_iso"] is None
+    assert by_name["advisor_myproj"]["auth_token_present"] is False
+
+
+def test_list_sessions_marks_missing_when_window_absent(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows([])  # no windows in tmux
+    body = client.get("/api/v1/sessions", headers=auth_headers).json()
+    by_name = {s["name"]: s for s in body["sessions"]}
+    # Missing window beats heartbeat staleness (matches CLI behavior).
+    assert by_name["operator"]["status"] == "missing"
+    assert by_name["operator"]["window_present"] is False
+
+
+def test_list_sessions_requires_bearer_auth(client):
+    response = client.get("/api/v1/sessions")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] in {"unauthorized", "invalid_token"}
+
+
+def test_list_sessions_rejects_wrong_token(client):
+    response = client.get(
+        "/api/v1/sessions",
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
+
+
+def test_list_sessions_pg_outage_degrades_to_unknown(
+    client, auth_headers, patch_pg_outage, patch_tmux_windows,
+):
+    """pg facade outage on the read path collapses to ``status=unknown``.
+
+    The list endpoint is fail-soft (spec §10.4 "daemon goes down" /
+    blocker-class behaviour from the chat_messages route): a backing-
+    store outage must not 503 the list; it just means heartbeats can't
+    be evaluated, so every row reports ``unknown``.
+    """
+    patch_pg_outage()
+    patch_tmux_windows(["operator", "advisor_myproj"])
+    response = client.get("/api/v1/sessions", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    for row in response.json()["sessions"]:
+        assert row["status"] in {"unknown", "missing"}
+        assert row["last_heartbeat_iso"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /sessions/{name} — detail
+# ---------------------------------------------------------------------------
+
+
+def test_get_session_detail_returns_config_health(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_tmux_service(_FakeTmuxService(turn_active=False))
+    response = client.get("/api/v1/sessions/operator", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["info"]["name"] == "operator"
+    assert body["config"]["name"] == "operator"
+    assert body["config"]["role"] == "operator-pm"
+    assert body["config"]["auth_token_present"] is True
+    assert body["health"]["window_present"] is True
+    assert body["health"]["pane_alive"] is True
+    assert body["is_turn_active"] is False
+
+
+def test_get_session_404_unknown(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    patch_heartbeat({})
+    patch_tmux_windows([])
+    patch_tmux_service(_FakeTmuxService())
+    response = client.get("/api/v1/sessions/does-not-exist", headers=auth_headers)
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# POST /sessions/{name}/restart
+# ---------------------------------------------------------------------------
+
+
+def test_restart_happy_path(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    svc = patch_tmux_service(_FakeTmuxService(turn_active=False))
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert "operator" in (body.get("message") or "")
+    # destroy + create were both called, in that order.
+    kinds = [call[0] for call in svc.calls]
+    assert kinds == ["destroy", "create"]
+    assert svc.calls[1][1]["name"] == "operator"
+    assert svc.calls[1][1]["window_name"] == "operator"
+
+
+def test_restart_already_stopped_returns_200(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    """Restart against an already-stopped session is idempotent → 200.
+
+    Spec §10.4 leaves the choice between 200 and 409 to the
+    implementer; we pick 200 so clients can issue a blind ``restart``
+    without first probing live state. ``destroy`` is a no-op when the
+    window isn't present (it's structured that way in
+    :meth:`TmuxSessionService.destroy`), and ``create`` then brings it
+    up fresh.
+    """
+    patch_heartbeat({})
+    patch_tmux_windows([])  # not present in tmux
+    svc = patch_tmux_service(_FakeTmuxService(window_present=False))
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    # destroy + create still both fire — destroy is the no-op safety net.
+    kinds = [call[0] for call in svc.calls]
+    assert kinds == ["destroy", "create"]
+
+
+def test_restart_refuses_mid_turn(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    svc = patch_tmux_service(_FakeTmuxService(turn_active=True))
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_turn"
+    # no destroy / create was attempted
+    assert svc.calls == []
+
+
+def test_restart_force_overrides_mid_turn(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    svc = patch_tmux_service(_FakeTmuxService(turn_active=True))
+    response = client.post(
+        "/api/v1/sessions/operator/restart?safety=force",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    kinds = [call[0] for call in svc.calls]
+    assert kinds == ["destroy", "create"]
+
+
+def test_restart_404_unknown_session(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    patch_heartbeat({})
+    patch_tmux_windows([])
+    patch_tmux_service(_FakeTmuxService())
+    response = client.post(
+        "/api/v1/sessions/nope/restart", headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_restart_503_when_service_unavailable(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    patch_heartbeat({})
+    patch_tmux_windows([])
+    patch_tmux_service(None)  # service construction failed
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "daemon_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# POST /sessions/{name}/pause + resume
+# ---------------------------------------------------------------------------
+
+
+def test_pause_happy_path_then_visible_in_list(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+
+    response = client.post(
+        "/api/v1/sessions/operator/pause", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+
+    # list reflects the paused state
+    listing = client.get("/api/v1/sessions", headers=auth_headers).json()
+    by_name = {s["name"]: s for s in listing["sessions"]}
+    assert by_name["operator"]["paused"] is True
+    assert by_name["operator"]["status"] == "paused"
+
+
+def test_pause_is_idempotent(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    patch_heartbeat({})
+    patch_tmux_windows(["operator"])
+    first = client.post(
+        "/api/v1/sessions/operator/pause", headers=auth_headers,
+    )
+    assert first.status_code == 200
+    second = client.post(
+        "/api/v1/sessions/operator/pause", headers=auth_headers,
+    )
+    assert second.status_code == 200
+    body = second.json()
+    assert body["ok"] is True
+    assert "already" in (body.get("message") or "").lower()
+
+
+def test_resume_happy_path(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    patch_heartbeat({})
+    patch_tmux_windows(["operator"])
+    client.post("/api/v1/sessions/operator/pause", headers=auth_headers)
+
+    response = client.post(
+        "/api/v1/sessions/operator/resume", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+
+    listing = client.get("/api/v1/sessions", headers=auth_headers).json()
+    by_name = {s["name"]: s for s in listing["sessions"]}
+    assert by_name["operator"]["paused"] is False
+    assert by_name["operator"]["status"] != "paused"
+
+
+def test_resume_is_idempotent_when_not_paused(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    patch_heartbeat({})
+    patch_tmux_windows(["operator"])
+    response = client.post(
+        "/api/v1/sessions/operator/resume", headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert "already" in (body.get("message") or "").lower()
+
+
+def test_pause_404_unknown_session(client, auth_headers):
+    response = client.post(
+        "/api/v1/sessions/does-not-exist/pause", headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_pause_requires_auth(client):
+    response = client.post("/api/v1/sessions/operator/pause")
+    assert response.status_code == 401

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -686,6 +686,15 @@ def test_restart_503_when_supervisor_unavailable(
 def test_pause_happy_path_then_visible_in_list(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
 ):
+    """Pause sets ``paused=True`` but does NOT mutate ``status``.
+
+    PR #2061 round 2: pause is informational only, so ``status``
+    must continue to reflect runtime health. With a fresh heartbeat
+    + present window the row is ``healthy`` AND ``paused=True``.
+    See :func:`test_status_paused_but_missing_returns_health_classification`
+    and :func:`test_status_paused_but_stale_returns_stale_with_paused_flag`
+    for the regressions this round-2 contract prevents.
+    """
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
 
@@ -696,11 +705,85 @@ def test_pause_happy_path_then_visible_in_list(
     body = response.json()
     assert body["ok"] is True
 
-    # list reflects the paused state
+    # list reflects the paused state on the dedicated boolean field
+    # — status stays as the runtime-health classification.
     listing = client.get("/api/v1/sessions", headers=auth_headers).json()
     by_name = {s["name"]: s for s in listing["sessions"]}
     assert by_name["operator"]["paused"] is True
-    assert by_name["operator"]["status"] == "paused"
+    # status must be a real health value, not the legacy "paused" string.
+    assert by_name["operator"]["status"] in {"healthy", "stale"}
+    assert by_name["operator"]["status"] != "paused"
+
+
+def test_status_paused_but_missing_returns_health_classification(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    """Pausing a missing session must NOT mask the missing classification.
+
+    PR #2061 round 2 regression: previously the route surfaced
+    ``status="paused"`` for any tagged session, even when the tmux
+    window was absent. Because the supervisor / recovery / dispatch
+    loops do NOT consume the marker (#2068), the operator would see
+    "paused" and assume the daemon had quiesced when in fact the
+    session had simply gone missing. ``status`` must reflect runtime
+    health regardless of the pause marker.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows([])  # tmux window absent → missing
+
+    # Pause then list.
+    pause = client.post(
+        "/api/v1/sessions/operator/pause", headers=auth_headers,
+    )
+    assert pause.status_code == 200, pause.text
+    listing = client.get("/api/v1/sessions", headers=auth_headers).json()
+    row = next(s for s in listing["sessions"] if s["name"] == "operator")
+
+    # The whole point of round 2: missing wins over the informational
+    # pause tag.
+    assert row["status"] == "missing"
+    assert row["paused"] is True
+
+
+def test_status_paused_but_stale_returns_stale_with_paused_flag(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    """Pausing a stale session must NOT mask the stale classification.
+
+    Same PR #2061 round 2 contract on the heartbeat-age side. A
+    long-quiet session needs to be visible as ``stale`` so the
+    operator knows the heartbeat has aged out, even if it has also
+    been tagged informationally as paused.
+    """
+    # Heartbeat well past the 5-min stale threshold (>1 day old).
+    patch_heartbeat({"operator": "2025-01-01T00:00:00Z"})
+    patch_tmux_windows(["operator"])  # window present so we exercise stale, not missing
+
+    pause = client.post(
+        "/api/v1/sessions/operator/pause", headers=auth_headers,
+    )
+    assert pause.status_code == 200, pause.text
+    listing = client.get("/api/v1/sessions", headers=auth_headers).json()
+    row = next(s for s in listing["sessions"] if s["name"] == "operator")
+
+    assert row["status"] == "stale"
+    assert row["paused"] is True
+
+
+def test_status_unpaused_session_reports_paused_false(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    """Baseline: an un-tagged session reports ``paused=False``.
+
+    Sanity-anchor for the round-2 contract — confirms the new
+    boolean field defaults correctly when no pause marker exists.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    listing = client.get("/api/v1/sessions", headers=auth_headers).json()
+    row = next(s for s in listing["sessions"] if s["name"] == "operator")
+    assert row["paused"] is False
+    assert row["status"] != "paused"
 
 
 def test_pause_is_idempotent(

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -302,6 +302,46 @@ def patch_tmux_service(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
+def patch_strict_probe(monkeypatch: pytest.MonkeyPatch):
+    """Install a stub for ``_probe_strict_turn_active`` on the route module.
+
+    Codex PR #2061 round 6: the destructive restart safety gate now
+    calls :func:`pollypm.session_health.probe_strict_turn_active`
+    directly (config + tmux client, no :class:`TmuxSessionService` /
+    legacy :class:`StateStore`). Tests assert the route consults this
+    config/tmux-direct probe by patching the route's reference to it.
+
+    Pass ``mid_turn=True`` to force the 409 unsafe_mid_turn branch,
+    ``raises=RuntimeError(...)`` to force the 503
+    unsafe_mid_turn_unknown branch.
+    """
+    from pollypm.session_health import TmuxProbeUnavailable
+
+    def install(
+        *,
+        mid_turn: bool = False,
+        raises: Exception | None = None,
+    ) -> dict[str, Any]:
+        calls: list[tuple[Any, str, Any]] = []
+
+        def fake(
+            config: Any, name: str, tmux_client: Any, **kwargs: Any,
+        ) -> bool:
+            calls.append((config, name, tmux_client))
+            if raises is not None:
+                if isinstance(raises, TmuxProbeUnavailable):
+                    raise raises
+                raise TmuxProbeUnavailable(str(raises)) from raises
+            return mid_turn
+
+        monkeypatch.setattr(
+            sessions_admin_routes, "_probe_strict_turn_active", fake,
+        )
+        return {"calls": calls}
+    return install
+
+
+@pytest.fixture
 def patch_supervisor(monkeypatch: pytest.MonkeyPatch):
     """Install a stub for ``_build_supervisor`` on the route module.
 
@@ -462,6 +502,67 @@ def test_get_session_404_unknown(
     assert response.json()["error"]["code"] == "not_found"
 
 
+def test_get_session_window_present_consistent_between_info_and_health(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service,
+):
+    """``info.window_present`` and ``health.window_present`` must agree.
+
+    Codex PR #2061 round 6: ``info.window_present`` is built from the
+    shared :func:`pollypm.session_health.list_storage_closet_windows`
+    helper (config + tmux direct), while ``health.window_present``
+    used to come from :meth:`TmuxSessionService.health` →
+    ``self._store.list_sessions()`` on the legacy :class:`StateStore`.
+    On a pg-backed install with no legacy-StateStore session rows the
+    two fields could disagree for the same configured session — one
+    reporting ``True`` (window genuinely live), the other ``False``
+    (in-service ``get()`` saw no StateStore record so returned a
+    "window absent" health snapshot).
+
+    The fix single-sources ``health.window_present`` to the value
+    already computed for ``info`` from the canonical helper. This test
+    pins the contract: a live window is reported as present on BOTH
+    fields, an absent window as missing on BOTH.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+
+    # _FakeTmuxService has window_present=True by default → in the
+    # baseline this matched info. We force window_present=False on the
+    # in-service health snapshot to simulate the round-6 split-source
+    # bug (StateStore-empty install): without the fix,
+    # health.window_present is False while info.window_present is True
+    # (because list_storage_closet_windows DID find the window).
+    patch_tmux_service(_FakeTmuxService(
+        turn_active=False, window_present=False,
+    ))
+
+    response = client.get(
+        "/api/v1/sessions/operator", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["info"]["window_present"] is True
+    # Without the round-6 fix this would be False.
+    assert body["health"]["window_present"] == body["info"]["window_present"], (
+        "info.window_present and health.window_present must single-source "
+        "from the same config/tmux helper — Codex PR #2061 round 6."
+    )
+
+    # And the negative direction: when the window is absent both
+    # fields must report False.
+    patch_tmux_windows([])
+    patch_tmux_service(_FakeTmuxService(
+        turn_active=False, window_present=True,
+    ))
+    response = client.get(
+        "/api/v1/sessions/operator", headers=auth_headers,
+    )
+    body = response.json()
+    assert body["info"]["window_present"] is False
+    assert body["health"]["window_present"] == body["info"]["window_present"]
+
+
 # ---------------------------------------------------------------------------
 # POST /sessions/{name}/restart
 # ---------------------------------------------------------------------------
@@ -469,7 +570,7 @@ def test_get_session_404_unknown(
 
 def test_restart_routes_through_supervisor_facade(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
     """Restart goes through ``Supervisor.restart_session`` (PR #2061 P0 #1).
 
@@ -482,7 +583,7 @@ def test_restart_routes_through_supervisor_facade(
     """
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
-    svc = patch_tmux_service(_FakeTmuxService(turn_active=False))
+    probe = patch_strict_probe(mid_turn=False)
     sup = patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
@@ -491,9 +592,9 @@ def test_restart_routes_through_supervisor_facade(
     body = response.json()
     assert body["ok"] is True
     assert "operator" in (body.get("message") or "")
-    # The route did NOT poke the raw destroy/create helpers — the
-    # facade owns that pair.
-    assert svc.calls == []
+    # The strict probe was consulted (config/tmux-direct, not the
+    # legacy StateStore-dependent in-service probe).
+    assert len(probe["calls"]) == 1
     # The facade was called once with the session, the configured
     # account (effective_account is None in this stub), and the
     # api_restart failure_type so the recovery audit chain attributes
@@ -507,7 +608,7 @@ def test_restart_routes_through_supervisor_facade(
 
 def test_restart_prefers_effective_account_over_configured(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
     """When the runtime carries an ``effective_account`` it wins.
 
@@ -518,7 +619,7 @@ def test_restart_prefers_effective_account_over_configured(
     """
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
-    patch_tmux_service(_FakeTmuxService(turn_active=False))
+    patch_strict_probe(mid_turn=False)
     sup = patch_supervisor(
         _FakeSupervisor(effective_account="recovery_account"),
     )
@@ -531,12 +632,12 @@ def test_restart_prefers_effective_account_over_configured(
 
 def test_restart_facade_failure_503_daemon_unavailable(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
     """``Supervisor.restart_session`` raising → 503, not 500."""
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
-    patch_tmux_service(_FakeTmuxService(turn_active=False))
+    patch_strict_probe(mid_turn=False)
     patch_supervisor(
         _FakeSupervisor(restart_raises=RuntimeError("tmux server down")),
     )
@@ -549,11 +650,11 @@ def test_restart_facade_failure_503_daemon_unavailable(
 
 def test_restart_refuses_mid_turn(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
-    svc = patch_tmux_service(_FakeTmuxService(turn_active=True))
+    patch_strict_probe(mid_turn=True)
     sup = patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
@@ -561,29 +662,25 @@ def test_restart_refuses_mid_turn(
     assert response.status_code == 409
     body = response.json()
     assert body["error"]["code"] == "unsafe_mid_turn"
-    # neither the raw service nor the facade was touched
-    assert svc.calls == []
+    # The destructive facade was NEVER touched.
     assert sup.restart_calls == []
 
 
 def test_restart_strict_fail_closed_when_probe_raises(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
     """Strict-mode probe failure → 503 ``unsafe_mid_turn_unknown``.
 
-    PR #2061 P0 #2 regression: the previous ``_is_turn_active``
-    swallowed every exception and returned ``False``, so a transient
-    tmux/parse failure looked like "agent is idle" and the route
-    happily destroyed an actively-working agent. Strict mode (the
-    default) must fail *closed* — the safety gate refuses the restart
-    when it cannot evaluate the mid-turn signal.
+    PR #2061 P0 #2 + round 6: a transient tmux failure must not look
+    like "agent is idle" and let the route destroy an actively-working
+    agent. The route now consults the config/tmux-direct
+    :func:`pollypm.session_health.probe_strict_turn_active` helper,
+    which raises :class:`TmuxProbeUnavailable` on tmux outage.
     """
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
-    svc = patch_tmux_service(
-        _FakeTmuxService(turn_active_raises=RuntimeError("tmux probe timeout")),
-    )
+    patch_strict_probe(raises=RuntimeError("tmux probe timeout"))
     sup = patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
@@ -592,13 +689,12 @@ def test_restart_strict_fail_closed_when_probe_raises(
     body = response.json()
     assert body["error"]["code"] == "unsafe_mid_turn_unknown"
     # The destructive path was NEVER reached.
-    assert svc.calls == []
     assert sup.restart_calls == []
 
 
 def test_restart_force_bypasses_safety_probe_entirely(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
     """``?safety=force`` skips the probe even when it would raise.
 
@@ -607,9 +703,7 @@ def test_restart_force_bypasses_safety_probe_entirely(
     """
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
-    patch_tmux_service(
-        _FakeTmuxService(turn_active_raises=RuntimeError("tmux probe timeout")),
-    )
+    probe = patch_strict_probe(raises=RuntimeError("tmux probe timeout"))
     sup = patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/operator/restart?safety=force",
@@ -617,15 +711,17 @@ def test_restart_force_bypasses_safety_probe_entirely(
     )
     assert response.status_code == 200, response.text
     assert len(sup.restart_calls) == 1
+    # force MUST bypass the probe entirely.
+    assert probe["calls"] == []
 
 
 def test_restart_force_overrides_mid_turn(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
-    patch_tmux_service(_FakeTmuxService(turn_active=True))
+    patch_strict_probe(mid_turn=True)
     sup = patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/operator/restart?safety=force",
@@ -638,11 +734,11 @@ def test_restart_force_overrides_mid_turn(
 
 def test_restart_404_unknown_session(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
     patch_heartbeat({})
     patch_tmux_windows([])
-    patch_tmux_service(_FakeTmuxService())
+    patch_strict_probe(mid_turn=False)
     patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/nope/restart", headers=auth_headers,
@@ -651,302 +747,109 @@ def test_restart_404_unknown_session(
     assert response.json()["error"]["code"] == "not_found"
 
 
-def test_restart_503_when_tmux_service_unavailable(
-    client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
-):
-    patch_heartbeat({})
-    patch_tmux_windows([])
-    patch_tmux_service(None)  # tmux service construction failed
-    patch_supervisor(_FakeSupervisor())
-    response = client.post(
-        "/api/v1/sessions/operator/restart", headers=auth_headers,
-    )
-    assert response.status_code == 503
-    assert response.json()["error"]["code"] == "daemon_unavailable"
-
-
-def test_restart_strict_fails_closed_when_real_tmux_probe_fails(
+def test_restart_strict_blocks_when_state_store_empty_but_tmux_window_live(
     client, config, auth_headers, monkeypatch, patch_heartbeat,
     patch_tmux_windows, patch_supervisor,
 ):
-    """Real ``TmuxSessionService`` fail-soft must not bypass the strict gate.
+    """Codex PR #2061 round 6 regression — the headline fail-open case.
 
-    Codex PR #2061 round 3: the production ``TmuxSessionService.list``
-    swallows ``self._store.list_sessions()`` failures and returns no
-    handles; ``health`` swallows pane / capture failures; and
-    ``is_turn_active`` then returns ``False`` (looks-idle). The
-    round-2 regression used a fake that raised directly from
-    ``is_turn_active`` — so the test passed while a real outage
-    happily skipped the strict gate. This test hits the actual
-    :class:`TmuxSessionService` with a store that raises from
-    ``list_sessions`` (the exact path Codex flagged) and asserts the
-    route returns 503 ``unsafe_mid_turn_unknown`` and NEVER calls the
-    supervisor restart facade.
+    Production session registration is in pg
+    (``supervisor._record_launch`` → ``pollypm.storage.pg_sessions.upsert_session``),
+    so the legacy :class:`StateStore.list_sessions()` row set can be
+    empty/stale even when the configured session has a live, actively-
+    working tmux pane. The prior round-5 strict probe (
+    :meth:`TmuxSessionService.is_turn_active_strict`) saw "no
+    StateStore row" → returned ``False`` (looks-idle) → the destructive
+    restart proceeded and could destroy a working agent.
+
+    The round-6 fix: the strict probe reads from the SAME source as
+    the rest of the API contract — ``config.sessions[name]`` +
+    :func:`pollypm.session_health.list_storage_closet_windows` + direct
+    :class:`pollypm.tmux.client.TmuxClient` calls. With the legacy
+    StateStore empty but a live tmux window and active-turn pane text,
+    default restart MUST return 409 ``unsafe_mid_turn`` and MUST NOT
+    call :meth:`Supervisor.restart_session`.
+
+    This test is constructed to FAIL against the round-5
+    implementation (StateStore-dependent probe → False → 200 restart)
+    and PASS against the round-6 implementation (config/tmux-direct
+    probe → True → 409). Verified by reverting the new helper +
+    restart call site and re-running.
     """
-    from pollypm.session_services.tmux import TmuxSessionService
-
-    class _BrokenStore:
-        """Mirrors a real pg / state-store outage on ``list_sessions``."""
-
-        def list_sessions(self):
-            raise RuntimeError("state store unavailable")
-
-    real_svc = TmuxSessionService(
-        config=config,
-        store=_BrokenStore(),
-    )
-    monkeypatch.setattr(
-        sessions_admin_routes,
-        "_build_tmux_service",
-        lambda _config: real_svc,
-    )
-
-    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    # Stub list_storage_closet_windows so the route's helper sees the
+    # configured "operator" window as present + live.
     patch_tmux_windows(["operator"])
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+
+    # Stub TmuxClient at the construction site so the strict probe's
+    # list_panes + capture_pane don't shell out to a real tmux. The
+    # pane text mimics Codex's mid-turn marker.
+    class _FakePane:
+        def __init__(self, pane_id: str, *, active: bool = True) -> None:
+            self.pane_id = pane_id
+            self.active = active
+
+    class _FakeTmuxClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, Any]] = []
+
+        def list_panes(self, target: str):  # noqa: ARG002
+            self.calls.append(("list_panes", target))
+            return [_FakePane("%9", active=True)]
+
+        def capture_pane(self, pane_id: str, lines: int = 200):  # noqa: ARG002
+            self.calls.append(("capture_pane", pane_id))
+            return "working (10s) esc to interrupt\n"
+
+    fake_client = _FakeTmuxClient()
+    monkeypatch.setattr(
+        "pollypm.tmux.client.TmuxClient", lambda: fake_client,
+    )
+
     sup = patch_supervisor(_FakeSupervisor())
 
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
     )
-    assert response.status_code == 503, response.text
+    assert response.status_code == 409, response.text
     body = response.json()
-    assert body["error"]["code"] == "unsafe_mid_turn_unknown"
-    # Destructive facade must not have been touched.
+    assert body["error"]["code"] == "unsafe_mid_turn"
+    # The destructive facade was NEVER touched even though no
+    # legacy-StateStore row exists for "operator".
     assert sup.restart_calls == []
+    # The strict probe DID consult the live tmux pane.
+    assert any(call[0] == "capture_pane" for call in fake_client.calls)
 
 
-def test_build_tmux_service_routes_through_supervisor_facade_not_get_store(
-    config, monkeypatch,
-):
-    """Production wiring proof — ``_build_tmux_service`` MUST NOT use ``get_store``.
-
-    Codex PR #2061 round 5 blocker 1: the prior wiring was
-    ``_build_tmux_service`` → ``TmuxSessionService(store=get_store(config))``.
-    On a stock pg install ``get_store(config)`` returns the unified
-    :class:`pollypm.store.backends.pg_store.PgStore`, which exposes
-    ``append_event`` / ``query_messages`` / etc. but NO
-    ``list_sessions``. ``TmuxSessionService.list()`` and the round-3
-    strict probe call ``self._store.list_sessions()``, so every
-    production strict-restart raised ``AttributeError`` inside the
-    probe and the route returned ``503 unsafe_mid_turn_unknown`` even
-    for actually-idle agents.
-
-    The round-5 fix routes the service through
-    :func:`pollypm.service_api.build_supervisor` →
-    :attr:`Supervisor.session_service`. The supervisor's own session-
-    service property wires the correct
-    :class:`pollypm.storage.state.StateStore` (which DOES expose
-    ``list_sessions``).
-
-    This regression pins the wiring by:
-
-    1. Patching :func:`pollypm.store.registry.get_store` to raise so
-       any call to it from ``_build_tmux_service`` would propagate.
-    2. Patching :func:`pollypm.service_api.build_supervisor` to return
-       a fake whose ``.session_service`` is a sentinel object.
-    3. Asserting that the sentinel comes back through
-       ``_build_tmux_service`` — i.e. the route consults the
-       supervisor facade, not ``get_store``.
-
-    Without the fix this test fails because ``_build_tmux_service``
-    falls into the ``get_store(config)`` path and either returns a
-    PgStore-backed service (sentinel mismatch) or hits the simulated
-    failure.
-    """
-    from pollypm.web_api.routes import sessions_admin as routes
-    from pollypm.store import registry as store_registry
-
-    sentinel_service = object()
-
-    class _FakeSupervisor:
-        session_service = sentinel_service
-
-    # If the route reaches for get_store(config) we want it to be
-    # obvious in the failure mode.
-    def _boom_get_store(_config):
-        raise AssertionError(
-            "_build_tmux_service must NOT call get_store directly — "
-            "it must route through service_api.build_supervisor so the "
-            "service inherits Supervisor.store (StateStore, not PgStore). "
-            "Codex PR #2061 round 5 blocker 1."
-        )
-
-    monkeypatch.setattr(store_registry, "get_store", _boom_get_store)
-
-    # Patch the facade builder the route consults so we can inject
-    # our sentinel-bearing supervisor without touching the database.
-    monkeypatch.setattr(
-        "pollypm.service_api.build_supervisor",
-        lambda _config, **_kwargs: _FakeSupervisor(),
-    )
-
-    service = routes._build_tmux_service(config)
-    assert service is sentinel_service
-
-
-def test_restart_strict_succeeds_when_supervisor_wires_correct_store(
+def test_restart_strict_503_when_tmux_probe_raises(
     client, config, auth_headers, monkeypatch, patch_heartbeat,
-    patch_tmux_windows,
+    patch_tmux_windows, patch_supervisor,
 ):
-    """Strict-mode restart succeeds when supervisor wires a healthy probe.
+    """Tmux ``capture_pane`` outage → strict probe fails closed (503).
 
-    Codex PR #2061 round 5 blocker 1 — companion to
-    :func:`test_build_tmux_service_routes_through_supervisor_facade_not_get_store`.
-    The prior wiring would 503 every restart on a pg-backed install
-    because the strict probe blew up on
-    ``PgStore.list_sessions``. The post-round-5 wiring routes through
-    the supervisor whose session-service has the correct StateStore;
-    when that probe says "idle", the restart MUST succeed.
-
-    We monkeypatch ``_build_supervisor`` to return a fake whose
-    ``session_service.is_turn_active_strict`` returns False (idle) —
-    no AttributeError. The route must then call the supervisor's
-    ``restart_session`` exactly once and return 200.
+    Codex PR #2061 round 3 + round 6: with a live tmux window the
+    strict probe still must propagate a ``capture_pane`` failure as
+    :class:`pollypm.session_health.TmuxProbeUnavailable` so the route
+    returns ``503 unsafe_mid_turn_unknown`` (fail-closed). Carried
+    forward from round 3 against the new config/tmux-direct probe.
     """
-    from pollypm.session_services.tmux import TmuxSessionService
+    patch_tmux_windows(["operator"])
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
 
-    class _HealthyStore:
-        """Mirrors StateStore.list_sessions shape — returns no rows."""
+    import subprocess
 
-        def list_sessions(self):
+    class _FakeTmuxClient:
+        def list_panes(self, target: str):  # noqa: ARG002
             return []
 
-    real_svc = TmuxSessionService(
-        config=config,
-        store=_HealthyStore(),
-    )
+        def capture_pane(self, pane_id: str, lines: int = 200):  # noqa: ARG002
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=["tmux", "capture-pane"],
+            )
 
-    class _FakeSupervisorWithHealthyProbe:
-        def __init__(self, svc: TmuxSessionService) -> None:
-            self.session_service = svc
-            self.restart_calls: list[dict[str, Any]] = []
-
-        def get_session_runtime(self, name: str) -> Any:  # noqa: ARG002
-            return None
-
-        def restart_session(
-            self, session_name: str, account_name: str, *, failure_type: str,
-        ) -> None:
-            self.restart_calls.append({
-                "session_name": session_name,
-                "account_name": account_name,
-                "failure_type": failure_type,
-            })
-
-    fake_sup = _FakeSupervisorWithHealthyProbe(real_svc)
     monkeypatch.setattr(
-        sessions_admin_routes,
-        "_build_supervisor",
-        lambda _config: fake_sup,
+        "pollypm.tmux.client.TmuxClient", lambda: _FakeTmuxClient(),
     )
-    # Do NOT monkeypatch _build_tmux_service — the production path
-    # must construct it from fake_sup.session_service.
-
-    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
-    patch_tmux_windows([])  # no live windows → strict probe returns False (idle)
-
-    response = client.post(
-        "/api/v1/sessions/operator/restart", headers=auth_headers,
-    )
-    # The strict probe must NOT spuriously 503; the route consults
-    # the supervisor's correctly-wired session service.
-    assert response.status_code == 200, response.text
-    assert len(fake_sup.restart_calls) == 1
-    assert fake_sup.restart_calls[0]["session_name"] == "operator"
-
-
-def test_restart_force_still_bypasses_strict_probe_failure(
-    client, config, auth_headers, monkeypatch, patch_heartbeat,
-    patch_tmux_windows, patch_supervisor,
-):
-    """``?safety=force`` must still bypass the round-3 strict probe.
-
-    The operator-escalation override is destructive by design and must
-    proceed even when the strict probe can't evaluate the mid-turn
-    signal. This is the round-3 counterpart of
-    :func:`test_restart_force_bypasses_safety_probe_entirely` against
-    the real-svc failure path.
-    """
-    from pollypm.session_services.tmux import TmuxSessionService
-
-    class _BrokenStore:
-        def list_sessions(self):
-            raise RuntimeError("state store unavailable")
-
-    real_svc = TmuxSessionService(
-        config=config,
-        store=_BrokenStore(),
-    )
-    monkeypatch.setattr(
-        sessions_admin_routes,
-        "_build_tmux_service",
-        lambda _config: real_svc,
-    )
-
-    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
-    patch_tmux_windows(["operator"])
-    sup = patch_supervisor(_FakeSupervisor())
-
-    response = client.post(
-        "/api/v1/sessions/operator/restart?safety=force",
-        headers=auth_headers,
-    )
-    assert response.status_code == 200, response.text
-    assert len(sup.restart_calls) == 1
-
-
-def test_restart_strict_fails_closed_when_real_capture_pane_fails(
-    client, config, auth_headers, monkeypatch, patch_heartbeat,
-    patch_tmux_windows, patch_supervisor,
-):
-    """``capture_pane`` failure on the real service must fail closed.
-
-    Codex PR #2061 round 3 named ``capture_pane`` as a second fail-soft
-    swallow point inside ``TmuxSessionService.health``. With a healthy
-    store + window the strict probe must still propagate a
-    ``capture_pane`` outage instead of returning "looks idle".
-    """
-    from pollypm.session_services.tmux import TmuxSessionService
-
-    # Configured session record so list_sessions succeeds.
-    session_record = SimpleNamespace(
-        name="operator", window_name="operator",
-        provider="claude", account="claude_primary", cwd="/tmp",
-    )
-
-    class _OkStore:
-        def list_sessions(self):
-            return [session_record]
-
-    real_svc = TmuxSessionService(
-        config=config,
-        store=_OkStore(),
-    )
-
-    # Window present (so the strict probe reaches the pane capture
-    # step), but ``capture_pane`` raises like a tmux outage would.
-    window = SimpleNamespace(
-        session=real_svc.storage_closet_session_name(),
-        name="operator",
-        pane_id="%9",
-        pane_dead=False,
-    )
-    monkeypatch.setattr(real_svc.tmux, "list_all_windows", lambda: [window])
-    monkeypatch.setattr(real_svc.tmux, "is_pane_alive", lambda _pid: True)
-
-    def _boom_capture(_pane_id, *, lines=200):  # noqa: ARG001
-        raise RuntimeError("tmux capture-pane failed")
-
-    monkeypatch.setattr(real_svc.tmux, "capture_pane", _boom_capture)
-    monkeypatch.setattr(
-        sessions_admin_routes,
-        "_build_tmux_service",
-        lambda _config: real_svc,
-    )
-
-    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
-    patch_tmux_windows(["operator"])
     sup = patch_supervisor(_FakeSupervisor())
 
     response = client.post(
@@ -958,20 +861,109 @@ def test_restart_strict_fails_closed_when_real_capture_pane_fails(
     assert sup.restart_calls == []
 
 
-def test_restart_503_when_supervisor_unavailable(
+def test_restart_strict_503_when_supervisor_unavailable(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service, patch_supervisor,
+    patch_strict_probe, patch_supervisor,
 ):
-    """Supervisor construction failure → 503 ``daemon_unavailable``."""
-    patch_heartbeat({})
-    patch_tmux_windows([])
-    patch_tmux_service(_FakeTmuxService(turn_active=False))
+    """Supervisor construction failure → 503 ``daemon_unavailable``.
+
+    Codex PR #2061 round 6 lifecycle note: supervisor construction is
+    deferred until AFTER the strict probe passes, so this only fires
+    on a healthy strict probe (no transient writable Supervisor on the
+    probe path). The route still returns 503 ``daemon_unavailable``
+    when the supervisor cannot be built for the actual restart.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_strict_probe(mid_turn=False)
     patch_supervisor(None)  # Supervisor() failed
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
     )
     assert response.status_code == 503
     assert response.json()["error"]["code"] == "daemon_unavailable"
+
+
+def test_restart_strict_probe_runs_before_supervisor_constructed(
+    client, auth_headers, monkeypatch, patch_heartbeat,
+    patch_tmux_windows, patch_strict_probe,
+):
+    """Codex PR #2061 round 6 lifecycle: probe-failure path skips Supervisor().
+
+    The route must NOT construct a transient writable Supervisor (which
+    opens the legacy sqlite ``state.db`` and runs migrations as a
+    side-effect) until after the strict safety probe passes. Otherwise
+    every probe-failure 503 still pays the sqlite open/migrate cost,
+    defeating the lifecycle cleanup.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_strict_probe(raises=RuntimeError("tmux probe timeout"))
+
+    # If ``_build_supervisor`` is called on the probe-failure path,
+    # this will explode (the AssertionError propagates out of the
+    # route as a 500, which is fail-LOUDER than the silent leak we
+    # used to have).
+    def _boom_build_supervisor(_config):
+        raise AssertionError(
+            "Supervisor MUST NOT be constructed on a probe-failure path — "
+            "Codex PR #2061 round 6 lifecycle cleanup."
+        )
+
+    monkeypatch.setattr(
+        sessions_admin_routes,
+        "_build_supervisor",
+        _boom_build_supervisor,
+    )
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    # Probe failed → 503 unsafe_mid_turn_unknown (not a 500 from the
+    # boom_build_supervisor sentinel).
+    assert response.status_code == 503, response.text
+    assert response.json()["error"]["code"] == "unsafe_mid_turn_unknown"
+
+
+def test_restart_strict_supervisor_closed_after_use(
+    client, auth_headers, monkeypatch, patch_heartbeat,
+    patch_tmux_windows, patch_strict_probe,
+):
+    """Per-request Supervisor is closed after the restart returns.
+
+    Codex PR #2061 round 6 lifecycle note: ``Supervisor.__init__``
+    opens the legacy sqlite ``state.db``; the route uses the
+    supervisor for one or two public calls and then discards it. The
+    route now explicitly calls ``supervisor.stop()`` in a ``finally``
+    so the connection doesn't leak across restart calls.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_strict_probe(mid_turn=False)
+
+    class _CloseTrackingSupervisor(_FakeSupervisor):
+        def __init__(self) -> None:
+            super().__init__()
+            self.stop_calls = 0
+
+        def stop(self) -> None:
+            self.stop_calls += 1
+
+    sup = _CloseTrackingSupervisor()
+    monkeypatch.setattr(
+        sessions_admin_routes, "_build_supervisor", lambda _c: sup,
+    )
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert len(sup.restart_calls) == 1
+    assert sup.stop_calls == 1, (
+        "Supervisor.stop() must be called in finally to close the "
+        "legacy sqlite state.db connection (Codex PR #2061 round 6 "
+        "lifecycle note)."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -892,6 +892,167 @@ def test_restart_strict_503_when_tmux_probe_raises(
     assert sup.restart_calls == []
 
 
+def test_restart_strict_503_when_tmux_has_session_times_out(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_supervisor,
+):
+    """Codex PR #2061 round 8 — rc=124 timeout from has-session → 503.
+
+    The real :meth:`pollypm.tmux.client.TmuxClient.run` synthesises a
+    ``CompletedProcess`` with ``returncode=124`` when the underlying
+    ``subprocess.TimeoutExpired`` fires under ``check=False``. The
+    prior fail-soft :meth:`TmuxClient.has_session` then returned
+    ``False`` for **any** non-zero rc, conflating a real "session
+    absent" (rc=1) with a wedged tmux server (rc=124). The strict
+    probe therefore treated a tmux outage as a definitive "nothing to
+    interrupt" and the destructive restart proceeded against an
+    unobservable agent — exact reproduction Codex documented in round 8.
+
+    Round 8 fix: a new :meth:`TmuxClient.has_session_strict` returns
+    ``False`` only on rc=1 and raises
+    :class:`pollypm.session_health.TmuxProbeUnavailable` on rc=124 /
+    any other rc / ``TimeoutExpired``. The strict probe in
+    :func:`pollypm.session_health.probe_strict_turn_active` now calls
+    that strict variant so the route maps tmux-server outage to
+    ``503 unsafe_mid_turn_unknown`` (fail-closed).
+
+    Reproducer reference: this test FAILS against round 7 (revert
+    ``has_session_strict`` to the fail-soft ``has_session`` call in
+    :func:`probe_strict_turn_active` → run → observe 200 ``ok`` with
+    ``Supervisor.restart_session`` called once instead of 503).
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+
+    import subprocess
+
+    from pollypm.tmux.client import TmuxClient
+
+    # Patch ``TmuxClient.run`` to return the rc=124 CompletedProcess
+    # the real wrapper would synthesise after a wedged-tmux timeout.
+    # We patch the method (not a stub class) so ``has_session_strict``
+    # exercises its real branch logic — the round-8 fix lives there.
+    def fake_run(self, *args, **kwargs):  # noqa: ARG001
+        return subprocess.CompletedProcess(
+            args=["tmux", *args],
+            returncode=124,
+            stdout="",
+            stderr="tmux command timed out after 15s",
+        )
+
+    monkeypatch.setattr(TmuxClient, "run", fake_run)
+    sup = patch_supervisor(_FakeSupervisor())
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_turn_unknown"
+    # The destructive facade was NEVER touched — round 8 fail-closed.
+    assert sup.restart_calls == []
+
+
+def test_restart_strict_503_when_tmux_has_session_raises_timeout(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_supervisor,
+):
+    """Codex PR #2061 round 8 — ``subprocess.TimeoutExpired`` → 503.
+
+    Defensive companion to
+    :func:`test_restart_strict_503_when_tmux_has_session_times_out`.
+    Today :meth:`TmuxClient.run` converts ``TimeoutExpired`` into
+    rc=124 under ``check=False``, but a future signature change or
+    test stub could re-raise. The strict variant must propagate
+    either flavour as :class:`TmuxProbeUnavailable` → 503.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+
+    import subprocess
+
+    from pollypm.tmux.client import TmuxClient
+
+    def fake_run(self, *args, **kwargs):  # noqa: ARG001
+        raise subprocess.TimeoutExpired(cmd=["tmux", *args], timeout=15)
+
+    monkeypatch.setattr(TmuxClient, "run", fake_run)
+    sup = patch_supervisor(_FakeSupervisor())
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_turn_unknown"
+    assert sup.restart_calls == []
+
+
+def test_get_session_does_not_construct_supervisor(
+    client, auth_headers, monkeypatch, patch_heartbeat, patch_tmux_windows,
+):
+    """Codex PR #2061 round 8 — GET detail path must not build Supervisor.
+
+    The previous GET detail wiring went through
+    :func:`_build_tmux_service` → :attr:`Supervisor.session_service`
+    purely to call :meth:`TmuxSessionService.health` +
+    :meth:`is_turn_active`. ``Supervisor.__init__`` opens the legacy
+    sqlite ``state.db`` (and runs migrations) as a side-effect, and
+    the GET path never called ``Supervisor.stop()`` → repeated polling
+    leaked fds + sqlite connections.
+
+    Round 8 fix: the GET path computes ``health`` directly from the
+    ``TmuxWindow`` already returned by
+    :func:`list_storage_closet_windows` (``pane_id`` / ``pane_dead`` /
+    ``pane_current_command``) and runs a small fail-soft
+    ``capture_pane`` for ``is_turn_active``. No Supervisor, no
+    StateStore, no transient connections.
+
+    This test pins the contract by exploding if either
+    :func:`_build_supervisor` or :func:`_build_tmux_service` is called
+    during a GET — fail-LOUDER than the silent leak it replaced.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+
+    def _boom_build_supervisor(_config):
+        raise AssertionError(
+            "GET /api/v1/sessions/{name} MUST NOT construct a "
+            "Supervisor — Codex PR #2061 round 8 lifecycle cleanup.",
+        )
+
+    def _boom_build_tmux_service(_config):
+        raise AssertionError(
+            "GET /api/v1/sessions/{name} MUST NOT build a transient "
+            "TmuxSessionService (which constructs a Supervisor) — "
+            "Codex PR #2061 round 8 lifecycle cleanup.",
+        )
+
+    monkeypatch.setattr(
+        sessions_admin_routes, "_build_supervisor", _boom_build_supervisor,
+    )
+    monkeypatch.setattr(
+        sessions_admin_routes, "_build_tmux_service",
+        _boom_build_tmux_service,
+    )
+
+    response = client.get(
+        "/api/v1/sessions/operator", headers=auth_headers,
+    )
+    # 200 — the GET path computed the detail payload entirely from
+    # config + the shared list_storage_closet_windows helper +
+    # latest_heartbeat. Neither Supervisor nor TmuxSessionService was
+    # constructed (which would have tripped the asserts above and
+    # surfaced as a 500).
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["info"]["name"] == "operator"
+    assert body["info"]["window_present"] is True
+    # The health snapshot still reports the live window — derived
+    # directly from the TmuxWindow returned by
+    # list_storage_closet_windows.
+    assert body["health"]["window_present"] is True
+    assert body["health"]["pane_alive"] is True
+
+
 def test_restart_strict_503_when_window_listing_raises(
     client, config, auth_headers, monkeypatch, patch_heartbeat,
     patch_supervisor,

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -662,6 +662,158 @@ def test_restart_503_when_tmux_service_unavailable(
     assert response.json()["error"]["code"] == "daemon_unavailable"
 
 
+def test_restart_strict_fails_closed_when_real_tmux_probe_fails(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_tmux_windows, patch_supervisor,
+):
+    """Real ``TmuxSessionService`` fail-soft must not bypass the strict gate.
+
+    Codex PR #2061 round 3: the production ``TmuxSessionService.list``
+    swallows ``self._store.list_sessions()`` failures and returns no
+    handles; ``health`` swallows pane / capture failures; and
+    ``is_turn_active`` then returns ``False`` (looks-idle). The
+    round-2 regression used a fake that raised directly from
+    ``is_turn_active`` — so the test passed while a real outage
+    happily skipped the strict gate. This test hits the actual
+    :class:`TmuxSessionService` with a store that raises from
+    ``list_sessions`` (the exact path Codex flagged) and asserts the
+    route returns 503 ``unsafe_mid_turn_unknown`` and NEVER calls the
+    supervisor restart facade.
+    """
+    from pollypm.session_services.tmux import TmuxSessionService
+
+    class _BrokenStore:
+        """Mirrors a real pg / state-store outage on ``list_sessions``."""
+
+        def list_sessions(self):
+            raise RuntimeError("state store unavailable")
+
+    real_svc = TmuxSessionService(
+        config=config,
+        store=_BrokenStore(),
+    )
+    monkeypatch.setattr(
+        sessions_admin_routes,
+        "_build_tmux_service",
+        lambda _config: real_svc,
+    )
+
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    sup = patch_supervisor(_FakeSupervisor())
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_turn_unknown"
+    # Destructive facade must not have been touched.
+    assert sup.restart_calls == []
+
+
+def test_restart_force_still_bypasses_strict_probe_failure(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_tmux_windows, patch_supervisor,
+):
+    """``?safety=force`` must still bypass the round-3 strict probe.
+
+    The operator-escalation override is destructive by design and must
+    proceed even when the strict probe can't evaluate the mid-turn
+    signal. This is the round-3 counterpart of
+    :func:`test_restart_force_bypasses_safety_probe_entirely` against
+    the real-svc failure path.
+    """
+    from pollypm.session_services.tmux import TmuxSessionService
+
+    class _BrokenStore:
+        def list_sessions(self):
+            raise RuntimeError("state store unavailable")
+
+    real_svc = TmuxSessionService(
+        config=config,
+        store=_BrokenStore(),
+    )
+    monkeypatch.setattr(
+        sessions_admin_routes,
+        "_build_tmux_service",
+        lambda _config: real_svc,
+    )
+
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    sup = patch_supervisor(_FakeSupervisor())
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart?safety=force",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert len(sup.restart_calls) == 1
+
+
+def test_restart_strict_fails_closed_when_real_capture_pane_fails(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_tmux_windows, patch_supervisor,
+):
+    """``capture_pane`` failure on the real service must fail closed.
+
+    Codex PR #2061 round 3 named ``capture_pane`` as a second fail-soft
+    swallow point inside ``TmuxSessionService.health``. With a healthy
+    store + window the strict probe must still propagate a
+    ``capture_pane`` outage instead of returning "looks idle".
+    """
+    from pollypm.session_services.tmux import TmuxSessionService
+
+    # Configured session record so list_sessions succeeds.
+    session_record = SimpleNamespace(
+        name="operator", window_name="operator",
+        provider="claude", account="claude_primary", cwd="/tmp",
+    )
+
+    class _OkStore:
+        def list_sessions(self):
+            return [session_record]
+
+    real_svc = TmuxSessionService(
+        config=config,
+        store=_OkStore(),
+    )
+
+    # Window present (so the strict probe reaches the pane capture
+    # step), but ``capture_pane`` raises like a tmux outage would.
+    window = SimpleNamespace(
+        session=real_svc.storage_closet_session_name(),
+        name="operator",
+        pane_id="%9",
+        pane_dead=False,
+    )
+    monkeypatch.setattr(real_svc.tmux, "list_all_windows", lambda: [window])
+    monkeypatch.setattr(real_svc.tmux, "is_pane_alive", lambda _pid: True)
+
+    def _boom_capture(_pane_id, *, lines=200):  # noqa: ARG001
+        raise RuntimeError("tmux capture-pane failed")
+
+    monkeypatch.setattr(real_svc.tmux, "capture_pane", _boom_capture)
+    monkeypatch.setattr(
+        sessions_admin_routes,
+        "_build_tmux_service",
+        lambda _config: real_svc,
+    )
+
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    sup = patch_supervisor(_FakeSupervisor())
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_turn_unknown"
+    assert sup.restart_calls == []
+
+
 def test_restart_503_when_supervisor_unavailable(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
     patch_tmux_service, patch_supervisor,

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -170,17 +170,26 @@ class _FakeTmuxService:
 
     Tracks calls to ``destroy`` / ``create`` and lets tests pre-program
     ``is_turn_active`` + ``health`` return values.
+
+    Post-#2061: the destructive restart path no longer talks to
+    ``_FakeTmuxService.destroy`` / ``create`` directly — those calls
+    happen inside the ``Supervisor.restart_session`` facade (covered by
+    :class:`_FakeSupervisor`). This stub still drives the mid-turn
+    safety probe (``is_turn_active``) and the detail-endpoint health
+    snapshot.
     """
 
     def __init__(
         self,
         *,
         turn_active: bool = False,
+        turn_active_raises: Exception | None = None,
         destroy_raises: Exception | None = None,
         create_raises: Exception | None = None,
         window_present: bool = True,
     ) -> None:
         self.turn_active = turn_active
+        self.turn_active_raises = turn_active_raises
         self.destroy_raises = destroy_raises
         self.create_raises = create_raises
         self.window_present = window_present
@@ -198,6 +207,8 @@ class _FakeTmuxService:
         return SimpleNamespace(name=kwargs["name"], window_name=kwargs.get("window_name"))
 
     def is_turn_active(self, name: str) -> bool:  # noqa: ARG002
+        if self.turn_active_raises is not None:
+            raise self.turn_active_raises
         return self.turn_active
 
     def health(self, name: str, *, capture_lines: int = 200) -> Any:  # noqa: ARG002
@@ -208,6 +219,43 @@ class _FakeTmuxService:
             pane_command="claude" if self.window_present else None,
             pane_text="",
         )
+
+
+class _FakeSupervisor:
+    """Stand-in for :class:`pollypm.supervisor.Supervisor` for restart tests.
+
+    Records every ``restart_session`` invocation so the test can assert
+    the route invoked the **canonical facade** (Codex PR #2061 P0 #1)
+    rather than reaching past it to the raw ``destroy``+``create``
+    helpers. Optionally raises to exercise the
+    ``daemon_unavailable`` recovery branch.
+    """
+
+    def __init__(
+        self,
+        *,
+        restart_raises: Exception | None = None,
+        effective_account: str | None = None,
+    ) -> None:
+        self.restart_raises = restart_raises
+        self.effective_account = effective_account
+        self.restart_calls: list[dict[str, Any]] = []
+
+    def _get_session_runtime(self, name: str) -> Any:  # noqa: ARG002
+        if self.effective_account is None:
+            return None
+        return SimpleNamespace(effective_account=self.effective_account)
+
+    def restart_session(
+        self, session_name: str, account_name: str, *, failure_type: str,
+    ) -> None:
+        self.restart_calls.append({
+            "session_name": session_name,
+            "account_name": account_name,
+            "failure_type": failure_type,
+        })
+        if self.restart_raises is not None:
+            raise self.restart_raises
 
 
 @pytest.fixture
@@ -246,6 +294,25 @@ def patch_tmux_service(monkeypatch: pytest.MonkeyPatch):
             lambda _config: service,
         )
         return service
+    return install
+
+
+@pytest.fixture
+def patch_supervisor(monkeypatch: pytest.MonkeyPatch):
+    """Install a stub for ``_build_supervisor`` on the route module.
+
+    Post-#2061 the restart endpoint routes through
+    :meth:`Supervisor.restart_session` (the canonical facade) instead
+    of poking ``TmuxSessionService.create()`` directly. Tests use this
+    fixture to assert the facade was called with the right
+    ``(session_name, account_name, failure_type)``.
+    """
+    def install(supervisor: _FakeSupervisor | None) -> _FakeSupervisor | None:
+        monkeypatch.setattr(
+            sessions_admin_routes, "_build_supervisor",
+            lambda _config: supervisor,
+        )
+        return supervisor
     return install
 
 
@@ -396,13 +463,23 @@ def test_get_session_404_unknown(
 # ---------------------------------------------------------------------------
 
 
-def test_restart_happy_path(
+def test_restart_routes_through_supervisor_facade(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service,
+    patch_tmux_service, patch_supervisor,
 ):
+    """Restart goes through ``Supervisor.restart_session`` (PR #2061 P0 #1).
+
+    Regression: the previous restart implementation called
+    ``TmuxSessionService.create()`` with no command, which falls back
+    to ``echo 'No command for {name}'`` and destroys live agents.
+    The route must hand off to the same facade ``pm
+    switch-session-account`` / the cockpit account-switch button use,
+    which consults the launch planner for the real provider command.
+    """
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
     svc = patch_tmux_service(_FakeTmuxService(turn_active=False))
+    sup = patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
     )
@@ -410,78 +487,159 @@ def test_restart_happy_path(
     body = response.json()
     assert body["ok"] is True
     assert "operator" in (body.get("message") or "")
-    # destroy + create were both called, in that order.
-    kinds = [call[0] for call in svc.calls]
-    assert kinds == ["destroy", "create"]
-    assert svc.calls[1][1]["name"] == "operator"
-    assert svc.calls[1][1]["window_name"] == "operator"
+    # The route did NOT poke the raw destroy/create helpers — the
+    # facade owns that pair.
+    assert svc.calls == []
+    # The facade was called once with the session, the configured
+    # account (effective_account is None in this stub), and the
+    # api_restart failure_type so the recovery audit chain attributes
+    # the relaunch correctly.
+    assert len(sup.restart_calls) == 1
+    call = sup.restart_calls[0]
+    assert call["session_name"] == "operator"
+    assert call["account_name"] == "claude_primary"
+    assert call["failure_type"] == "api_restart"
 
 
-def test_restart_already_stopped_returns_200(
+def test_restart_prefers_effective_account_over_configured(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service,
+    patch_tmux_service, patch_supervisor,
 ):
-    """Restart against an already-stopped session is idempotent → 200.
+    """When the runtime carries an ``effective_account`` it wins.
 
-    Spec §10.4 leaves the choice between 200 and 409 to the
-    implementer; we pick 200 so clients can issue a blind ``restart``
-    without first probing live state. ``destroy`` is a no-op when the
-    window isn't present (it's structured that way in
-    :meth:`TmuxSessionService.destroy`), and ``create`` then brings it
-    up fresh.
+    A session that previously failed over to a recovery account
+    should keep using that account on operator-driven restart —
+    otherwise the relaunch slams the original (failed) account and
+    immediately re-triggers the same recovery loop.
     """
-    patch_heartbeat({})
-    patch_tmux_windows([])  # not present in tmux
-    svc = patch_tmux_service(_FakeTmuxService(window_present=False))
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_tmux_service(_FakeTmuxService(turn_active=False))
+    sup = patch_supervisor(
+        _FakeSupervisor(effective_account="recovery_account"),
+    )
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
     )
     assert response.status_code == 200, response.text
-    # destroy + create still both fire — destroy is the no-op safety net.
-    kinds = [call[0] for call in svc.calls]
-    assert kinds == ["destroy", "create"]
+    assert sup.restart_calls[0]["account_name"] == "recovery_account"
+
+
+def test_restart_facade_failure_503_daemon_unavailable(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service, patch_supervisor,
+):
+    """``Supervisor.restart_session`` raising → 503, not 500."""
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_tmux_service(_FakeTmuxService(turn_active=False))
+    patch_supervisor(
+        _FakeSupervisor(restart_raises=RuntimeError("tmux server down")),
+    )
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503, response.text
+    assert response.json()["error"]["code"] == "daemon_unavailable"
 
 
 def test_restart_refuses_mid_turn(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service,
+    patch_tmux_service, patch_supervisor,
 ):
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
     svc = patch_tmux_service(_FakeTmuxService(turn_active=True))
+    sup = patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
     )
     assert response.status_code == 409
     body = response.json()
     assert body["error"]["code"] == "unsafe_mid_turn"
-    # no destroy / create was attempted
+    # neither the raw service nor the facade was touched
     assert svc.calls == []
+    assert sup.restart_calls == []
 
 
-def test_restart_force_overrides_mid_turn(
+def test_restart_strict_fail_closed_when_probe_raises(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service,
+    patch_tmux_service, patch_supervisor,
 ):
+    """Strict-mode probe failure → 503 ``unsafe_mid_turn_unknown``.
+
+    PR #2061 P0 #2 regression: the previous ``_is_turn_active``
+    swallowed every exception and returned ``False``, so a transient
+    tmux/parse failure looked like "agent is idle" and the route
+    happily destroyed an actively-working agent. Strict mode (the
+    default) must fail *closed* — the safety gate refuses the restart
+    when it cannot evaluate the mid-turn signal.
+    """
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
     patch_tmux_windows(["operator"])
-    svc = patch_tmux_service(_FakeTmuxService(turn_active=True))
+    svc = patch_tmux_service(
+        _FakeTmuxService(turn_active_raises=RuntimeError("tmux probe timeout")),
+    )
+    sup = patch_supervisor(_FakeSupervisor())
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_turn_unknown"
+    # The destructive path was NEVER reached.
+    assert svc.calls == []
+    assert sup.restart_calls == []
+
+
+def test_restart_force_bypasses_safety_probe_entirely(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service, patch_supervisor,
+):
+    """``?safety=force`` skips the probe even when it would raise.
+
+    Operator-escalation override: force is destructive *by design*,
+    so a flaky probe must not block it.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_tmux_service(
+        _FakeTmuxService(turn_active_raises=RuntimeError("tmux probe timeout")),
+    )
+    sup = patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/operator/restart?safety=force",
         headers=auth_headers,
     )
     assert response.status_code == 200, response.text
-    kinds = [call[0] for call in svc.calls]
-    assert kinds == ["destroy", "create"]
+    assert len(sup.restart_calls) == 1
+
+
+def test_restart_force_overrides_mid_turn(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service, patch_supervisor,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_tmux_service(_FakeTmuxService(turn_active=True))
+    sup = patch_supervisor(_FakeSupervisor())
+    response = client.post(
+        "/api/v1/sessions/operator/restart?safety=force",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert len(sup.restart_calls) == 1
+    assert sup.restart_calls[0]["session_name"] == "operator"
 
 
 def test_restart_404_unknown_session(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service,
+    patch_tmux_service, patch_supervisor,
 ):
     patch_heartbeat({})
     patch_tmux_windows([])
     patch_tmux_service(_FakeTmuxService())
+    patch_supervisor(_FakeSupervisor())
     response = client.post(
         "/api/v1/sessions/nope/restart", headers=auth_headers,
     )
@@ -489,13 +647,30 @@ def test_restart_404_unknown_session(
     assert response.json()["error"]["code"] == "not_found"
 
 
-def test_restart_503_when_service_unavailable(
+def test_restart_503_when_tmux_service_unavailable(
     client, auth_headers, patch_heartbeat, patch_tmux_windows,
-    patch_tmux_service,
+    patch_tmux_service, patch_supervisor,
 ):
     patch_heartbeat({})
     patch_tmux_windows([])
-    patch_tmux_service(None)  # service construction failed
+    patch_tmux_service(None)  # tmux service construction failed
+    patch_supervisor(_FakeSupervisor())
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "daemon_unavailable"
+
+
+def test_restart_503_when_supervisor_unavailable(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_tmux_service, patch_supervisor,
+):
+    """Supervisor construction failure → 503 ``daemon_unavailable``."""
+    patch_heartbeat({})
+    patch_tmux_windows([])
+    patch_tmux_service(_FakeTmuxService(turn_active=False))
+    patch_supervisor(None)  # Supervisor() failed
     response = client.post(
         "/api/v1/sessions/operator/restart", headers=auth_headers,
     )
@@ -543,7 +718,47 @@ def test_pause_is_idempotent(
     assert second.status_code == 200
     body = second.json()
     assert body["ok"] is True
-    assert "already" in (body.get("message") or "").lower()
+    msg = (body.get("message") or "").lower()
+    assert "already" in msg
+
+
+def test_pause_response_labels_marker_informational(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    """PR #2061 P0 #3: pause must NOT imply daemon-side enforcement.
+
+    The supervisor / recovery / dispatch loops don't consume the
+    pause marker yet. The response body must surface that fact so an
+    operator knows they have *tagged* the session, not quiesced the
+    daemon. Until the loops learn to consult the marker, this is the
+    contract we keep — narrow the API rather than mislead.
+    """
+    patch_heartbeat({})
+    patch_tmux_windows(["operator"])
+    response = client.post(
+        "/api/v1/sessions/operator/pause", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    msg = (body.get("message") or "").lower()
+    assert "informational" in msg, msg
+    assert "do not" in msg or "does not" in msg or "not yet" in msg, msg
+
+
+def test_resume_response_labels_marker_informational(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+):
+    """Same P0 #3 contract on the resume side."""
+    patch_heartbeat({})
+    patch_tmux_windows(["operator"])
+    # Pause then resume to hit the "clear" branch.
+    client.post("/api/v1/sessions/operator/pause", headers=auth_headers)
+    response = client.post(
+        "/api/v1/sessions/operator/resume", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    msg = (response.json().get("message") or "").lower()
+    assert "informational" in msg, msg
 
 
 def test_resume_happy_path(

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -782,16 +782,34 @@ def test_restart_strict_blocks_when_state_store_empty_but_tmux_window_live(
     patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
 
     # Stub TmuxClient at the construction site so the strict probe's
-    # list_panes + capture_pane don't shell out to a real tmux. The
-    # pane text mimics Codex's mid-turn marker.
+    # has_session + list_windows + list_panes + capture_pane don't
+    # shell out to a real tmux. Round 7: the probe now owns window
+    # discovery, so the fake must implement ``has_session`` /
+    # ``list_windows`` too — not just the pane-level calls.
+    # The pane text mimics Codex's mid-turn marker.
     class _FakePane:
         def __init__(self, pane_id: str, *, active: bool = True) -> None:
             self.pane_id = pane_id
             self.active = active
 
+    class _FakeWindow:
+        def __init__(self, name: str, pane_id: str) -> None:
+            self.name = name
+            self.pane_id = pane_id
+            self.pane_dead = False
+            self.session = "pollypm-test-storage-closet"
+
     class _FakeTmuxClient:
         def __init__(self) -> None:
             self.calls: list[tuple[str, Any]] = []
+
+        def has_session(self, name: str) -> bool:
+            self.calls.append(("has_session", name))
+            return True
+
+        def list_windows(self, name: str):  # noqa: ARG002
+            self.calls.append(("list_windows", name))
+            return [_FakeWindow("operator", "%9")]
 
         def list_panes(self, target: str):  # noqa: ARG002
             self.calls.append(("list_panes", target))
@@ -838,7 +856,20 @@ def test_restart_strict_503_when_tmux_probe_raises(
 
     import subprocess
 
+    class _FakeWindow:
+        def __init__(self, name: str, pane_id: str) -> None:
+            self.name = name
+            self.pane_id = pane_id
+            self.pane_dead = False
+            self.session = "pollypm-test-storage-closet"
+
     class _FakeTmuxClient:
+        def has_session(self, name: str) -> bool:  # noqa: ARG002
+            return True
+
+        def list_windows(self, name: str):  # noqa: ARG002
+            return [_FakeWindow("operator", "%9")]
+
         def list_panes(self, target: str):  # noqa: ARG002
             return []
 
@@ -859,6 +890,151 @@ def test_restart_strict_503_when_tmux_probe_raises(
     body = response.json()
     assert body["error"]["code"] == "unsafe_mid_turn_unknown"
     assert sup.restart_calls == []
+
+
+def test_restart_strict_503_when_window_listing_raises(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_supervisor,
+):
+    """Codex PR #2061 round 7 — window listing failure → fail-closed 503.
+
+    The round-6 implementation threaded the fail-soft
+    :func:`_list_storage_closet_windows` helper into the probe; that
+    helper catches every tmux failure (``CalledProcessError``,
+    ``FileNotFoundError``, timeout, etc.) and returns ``{}``. The
+    probe then saw "no window matching this session" → returned
+    ``False`` (looks idle) → the destructive restart proceeded against
+    an unobservable agent. Round 7 fix: the probe owns window
+    discovery directly via ``TmuxClient.has_session`` /
+    ``TmuxClient.list_windows`` so a tmux failure raises
+    :class:`TmuxProbeUnavailable` → 503 ``unsafe_mid_turn_unknown``.
+
+    Pointedly we do NOT patch ``_list_storage_closet_windows`` here —
+    the round-6 path would route through that fail-soft helper and
+    swallow the ``CalledProcessError`` into ``{}`` → "absent" → 200
+    restart. Round 7 bypasses the helper entirely, so a raise from
+    ``has_session`` propagates as ``TmuxProbeUnavailable`` → 503.
+    Reproducer reference: this test FAILS against round 6 (revert the
+    ``windows=`` signature in :func:`probe_strict_turn_active` and the
+    route's ``_list_storage_closet_windows`` threading → run the test
+    → observe 200 ``ok`` with ``Supervisor.restart_session`` called
+    instead of 503).
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+
+    import subprocess
+
+    class _FakeTmuxClient:
+        """Tmux outage: has_session raises CalledProcessError."""
+
+        def has_session(self, name: str):  # noqa: ARG002
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=["tmux", "has-session"],
+            )
+
+        def list_windows(self, name: str):  # noqa: ARG002 — defensive
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=["tmux", "list-windows"],
+            )
+
+    monkeypatch.setattr(
+        "pollypm.tmux.client.TmuxClient", lambda: _FakeTmuxClient(),
+    )
+    sup = patch_supervisor(_FakeSupervisor())
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_turn_unknown"
+    # The destructive facade was NEVER touched — round 7 fail-closed.
+    assert sup.restart_calls == []
+
+
+def test_restart_strict_proceeds_when_window_genuinely_absent(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_supervisor,
+):
+    """Codex PR #2061 round 7 — definitive "no window" still allows restart.
+
+    The fail-closed gate added in round 7 must NOT regress the
+    legitimate "window is genuinely absent" case: tmux is up, replies
+    successfully, but there's no storage-closet window for this
+    session (e.g. first boot, after a crash). The probe should return
+    ``False`` (nothing to interrupt) so the restart can create a fresh
+    window — same behaviour as round 6, just now reached via a
+    successful tmux call instead of a swallowed exception.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+
+    class _FakeTmuxClient:
+        """Tmux works fine, just no storage-closet session yet."""
+
+        def has_session(self, name: str) -> bool:  # noqa: ARG002
+            # Reliable "no" from tmux — analogous to returncode=1 with
+            # "session not found" — NOT a server outage.
+            return False
+
+        def list_windows(self, name: str):  # noqa: ARG002 — not reached
+            raise AssertionError(
+                "list_windows must not be called when has_session is False",
+            )
+
+    monkeypatch.setattr(
+        "pollypm.tmux.client.TmuxClient", lambda: _FakeTmuxClient(),
+    )
+    sup = patch_supervisor(_FakeSupervisor())
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    # The relaunch facade was invoked — definitive "no window" is a
+    # green-light for the strict gate.
+    assert len(sup.restart_calls) == 1
+    assert sup.restart_calls[0]["session_name"] == "operator"
+
+
+def test_restart_force_still_bypasses_window_listing_failure(
+    client, config, auth_headers, monkeypatch, patch_heartbeat,
+    patch_supervisor,
+):
+    """Codex PR #2061 round 7 — ``?safety=force`` still bypasses a broken probe.
+
+    Operator escalation override: ``force`` is destructive *by design*
+    and exists precisely so a flaky probe can be worked around. A
+    tmux outage that would 503 the default strict path must still let
+    ``?safety=force`` reach :meth:`Supervisor.restart_session`. This
+    pins that the round-7 fail-closed contract was applied to the
+    strict gate, not to the entire restart path.
+    """
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+
+    import subprocess
+
+    class _FakeTmuxClient:
+        def has_session(self, name: str):  # noqa: ARG002
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=["tmux", "has-session"],
+            )
+
+    monkeypatch.setattr(
+        "pollypm.tmux.client.TmuxClient", lambda: _FakeTmuxClient(),
+    )
+    sup = patch_supervisor(_FakeSupervisor())
+
+    response = client.post(
+        "/api/v1/sessions/operator/restart?safety=force",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    # Force bypassed the probe entirely → facade called even though
+    # tmux is broken.
+    assert len(sup.restart_calls) == 1
+    assert sup.restart_calls[0]["session_name"] == "operator"
 
 
 def test_restart_strict_503_when_supervisor_unavailable(


### PR DESCRIPTION
## Summary
- Phase 2 surface #8 from `~/Desktop/pollypm-phase2-endpoints-spec.md` §10 — `GET /api/v1/sessions`, `GET /api/v1/sessions/{name}`, plus `POST .../restart`, `.../pause`, `.../resume`.
- Mirrors `pm sessions` (#2039) classification (healthy / stale / missing / unknown) plus a new `paused` state surfaced from `<base_dir>/paused-sessions.json`.
- Restart goes through `TmuxSessionService.destroy` + `create` with an `unsafe_mid_turn` safety gate overridable via `?safety=force`; `?safety=force` matches the spec's §10.3 risk taxonomy.

## Files
- `src/pollypm/web_api/routes/sessions_admin.py` — router (5 handlers).
- `src/pollypm/web_api/app.py` — wires the router under `/api/v1` with the standard bearer-auth dependency.
- `tests/test_sessions_admin_endpoint.py` — 19 cases (list / detail / restart / pause / resume + auth + pg outage degradation + service-unavailable).
- `docs/api/openapi.yaml` — paths + `Sessions` tag + new `SessionInfo` / `SessionDetail` / `SessionConfigView` / `SessionHealthSnapshot` / `SessionsListResponse` schemas + `SessionName` path param.

## Test plan
- [x] `pytest --noconftest tests/test_sessions_admin_endpoint.py -v` — 19 passed
- [x] `pytest --noconftest tests/web_api/test_openapi_conformance.py` — YAML still validates as OpenAPI 3.1; emitted-impl OpenAPI still validates
- [ ] Manual smoke against a real `pm serve` (deferred — covered by Phase 2 §15 Q9 user-testing protocol)

## Spec gaps / follow-ups
- Pause/resume currently lives in a project-local JSON marker (`<base_dir>/paused-sessions.json`). The recovery loop / supervisor doesn't yet consume it; this PR is informational + cockpit-visible. Wiring the supervisor to honor the marker is a follow-up (worth its own issue — out of scope for this small PR per spec §14 Q9 "1 PR (restart/pause/resume)").
- Worker (per-task) sessions are intentionally NOT addressable on this surface (spec §10.2 + §13.9 — `/api/v1/chat/sessions` already exposes worker chat surfaces); the 404 hint points clients at that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)