### PR TITLE
feat(api): GET /api/v1/audit/{grep,stats} — Phase 2 audit query

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4095,6 +4095,18 @@ components:
             Paired with `_truncated_by_deadline` so a truncated
             response reports how far it got across live + rotated
             logs. (Codex P0 finding, PR #2062 round 4.)
+        _corrupt_archives_skipped:
+          type: integer
+          default: 0
+          minimum: 0
+          description: |
+            Count of rotated `.gz` archives skipped during this query
+            due to truncation, corruption, or read errors
+            (`EOFError`, `gzip.BadGzipFile`, `zlib.error`). The query
+            continues over the live log + other archives best-effort
+            instead of letting the exception escape as a 500. Non-zero
+            means at least one archive needs operator attention.
+            (Codex round-7 finding, PR #2062.)
 
     AuditStatsResponse:
       type: object
@@ -4138,3 +4150,13 @@ components:
             Paired with `_truncated_by_deadline` so a truncated
             response reports how far it got across live + rotated
             logs. (Codex P0 finding, PR #2062 round 6.)
+        _corrupt_archives_skipped:
+          type: integer
+          default: 0
+          minimum: 0
+          description: |
+            Same semantics as in `AuditGrepResponse`: count of rotated
+            `.gz` archives skipped during this aggregation due to
+            truncation, corruption, or read errors. Non-zero means at
+            least one archive needs operator attention. (Codex round-7
+            finding, PR #2062.)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2002,13 +2002,25 @@ paths:
         rotation-aware file walker so live `.jsonl` + gzipped
         `.gz` archives are searched together.
 
-        Filters apply in cheap→expensive order: regex first against
-        the raw JSONL line, then exact `event_type` match, then
-        `since` cutoff. The response is capped at `limit` matches
-        (default 100, max 1000 per spec §8.3).
+        Filters apply in cheap→expensive order: substring/regex
+        first against the raw JSONL line, then exact `event_type`
+        match, then `since` cutoff. The response is capped at `limit`
+        matches (default 100, max 1000 per spec §8.3).
+
+        `pattern` is a LITERAL substring by default; pass
+        `safe_regex=true` to interpret it as a Python `re.search`
+        regex. Both modes cap the pattern at 200 characters to keep
+        ReDoS exposure off the API worker (see PR #2062 round 2 —
+        Codex P0 finding). If you need a more elaborate forensic
+        query, use the CLI (`pm audit grep`) where the operator
+        explicitly trusts the local pattern.
 
         `next_cursor` is reserved for a future cursor-paginated
         variant; today the endpoint always returns `null`.
+        `_malformed_rows_skipped` is non-zero when at least one
+        archived row failed `Event` validation (typically a non-ISO
+        `ts` from an old schema) and was dropped rather than 500'ing
+        the response.
       parameters:
         - in: query
           name: project
@@ -2028,10 +2040,24 @@ paths:
           description: Exact match on the `.event` field (not a regex).
         - in: query
           name: pattern
-          schema: { type: string }
+          schema:
+            type: string
+            maxLength: 200
           description: |
-            Python `re.search` regex applied to the raw JSONL line.
-            Omit to match every record.
+            Substring matched against the raw JSONL line. Literal by
+            default; pass `safe_regex=true` to interpret as a Python
+            `re.search` pattern. Capped at 200 characters; longer
+            patterns return `400 invalid_request`.
+        - in: query
+          name: safe_regex
+          schema:
+            type: boolean
+            default: false
+          description: |
+            Opt in to regex semantics for `pattern`. Default false
+            (literal substring) keeps ReDoS hazards off the API
+            worker — operators who need a true regex pass this
+            explicitly.
         - in: query
           name: limit
           schema:
@@ -2062,15 +2088,23 @@ paths:
         uses, so totals + per-event / per-severity counts match what
         a manual grep would produce. `severity` maps to the audit
         record's `status` field (`ok` / `warn` / `error`).
+
+        `since` is REQUIRED on the HTTP surface — unbounded
+        full-history scans across every rotated `.gz` archive can
+        block the API worker for an arbitrary length of time. Use
+        the CLI (`pm audit grep`) when an operator explicitly wants
+        whole-history aggregation. (Codex P0 finding, PR #2062
+        round 2.)
       parameters:
         - in: query
           name: project
           schema: { type: string }
         - in: query
           name: since
+          required: true
           schema: { type: string }
           description: |
-            ISO-8601 or shortcut (`1h` / `24h` / `7d`).
+            REQUIRED. ISO-8601 or shortcut (`1h` / `24h` / `7d`).
       responses:
         "200":
           description: Aggregate counts.
@@ -3972,9 +4006,18 @@ components:
             $ref: "#/components/schemas/Event"
         next_cursor:
           type: string
+          nullable: true
           description: |
             Reserved for cursor-paginated variants. Always `null`
             today; clients should accept and ignore the field.
+        _malformed_rows_skipped:
+          type: integer
+          default: 0
+          description: |
+            Diagnostic counter. Non-zero when at least one archived
+            row failed `Event` validation (typically a non-ISO `ts`
+            from an old schema version) and was skipped rather than
+            failing the response. (Codex P0 finding, PR #2062 round 2.)
 
     AuditStatsResponse:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2002,10 +2002,17 @@ paths:
         rotation-aware file walker so live `.jsonl` + gzipped
         `.gz` archives are searched together.
 
-        Filters apply in cheap→expensive order: substring/regex
-        first against the raw JSONL line, then exact `event_type`
-        match, then `since` cutoff. The response is capped at `limit`
-        matches (default 100, max 1000 per spec §8.3).
+        Filters apply in cheap→expensive order (Codex round-10
+        reorder, PR #2062): JSON decode, then exact `event_type`
+        match, then `ts` parse, then `since` cutoff, then
+        `pattern` substring/regex match on the raw line. The
+        pattern runs LAST so the `safe_regex=true` per-line
+        wall-clock budget is only spent on rows already inside the
+        requested `since` window — this ordering is part of the
+        safety/performance contract for regex mode (paired with the
+        `safe_regex` + `since` requirement and `deadline_seconds`
+        bound). The response is capped at `limit` matches (default
+        100, max 1000 per spec §8.3).
 
         `pattern` is a LITERAL substring by default; pass
         `safe_regex=true` to interpret it as a Python `re.search`

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4018,6 +4018,17 @@ components:
             row failed `Event` validation (typically a non-ISO `ts`
             from an old schema version) and was skipped rather than
             failing the response. (Codex P0 finding, PR #2062 round 2.)
+        _pattern_timeouts:
+          type: integer
+          default: 0
+          description: |
+            Diagnostic counter. Non-zero when at least one line's regex
+            search exceeded the per-line timeout (100 ms) and was
+            skipped as a no-match. Always zero when `safe_regex=false`
+            (the default literal-substring mode). Surfaced so operators
+            running a deliberately exploratory regex can tell when the
+            ReDoS guardrail fired vs. there genuinely being no matches.
+            (Codex P0 finding, PR #2062 round 2.)
 
     AuditStatsResponse:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -54,6 +54,11 @@ tags:
     description: Inbox items and threads.
   - name: Events
     description: Realtime audit-log stream.
+  - name: Audit
+    description: |
+      Historical audit-log queries (grep + stats). The streaming
+      counterpart lives under the ``Events`` tag at
+      ``GET /api/v1/events``.
   - name: Chat
     description: |
       Chat-surface discovery and message history. The discovery endpoint
@@ -1986,6 +1991,98 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /audit/grep:
+    get:
+      tags: [Audit]
+      operationId: grepAudit
+      summary: Search audit-log events (rotation-aware)
+      description: |
+        Returns audit events that match the supplied filters. Mirrors
+        the `pm audit grep` CLI command (PR #2036) and reuses its
+        rotation-aware file walker so live `.jsonl` + gzipped
+        `.gz` archives are searched together.
+
+        Filters apply in cheap→expensive order: regex first against
+        the raw JSONL line, then exact `event_type` match, then
+        `since` cutoff. The response is capped at `limit` matches
+        (default 100, max 1000 per spec §8.3).
+
+        `next_cursor` is reserved for a future cursor-paginated
+        variant; today the endpoint always returns `null`.
+      parameters:
+        - in: query
+          name: project
+          schema: { type: string }
+          description: Scope to one project (per-project log + central tail).
+        - in: query
+          name: since
+          schema: { type: string }
+          description: |
+            ISO-8601 timestamp (e.g. `2026-05-21T03:14:15Z`) or a
+            shortcut of the form `<N><unit>` where unit is one of
+            `s` / `m` / `h` / `d` / `w` (seconds / minutes / hours /
+            days / weeks). Result is `now - delta` in UTC.
+        - in: query
+          name: event_type
+          schema: { type: string }
+          description: Exact match on the `.event` field (not a regex).
+        - in: query
+          name: pattern
+          schema: { type: string }
+          description: |
+            Python `re.search` regex applied to the raw JSONL line.
+            Omit to match every record.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+          description: Cap matches returned. Max 1000 per spec §8.3.
+      responses:
+        "200":
+          description: Matching events, capped at `limit`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditGrepResponse"
+        "400":
+          $ref: "#/components/responses/InvalidRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /audit/stats:
+    get:
+      tags: [Audit]
+      operationId: statsAudit
+      summary: Aggregate counts of audit events by type and severity
+      description: |
+        Aggregates over the same target-file set the grep endpoint
+        uses, so totals + per-event / per-severity counts match what
+        a manual grep would produce. `severity` maps to the audit
+        record's `status` field (`ok` / `warn` / `error`).
+      parameters:
+        - in: query
+          name: project
+          schema: { type: string }
+        - in: query
+          name: since
+          schema: { type: string }
+          description: |
+            ISO-8601 or shortcut (`1h` / `24h` / `7d`).
+      responses:
+        "200":
+          description: Aggregate counts.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditStatsResponse"
+        "400":
+          $ref: "#/components/responses/InvalidRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -3863,3 +3960,43 @@ components:
           description: |
             True when the caller's `?limit` exceeded the route's 200-row
             cap and was silently clamped (Phase 2 §11.3).
+
+    # ---- Audit query (grep + stats) --------------------------------
+    AuditGrepResponse:
+      type: object
+      required: [events]
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/Event"
+        next_cursor:
+          type: string
+          description: |
+            Reserved for cursor-paginated variants. Always `null`
+            today; clients should accept and ignore the field.
+
+    AuditStatsResponse:
+      type: object
+      required: [total, by_event, by_severity]
+      properties:
+        total:
+          type: integer
+          description: Total events matching the project / since filters.
+        by_event:
+          type: object
+          additionalProperties: { type: integer }
+          description: Per-event-name counts.
+        by_severity:
+          type: object
+          additionalProperties: { type: integer }
+          description: |
+            Per-severity counts. Severity values track the audit
+            writer's `status` field (`ok` / `warn` / `error`).
+        since:
+          type: string
+          format: date-time
+          description: |
+            Normalized cutoff the server applied — echoes whatever
+            shortcut the client passed so it can confirm the
+            interpretation.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -4160,3 +4160,16 @@ components:
             truncation, corruption, or read errors. Non-zero means at
             least one archive needs operator attention. (Codex round-7
             finding, PR #2062.)
+        _malformed_rows_skipped:
+          type: integer
+          default: 0
+          minimum: 0
+          description: |
+            Diagnostic counter mirroring `AuditGrepResponse`. Non-zero
+            when at least one archived row failed the walker's `ts`
+            parse gate (typically a non-ISO timestamp from an old
+            schema version) and was skipped instead of inflating
+            `total` / `by_event` / `by_severity`. Lets callers tell a
+            clean aggregation from one where archived rows were
+            silently dropped without having to cross-check via
+            `/audit/grep`. (Codex round-9 finding, PR #2062.)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2119,6 +2119,14 @@ paths:
         the CLI (`pm audit grep`) when an operator explicitly wants
         whole-history aggregation. (Codex P0 finding, PR #2062
         round 2.)
+
+        `deadline_seconds` (default 10.0) imposes a request-level
+        wall-clock cap on top of the `since` semantic bound, because
+        the walker still reads every target file/line until it parses
+        `ts` and filters. When exceeded, the response sets
+        `_truncated_by_deadline=true` and `_lines_scanned` reports
+        how far the walker got across live + rotated logs. (Codex
+        P0 finding, PR #2062 round 6.)
       parameters:
         - in: query
           name: project
@@ -2129,6 +2137,22 @@ paths:
           schema: { type: string }
           description: |
             REQUIRED. ISO-8601 or shortcut (`1h` / `24h` / `7d`).
+        - in: query
+          name: deadline_seconds
+          schema:
+            type: number
+            format: float
+            minimum: 0.5
+            maximum: 120.0
+            default: 10.0
+          description: |
+            Request-level wall-clock budget (seconds). Default 10.0.
+            Stats has a higher default than `/audit/grep` (5.0)
+            because aggregation has no early-exit on match-count.
+            When exceeded the walker stops, the response sets
+            `_truncated_by_deadline=true`, and `_lines_scanned`
+            reports how many non-empty lines were examined
+            (PR #2062 round 6).
       responses:
         "200":
           description: Aggregate counts.
@@ -4096,3 +4120,21 @@ components:
             Normalized cutoff the server applied — echoes whatever
             shortcut the client passed so it can confirm the
             interpretation.
+        _truncated_by_deadline:
+          type: boolean
+          default: false
+          description: |
+            `true` when the request-level wall-clock deadline
+            (`deadline_seconds`) fired before the walker finished
+            scanning every target file. Distinguishes a complete
+            aggregation from a bounded one so the caller can re-issue
+            with a tighter project/since. (Codex P0 finding, PR #2062
+            round 6.)
+        _lines_scanned:
+          type: integer
+          default: 0
+          description: |
+            How many non-empty lines the walker actually examined.
+            Paired with `_truncated_by_deadline` so a truncated
+            response reports how far it got across live + rotated
+            logs. (Codex P0 finding, PR #2062 round 6.)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2021,6 +2021,15 @@ paths:
         archived row failed `Event` validation (typically a non-ISO
         `ts` from an old schema) and was dropped rather than 500'ing
         the response.
+
+        Round-4 (PR #2062) added request-level bounds for the regex
+        path: `safe_regex=true` now REQUIRES `since` (returns
+        `400 invalid_request` without it — `limit` only caps matches,
+        not scanned lines, so the window must be bounded up front),
+        and `deadline_seconds` (default 5.0) imposes a wall-clock
+        budget. When the deadline fires the response sets
+        `_truncated_by_deadline=true` and `_lines_scanned` reports
+        how far the walker got.
       parameters:
         - in: query
           name: project
@@ -2066,6 +2075,21 @@ paths:
             maximum: 1000
             default: 100
           description: Cap matches returned. Max 1000 per spec §8.3.
+        - in: query
+          name: deadline_seconds
+          schema:
+            type: number
+            format: float
+            minimum: 0.5
+            maximum: 60.0
+            default: 5.0
+          description: |
+            Request-level wall-clock budget (seconds). When exceeded
+            the walker stops, the response sets
+            `_truncated_by_deadline=true`, and `_lines_scanned`
+            reports how many non-empty lines were examined. Caps
+            no-match pathological regex cost; required because `limit`
+            only caps matches, not scanned lines (PR #2062 round 4).
       responses:
         "200":
           description: Matching events, capped at `limit`.
@@ -4029,6 +4053,24 @@ components:
             running a deliberately exploratory regex can tell when the
             ReDoS guardrail fired vs. there genuinely being no matches.
             (Codex P0 finding, PR #2062 round 2.)
+        _truncated_by_deadline:
+          type: boolean
+          default: false
+          description: |
+            `true` when the request-level wall-clock deadline
+            (`deadline_seconds`) fired before the walker finished
+            scanning every target file. Lets callers tell a
+            complete-but-empty scan from a bounded-and-truncated one
+            so they can re-run with a tighter filter or larger budget.
+            (Codex P0 finding, PR #2062 round 4.)
+        _lines_scanned:
+          type: integer
+          default: 0
+          description: |
+            How many non-empty lines the walker actually examined.
+            Paired with `_truncated_by_deadline` so a truncated
+            response reports how far it got across live + rotated
+            logs. (Codex P0 finding, PR #2062 round 4.)
 
     AuditStatsResponse:
       type: object

--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -33,14 +33,241 @@ from __future__ import annotations
 
 import gzip
 import json
+import multiprocessing
+import multiprocessing.connection
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, MutableMapping
 
 from pollypm.audit.log import central_log_path
 from pollypm.config import load_config
 from pollypm.projects import project_audit_log_path
+
+
+# ---------------------------------------------------------------------------
+# Bounded-time regex search — ReDoS guardrail (PR #2062 round 2 Codex P0).
+# ---------------------------------------------------------------------------
+#
+# Stdlib ``re`` has no per-call timeout. The 200-char pattern cap added in
+# round 1 keeps the *pattern* small but does nothing to stop a short
+# pathological pattern like ``(a+)+b`` against backtracking-heavy input
+# (each input line independently triggers catastrophic backtracking that
+# the C engine will not surface back to Python until it finishes — and
+# the engine holds the GIL throughout, so daemon threads don't help
+# either: the calling thread can't wake up to honour its timeout).
+#
+# The only stdlib path that actually interrupts a runaway match is the
+# OS killing the process. We pay for that with a fork per request: a
+# child worker is spawned lazily the first time we need to match a
+# regex line, and the parent drives it via a Pipe with a per-line
+# wall-clock deadline. When a line exceeds the deadline the child is
+# ``terminate()``d (kernel signal — works through the GIL because the
+# C runtime checks pending signals at every regex backtrack step in
+# CPython's signal-aware loop), a fresh child is spawned, and the
+# diagnostic counter is bumped. Worst-case cost: ``(matched_lines + N_timeouts) * fork_cost``.
+#
+# We deliberately don't ship a long-lived pool because the only point
+# of forking is to make ``terminate()`` available — sharing a worker
+# across requests would let one ReDoS query break the next request's
+# search even without a timeout.
+_PER_LINE_TIMEOUT_S = 0.1  # 100 ms per line is well above any sane operator regex.
+
+# Startup is much slower than steady state: spawning a forkserver helper
+# (first call only) plus forking and importing ``pollypm.audit.query``
+# in the child can take ~1-2 s on a cold macOS test runner. We grant the
+# very first line a generous startup grace so the legitimate operator
+# query doesn't get falsely timed out by fork-server warmup. Once the
+# child is alive and answering, subsequent lines are bound by
+# ``_PER_LINE_TIMEOUT_S``.
+_STARTUP_GRACE_S = 5.0
+
+# ``fork`` is fastest but unsafe in multi-threaded parents (TestClient,
+# FastAPI workers), and CPython deprecated it on Linux/macOS in 3.12+.
+# ``forkserver`` runs a tiny single-threaded helper that fork()s the
+# worker on demand — safe with threads, only available on POSIX.
+# ``spawn`` is the fallback (Windows or unusual platforms) but is
+# significantly slower (~200 ms per child). The choice happens once at
+# import; on the supported platforms (macOS / Linux) we always land on
+# ``forkserver``.
+try:
+    _MP_CTX = multiprocessing.get_context("forkserver")
+    # Preload our own module in the forkserver helper so each child
+    # fork doesn't have to re-import it. Cuts steady-state respawn
+    # cost from ~80 ms (cold import) to ~10 ms (fork only).
+    try:
+        _MP_CTX.set_forkserver_preload(["pollypm.audit.query"])
+    except Exception:  # noqa: BLE001 — best-effort optimisation
+        pass
+except ValueError:
+    _MP_CTX = multiprocessing.get_context("spawn")
+
+
+def _regex_worker_main(
+    pattern_str: str,
+    request_conn: "multiprocessing.connection.Connection",
+) -> None:
+    """Worker entry point. Compiles ``pattern_str`` once and loops on lines."""
+    compiled = re.compile(pattern_str)
+    while True:
+        try:
+            line = request_conn.recv()
+        except (EOFError, OSError):
+            return
+        if line is None:  # graceful shutdown sentinel
+            return
+        try:
+            match = compiled.search(line)
+        except Exception:  # noqa: BLE001
+            match = None
+        try:
+            request_conn.send(bool(match))
+        except (BrokenPipeError, OSError):
+            return
+
+
+class _BoundedRegexSession:
+    """Per-request driver for the regex worker process.
+
+    Lazily spawns a child the first time :meth:`search` is called, and
+    keeps the same child for subsequent lines. When a search exceeds
+    the per-line deadline the child is killed and a fresh one is
+    spawned on the next call — the abandoned worker can take as long
+    as it needs to finish backtracking; the OS reaps it.
+
+    Call :meth:`close` (or use as a context manager) at the end of the
+    request to terminate the child cleanly.
+    """
+
+    def __init__(self, pattern: re.Pattern[str]) -> None:
+        self._pattern_str = pattern.pattern
+        self._process: multiprocessing.Process | None = None
+        self._conn: "multiprocessing.connection.Connection | None" = None
+        # First call to a fresh worker pays for forkserver warmup +
+        # ``import pollypm.audit.query`` in the child; subsequent calls
+        # only pay the round-trip. Track first-call separately so the
+        # initial line isn't falsely flagged as a ReDoS timeout.
+        self._needs_warmup = True
+
+    def __enter__(self) -> "_BoundedRegexSession":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.close()
+
+    def _spawn(self) -> None:
+        parent_conn, child_conn = _MP_CTX.Pipe(duplex=True)
+        process = _MP_CTX.Process(
+            target=_regex_worker_main,
+            args=(self._pattern_str, child_conn),
+            name="audit-regex-worker",
+            daemon=True,
+        )
+        process.start()
+        # Close the child end in the parent so EOF propagates when the
+        # child dies (otherwise our recv() blocks forever).
+        child_conn.close()
+        self._process = process
+        self._conn = parent_conn
+
+    def search(self, line: str) -> tuple[bool, bool]:
+        """Return ``(matched, timed_out)`` for ``line``.
+
+        On timeout: kills the child, returns ``(False, True)``. The
+        next call respawns. On crash: returns ``(False, True)`` too —
+        we'd rather count a phantom timeout than silently drop matches.
+        """
+        if self._process is None or self._conn is None:
+            self._spawn()
+        assert self._conn is not None
+        assert self._process is not None
+        try:
+            self._conn.send(line)
+        except (BrokenPipeError, OSError):
+            self._teardown()
+            return (False, True)
+        # Wait for the child's response with a wall-clock deadline.
+        # ``poll`` is the only Pipe API that takes a timeout in stdlib
+        # multiprocessing.
+        deadline = _STARTUP_GRACE_S if self._needs_warmup else _PER_LINE_TIMEOUT_S
+        self._needs_warmup = False
+        if not self._conn.poll(deadline):
+            self._teardown()
+            return (False, True)
+        try:
+            matched = bool(self._conn.recv())
+        except (EOFError, OSError):
+            self._teardown()
+            return (False, True)
+        return (matched, False)
+
+    def _teardown(self) -> None:
+        if self._process is not None:
+            try:
+                self._process.terminate()
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                self._process.join(timeout=0.5)
+            except Exception:  # noqa: BLE001
+                pass
+            if self._process.is_alive():
+                try:
+                    self._process.kill()
+                except Exception:  # noqa: BLE001
+                    pass
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._process = None
+        self._conn = None
+        # Don't re-arm warmup grace for respawns: by the time a respawn
+        # happens, the forkserver helper is already running and module
+        # imports are cached, so subsequent forks land within the
+        # per-line timeout. Re-arming would let a sustained ReDoS
+        # attack reset the budget on every line.
+
+    def close(self) -> None:
+        # Polite shutdown: send sentinel, give the child a moment, then
+        # terminate if it ignores us.
+        if self._conn is not None and self._process is not None and self._process.is_alive():
+            try:
+                self._conn.send(None)
+            except (BrokenPipeError, OSError):
+                pass
+        self._teardown()
+
+
+def safe_pattern_search(
+    pattern: re.Pattern[str], line: str
+) -> re.Match[str] | None:
+    """Bounded-time wrapper around ``pattern.search``.
+
+    Compatibility shim — spawns a one-shot worker process, runs the
+    search with the per-line timeout, and returns the match (or
+    ``None`` on no-match / timeout / crash). Callers that need to
+    distinguish timeout from no-match should use
+    :class:`_BoundedRegexSession` directly so they can read both
+    return-tuple fields.
+
+    Because each call forks its own worker, this helper is only
+    appropriate for one-off lookups. The walker in
+    :func:`iter_matching_events` uses :class:`_BoundedRegexSession`
+    instead so the fork cost is amortised across an entire request.
+    """
+    with _BoundedRegexSession(pattern) as session:
+        matched, _timed_out = session.search(line)
+    if not matched:
+        return None
+    # The worker only returned a bool to keep the IPC payload tiny; the
+    # caller of this helper only needs match-or-not, so we re-run the
+    # search in-process on the matched line to materialise the Match
+    # object. This is safe because we already know the line did NOT
+    # cause catastrophic backtracking (otherwise the worker would have
+    # timed out instead of returning True).
+    return pattern.search(line)
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +496,8 @@ def iter_matching_events(
     literal: str | None = None,
     since: datetime | None,
     event_type: str | None,
+    stats: MutableMapping[str, int] | None = None,
+    bounded_regex: bool = False,
 ) -> Iterator[dict]:
     """Stream parsed events from ``targets`` that pass every filter.
 
@@ -288,37 +517,74 @@ def iter_matching_events(
     Malformed JSON lines are skipped silently — the live audit log can
     have a truncated tail mid-write and we don't want one bad line to
     mask the rest of the matches.
+
+    Regex behaviour depends on ``bounded_regex``:
+
+    * ``False`` (default — CLI / trusted-caller path): runs
+      ``pattern.search`` inline. The operator chose the pattern; if it
+      backtracks catastrophically that's on them and ``Ctrl+C`` is the
+      escape hatch.
+    * ``True`` (HTTP / untrusted-caller path): each line goes through
+      a multiprocessing worker with a per-line wall-clock budget
+      (:data:`_PER_LINE_TIMEOUT_S`). Timed-out lines are treated as
+      no-matches and (if ``stats`` is provided)
+      ``stats["pattern_timeouts"]`` is bumped so the caller can
+      surface the count in its response envelope.
     """
     since_iso = since.isoformat() if since is not None else None
-    for path in targets:
-        for chain_path in walk_log_chain(path):
-            for line in open_log_lines(chain_path):
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                # Cheap reject — literal substring is much cheaper than
-                # regex and immune to catastrophic backtracking.
-                if literal:
-                    if literal not in stripped:
+    use_bounded_regex = (
+        bounded_regex and pattern is not None and pattern.pattern and not literal
+    )
+    session: _BoundedRegexSession | None = (
+        _BoundedRegexSession(pattern) if use_bounded_regex else None  # type: ignore[arg-type]
+    )
+    try:
+        for path in targets:
+            for chain_path in walk_log_chain(path):
+                for line in open_log_lines(chain_path):
+                    stripped = line.strip()
+                    if not stripped:
                         continue
-                elif pattern is not None and pattern.pattern:
-                    if not pattern.search(stripped):
-                        continue
-                try:
-                    record = json.loads(stripped)
-                except json.JSONDecodeError:
-                    continue
-                if not isinstance(record, dict):
-                    continue
-                if event_type is not None and record.get("event") != event_type:
-                    continue
-                if since_iso is not None:
-                    ts_str = str(record.get("ts", ""))
-                    if ts_str and ts_str < since_iso:
-                        parsed = parse_event_ts(ts_str)
-                        if parsed is None or parsed < since:
+                    # Cheap reject — literal substring is much cheaper
+                    # than regex and immune to catastrophic backtracking.
+                    if literal:
+                        if literal not in stripped:
                             continue
-                yield record
+                    elif session is not None:
+                        matched, timed_out = session.search(stripped)
+                        if timed_out:
+                            if stats is not None:
+                                stats["pattern_timeouts"] = (
+                                    stats.get("pattern_timeouts", 0) + 1
+                                )
+                            continue
+                        if not matched:
+                            continue
+                    elif pattern is not None and pattern.pattern:
+                        # Trusted-caller path (CLI / in-process callers
+                        # that opted out of bounded_regex). The operator
+                        # owns the pattern; if it backtracks they can
+                        # Ctrl+C.
+                        if not pattern.search(stripped):
+                            continue
+                    try:
+                        record = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    if event_type is not None and record.get("event") != event_type:
+                        continue
+                    if since_iso is not None:
+                        ts_str = str(record.get("ts", ""))
+                        if ts_str and ts_str < since_iso:
+                            parsed = parse_event_ts(ts_str)
+                            if parsed is None or parsed < since:
+                                continue
+                    yield record
+    finally:
+        if session is not None:
+            session.close()
 
 
 __all__ = [
@@ -327,5 +593,6 @@ __all__ = [
     "parse_event_ts",
     "parse_since",
     "resolve_target_files",
+    "safe_pattern_search",
     "walk_log_chain",
 ]

--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -171,12 +171,22 @@ class _BoundedRegexSession:
         self._process = process
         self._conn = parent_conn
 
-    def search(self, line: str) -> tuple[bool, bool]:
+    def search(
+        self, line: str, *, max_wall_clock_s: float | None = None
+    ) -> tuple[bool, bool]:
         """Return ``(matched, timed_out)`` for ``line``.
 
         On timeout: kills the child, returns ``(False, True)``. The
         next call respawns. On crash: returns ``(False, True)`` too —
         we'd rather count a phantom timeout than silently drop matches.
+
+        ``max_wall_clock_s`` (Codex round-5 finding, PR #2062) clamps
+        BOTH the steady-state per-line timeout AND the first-call
+        startup grace to the remaining request budget. Without this,
+        an operator who specifies ``deadline_seconds=0.5`` on a regex
+        request can still pay the full ``_STARTUP_GRACE_S = 5.0`` on
+        the first line before the walker can truncate — contradicting
+        the request-level deadline contract.
         """
         if self._process is None or self._conn is None:
             self._spawn()
@@ -190,8 +200,18 @@ class _BoundedRegexSession:
         # Wait for the child's response with a wall-clock deadline.
         # ``poll`` is the only Pipe API that takes a timeout in stdlib
         # multiprocessing.
-        deadline = _STARTUP_GRACE_S if self._needs_warmup else _PER_LINE_TIMEOUT_S
+        base_deadline = (
+            _STARTUP_GRACE_S if self._needs_warmup else _PER_LINE_TIMEOUT_S
+        )
         self._needs_warmup = False
+        if max_wall_clock_s is not None:
+            # Clamp to remaining request budget. ``max(0.0, …)`` keeps
+            # ``poll`` from rejecting a negative timeout if the caller
+            # is already past their deadline — in that case we want a
+            # non-blocking poll that returns immediately.
+            deadline = max(0.0, min(base_deadline, max_wall_clock_s))
+        else:
+            deadline = base_deadline
         if not self._conn.poll(deadline):
             self._teardown()
             return (False, True)
@@ -554,6 +574,14 @@ def iter_matching_events(
     + ``stats["lines_scanned"]`` so the caller can tell the response
     is bounded rather than complete. ``None`` (default — CLI path) =
     no deadline; the CLI operator owns the clock via Ctrl+C.
+
+    Round-5 follow-up: the remaining budget is also passed into
+    :meth:`_BoundedRegexSession.search` so the worker's per-line poll
+    (including the first-line startup grace) cannot itself exceed the
+    request deadline. Otherwise a caller requesting ``deadline_s=0.5``
+    on a pathological pattern would still spend ``_STARTUP_GRACE_S``
+    (~5 s) on the very first line before the walker's pre-line check
+    could fire again.
     """
     use_bounded_regex = (
         bounded_regex and pattern is not None and pattern.pattern and not literal
@@ -578,10 +606,13 @@ def iter_matching_events(
                     stripped = line.strip()
                     if not stripped:
                         continue
-                    if deadline_at is not None and time.monotonic() >= deadline_at:
-                        if stats is not None:
-                            stats["truncated_by_deadline"] = 1
-                        return
+                    remaining_budget: float | None = None
+                    if deadline_at is not None:
+                        remaining_budget = deadline_at - time.monotonic()
+                        if remaining_budget <= 0:
+                            if stats is not None:
+                                stats["truncated_by_deadline"] = 1
+                            return
                     if stats is not None:
                         stats["lines_scanned"] = (
                             stats.get("lines_scanned", 0) + 1
@@ -592,7 +623,12 @@ def iter_matching_events(
                         if literal not in stripped:
                             continue
                     elif session is not None:
-                        matched, timed_out = session.search(stripped)
+                        # Codex round-5: pass remaining request budget so
+                        # the worker poll (including first-line startup
+                        # grace) can't outrun the request-level deadline.
+                        matched, timed_out = session.search(
+                            stripped, max_wall_clock_s=remaining_budget
+                        )
                         if timed_out:
                             if stats is not None:
                                 stats["pattern_timeouts"] = (

--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -559,26 +559,30 @@ def iter_matching_events(
     substring) should be supplied — both ``None`` means "match every
     line." Supplying both is allowed (regex wins) but discouraged.
 
-    Filters apply in cheap→expensive order:
+    Filters apply in cheap→expensive order. Codex round-10 (PR #2062)
+    reordered so the bounded-regex pattern only runs on rows inside
+    the requested ``since`` window — old pathological rows can no
+    longer drain the request deadline:
 
-    1. ``literal`` / ``pattern`` substring or regex match on the raw
-       line.
-    2. JSON decode.
-    3. ``event_type``: exact ``.event`` field match (string equality,
+    1. JSON decode.
+    2. ``event_type``: exact ``.event`` field match (string equality,
        NOT regex).
-    4. ``ts`` parse — rows whose ``ts`` field is missing, non-string,
+    3. ``ts`` parse — rows whose ``ts`` field is missing, non-string,
        or fails ISO-8601 parsing are dropped and counted under
        ``stats["malformed_rows_skipped"]`` (Codex round-3 finding,
        PR #2062). Both ``since`` filtering AND ``/audit/stats`` totals
        go through this gate so a malformed archived row can't inflate
        the count.
-    5. ``since``: drop events whose parsed ``ts`` is older than the
+    4. ``since``: drop events whose parsed ``ts`` is older than the
        cutoff. Parsed as ``datetime`` objects so a record like
        ``2026-05-21T01:00:00+02:00`` (≡ ``2026-05-20T23:00:00Z``) is
        correctly excluded by ``since=2026-05-21T00:00:00Z`` — earlier
        round-2 code did a raw-string lex compare here, which let
        lex-greater-but-time-earlier rows through (timezone offsets
        sort wrong; malformed strings passed through entirely).
+    5. ``literal`` / ``pattern`` substring or regex match on the raw
+       line. For the bounded (HTTP) regex path this runs LAST so the
+       per-line wall-clock budget is only spent on in-window rows.
 
     Malformed JSON lines are skipped silently — the live audit log can
     have a truncated tail mid-write and we don't want one bad line to
@@ -649,33 +653,18 @@ def iter_matching_events(
                         stats["lines_scanned"] = (
                             stats.get("lines_scanned", 0) + 1
                         )
-                    # Cheap reject — literal substring is much cheaper
-                    # than regex and immune to catastrophic backtracking.
-                    if literal:
-                        if literal not in stripped:
-                            continue
-                    elif session is not None:
-                        # Codex round-5: pass remaining request budget so
-                        # the worker poll (including first-line startup
-                        # grace) can't outrun the request-level deadline.
-                        matched, timed_out = session.search(
-                            stripped, max_wall_clock_s=remaining_budget
-                        )
-                        if timed_out:
-                            if stats is not None:
-                                stats["pattern_timeouts"] = (
-                                    stats.get("pattern_timeouts", 0) + 1
-                                )
-                            continue
-                        if not matched:
-                            continue
-                    elif pattern is not None and pattern.pattern:
-                        # Trusted-caller path (CLI / in-process callers
-                        # that opted out of bounded_regex). The operator
-                        # owns the pattern; if it backtracks they can
-                        # Ctrl+C.
-                        if not pattern.search(stripped):
-                            continue
+                    # Codex round-10 (PR #2062): parse + window-filter
+                    # BEFORE running the line-level pattern. The bounded
+                    # regex path advertises ``since`` as the work bound
+                    # (see ``grep_audit_endpoint`` + openapi prose); if
+                    # the regex runs first, a wall of old pathological
+                    # no-match rows at the front of the live log can
+                    # spend the entire deadline_seconds budget on rows
+                    # that ``since`` would have rejected anyway. The
+                    # JSON decode + ts parse are cheap (microseconds)
+                    # next to a single per-line regex timeout (~100 ms),
+                    # so the reorder is a win for the literal/trusted
+                    # paths too — it just moves a cheap gate earlier.
                     try:
                         record = json.loads(stripped)
                     except json.JSONDecodeError:
@@ -701,7 +690,39 @@ def iter_matching_events(
                             )
                         continue
                     if since is not None and parsed_ts < since:
+                        # Outside the requested window — skip BEFORE
+                        # spending the per-line regex budget on a row
+                        # the caller never asked about.
                         continue
+                    # In-window: now run the line-level pattern. Cheap
+                    # reject (``literal``) first — substring is much
+                    # cheaper than regex and immune to catastrophic
+                    # backtracking.
+                    if literal:
+                        if literal not in stripped:
+                            continue
+                    elif session is not None:
+                        # Codex round-5: pass remaining request budget so
+                        # the worker poll (including first-line startup
+                        # grace) can't outrun the request-level deadline.
+                        matched, timed_out = session.search(
+                            stripped, max_wall_clock_s=remaining_budget
+                        )
+                        if timed_out:
+                            if stats is not None:
+                                stats["pattern_timeouts"] = (
+                                    stats.get("pattern_timeouts", 0) + 1
+                                )
+                            continue
+                        if not matched:
+                            continue
+                    elif pattern is not None and pattern.pattern:
+                        # Trusted-caller path (CLI / in-process callers
+                        # that opted out of bounded_regex). The operator
+                        # owns the pattern; if it backtracks they can
+                        # Ctrl+C.
+                        if not pattern.search(stripped):
+                            continue
                     yield record
     finally:
         if session is not None:

--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -36,6 +36,7 @@ import json
 import multiprocessing
 import multiprocessing.connection
 import re
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable, Iterator, MutableMapping
@@ -498,6 +499,7 @@ def iter_matching_events(
     event_type: str | None,
     stats: MutableMapping[str, int] | None = None,
     bounded_regex: bool = False,
+    deadline_s: float | None = None,
 ) -> Iterator[dict]:
     """Stream parsed events from ``targets`` that pass every filter.
 
@@ -542,12 +544,32 @@ def iter_matching_events(
       no-matches and (if ``stats`` is provided)
       ``stats["pattern_timeouts"]`` is bumped so the caller can
       surface the count in its response envelope.
+
+    Request-level bound (Codex round-4 finding, PR #2062): ``limit``
+    caps matches but NOT scanned lines. A pathological no-match regex
+    can still hold an API worker for ``per_line_timeout * timed_out_lines``
+    across every live + rotated log. ``deadline_s`` adds a wall-clock
+    request budget: after each line the walker checks elapsed time and
+    stops if exceeded, surfacing ``stats["truncated_by_deadline"] = 1``
+    + ``stats["lines_scanned"]`` so the caller can tell the response
+    is bounded rather than complete. ``None`` (default — CLI path) =
+    no deadline; the CLI operator owns the clock via Ctrl+C.
     """
     use_bounded_regex = (
         bounded_regex and pattern is not None and pattern.pattern and not literal
     )
     session: _BoundedRegexSession | None = (
         _BoundedRegexSession(pattern) if use_bounded_regex else None  # type: ignore[arg-type]
+    )
+    # Request-level deadline (Codex round-4): check elapsed wall-clock
+    # after every non-empty line. The literal/regex cost is paid before
+    # the check, but the per-line timeout already bounds a single line
+    # so the budget overshoot is at most one per_line_timeout (~100 ms
+    # in HTTP mode) — bounded and predictable.
+    deadline_at: float | None = (
+        time.monotonic() + deadline_s
+        if deadline_s is not None and deadline_s > 0
+        else None
     )
     try:
         for path in targets:
@@ -556,6 +578,14 @@ def iter_matching_events(
                     stripped = line.strip()
                     if not stripped:
                         continue
+                    if deadline_at is not None and time.monotonic() >= deadline_at:
+                        if stats is not None:
+                            stats["truncated_by_deadline"] = 1
+                        return
+                    if stats is not None:
+                        stats["lines_scanned"] = (
+                            stats.get("lines_scanned", 0) + 1
+                        )
                     # Cheap reject — literal substring is much cheaper
                     # than regex and immune to catastrophic backtracking.
                     if literal:

--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -33,10 +33,12 @@ from __future__ import annotations
 
 import gzip
 import json
+import logging
 import multiprocessing
 import multiprocessing.connection
 import re
 import time
+import zlib
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable, Iterator, MutableMapping
@@ -44,6 +46,8 @@ from typing import Iterable, Iterator, MutableMapping
 from pollypm.audit.log import central_log_path
 from pollypm.config import load_config
 from pollypm.projects import project_audit_log_path
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -401,25 +405,53 @@ def walk_log_chain(live: Path) -> Iterator[Path]:
         yield archive
 
 
-def open_log_lines(path: Path) -> Iterator[str]:
+def open_log_lines(
+    path: Path,
+    *,
+    stats: MutableMapping[str, int] | None = None,
+) -> Iterator[str]:
     """Stream decoded text lines from a live ``.jsonl`` or gzipped archive.
 
     Routes ``.gz`` paths through :func:`gzip.open` in text mode so the
     caller gets the same line iteration shape regardless of file
     format. Decoding errors are swallowed per-file (best-effort: a
     corrupt archive shouldn't break grep across the other files).
+
+    Round-7 hardening (Codex PR #2062): a truncated gzip raises
+    :class:`EOFError` mid-iteration (``Compressed file ended before the
+    end-of-stream marker was reached``); a corrupted gzip header raises
+    :class:`gzip.BadGzipFile`; deeper deflate corruption can surface
+    :class:`zlib.error`. None of those are ``OSError`` subclasses, so
+    the previous narrow ``except OSError`` let them escape past
+    :func:`iter_matching_events` and bubble up to the HTTP route as a
+    500 — defeating the "one bad archive shouldn't break the grep"
+    contract documented above. We now catch the full corrupt-archive
+    set and (when ``stats`` is provided) bump
+    ``stats["corrupt_archives_skipped"]`` so callers can surface the
+    diagnostic in their response envelope (mirrors the
+    ``malformed_rows_skipped`` / ``pattern_timeouts`` pattern).
     """
     try:
         if path.suffix == ".gz":
             fh = gzip.open(path, "rt", encoding="utf-8", errors="replace")
         else:
             fh = open(path, "r", encoding="utf-8", errors="replace")
-    except OSError:
+    except (OSError, EOFError, gzip.BadGzipFile, zlib.error) as exc:
+        logger.warning("Skipping corrupt audit archive %s: %s", path, exc)
+        if stats is not None:
+            stats["corrupt_archives_skipped"] = (
+                stats.get("corrupt_archives_skipped", 0) + 1
+            )
         return
     try:
         for line in fh:
             yield line
-    except OSError:
+    except (OSError, EOFError, gzip.BadGzipFile, zlib.error) as exc:
+        logger.warning("Truncated audit archive %s: %s", path, exc)
+        if stats is not None:
+            stats["corrupt_archives_skipped"] = (
+                stats.get("corrupt_archives_skipped", 0) + 1
+            )
         return
     finally:
         try:
@@ -602,7 +634,7 @@ def iter_matching_events(
     try:
         for path in targets:
             for chain_path in walk_log_chain(path):
-                for line in open_log_lines(chain_path):
+                for line in open_log_lines(chain_path, stats=stats):
                     stripped = line.strip()
                     if not stripped:
                         continue

--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -1,0 +1,331 @@
+"""Rotation-aware audit-log query helpers (CLI + HTTP shared core).
+
+Public domain module owned by :mod:`pollypm.audit` so the HTTP surface
+in :mod:`pollypm.web_api.routes.audit` can call the same rotation-aware
+walker the CLI uses (``pm audit grep`` — see #2036) without reaching
+into a presentation-layer ``cli_features.*`` module. The split was
+introduced in PR #2062 round 1 review (Codex P1 boundary finding):
+
+* CLI modules stay thin Typer adapters.
+* HTTP routes call this module directly.
+* Both surfaces share the same ``ts``-parsing + rotation-aware
+  semantics so behaviour matches across the operator's `pm audit grep`
+  invocation and a programmatic API client.
+
+The helpers exposed here:
+
+* :func:`parse_since` — ISO-8601 + ``<N><unit>`` shortcut parser.
+  Raises :class:`ValueError` (not ``typer.BadParameter`` — caller is
+  responsible for translating to its own error envelope).
+* :func:`resolve_target_files` — picks the live + central-tail paths
+  for one project (with a filter) or every registered project (without).
+* :func:`walk_log_chain` — yields live ``.jsonl`` then ``.gz`` archives
+  newest-first.
+* :func:`open_log_lines` — text-mode line iterator (gzip-aware).
+* :func:`parse_event_ts` — best-effort ``ts`` → ``datetime`` parser.
+* :func:`iter_matching_events` — apply filters cheap→expensive and
+  stream matching dict records.
+
+Nothing here writes to disk; nothing imports from Typer or FastAPI.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from pollypm.audit.log import central_log_path
+from pollypm.config import load_config
+from pollypm.projects import project_audit_log_path
+
+
+# ---------------------------------------------------------------------------
+# --since parsing (ISO 8601 or shortcuts like ``1h`` / ``24h`` / ``7d``).
+# ---------------------------------------------------------------------------
+
+
+_SHORTCUT_RE = re.compile(r"^\s*(\d+)\s*([smhdw])\s*$", re.IGNORECASE)
+_SHORTCUT_UNITS = {
+    "s": "seconds",
+    "m": "minutes",
+    "h": "hours",
+    "d": "days",
+    "w": "weeks",
+}
+
+
+def parse_since(value: str) -> datetime:
+    """Parse a ``--since`` value into a timezone-aware UTC datetime.
+
+    Accepts either:
+
+    * an ISO-8601 timestamp (``2026-05-21T03:14:15+00:00`` /
+      ``2026-05-21T03:14:15Z`` / ``2026-05-21`` etc.), or
+    * a shortcut of the form ``<N><unit>`` where unit is one of
+      ``s``/``m``/``h``/``d``/``w`` (seconds / minutes / hours /
+      days / weeks). The result is ``now - delta`` in UTC.
+
+    Naive ISO inputs are interpreted as UTC. Raises :class:`ValueError`
+    on parse failure — callers (CLI / HTTP) translate to their own
+    error envelopes.
+    """
+    match = _SHORTCUT_RE.match(value)
+    if match:
+        n = int(match.group(1))
+        unit = _SHORTCUT_UNITS[match.group(2).lower()]
+        delta = timedelta(**{unit: n})
+        return datetime.now(timezone.utc) - delta
+    iso = value.strip()
+    if iso.endswith("Z"):
+        iso = iso[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(iso)
+    except ValueError as exc:
+        raise ValueError(
+            f"invalid since value {value!r}: expected ISO-8601 "
+            "(e.g. 2026-05-21T03:14:15Z) or shortcut like 1h / 24h / 7d"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def parse_event_ts(ts: str) -> datetime | None:
+    """Parse an audit-event ``ts`` string into a UTC datetime, or None."""
+    if not ts:
+        return None
+    raw = ts.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# File discovery — rotation-aware.
+# ---------------------------------------------------------------------------
+
+
+def _archive_sort_key(path: Path) -> tuple[float, str]:
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    return (mtime, path.name)
+
+
+def walk_log_chain(live: Path) -> Iterator[Path]:
+    """Yield ``live`` first, then ``live.<ts>[.bump].gz`` archives newest-first.
+
+    Yields only paths that exist. The caller is responsible for
+    opening with the right decompressor (``open`` vs ``gzip.open``).
+    Missing parent directory is treated as no-files.
+    """
+    if live.exists():
+        yield live
+    parent = live.parent
+    if not parent.exists():
+        return
+    prefix = live.name + "."
+    archives: list[Path] = []
+    try:
+        for sibling in parent.iterdir():
+            if not sibling.is_file():
+                continue
+            if not sibling.name.startswith(prefix):
+                continue
+            if not sibling.name.endswith(".gz"):
+                continue
+            archives.append(sibling)
+    except OSError:
+        return
+    archives.sort(key=_archive_sort_key, reverse=True)
+    for archive in archives:
+        yield archive
+
+
+def open_log_lines(path: Path) -> Iterator[str]:
+    """Stream decoded text lines from a live ``.jsonl`` or gzipped archive.
+
+    Routes ``.gz`` paths through :func:`gzip.open` in text mode so the
+    caller gets the same line iteration shape regardless of file
+    format. Decoding errors are swallowed per-file (best-effort: a
+    corrupt archive shouldn't break grep across the other files).
+    """
+    try:
+        if path.suffix == ".gz":
+            fh = gzip.open(path, "rt", encoding="utf-8", errors="replace")
+        else:
+            fh = open(path, "r", encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    try:
+        for line in fh:
+            yield line
+    except OSError:
+        return
+    finally:
+        try:
+            fh.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Target file selection — central + per-project, project filter aware.
+# ---------------------------------------------------------------------------
+
+
+def resolve_target_files(
+    *,
+    project_filter: str | None,
+    config_path: Path | None = None,
+    config: "object | None" = None,
+) -> list[Path]:
+    """Return the live audit-log paths to walk for this query.
+
+    With ``project_filter`` set, only that project's per-project log +
+    its central tail are returned. Without it, every registered
+    project's per-project log + every central tail in the audit home
+    is included so an operator can grep across the whole fleet.
+
+    Per-project paths are returned even when they don't currently
+    exist — :func:`walk_log_chain` filters those out, but we still
+    include them so a project whose ``.pollypm`` was archived has a
+    chance to surface via its central tail (which is added separately).
+
+    Callers pass either ``config_path`` (CLI — loads from disk) or
+    ``config`` (web API — already in memory). When both are supplied
+    the in-memory ``config`` wins.
+    """
+    targets: list[Path] = []
+    seen: set[Path] = set()
+
+    def _add(path: Path) -> None:
+        try:
+            key = path.resolve()
+        except OSError:
+            key = path
+        if key in seen:
+            return
+        seen.add(key)
+        targets.append(path)
+
+    if config is None and config_path is not None:
+        try:
+            config = load_config(config_path)
+        except Exception:  # noqa: BLE001
+            config = None
+
+    if project_filter is not None:
+        if config is not None:
+            project = config.projects.get(project_filter)
+            if project is not None:
+                _add(project_audit_log_path(Path(project.path)))
+        _add(central_log_path(project_filter))
+        return targets
+
+    if config is not None:
+        for project in config.projects.values():
+            try:
+                _add(project_audit_log_path(Path(project.path)))
+            except Exception:  # noqa: BLE001
+                continue
+            _add(central_log_path(project.key))
+
+    central_root = central_log_path("_probe").parent
+    if central_root.exists():
+        try:
+            for sibling in central_root.iterdir():
+                if not sibling.is_file():
+                    continue
+                if sibling.suffix != ".jsonl":
+                    continue
+                _add(sibling)
+        except OSError:
+            pass
+
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# Filtering.
+# ---------------------------------------------------------------------------
+
+
+def iter_matching_events(
+    *,
+    targets: Iterable[Path],
+    pattern: re.Pattern[str] | None = None,
+    literal: str | None = None,
+    since: datetime | None,
+    event_type: str | None,
+) -> Iterator[dict]:
+    """Stream parsed events from ``targets`` that pass every filter.
+
+    Exactly one of ``pattern`` (compiled regex) or ``literal`` (plain
+    substring) should be supplied — both ``None`` means "match every
+    line." Supplying both is allowed (regex wins) but discouraged.
+
+    Filters apply in cheap→expensive order:
+
+    1. ``literal`` / ``pattern`` substring or regex match on the raw
+       line.
+    2. JSON decode.
+    3. ``event_type``: exact ``.event`` field match (string equality,
+       NOT regex).
+    4. ``since``: drop events with ``ts < since``.
+
+    Malformed JSON lines are skipped silently — the live audit log can
+    have a truncated tail mid-write and we don't want one bad line to
+    mask the rest of the matches.
+    """
+    since_iso = since.isoformat() if since is not None else None
+    for path in targets:
+        for chain_path in walk_log_chain(path):
+            for line in open_log_lines(chain_path):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                # Cheap reject — literal substring is much cheaper than
+                # regex and immune to catastrophic backtracking.
+                if literal:
+                    if literal not in stripped:
+                        continue
+                elif pattern is not None and pattern.pattern:
+                    if not pattern.search(stripped):
+                        continue
+                try:
+                    record = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                if event_type is not None and record.get("event") != event_type:
+                    continue
+                if since_iso is not None:
+                    ts_str = str(record.get("ts", ""))
+                    if ts_str and ts_str < since_iso:
+                        parsed = parse_event_ts(ts_str)
+                        if parsed is None or parsed < since:
+                            continue
+                yield record
+
+
+__all__ = [
+    "iter_matching_events",
+    "open_log_lines",
+    "parse_event_ts",
+    "parse_since",
+    "resolve_target_files",
+    "walk_log_chain",
+]

--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -512,7 +512,19 @@ def iter_matching_events(
     2. JSON decode.
     3. ``event_type``: exact ``.event`` field match (string equality,
        NOT regex).
-    4. ``since``: drop events with ``ts < since``.
+    4. ``ts`` parse — rows whose ``ts`` field is missing, non-string,
+       or fails ISO-8601 parsing are dropped and counted under
+       ``stats["malformed_rows_skipped"]`` (Codex round-3 finding,
+       PR #2062). Both ``since`` filtering AND ``/audit/stats`` totals
+       go through this gate so a malformed archived row can't inflate
+       the count.
+    5. ``since``: drop events whose parsed ``ts`` is older than the
+       cutoff. Parsed as ``datetime`` objects so a record like
+       ``2026-05-21T01:00:00+02:00`` (≡ ``2026-05-20T23:00:00Z``) is
+       correctly excluded by ``since=2026-05-21T00:00:00Z`` — earlier
+       round-2 code did a raw-string lex compare here, which let
+       lex-greater-but-time-earlier rows through (timezone offsets
+       sort wrong; malformed strings passed through entirely).
 
     Malformed JSON lines are skipped silently — the live audit log can
     have a truncated tail mid-write and we don't want one bad line to
@@ -531,7 +543,6 @@ def iter_matching_events(
       ``stats["pattern_timeouts"]`` is bumped so the caller can
       surface the count in its response envelope.
     """
-    since_iso = since.isoformat() if since is not None else None
     use_bounded_regex = (
         bounded_regex and pattern is not None and pattern.pattern and not literal
     )
@@ -575,12 +586,24 @@ def iter_matching_events(
                         continue
                     if event_type is not None and record.get("event") != event_type:
                         continue
-                    if since_iso is not None:
-                        ts_str = str(record.get("ts", ""))
-                        if ts_str and ts_str < since_iso:
-                            parsed = parse_event_ts(ts_str)
-                            if parsed is None or parsed < since:
-                                continue
+                    # Always parse the timestamp — both ``since``
+                    # filtering and downstream counters need a real
+                    # ``datetime`` (string compare is broken for
+                    # tz-offset rows; see docstring filter step 4).
+                    # Malformed rows are dropped + counted so callers
+                    # can surface the diagnostic.
+                    ts_raw = record.get("ts")
+                    parsed_ts = (
+                        parse_event_ts(ts_raw) if isinstance(ts_raw, str) else None
+                    )
+                    if parsed_ts is None:
+                        if stats is not None:
+                            stats["malformed_rows_skipped"] = (
+                                stats.get("malformed_rows_skipped", 0) + 1
+                            )
+                        continue
+                    if since is not None and parsed_ts < since:
+                        continue
                     yield record
     finally:
         if session is not None:

--- a/src/pollypm/cli_features/audit.py
+++ b/src/pollypm/cli_features/audit.py
@@ -33,7 +33,6 @@ import typer
 
 from pollypm.audit.query import (
     iter_matching_events as _iter_matching_events,
-    open_log_lines as _open_log_lines,
     parse_event_ts as _parse_event_ts,
     parse_since as _parse_since_neutral,
     resolve_target_files as _resolve_target_files,
@@ -250,4 +249,14 @@ __all__ = [
     "audit_app",
     "format_event",
     "parse_since",
+    # Re-exports from the neutral query module — kept for the CLI test
+    # surface (``tests/test_cli_audit_grep.py``) which historically
+    # imported the rotation-aware helpers via this module. Re-exporting
+    # explicitly via ``__all__`` (rather than dropping them) keeps that
+    # test surface stable AND silences F401 for the underscored aliases.
+    "_iter_matching_events",
+    "_parse_event_ts",
+    "_parse_since_neutral",
+    "_resolve_target_files",
+    "_walk_log_chain",
 ]

--- a/src/pollypm/cli_features/audit.py
+++ b/src/pollypm/cli_features/audit.py
@@ -205,7 +205,8 @@ def _open_log_lines(path: Path) -> Iterator[str]:
 def _resolve_target_files(
     *,
     project_filter: str | None,
-    config_path: Path,
+    config_path: Path | None = None,
+    config: "object | None" = None,
 ) -> list[Path]:
     """Return the live audit-log paths to walk for this query.
 
@@ -218,6 +219,11 @@ def _resolve_target_files(
     exist — :func:`_walk_log_chain` filters those out, but we still
     include them so a project whose ``.pollypm`` was archived has a
     chance to surface via its central tail (which is added separately).
+
+    Callers pass either ``config_path`` (CLI — loads from disk) or
+    ``config`` (web API — already in memory). When both are supplied
+    the in-memory ``config`` wins; the CLI never sets ``config`` so
+    behaviour is unchanged for the existing ``pm audit grep`` path.
     """
     targets: list[Path] = []
     seen: set[Path] = set()
@@ -233,10 +239,11 @@ def _resolve_target_files(
         seen.add(key)
         targets.append(path)
 
-    try:
-        config = load_config(config_path)
-    except Exception:  # noqa: BLE001
-        config = None
+    if config is None and config_path is not None:
+        try:
+            config = load_config(config_path)
+        except Exception:  # noqa: BLE001
+            config = None
 
     if project_filter is not None:
         # Per-project log (best path: live config). When config can't

--- a/src/pollypm/cli_features/audit.py
+++ b/src/pollypm/cli_features/audit.py
@@ -24,19 +24,23 @@ rotation layout, gunzips transparently, and pretty-prints.
 
 from __future__ import annotations
 
-import gzip
 import json
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Iterator
 
 import typer
 
-from pollypm.audit.log import central_log_path
+from pollypm.audit.query import (
+    iter_matching_events as _iter_matching_events,
+    open_log_lines as _open_log_lines,
+    parse_event_ts as _parse_event_ts,
+    parse_since as _parse_since_neutral,
+    resolve_target_files as _resolve_target_files,
+    walk_log_chain as _walk_log_chain,
+)
 from pollypm.cli_help import help_with_examples
-from pollypm.config import DEFAULT_CONFIG_PATH, load_config
-from pollypm.projects import project_audit_log_path
+from pollypm.config import DEFAULT_CONFIG_PATH
 
 
 audit_app = typer.Typer(
@@ -67,225 +71,30 @@ audit_app = typer.Typer(
 
 
 # ---------------------------------------------------------------------------
-# --since parsing (ISO 8601 or shortcuts like ``1h`` / ``24h`` / ``7d``).
+# Typer-friendly --since wrapper. Domain implementation lives in
+# :mod:`pollypm.audit.query` so the HTTP surface can share it.
 # ---------------------------------------------------------------------------
-
-
-_SHORTCUT_RE = re.compile(r"^\s*(\d+)\s*([smhdw])\s*$", re.IGNORECASE)
-_SHORTCUT_UNITS = {
-    "s": "seconds",
-    "m": "minutes",
-    "h": "hours",
-    "d": "days",
-    "w": "weeks",
-}
 
 
 def parse_since(value: str) -> datetime:
     """Parse ``--since`` into a timezone-aware UTC datetime.
 
-    Accepts either:
-
-    * an ISO-8601 timestamp (``2026-05-21T03:14:15+00:00`` /
-      ``2026-05-21T03:14:15Z`` / ``2026-05-21`` etc.), or
-    * a shortcut of the form ``<N><unit>`` where unit is one of
-      ``s``/``m``/``h``/``d``/``w`` (seconds / minutes / hours /
-      days / weeks). The result is ``now - delta`` in UTC.
-
-    Naive ISO inputs are interpreted as UTC. Raises
-    :class:`typer.BadParameter` on parse failure so the CLI surfaces
-    the error inline instead of crashing with a stack trace.
+    Thin Typer wrapper around :func:`pollypm.audit.query.parse_since` —
+    re-raises the neutral ``ValueError`` as :class:`typer.BadParameter`
+    so the CLI surfaces the error inline instead of crashing with a
+    stack trace.
     """
-    match = _SHORTCUT_RE.match(value)
-    if match:
-        n = int(match.group(1))
-        unit = _SHORTCUT_UNITS[match.group(2).lower()]
-        delta = timedelta(**{unit: n})
-        return datetime.now(timezone.utc) - delta
-    # ISO-8601 path. ``fromisoformat`` accepts ``Z`` suffix on 3.11+ but
-    # we mirror the audit-log emit format which uses ``+00:00`` — strip
-    # a trailing ``Z`` to stay portable across Python versions.
-    iso = value.strip()
-    if iso.endswith("Z"):
-        iso = iso[:-1] + "+00:00"
     try:
-        parsed = datetime.fromisoformat(iso)
+        return _parse_since_neutral(value)
     except ValueError as exc:
         raise typer.BadParameter(
             f"invalid --since value {value!r}: expected ISO-8601 "
             "(e.g. 2026-05-21T03:14:15Z) or shortcut like 1h / 24h / 7d"
         ) from exc
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 # ---------------------------------------------------------------------------
-# File discovery — rotation-aware.
-# ---------------------------------------------------------------------------
-
-
-def _archive_sort_key(path: Path) -> tuple[float, str]:
-    """Sort key for ``audit.jsonl.<ts>[.bump].gz`` archives.
-
-    We want newest-first iteration. Use mtime as primary because the
-    rotation timestamp is embedded in the filename but tests + edge
-    cases can leave clock-skew; fall back to filename for stable
-    ordering within the same mtime second.
-    """
-    try:
-        mtime = path.stat().st_mtime
-    except OSError:
-        mtime = 0.0
-    return (mtime, path.name)
-
-
-def _walk_log_chain(live: Path) -> Iterator[Path]:
-    """Yield ``live`` first, then ``live.<ts>[.bump].gz`` archives newest-first.
-
-    Yields only paths that exist. The caller is responsible for
-    opening with the right decompressor (``open`` vs ``gzip.open``).
-    Missing parent directory is treated as no-files.
-    """
-    if live.exists():
-        yield live
-    parent = live.parent
-    if not parent.exists():
-        return
-    prefix = live.name + "."
-    archives: list[Path] = []
-    try:
-        for sibling in parent.iterdir():
-            if not sibling.is_file():
-                continue
-            if not sibling.name.startswith(prefix):
-                continue
-            if not sibling.name.endswith(".gz"):
-                continue
-            archives.append(sibling)
-    except OSError:
-        return
-    archives.sort(key=_archive_sort_key, reverse=True)
-    for archive in archives:
-        yield archive
-
-
-def _open_log_lines(path: Path) -> Iterator[str]:
-    """Stream decoded text lines from a live ``.jsonl`` or gzipped archive.
-
-    Routes ``.gz`` paths through :func:`gzip.open` in text mode so the
-    caller gets the same line iteration shape regardless of file
-    format. Decoding errors are swallowed per-file (best-effort: a
-    corrupt archive shouldn't break grep across the other files).
-    """
-    try:
-        if path.suffix == ".gz":
-            fh = gzip.open(path, "rt", encoding="utf-8", errors="replace")
-        else:
-            fh = open(path, "r", encoding="utf-8", errors="replace")
-    except OSError:
-        return
-    try:
-        for line in fh:
-            yield line
-    except OSError:
-        return
-    finally:
-        try:
-            fh.close()
-        except Exception:  # noqa: BLE001 — close-time errors are noise
-            pass
-
-
-# ---------------------------------------------------------------------------
-# Target file selection — central + per-project, project filter aware.
-# ---------------------------------------------------------------------------
-
-
-def _resolve_target_files(
-    *,
-    project_filter: str | None,
-    config_path: Path | None = None,
-    config: "object | None" = None,
-) -> list[Path]:
-    """Return the live audit-log paths to walk for this query.
-
-    With ``--project NAME`` set, only that project's per-project log +
-    its central tail are returned. Without it, every registered
-    project's per-project log + every central tail in the audit home
-    is included so an operator can grep across the whole fleet.
-
-    Per-project paths are returned even when they don't currently
-    exist — :func:`_walk_log_chain` filters those out, but we still
-    include them so a project whose ``.pollypm`` was archived has a
-    chance to surface via its central tail (which is added separately).
-
-    Callers pass either ``config_path`` (CLI — loads from disk) or
-    ``config`` (web API — already in memory). When both are supplied
-    the in-memory ``config`` wins; the CLI never sets ``config`` so
-    behaviour is unchanged for the existing ``pm audit grep`` path.
-    """
-    targets: list[Path] = []
-    seen: set[Path] = set()
-
-    def _add(path: Path) -> None:
-        # Use ``resolve()`` so symlinked workspaces don't double-up.
-        try:
-            key = path.resolve()
-        except OSError:
-            key = path
-        if key in seen:
-            return
-        seen.add(key)
-        targets.append(path)
-
-    if config is None and config_path is not None:
-        try:
-            config = load_config(config_path)
-        except Exception:  # noqa: BLE001
-            config = None
-
-    if project_filter is not None:
-        # Per-project log (best path: live config). When config can't
-        # be loaded or the project isn't registered, fall through to
-        # the central-tail-only branch — the operator may be grepping
-        # a project that was removed from config but whose central
-        # tail still carries the relevant trail.
-        if config is not None:
-            project = config.projects.get(project_filter)
-            if project is not None:
-                _add(project_audit_log_path(Path(project.path)))
-        _add(central_log_path(project_filter))
-        return targets
-
-    # No filter: walk every registered project + every central tail.
-    if config is not None:
-        for project in config.projects.values():
-            try:
-                _add(project_audit_log_path(Path(project.path)))
-            except Exception:  # noqa: BLE001
-                continue
-            _add(central_log_path(project.key))
-
-    # Also include any central-tail files for projects that aren't
-    # in config (renamed / removed projects whose tail still exists).
-    central_root = central_log_path("_probe").parent
-    if central_root.exists():
-        try:
-            for sibling in central_root.iterdir():
-                if not sibling.is_file():
-                    continue
-                if sibling.suffix != ".jsonl":
-                    continue
-                _add(sibling)
-        except OSError:
-            pass
-
-    return targets
-
-
-# ---------------------------------------------------------------------------
-# Filtering + formatting.
+# CLI-specific formatting.
 # ---------------------------------------------------------------------------
 
 
@@ -294,22 +103,6 @@ _STATUS_COLORS = {
     "error": typer.colors.RED,
     "ok": typer.colors.GREEN,
 }
-
-
-def _parse_event_ts(ts: str) -> datetime | None:
-    """Parse an audit event ``ts`` field into a UTC datetime, or None."""
-    if not ts:
-        return None
-    raw = ts.strip()
-    if raw.endswith("Z"):
-        raw = raw[:-1] + "+00:00"
-    try:
-        parsed = datetime.fromisoformat(raw)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 def format_event(record: dict, *, color: bool = True) -> str:
@@ -371,63 +164,6 @@ def format_event(record: dict, *, color: bool = True) -> str:
     if summary:
         line = f"{line} — {summary}"
     return line
-
-
-def _iter_matching_events(
-    *,
-    targets: Iterable[Path],
-    pattern: re.Pattern[str],
-    since: datetime | None,
-    event_type: str | None,
-) -> Iterator[dict]:
-    """Stream parsed events from ``targets`` that pass every filter.
-
-    Filters apply in cheap→expensive order:
-
-    1. ``event_type``: exact ``.event`` field match (string equality,
-       NOT regex).
-    2. ``since``: drop events with ``ts < since``.
-    3. ``pattern``: ``re.search`` over the full line text. Matching the
-       raw line (not a stringified parse) means operators can grep
-       metadata fields without knowing the JSON shape.
-
-    Malformed JSON lines are skipped silently — the live audit log
-    can have a truncated tail mid-write and we don't want one bad
-    line to mask the rest of the matches.
-    """
-    since_iso = since.isoformat() if since is not None else None
-    for path in targets:
-        for chain_path in _walk_log_chain(path):
-            for line in _open_log_lines(chain_path):
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                # Pattern match first against the raw line — fastest
-                # possible reject for non-matches, which dominate in
-                # a typical grep against a long log.
-                if not pattern.search(stripped):
-                    continue
-                try:
-                    record = json.loads(stripped)
-                except json.JSONDecodeError:
-                    continue
-                if not isinstance(record, dict):
-                    continue
-                if event_type is not None and record.get("event") != event_type:
-                    continue
-                if since_iso is not None:
-                    ts_str = str(record.get("ts", ""))
-                    # ISO-8601 UTC sorts lexicographically; compare as
-                    # strings to skip a datetime parse on the hot path.
-                    if ts_str and ts_str < since_iso:
-                        # Parse-and-compare fallback for the rare ts
-                        # that doesn't lex-sort against our since
-                        # (e.g. naive iso vs aware). Cheap because we
-                        # only land here for matches.
-                        parsed = _parse_event_ts(ts_str)
-                        if parsed is None or parsed < since:
-                            continue
-                yield record
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -37,6 +37,7 @@ from pollypm.web_api.errors import (
     handle_unhandled_exception,
     handle_validation_error,
 )
+from pollypm.web_api.routes import audit as audit_routes
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
 from pollypm.web_api.routes import chat_send as chat_send_routes
 from pollypm.web_api.routes import config as config_routes
@@ -366,6 +367,10 @@ def create_app(
         prefix=API_V1_PREFIX,
         dependencies=auth_deps,
     )
+    # Phase 2 surface #6 — historical audit query (grep + stats). The
+    # streaming side already ships at ``/api/v1/events`` (Phase 1 SSE);
+    # we deliberately do not re-route that path here.
+    app.include_router(audit_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     # P2 of the chat-endpoints spec — GET /api/v1/chat/sessions and
     # GET /api/v1/chat/{session_name}/messages. Sits under the same
     # ``/chat`` prefix the P3 send endpoint shares so all

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -319,7 +319,14 @@ def grep_audit_endpoint(
 
     Streams the rotation-aware target files (live ``.jsonl`` + ``.gz``
     archives newest-first) and applies filters in cheap→expensive
-    order: substring/regex first, then ``event_type``, then ``since``.
+    order (Codex round-10 reorder, PR #2062): JSON decode → exact
+    ``event_type`` match → ``ts`` parse → ``since`` cutoff →
+    ``pattern`` substring/regex match on the raw line. The pattern
+    runs LAST so the ``safe_regex=true`` per-line wall-clock budget
+    is only spent on rows already inside the requested ``since``
+    window — this ordering is part of the safety/performance
+    contract for regex mode (paired with the ``safe_regex`` +
+    ``since`` requirement and ``deadline_seconds`` bound below).
     The response is capped at ``limit`` matches; the spec leaves
     cursor pagination to a follow-up PR (always returns
     ``next_cursor=null`` today).

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -1,0 +1,272 @@
+"""Audit query endpoints (Phase 2 — surface #6).
+
+Implements the historical-query side of the audit surface:
+
+* ``GET /api/v1/audit/grep`` — mirrors ``pm audit grep`` (PR #2036).
+  Filters: ``project``, ``since`` (ISO-8601 or ``1h``/``24h``/``7d``
+  shortcut), ``event_type`` (exact match on ``.event``), ``pattern``
+  (Python ``re.search`` regex on the raw JSONL line), ``limit``
+  (default 100, max 1000).
+* ``GET /api/v1/audit/stats`` — aggregate counts over the same target
+  files. Returns ``{by_event, by_severity, total, since}``.
+
+The streaming side (``GET /api/v1/audit/stream``) is already shipped
+as ``GET /api/v1/events`` (Phase 1 SSE). This module intentionally does
+not re-route that path — it would duplicate the stream multiplexer for
+no operator benefit (see Phase 2 spec §8.1).
+
+Helper reuse (per spec): the route module is a thin adapter over the
+private helpers in :mod:`pollypm.cli_features.audit`:
+
+* :func:`_resolve_target_files` — picks the right per-project +
+  central-tail paths based on the ``project`` filter. The web API
+  passes the in-memory :class:`PollyPMConfig` directly so the helper
+  doesn't reload the user's config from disk on every request.
+* :func:`_iter_matching_events` — applies the cheap→expensive filter
+  chain (regex first against the raw line, then ``event_type``
+  equality, then ``since``). Streams rather than slurps so a multi-MB
+  rotated ``.gz`` archive doesn't blow memory.
+* :func:`parse_since` — ISO-8601 / shortcut parsing, identical to the
+  CLI surface so the API contract matches what ``pm audit grep --since``
+  accepts.
+
+This is intentionally a separate router file (not folded into
+``events.py``) because the streaming and grep surfaces have distinct
+auth requirements (SSE uses ``?token=`` query auth; grep + stats use
+bearer-only) and distinct response shapes (``text/event-stream`` vs.
+``application/json``).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from pollypm.cli_features.audit import (
+    _iter_matching_events,
+    _resolve_target_files,
+    parse_since,
+)
+from pollypm.web_api.errors import invalid_request
+from pollypm.web_api.models import Event
+from pollypm.web_api.routes._deps import ConfigDep
+
+router = APIRouter(tags=["Audit"])
+
+
+# Cap matches in a single grep response. The spec calls for 1000 hard
+# max with a default of 100. Spec §8.3 — "Cap one response at 1000
+# events; client must paginate."
+_GREP_LIMIT_DEFAULT = 100
+_GREP_LIMIT_MAX = 1000
+
+
+class AuditGrepResponse(BaseModel):
+    """Body for ``GET /audit/grep``.
+
+    Matches the spec §8.1 envelope. ``next_cursor`` is reserved for
+    future paging (cursor encoding lives outside this PR per the
+    "Phase 2 audit query" scope) — we always return ``None`` today so
+    clients see the field shape without depending on its value.
+    """
+
+    events: list[Event]
+    next_cursor: str | None = None
+
+
+class AuditStatsResponse(BaseModel):
+    """Body for ``GET /audit/stats``.
+
+    Aggregates over the same target-file set the grep endpoint uses
+    so totals + per-event / per-severity counts match what a manual
+    grep would produce. ``since`` echoes the parsed-and-normalized
+    cutoff so the client can confirm the server interpreted shortcuts
+    like ``24h`` against its own clock.
+    """
+
+    total: int
+    by_event: dict[str, int] = Field(default_factory=dict)
+    by_severity: dict[str, int] = Field(default_factory=dict)
+    since: datetime | None = None
+
+
+def _parse_since_or_400(value: str | None) -> datetime | None:
+    """Wrap :func:`parse_since` to raise the typed API error.
+
+    The CLI helper raises ``typer.BadParameter`` for invalid inputs;
+    we re-raise as ``400 invalid_request`` so the API contract (spec
+    §6 error envelope) is consistent. Returns ``None`` when the
+    caller passed nothing — no filter requested.
+    """
+    if value is None:
+        return None
+    try:
+        return parse_since(value)
+    except Exception as exc:  # noqa: BLE001 — typer.BadParameter is the only path, but stay defensive
+        raise invalid_request(
+            f"invalid 'since' value {value!r}",
+            hint="ISO-8601 (e.g. 2026-05-21T03:14:15Z) or shortcut like 1h / 24h / 7d",
+        ) from exc
+
+
+def _compile_pattern_or_400(pattern: str | None) -> re.Pattern[str]:
+    """Compile the grep pattern or raise ``400 invalid_request``.
+
+    ``None`` / empty pattern is treated as "match everything" so the
+    endpoint works as a project/event-type filter without forcing the
+    caller to send ``pattern=.``.
+    """
+    if not pattern:
+        return re.compile(r"")
+    try:
+        return re.compile(pattern)
+    except re.error as exc:
+        raise invalid_request(
+            f"invalid 'pattern' regex {pattern!r}: {exc}",
+            hint="Use Python re.search syntax.",
+        ) from exc
+
+
+def _coerce_record_to_event(record: dict[str, Any]) -> Event:
+    """Reshape an audit JSON record into the ``Event`` response model.
+
+    Tolerates the schema-version + ts shape the writer emits (see
+    :func:`pollypm.audit.log._build_record`). Strings that pydantic
+    cannot parse as ``datetime`` are passed through verbatim; the
+    response_model serializer will normalize them on output.
+    """
+    return Event(
+        schema=int(record.get("schema", 1)),
+        ts=record.get("ts") or datetime.now(timezone.utc),
+        project=str(record.get("project") or ""),
+        event=str(record.get("event") or ""),
+        subject=str(record.get("subject") or ""),
+        actor=str(record.get("actor") or ""),
+        status=str(record.get("status") or "ok"),
+        metadata=record.get("metadata") or None,
+    )
+
+
+@router.get(
+    "/audit/grep",
+    response_model=AuditGrepResponse,
+    summary="Search audit-log events (rotation-aware)",
+    operation_id="grepAudit",
+)
+def grep_audit_endpoint(
+    config: ConfigDep,
+    project: Annotated[
+        str | None,
+        Query(description="Scope to one project (per-project log + central tail)."),
+    ] = None,
+    since: Annotated[
+        str | None,
+        Query(description="ISO-8601 timestamp or shortcut (1h, 24h, 7d)."),
+    ] = None,
+    event_type: Annotated[
+        str | None,
+        Query(description="Exact match on the .event field (not a regex)."),
+    ] = None,
+    pattern: Annotated[
+        str | None,
+        Query(description="Python regex (re.search) over the raw JSONL line."),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=_GREP_LIMIT_MAX,
+            description=(
+                "Cap matches in the response. Default 100, max 1000 (spec §8.3)."
+            ),
+        ),
+    ] = _GREP_LIMIT_DEFAULT,
+) -> AuditGrepResponse:
+    """Return audit events matching the supplied filters.
+
+    Streams the rotation-aware target files (live ``.jsonl`` + ``.gz``
+    archives newest-first) and applies filters in cheap→expensive
+    order: regex first, then ``event_type``, then ``since``. The
+    response is capped at ``limit`` matches; the spec leaves cursor
+    pagination to a follow-up PR (always returns ``next_cursor=null``
+    today).
+    """
+    since_dt = _parse_since_or_400(since)
+    compiled = _compile_pattern_or_400(pattern)
+    targets = _resolve_target_files(project_filter=project, config=config)
+
+    events: list[Event] = []
+    for record in _iter_matching_events(
+        targets=targets,
+        pattern=compiled,
+        since=since_dt,
+        event_type=event_type,
+    ):
+        events.append(_coerce_record_to_event(record))
+        if len(events) >= limit:
+            break
+
+    return AuditGrepResponse(events=events, next_cursor=None)
+
+
+@router.get(
+    "/audit/stats",
+    response_model=AuditStatsResponse,
+    summary="Aggregate counts of audit events by type and severity",
+    operation_id="statsAudit",
+)
+def stats_audit_endpoint(
+    config: ConfigDep,
+    project: Annotated[
+        str | None,
+        Query(description="Scope to one project (per-project log + central tail)."),
+    ] = None,
+    since: Annotated[
+        str | None,
+        Query(description="ISO-8601 timestamp or shortcut (1h, 24h, 7d)."),
+    ] = None,
+) -> AuditStatsResponse:
+    """Return per-event and per-severity counts over the target files.
+
+    Uses the same target-file resolver + matching engine as
+    :func:`grep_audit_endpoint` but with a match-everything pattern
+    so the aggregation reflects the full set the operator could grep
+    (subject only to ``project`` + ``since``). ``severity`` maps to
+    the audit record's ``status`` field (``ok`` / ``warn`` / ``error``)
+    — the same vocabulary :func:`pollypm.audit.log.emit` writes today.
+    """
+    since_dt = _parse_since_or_400(since)
+    targets = _resolve_target_files(project_filter=project, config=config)
+
+    by_event: dict[str, int] = {}
+    by_severity: dict[str, int] = {}
+    total = 0
+    for record in _iter_matching_events(
+        targets=targets,
+        pattern=re.compile(r""),
+        since=since_dt,
+        event_type=None,
+    ):
+        total += 1
+        event_name = str(record.get("event") or "")
+        severity = str(record.get("status") or "ok")
+        by_event[event_name] = by_event.get(event_name, 0) + 1
+        by_severity[severity] = by_severity.get(severity, 0) + 1
+
+    return AuditStatsResponse(
+        total=total,
+        by_event=by_event,
+        by_severity=by_severity,
+        since=since_dt,
+    )
+
+
+__all__ = [
+    "AuditGrepResponse",
+    "AuditStatsResponse",
+    "router",
+]

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -100,6 +100,15 @@ class AuditGrepResponse(BaseModel):
     bounded-and-truncated one. ``limit`` caps returned matches; it
     does NOT cap scanned lines, so a no-match pathological regex
     still costs per-line work — the deadline is the hard upper bound.
+
+    ``_corrupt_archives_skipped`` (Codex round-7 finding, PR #2062)
+    counts rotated ``.gz`` archives the walker could not finish
+    reading — truncated mid-deflate (``EOFError``), bad gzip header
+    (``gzip.BadGzipFile``), or deeper deflate corruption
+    (``zlib.error``). The walker now treats those as best-effort
+    (one bad archive shouldn't break grep over the remaining files)
+    instead of letting the exception escape as a 500. Non-zero means
+    at least one archive needs operator attention.
     """
 
     events: list[Event]
@@ -110,6 +119,9 @@ class AuditGrepResponse(BaseModel):
         default=False, alias="_truncated_by_deadline"
     )
     lines_scanned: int = Field(default=0, alias="_lines_scanned")
+    corrupt_archives_skipped: int = Field(
+        default=0, alias="_corrupt_archives_skipped"
+    )
 
     model_config = {"populate_by_name": True}
 
@@ -141,6 +153,9 @@ class AuditStatsResponse(BaseModel):
         default=False, alias="_truncated_by_deadline"
     )
     lines_scanned: int = Field(default=0, alias="_lines_scanned")
+    corrupt_archives_skipped: int = Field(
+        default=0, alias="_corrupt_archives_skipped"
+    )
 
     model_config = {"populate_by_name": True}
 
@@ -367,6 +382,7 @@ def grep_audit_endpoint(
         _pattern_timeouts=walker_stats.get("pattern_timeouts", 0),
         _truncated_by_deadline=bool(walker_stats.get("truncated_by_deadline", 0)),
         _lines_scanned=walker_stats.get("lines_scanned", 0),
+        _corrupt_archives_skipped=walker_stats.get("corrupt_archives_skipped", 0),
     )
 
 
@@ -461,6 +477,7 @@ def stats_audit_endpoint(
         since=since_dt,
         _truncated_by_deadline=bool(walker_stats.get("truncated_by_deadline", 0)),
         _lines_scanned=walker_stats.get("lines_scanned", 0),
+        _corrupt_archives_skipped=walker_stats.get("corrupt_archives_skipped", 0),
     )
 
 

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -84,11 +84,19 @@ class AuditGrepResponse(BaseModel):
     means at least one archived line failed Pydantic ``Event``
     validation (typically a non-ISO ``ts`` from a pre-schema row) and
     was dropped rather than 500'ing the response.
+
+    ``_pattern_timeouts`` counts lines where the bounded-time regex
+    search exceeded the per-line timeout. Non-zero means a pathological
+    ReDoS pattern is being thrown at the API; the request still
+    returned within bounded time (each timed-out line is treated as a
+    no-match) but the operator should know which queries triggered the
+    safety net. Always zero in literal-substring mode.
     """
 
     events: list[Event]
     next_cursor: str | None = None
     malformed_rows_skipped: int = Field(default=0, alias="_malformed_rows_skipped")
+    pattern_timeouts: int = Field(default=0, alias="_pattern_timeouts")
 
     model_config = {"populate_by_name": True}
 
@@ -144,9 +152,12 @@ def _validate_pattern_length(pattern: str) -> None:
 def _compile_safe_regex_or_400(pattern: str) -> re.Pattern[str]:
     """Compile an opt-in regex, after the length cap has been checked.
 
-    Stdlib ``re`` has no timeout knob, so the only guardrails we ship
-    are (a) the length cap above and (b) requiring ``safe_regex=true``
-    so a client can't enable catastrophic backtracking by accident.
+    Compiling a regex is cheap and deterministic; the catastrophic
+    backtracking risk is at *match time*. The query walker pipes each
+    line through :func:`pollypm.audit.query.safe_pattern_search`, which
+    runs the search on a bounded-time worker pool — a short pathological
+    pattern like ``(a+)+b`` can no longer hang the request. See the
+    module docstring "Round 2 guardrails" section for the full chain.
     """
     try:
         return re.compile(pattern)
@@ -264,12 +275,15 @@ def grep_audit_endpoint(
 
     events: list[Event] = []
     malformed = 0
+    walker_stats: dict[str, int] = {}
     for record in iter_matching_events(
         targets=targets,
         pattern=compiled,
         literal=literal,
         since=since_dt,
         event_type=event_type,
+        stats=walker_stats,
+        bounded_regex=True,
     ):
         event = _coerce_record_to_event(record)
         if event is None:
@@ -283,6 +297,7 @@ def grep_audit_endpoint(
         events=events,
         next_cursor=None,
         _malformed_rows_skipped=malformed,
+        _pattern_timeouts=walker_stats.get("pattern_timeouts", 0),
     )
 
 

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -91,12 +91,25 @@ class AuditGrepResponse(BaseModel):
     returned within bounded time (each timed-out line is treated as a
     no-match) but the operator should know which queries triggered the
     safety net. Always zero in literal-substring mode.
+
+    ``_truncated_by_deadline`` (Codex round-4 finding, PR #2062) is
+    ``True`` when the request-level wall-clock deadline fired before
+    the walker finished scanning every target file. ``_lines_scanned``
+    reports how many non-empty lines were actually examined. Together
+    they let the caller distinguish a complete-but-empty scan from a
+    bounded-and-truncated one. ``limit`` caps returned matches; it
+    does NOT cap scanned lines, so a no-match pathological regex
+    still costs per-line work — the deadline is the hard upper bound.
     """
 
     events: list[Event]
     next_cursor: str | None = None
     malformed_rows_skipped: int = Field(default=0, alias="_malformed_rows_skipped")
     pattern_timeouts: int = Field(default=0, alias="_pattern_timeouts")
+    truncated_by_deadline: bool = Field(
+        default=False, alias="_truncated_by_deadline"
+    )
+    lines_scanned: int = Field(default=0, alias="_lines_scanned")
 
     model_config = {"populate_by_name": True}
 
@@ -246,6 +259,20 @@ def grep_audit_endpoint(
             ),
         ),
     ] = _GREP_LIMIT_DEFAULT,
+    deadline_seconds: Annotated[
+        float,
+        Query(
+            ge=0.5,
+            le=60.0,
+            description=(
+                "Request-level wall-clock budget (seconds). Default 5.0. "
+                "When exceeded, the response sets _truncated_by_deadline=true "
+                "and _lines_scanned reports how far the walker got. Caps "
+                "no-match pathological regex cost; required because 'limit' "
+                "only caps matches, not scanned lines (Codex round-4)."
+            ),
+        ),
+    ] = 5.0,
 ) -> AuditGrepResponse:
     """Return audit events matching the supplied filters.
 
@@ -271,6 +298,24 @@ def grep_audit_endpoint(
         # — operator probably just enabled it speculatively.
         pass
 
+    # Round-4 (Codex): ``safe_regex=true`` MUST come with ``since`` so the
+    # pattern only runs over a bounded slice of history — mirrors the
+    # round-2 stats invariant. Without this, a no-match pathological
+    # regex (``(a+)+b``) walks every live + rotated log; ``deadline_s``
+    # bounds wall-clock but ``since`` bounds the row count up front,
+    # which is cheaper and gives the operator an actionable error.
+    # Checked AFTER pattern compilation so a malformed regex still
+    # surfaces its own 400 first — operator gets the actionable error.
+    if safe_regex and since_dt is None:
+        raise invalid_request(
+            "'since' is required when 'safe_regex=true'",
+            hint=(
+                "Pass an ISO-8601 timestamp or shortcut (e.g. since=24h). "
+                "Regex mode walks every line in the window; bound it. "
+                "Literal-substring mode (default) has no such requirement."
+            ),
+        )
+
     targets = resolve_target_files(project_filter=project, config=config)
 
     events: list[Event] = []
@@ -284,6 +329,7 @@ def grep_audit_endpoint(
         event_type=event_type,
         stats=walker_stats,
         bounded_regex=True,
+        deadline_s=deadline_seconds,
     ):
         event = _coerce_record_to_event(record)
         if event is None:
@@ -305,6 +351,8 @@ def grep_audit_endpoint(
             malformed + walker_stats.get("malformed_rows_skipped", 0)
         ),
         _pattern_timeouts=walker_stats.get("pattern_timeouts", 0),
+        _truncated_by_deadline=bool(walker_stats.get("truncated_by_deadline", 0)),
+        _lines_scanned=walker_stats.get("lines_scanned", 0),
     )
 
 

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -123,12 +123,26 @@ class AuditStatsResponse(BaseModel):
     cutoff so the client can confirm the server interpreted shortcuts
     like ``24h`` against its own clock. The HTTP surface requires
     ``since`` to keep stats bounded (see module docstring).
+
+    ``_truncated_by_deadline`` + ``_lines_scanned`` (Codex round-6
+    finding, PR #2062) mirror the grep envelope: ``since`` is a
+    semantic bound but the walker still walks every target file/line
+    until it parses ``ts`` and filters. ``deadline_seconds`` is the
+    request-level wall-clock cap; when it fires the caller can tell
+    a complete aggregation from a bounded one and re-issue with a
+    tighter project/since to make progress.
     """
 
     total: int
     by_event: dict[str, int] = Field(default_factory=dict)
     by_severity: dict[str, int] = Field(default_factory=dict)
     since: datetime | None = None
+    truncated_by_deadline: bool = Field(
+        default=False, alias="_truncated_by_deadline"
+    )
+    lines_scanned: int = Field(default=0, alias="_lines_scanned")
+
+    model_config = {"populate_by_name": True}
 
 
 def _parse_since_or_400(value: str | None) -> datetime | None:
@@ -378,6 +392,24 @@ def stats_audit_endpoint(
             ),
         ),
     ] = None,
+    deadline_seconds: Annotated[
+        float,
+        Query(
+            ge=0.5,
+            le=120.0,
+            description=(
+                "Request-level wall-clock budget (seconds). Default 10.0 "
+                "(higher than /audit/grep's 5.0 because aggregation has "
+                "no early-exit on match-count). When exceeded the walker "
+                "stops, the response sets _truncated_by_deadline=true, "
+                "and _lines_scanned reports how many non-empty lines "
+                "were examined. Required because `since` is only a "
+                "semantic bound — the walker still reads every target "
+                "file/line until it parses `ts` and filters "
+                "(Codex round-6 finding)."
+            ),
+        ),
+    ] = 10.0,
 ) -> AuditStatsResponse:
     """Return per-event and per-severity counts over the target files.
 
@@ -414,6 +446,7 @@ def stats_audit_endpoint(
         since=since_dt,
         event_type=None,
         stats=walker_stats,
+        deadline_s=deadline_seconds,
     ):
         total += 1
         event_name = str(record.get("event") or "")
@@ -426,6 +459,8 @@ def stats_audit_endpoint(
         by_event=by_event,
         by_severity=by_severity,
         since=since_dt,
+        _truncated_by_deadline=bool(walker_stats.get("truncated_by_deadline", 0)),
+        _lines_scanned=walker_stats.get("lines_scanned", 0),
     )
 
 

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -143,6 +143,15 @@ class AuditStatsResponse(BaseModel):
     request-level wall-clock cap; when it fires the caller can tell
     a complete aggregation from a bounded one and re-issue with a
     tighter project/since to make progress.
+
+    ``_malformed_rows_skipped`` (Codex round-9 finding, PR #2062)
+    mirrors the grep envelope: the parse-gated walker bumps the
+    counter when a row's ``ts`` won't parse (typically a non-ISO
+    string from a pre-schema archived row). The previous route
+    dropped this; surfacing it lets the operator distinguish
+    "two events matched" from "two events matched + N archived
+    rows were silently skipped" without having to cross-check via
+    ``/audit/grep``.
     """
 
     total: int
@@ -155,6 +164,9 @@ class AuditStatsResponse(BaseModel):
     lines_scanned: int = Field(default=0, alias="_lines_scanned")
     corrupt_archives_skipped: int = Field(
         default=0, alias="_corrupt_archives_skipped"
+    )
+    malformed_rows_skipped: int = Field(
+        default=0, alias="_malformed_rows_skipped"
     )
 
     model_config = {"populate_by_name": True}
@@ -451,9 +463,10 @@ def stats_audit_endpoint(
     # Round-3 fix: route stats through the same parse-gated walker as
     # grep so malformed-ts rows (and the broken-string-compare bug in
     # round 2) can't inflate ``total``. We pass a ``stats`` dict so
-    # the walker bumps ``malformed_rows_skipped`` for us; we don't
-    # surface the counter in the response today, but reading it keeps
-    # the walker contract symmetric across both endpoints.
+    # the walker bumps ``malformed_rows_skipped`` for us; round-9
+    # surfaces the counter in the response so callers can distinguish
+    # a clean aggregation from one where archived rows were silently
+    # skipped.
     walker_stats: dict[str, int] = {}
     for record in iter_matching_events(
         targets=targets,
@@ -478,6 +491,7 @@ def stats_audit_endpoint(
         _truncated_by_deadline=bool(walker_stats.get("truncated_by_deadline", 0)),
         _lines_scanned=walker_stats.get("lines_scanned", 0),
         _corrupt_archives_skipped=walker_stats.get("corrupt_archives_skipped", 0),
+        _malformed_rows_skipped=walker_stats.get("malformed_rows_skipped", 0),
     )
 
 

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -5,36 +5,36 @@ Implements the historical-query side of the audit surface:
 * ``GET /api/v1/audit/grep`` — mirrors ``pm audit grep`` (PR #2036).
   Filters: ``project``, ``since`` (ISO-8601 or ``1h``/``24h``/``7d``
   shortcut), ``event_type`` (exact match on ``.event``), ``pattern``
-  (Python ``re.search`` regex on the raw JSONL line), ``limit``
-  (default 100, max 1000).
+  (literal substring by default; opt-in regex via ``safe_regex=true``),
+  ``limit`` (default 100, max 1000).
 * ``GET /api/v1/audit/stats`` — aggregate counts over the same target
-  files. Returns ``{by_event, by_severity, total, since}``.
+  files. Returns ``{by_event, by_severity, total, since}``. The HTTP
+  surface REQUIRES a bounded time window (``since`` query param) —
+  unbounded full-history scans must use the CLI (``pm audit grep``).
 
 The streaming side (``GET /api/v1/audit/stream``) is already shipped
 as ``GET /api/v1/events`` (Phase 1 SSE). This module intentionally does
 not re-route that path — it would duplicate the stream multiplexer for
 no operator benefit (see Phase 2 spec §8.1).
 
-Helper reuse (per spec): the route module is a thin adapter over the
-private helpers in :mod:`pollypm.cli_features.audit`:
+Module boundary (Codex P1 review, PR #2062 round 2): rotation-aware
+query helpers live in :mod:`pollypm.audit.query`, NOT in
+``cli_features.audit``. The CLI module is a thin Typer adapter over
+the same domain code; both surfaces share parse/walk semantics.
 
-* :func:`_resolve_target_files` — picks the right per-project +
-  central-tail paths based on the ``project`` filter. The web API
-  passes the in-memory :class:`PollyPMConfig` directly so the helper
-  doesn't reload the user's config from disk on every request.
-* :func:`_iter_matching_events` — applies the cheap→expensive filter
-  chain (regex first against the raw line, then ``event_type``
-  equality, then ``since``). Streams rather than slurps so a multi-MB
-  rotated ``.gz`` archive doesn't blow memory.
-* :func:`parse_since` — ISO-8601 / shortcut parsing, identical to the
-  CLI surface so the API contract matches what ``pm audit grep --since``
-  accepts.
+HTTP guardrails added in round 2:
 
-This is intentionally a separate router file (not folded into
-``events.py``) because the streaming and grep surfaces have distinct
-auth requirements (SSE uses ``?token=`` query auth; grep + stats use
-bearer-only) and distinct response shapes (``text/event-stream`` vs.
-``application/json``).
+* ReDoS: ``pattern`` is a LITERAL substring match by default. Regex
+  is opt-in via ``safe_regex=true``; both modes cap pattern length
+  at :data:`_PATTERN_LENGTH_MAX` so a pathological client can't ship
+  a 100 KB regex through the audit walker.
+* Malformed rows: corrupt ``ts`` values (and any other
+  ``ValidationError``-raising field) are skipped per-row with a counted
+  diagnostic on the response (``_malformed_rows_skipped``) — one bad
+  archived line no longer 500s the entire query.
+* Unbounded stats: ``/audit/stats`` requires ``since``; without it the
+  endpoint returns ``400 invalid_request`` pointing the operator at
+  the CLI for whole-history aggregation.
 """
 
 from __future__ import annotations
@@ -44,12 +44,12 @@ from datetime import datetime, timezone
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
-from pollypm.cli_features.audit import (
-    _iter_matching_events,
-    _resolve_target_files,
+from pollypm.audit.query import (
+    iter_matching_events,
     parse_since,
+    resolve_target_files,
 )
 from pollypm.web_api.errors import invalid_request
 from pollypm.web_api.models import Event
@@ -64,6 +64,13 @@ router = APIRouter(tags=["Audit"])
 _GREP_LIMIT_DEFAULT = 100
 _GREP_LIMIT_MAX = 1000
 
+# Cap pattern length (literal AND regex). Anything longer is almost
+# certainly an abuse vector — operator patterns top out around 50
+# chars in practice. 200 chars leaves headroom for json-escape-heavy
+# regexes without giving an attacker room for a 50 KB catastrophic
+# backtracker (Codex round-1 P0 ReDoS finding).
+_PATTERN_LENGTH_MAX = 200
+
 
 class AuditGrepResponse(BaseModel):
     """Body for ``GET /audit/grep``.
@@ -72,10 +79,18 @@ class AuditGrepResponse(BaseModel):
     future paging (cursor encoding lives outside this PR per the
     "Phase 2 audit query" scope) — we always return ``None`` today so
     clients see the field shape without depending on its value.
+
+    ``_malformed_rows_skipped`` is a diagnostic counter — non-zero
+    means at least one archived line failed Pydantic ``Event``
+    validation (typically a non-ISO ``ts`` from a pre-schema row) and
+    was dropped rather than 500'ing the response.
     """
 
     events: list[Event]
     next_cursor: str | None = None
+    malformed_rows_skipped: int = Field(default=0, alias="_malformed_rows_skipped")
+
+    model_config = {"populate_by_name": True}
 
 
 class AuditStatsResponse(BaseModel):
@@ -85,7 +100,8 @@ class AuditStatsResponse(BaseModel):
     so totals + per-event / per-severity counts match what a manual
     grep would produce. ``since`` echoes the parsed-and-normalized
     cutoff so the client can confirm the server interpreted shortcuts
-    like ``24h`` against its own clock.
+    like ``24h`` against its own clock. The HTTP surface requires
+    ``since`` to keep stats bounded (see module docstring).
     """
 
     total: int
@@ -97,31 +113,41 @@ class AuditStatsResponse(BaseModel):
 def _parse_since_or_400(value: str | None) -> datetime | None:
     """Wrap :func:`parse_since` to raise the typed API error.
 
-    The CLI helper raises ``typer.BadParameter`` for invalid inputs;
-    we re-raise as ``400 invalid_request`` so the API contract (spec
-    §6 error envelope) is consistent. Returns ``None`` when the
-    caller passed nothing — no filter requested.
+    The neutral helper raises :class:`ValueError`; we re-raise as
+    ``400 invalid_request`` so the API contract (spec §6 error
+    envelope) is consistent. Returns ``None`` when the caller passed
+    nothing — no filter requested.
     """
     if value is None:
         return None
     try:
         return parse_since(value)
-    except Exception as exc:  # noqa: BLE001 — typer.BadParameter is the only path, but stay defensive
+    except ValueError as exc:
         raise invalid_request(
             f"invalid 'since' value {value!r}",
             hint="ISO-8601 (e.g. 2026-05-21T03:14:15Z) or shortcut like 1h / 24h / 7d",
         ) from exc
 
 
-def _compile_pattern_or_400(pattern: str | None) -> re.Pattern[str]:
-    """Compile the grep pattern or raise ``400 invalid_request``.
+def _validate_pattern_length(pattern: str) -> None:
+    """Reject over-long patterns up-front (ReDoS guardrail, P0)."""
+    if len(pattern) > _PATTERN_LENGTH_MAX:
+        raise invalid_request(
+            f"'pattern' is {len(pattern)} chars; max is {_PATTERN_LENGTH_MAX}",
+            hint=(
+                "Audit-grep patterns are operator-scale (a few dozen chars). "
+                "Truncate the pattern or filter via project/event_type/since."
+            ),
+        )
 
-    ``None`` / empty pattern is treated as "match everything" so the
-    endpoint works as a project/event-type filter without forcing the
-    caller to send ``pattern=.``.
+
+def _compile_safe_regex_or_400(pattern: str) -> re.Pattern[str]:
+    """Compile an opt-in regex, after the length cap has been checked.
+
+    Stdlib ``re`` has no timeout knob, so the only guardrails we ship
+    are (a) the length cap above and (b) requiring ``safe_regex=true``
+    so a client can't enable catastrophic backtracking by accident.
     """
-    if not pattern:
-        return re.compile(r"")
     try:
         return re.compile(pattern)
     except re.error as exc:
@@ -131,29 +157,38 @@ def _compile_pattern_or_400(pattern: str | None) -> re.Pattern[str]:
         ) from exc
 
 
-def _coerce_record_to_event(record: dict[str, Any]) -> Event:
+def _coerce_record_to_event(record: dict[str, Any]) -> Event | None:
     """Reshape an audit JSON record into the ``Event`` response model.
 
-    Tolerates the schema-version + ts shape the writer emits (see
-    :func:`pollypm.audit.log._build_record`). Strings that pydantic
-    cannot parse as ``datetime`` are passed through verbatim; the
-    response_model serializer will normalize them on output.
+    Returns ``None`` instead of raising when the record is too
+    malformed for Pydantic to accept (typically a non-ISO ``ts``
+    string from a pre-schema archived row). Callers should increment
+    a diagnostic counter so the operator can tell that historical
+    rows were silently dropped vs. there simply being no matches.
     """
-    return Event(
-        schema=int(record.get("schema", 1)),
-        ts=record.get("ts") or datetime.now(timezone.utc),
-        project=str(record.get("project") or ""),
-        event=str(record.get("event") or ""),
-        subject=str(record.get("subject") or ""),
-        actor=str(record.get("actor") or ""),
-        status=str(record.get("status") or "ok"),
-        metadata=record.get("metadata") or None,
-    )
+    try:
+        return Event(
+            schema=int(record.get("schema", 1)),
+            ts=record.get("ts") or datetime.now(timezone.utc),
+            project=str(record.get("project") or ""),
+            event=str(record.get("event") or ""),
+            subject=str(record.get("subject") or ""),
+            actor=str(record.get("actor") or ""),
+            status=str(record.get("status") or "ok"),
+            metadata=record.get("metadata") or None,
+        )
+    except ValidationError:
+        return None
+    except (TypeError, ValueError):
+        # ``int(record.get("schema"))`` etc. can blow up on garbage
+        # input types — treat the same as a validation miss.
+        return None
 
 
 @router.get(
     "/audit/grep",
     response_model=AuditGrepResponse,
+    response_model_by_alias=True,
     summary="Search audit-log events (rotation-aware)",
     operation_id="grepAudit",
 )
@@ -173,8 +208,23 @@ def grep_audit_endpoint(
     ] = None,
     pattern: Annotated[
         str | None,
-        Query(description="Python regex (re.search) over the raw JSONL line."),
+        Query(
+            description=(
+                "Substring matched against the raw JSONL line. Literal by "
+                "default; pass safe_regex=true to interpret as a Python "
+                f"re.search pattern. Capped at {_PATTERN_LENGTH_MAX} chars."
+            ),
+        ),
     ] = None,
+    safe_regex: Annotated[
+        bool,
+        Query(
+            description=(
+                "Opt in to regex semantics for 'pattern'. Default false "
+                "(literal substring) avoids ReDoS hazards on the API worker."
+            ),
+        ),
+    ] = False,
     limit: Annotated[
         int,
         Query(
@@ -190,27 +240,50 @@ def grep_audit_endpoint(
 
     Streams the rotation-aware target files (live ``.jsonl`` + ``.gz``
     archives newest-first) and applies filters in cheap→expensive
-    order: regex first, then ``event_type``, then ``since``. The
-    response is capped at ``limit`` matches; the spec leaves cursor
-    pagination to a follow-up PR (always returns ``next_cursor=null``
-    today).
+    order: substring/regex first, then ``event_type``, then ``since``.
+    The response is capped at ``limit`` matches; the spec leaves
+    cursor pagination to a follow-up PR (always returns
+    ``next_cursor=null`` today).
     """
     since_dt = _parse_since_or_400(since)
-    compiled = _compile_pattern_or_400(pattern)
-    targets = _resolve_target_files(project_filter=project, config=config)
+
+    literal: str | None = None
+    compiled: re.Pattern[str] | None = None
+    if pattern:
+        _validate_pattern_length(pattern)
+        if safe_regex:
+            compiled = _compile_safe_regex_or_400(pattern)
+        else:
+            literal = pattern
+    elif safe_regex:
+        # Treat ``safe_regex=true`` with no pattern as "match anything"
+        # — operator probably just enabled it speculatively.
+        pass
+
+    targets = resolve_target_files(project_filter=project, config=config)
 
     events: list[Event] = []
-    for record in _iter_matching_events(
+    malformed = 0
+    for record in iter_matching_events(
         targets=targets,
         pattern=compiled,
+        literal=literal,
         since=since_dt,
         event_type=event_type,
     ):
-        events.append(_coerce_record_to_event(record))
+        event = _coerce_record_to_event(record)
+        if event is None:
+            malformed += 1
+            continue
+        events.append(event)
         if len(events) >= limit:
             break
 
-    return AuditGrepResponse(events=events, next_cursor=None)
+    return AuditGrepResponse(
+        events=events,
+        next_cursor=None,
+        _malformed_rows_skipped=malformed,
+    )
 
 
 @router.get(
@@ -227,27 +300,40 @@ def stats_audit_endpoint(
     ] = None,
     since: Annotated[
         str | None,
-        Query(description="ISO-8601 timestamp or shortcut (1h, 24h, 7d)."),
+        Query(
+            description=(
+                "REQUIRED. ISO-8601 timestamp or shortcut (1h, 24h, 7d). "
+                "The HTTP surface refuses unbounded full-history stats — "
+                "use the CLI (`pm audit grep`) for that."
+            ),
+        ),
     ] = None,
 ) -> AuditStatsResponse:
     """Return per-event and per-severity counts over the target files.
 
-    Uses the same target-file resolver + matching engine as
-    :func:`grep_audit_endpoint` but with a match-everything pattern
-    so the aggregation reflects the full set the operator could grep
-    (subject only to ``project`` + ``since``). ``severity`` maps to
-    the audit record's ``status`` field (``ok`` / ``warn`` / ``error``)
-    — the same vocabulary :func:`pollypm.audit.log.emit` writes today.
+    Bounded by ``since`` (mandatory on the HTTP surface — see module
+    docstring). ``severity`` maps to the audit record's ``status``
+    field (``ok`` / ``warn`` / ``error``) — the same vocabulary
+    :func:`pollypm.audit.log.emit` writes today.
     """
+    if since is None:
+        raise invalid_request(
+            "'since' is required for /audit/stats",
+            hint=(
+                "Pass an ISO-8601 timestamp or shortcut (e.g. since=24h). "
+                "Use the CLI `pm audit grep` for unbounded history scans."
+            ),
+        )
     since_dt = _parse_since_or_400(since)
-    targets = _resolve_target_files(project_filter=project, config=config)
+    targets = resolve_target_files(project_filter=project, config=config)
 
     by_event: dict[str, int] = {}
     by_severity: dict[str, int] = {}
     total = 0
-    for record in _iter_matching_events(
+    for record in iter_matching_events(
         targets=targets,
-        pattern=re.compile(r""),
+        pattern=None,
+        literal=None,
         since=since_dt,
         event_type=None,
     ):

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -293,10 +293,17 @@ def grep_audit_endpoint(
         if len(events) >= limit:
             break
 
+    # Total malformed = rows dropped by the walker's ts-parse gate
+    # (Codex round-3) PLUS rows that survived parsing but failed the
+    # Pydantic ``Event`` model (older / partial schemas). Surfacing
+    # both under one counter keeps the contract simple: any non-zero
+    # value means archived rows were silently skipped.
     return AuditGrepResponse(
         events=events,
         next_cursor=None,
-        _malformed_rows_skipped=malformed,
+        _malformed_rows_skipped=(
+            malformed + walker_stats.get("malformed_rows_skipped", 0)
+        ),
         _pattern_timeouts=walker_stats.get("pattern_timeouts", 0),
     )
 
@@ -345,12 +352,20 @@ def stats_audit_endpoint(
     by_event: dict[str, int] = {}
     by_severity: dict[str, int] = {}
     total = 0
+    # Round-3 fix: route stats through the same parse-gated walker as
+    # grep so malformed-ts rows (and the broken-string-compare bug in
+    # round 2) can't inflate ``total``. We pass a ``stats`` dict so
+    # the walker bumps ``malformed_rows_skipped`` for us; we don't
+    # surface the counter in the response today, but reading it keeps
+    # the walker contract symmetric across both endpoints.
+    walker_stats: dict[str, int] = {}
     for record in iter_matching_events(
         targets=targets,
         pattern=None,
         literal=None,
         since=since_dt,
         event_type=None,
+        stats=walker_stats,
     ):
         total += 1
         event_name = str(record.get("event") or "")

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -741,3 +741,129 @@ def test_audit_grep_short_pathological_pattern_does_not_hang(
     # three do, but we only assert >= 1 to keep the test robust on a
     # faster future machine where some lines happen to complete in time.
     assert body.get("_pattern_timeouts", 0) >= 1, body
+
+
+# ---------------------------------------------------------------------------
+# Round-3 guardrails (Codex review on PR #2062): parsed-timestamp ``since``
+# comparison + malformed-row gating for both grep AND stats.
+# See ``src/pollypm/audit/query.py::iter_matching_events`` docstring step 4.
+# ---------------------------------------------------------------------------
+
+
+def test_audit_grep_since_handles_tz_offsets(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """``since`` must compare parsed datetimes, not raw ISO strings.
+
+    Round-2 code did a lexicographic ``line < since_iso`` compare which
+    let timezone-offset rows leak through: ``2026-05-21T01:00:00+02:00``
+    is lexicographically AFTER ``2026-05-21T00:00:00+00:00`` but is
+    actually ``2026-05-20T23:00:00Z`` — one hour BEFORE the cutoff, so
+    it must be EXCLUDED. Round-3 fixes the compare by parsing both sides.
+    """
+    # 01:00 local with +02:00 offset = 23:00 UTC the previous day.
+    older_tz_offset_ts = "2026-05-21T01:00:00+02:00"
+    # Anything clearly fresher than the cutoff so we can confirm the
+    # filter still admits valid rows in the same query.
+    fresh_ts = "2026-05-21T05:00:00+00:00"
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(subject="myproj/should-be-excluded", ts=older_tz_offset_ts),
+            _make_event(subject="myproj/should-be-kept", ts=fresh_ts),
+        ],
+    )
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={
+            "project": "myproj",
+            "since": "2026-05-21T00:00:00Z",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    subjects = [e["subject"] for e in response.json()["events"]]
+    # The +02:00 row is older than the cutoff in real time; it MUST be
+    # dropped. Round-2 (raw string compare) erroneously included it.
+    assert "myproj/should-be-excluded" not in subjects
+    assert subjects == ["myproj/should-be-kept"]
+
+
+def test_audit_grep_malformed_ts_skipped(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Rows whose ``ts`` doesn't parse must be excluded + counted.
+
+    Independent of ``since`` — even with no time-window filter, a
+    record with ``ts="not-a-date"`` is unsafe to keep (the response
+    model needs a datetime, and downstream consumers expect ordered
+    chronology). The walker drops it and increments the diagnostic
+    counter so the operator sees that history was silently elided.
+    """
+    log_path = _per_project_log(project_root)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    good = _make_event(subject="myproj/good", ts="2026-05-21T00:00:00+00:00")
+    bad = _make_event(subject="myproj/bad", ts="not-a-date")
+    with open(log_path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(good) + "\n")
+        fh.write(json.dumps(bad) + "\n")
+
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    subjects = [e["subject"] for e in body["events"]]
+    assert subjects == ["myproj/good"]
+    # The malformed row was caught by the walker (round-3 parse gate)
+    # rather than the older Pydantic-level coerce — either way the
+    # counter on the response envelope must reflect it.
+    assert body["_malformed_rows_skipped"] >= 1
+
+
+def test_audit_stats_skips_malformed_rows(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """``/audit/stats`` total must NOT count malformed-ts rows.
+
+    Round-2 stats iterated raw rows without validating ``ts`` — a
+    corrupt archive row inflated ``total``. Round-3 routes stats
+    through the same parse-gated walker, so totals stay symmetric
+    with what ``/audit/grep`` would return.
+    """
+    log_path = _per_project_log(project_root)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    valid = [
+        _make_event(event="task.created", ts="2026-05-21T00:00:00+00:00"),
+        _make_event(event="task.created", ts="2026-05-21T00:01:00+00:00"),
+    ]
+    invalid = [
+        _make_event(event="task.created", ts="not-a-date"),
+        _make_event(event="task.created", ts="2026-13-45T99:99:99Z"),
+    ]
+    with open(log_path, "w", encoding="utf-8") as fh:
+        for record in valid + invalid:
+            fh.write(json.dumps(record) + "\n")
+
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj", "since": "30d"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Only the two valid rows count — the malformed pair is gated out
+    # before reaching the by-event counter.
+    assert body["total"] == 2
+    assert body["by_event"] == {"task.created": 2}

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -1286,3 +1286,101 @@ def test_audit_stats_request_deadline_truncates_large_scan(
     assert 1 <= body.get("_lines_scanned", 0) < total_rows, body
     # Every row was outside ``since=24h`` so no aggregation is reported.
     assert body["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Round-10 guardrail (Codex review on PR #2062): the bounded-regex path
+# advertises ``since`` as the work bound — but ``iter_matching_events`` was
+# running the pattern against the raw line BEFORE parsing ``ts`` and applying
+# the ``since`` cutoff. That meant ``safe_regex=true&since=24h`` could spend
+# the full ``deadline_seconds`` on pathological no-match rows that the
+# ``since`` window would have rejected anyway. The reorder (parse + window
+# filter BEFORE regex) is what this test pins.
+# ---------------------------------------------------------------------------
+def test_audit_grep_regex_skips_old_rows_before_pattern(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bounded regex must only run on rows inside the ``since`` window.
+
+    Pre-round-10 the walker burned the per-line regex budget on every
+    row that hit the file — including old archived rows that the
+    ``since`` cutoff would have dropped on the next gate. With a
+    pathological pattern + tight ``deadline_seconds`` that meant a
+    wall of old rows at the front of the log could exhaust the request
+    deadline before the walker ever reached a fresh in-window row.
+
+    Setup mirrors the Codex finding shape:
+      - 100 OLDER rows (timestamp pre-dates ``since``) sitting in
+        front of the in-window slice.
+      - 5 IN-WINDOW rows the caller actually asked about.
+      - ``safe_regex=true`` with a pattern that, under the old order,
+        would be evaluated against all 105 raw lines.
+
+    The contract pin: the bounded regex session's ``search`` MUST be
+    invoked at most ``in_window_rows`` times (5), not the full 105.
+    On the pre-round-10 head the counter hits 100+ and the test fails.
+    """
+    from pollypm.audit import query as audit_query
+
+    # In-window window cutoff: anything older than 1 h ago is dropped.
+    now = datetime.now(timezone.utc)
+    old_ts = (now - timedelta(days=30)).isoformat()
+    fresh_ts = (now - timedelta(minutes=5)).isoformat()
+
+    old_rows = [
+        _make_event(subject=f"old-{i}", ts=old_ts) for i in range(100)
+    ]
+    fresh_rows = [
+        _make_event(subject=f"fresh-{i}", ts=fresh_ts) for i in range(5)
+    ]
+    _write_jsonl(
+        _per_project_log(project_root),
+        # Old rows FIRST so under the old (regex-before-since) order the
+        # walker spends its full deadline on them before ever reaching
+        # the in-window slice.
+        old_rows + fresh_rows,
+    )
+
+    # Count every call into the bounded-regex session. We don't care
+    # whether it matched — only whether the walker reached it at all.
+    # If the reorder works, ``search`` runs only on in-window rows.
+    call_count = {"n": 0}
+    real_search = audit_query._BoundedRegexSession.search
+
+    def counting_search(self, line, *, max_wall_clock_s=None):  # type: ignore[no-untyped-def]
+        call_count["n"] += 1
+        return real_search(self, line, max_wall_clock_s=max_wall_clock_s)
+
+    monkeypatch.setattr(
+        audit_query._BoundedRegexSession, "search", counting_search
+    )
+
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={
+            "project": "myproj",
+            # Simple, non-pathological pattern — the test is about WHICH
+            # rows the regex runs on, not about ReDoS handling. Matches
+            # nothing (subjects start with ``old-``/``fresh-``).
+            "pattern": "no-such-substring",
+            "safe_regex": "true",
+            "since": "1h",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # No subject matches the pattern → empty result set is expected.
+    assert body["events"] == []
+    # The contract: regex evaluated only on in-window rows (5), not on
+    # the 100 older rows the ``since`` window already excludes.
+    # Pre-round-10 the counter is 105; post-round-10 it's <= 5.
+    assert call_count["n"] <= len(fresh_rows), (
+        f"bounded regex ran on {call_count['n']} rows; "
+        f"since=1h should have limited it to <= {len(fresh_rows)} "
+        f"(old rows must be filtered BEFORE the pattern)"
+    )

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -356,6 +356,75 @@ def test_grep_walks_rotated_gz_archives(
     assert subjects == ["myproj/live", "myproj/archived"]
 
 
+def test_grep_skips_truncated_gz_archive_and_counts_it(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Codex round-7 (PR #2062): a truncated ``.gz`` archive must not 500.
+
+    Before the fix the walker only caught ``OSError`` around
+    ``gzip.open(...)``/iteration; truncated archives raise
+    :class:`EOFError` mid-iteration, which escaped past
+    :func:`iter_matching_events` and bubbled to the route as a 500 —
+    one bad rotated file would take out the whole grep. The fix
+    catches ``EOFError`` / ``gzip.BadGzipFile`` / ``zlib.error``,
+    bumps ``stats["corrupt_archives_skipped"]``, and the route
+    surfaces it as ``_corrupt_archives_skipped`` on the response.
+    """
+    live = _per_project_log(project_root)
+    _write_jsonl(live, [_make_event(subject="myproj/live")])
+
+    # Build a real gzip stream, then truncate it mid-deflate so
+    # iteration raises EOFError (not OSError) — exact failure mode
+    # Codex flagged.
+    valid_archive = live.with_name(live.name + ".1700000000.gz")
+    _write_jsonl_gz(valid_archive, [_make_event(subject="myproj/valid_arch")])
+    valid_bytes = valid_archive.read_bytes()
+    truncated_archive = live.with_name(live.name + ".1699000000.gz")
+    truncated_archive.write_bytes(valid_bytes[: len(valid_bytes) // 2])
+    os.utime(valid_archive, (1_700_000_000, 1_700_000_000))
+    os.utime(truncated_archive, (1_699_000_000, 1_699_000_000))
+
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "pattern": "myproj/"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    subjects = [e["subject"] for e in body["events"]]
+    # Live + valid archive survive; truncated archive is skipped.
+    assert "myproj/live" in subjects
+    assert "myproj/valid_arch" in subjects
+    assert body.get("_corrupt_archives_skipped", 0) >= 1, body
+
+
+def test_grep_skips_bad_gzip_header_archive(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Bogus header (``gzip.BadGzipFile``) is also best-effort skipped."""
+    live = _per_project_log(project_root)
+    _write_jsonl(live, [_make_event(subject="myproj/live")])
+    bogus = live.with_name(live.name + ".1698000000.gz")
+    bogus.write_bytes(b"this is not a gzip file at all")
+    os.utime(bogus, (1_698_000_000, 1_698_000_000))
+
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "pattern": "myproj/"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert any(e["subject"] == "myproj/live" for e in body["events"])
+    assert body.get("_corrupt_archives_skipped", 0) >= 1, body
+
+
 def test_grep_limit_caps_result_count(
     client: TestClient,
     auth_headers: dict[str, str],

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -267,6 +267,8 @@ def test_grep_regex_pattern_filters_lines(
             "project": "myproj",
             "pattern": r"myproj/\d+",
             "safe_regex": "true",
+            # Round-4: regex mode requires ``since`` to bound the scan.
+            "since": "30d",
         },
         headers=auth_headers,
     )
@@ -723,6 +725,12 @@ def test_audit_grep_short_pathological_pattern_does_not_hang(
             "project": "myproj",
             "pattern": "(a+)+b",
             "safe_regex": "true",
+            # Round-4: regex mode requires ``since``; pick a window
+            # generous enough to keep all three rows in scope.
+            "since": "30d",
+            # Round-4: deadline well above the 3-row worst case so we're
+            # still measuring the per-line bound, not the request bound.
+            "deadline_seconds": "30.0",
         },
         headers=auth_headers,
     )
@@ -867,3 +875,125 @@ def test_audit_stats_skips_malformed_rows(
     # before reaching the by-event counter.
     assert body["total"] == 2
     assert body["by_event"] == {"task.created": 2}
+
+
+# ---------------------------------------------------------------------------
+# Round-4 guardrails (Codex review on PR #2062): request-level bound for the
+# HTTP regex path. ``limit`` caps matches, not scanned lines, so a no-match
+# pathological regex over many rows can still hold an API worker for roughly
+# ``per_line_timeout * timed_out_lines``. The deadline + safe_regex-requires-
+# since invariants bound that work explicitly and surface a diagnostic so
+# callers can tell complete-but-empty from bounded-and-truncated.
+# ---------------------------------------------------------------------------
+
+
+def test_audit_grep_request_deadline_truncates_pathological_scan(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Request-level deadline halts a no-match pathological regex scan.
+
+    Round-3 left ``limit`` capping matches only; a no-match regex still
+    walks every line. With many pathological rows the per-line timeout
+    (100 ms) stacks: 30 rows = ~3 s, 100 = ~10 s, etc. ``deadline_s=1.0``
+    must cap total wall-clock and surface ``_truncated_by_deadline=true``
+    so the caller knows results are bounded, not complete. Verifies the
+    regression FAILED on round-3 (no truncation field surfaced) and now
+    PASSES with the request-level bound wired through.
+    """
+    import time
+
+    # 60 pathological rows: each timed-out line costs ~100 ms timeout +
+    # worker respawn (~500 ms on macOS) → un-bounded baseline is roughly
+    # 60 × 0.6 s ≈ 36 s. The deadline must cut this off well before then.
+    pathological_subject = "a" * 40 + "!"
+    total_rows = 60
+    _write_jsonl(
+        _per_project_log(project_root),
+        [_make_event(subject=pathological_subject) for _ in range(total_rows)],
+    )
+
+    start = time.monotonic()
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={
+            "project": "myproj",
+            "pattern": "(a+)+b",
+            "safe_regex": "true",
+            "since": "30d",
+            "deadline_seconds": "1.0",
+        },
+        headers=auth_headers,
+    )
+    elapsed = time.monotonic() - start
+
+    # The deadline check fires BEFORE each line is searched, but a line
+    # already in flight when the deadline elapses still runs to per-line
+    # completion (~100 ms timeout + ~500 ms respawn). 15 s ceiling sits
+    # comfortably below the ~36 s un-bounded baseline (60 rows × ~600 ms)
+    # while absorbing forkserver warmup variability on a loaded CI host.
+    assert elapsed < 15.0, (
+        f"deadline did not fire; elapsed={elapsed:.3f}s "
+        f"(un-bounded would be ~{total_rows * 0.6:.0f}s)"
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Bounded-truncation diagnostic must be set so the caller can tell
+    # this from a complete-but-empty scan.
+    assert body.get("_truncated_by_deadline") is True, body
+    # And the walker must have stopped strictly before the full row set
+    # (otherwise the deadline didn't actually save work).
+    assert body.get("_lines_scanned", 0) < total_rows, body
+    assert body.get("_lines_scanned", 0) >= 1, body
+    # No matches expected — pathological pattern never hits ``b``.
+    assert body["events"] == []
+
+
+def test_audit_grep_regex_mode_requires_since(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """``safe_regex=true`` without ``since`` → ``400 invalid_request``.
+
+    Mirrors the round-2 ``/audit/stats`` invariant: regex mode walks
+    every line in the window, so the window must be bounded. Literal-
+    substring mode (default) is immune to ReDoS and stays unbounded.
+    """
+    _write_jsonl(
+        _per_project_log(project_root),
+        [_make_event(subject="myproj/whatever")],
+    )
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={
+            "project": "myproj",
+            "pattern": "foo",
+            "safe_regex": "true",
+            # NB: no ``since`` — must 400.
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "since" in body["error"]["message"].lower()
+    hint = (body["error"].get("hint") or "").lower()
+    assert "since" in hint or "literal" in hint
+
+    # Sanity check: the same request WITH ``since`` must succeed (so the
+    # 400 is specifically about the missing window, not the pattern).
+    ok_response = client.get(
+        "/api/v1/audit/grep",
+        params={
+            "project": "myproj",
+            "pattern": "foo",
+            "safe_regex": "true",
+            "since": "30d",
+        },
+        headers=auth_headers,
+    )
+    assert ok_response.status_code == 200, ok_response.text

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -677,3 +677,67 @@ def test_audit_stats_requires_time_window(
     # Hint should mention the CLI escape hatch for unbounded scans.
     hint = (body["error"].get("hint") or "").lower()
     assert "since" in hint or "cli" in hint or "pm audit" in hint
+
+
+def test_audit_grep_short_pathological_pattern_does_not_hang(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """ReDoS-style pattern ``(a+)+b`` against backtracking-heavy input.
+
+    Round 1's 200-char pattern cap doesn't stop this — the pattern is
+    only six characters but each line of ``a``s triggers catastrophic
+    backtracking in the stdlib ``re`` engine, which holds the GIL
+    throughout (so daemon threads can't time it out from Python). Round
+    2 runs each ``pattern.search`` inside a ``multiprocessing`` worker
+    so the OS can ``terminate()`` the child when its wall-clock budget
+    expires; the line is counted in ``_pattern_timeouts`` and the
+    response still returns.
+
+    Without the guardrail, ``(a+)+b`` against 40 ``a``s + ``!`` runs
+    for tens of seconds per line on Python 3.14 (190 s at n=30 in our
+    local benchmark, exponential in n). The test asserts a generous
+    8 s ceiling — well below the un-guarded backtrack cost but loose
+    enough to absorb the cost of respawning the worker process after
+    each timeout (a forkserver respawn is ~50 ms steady state but can
+    push into the second-range under TestClient + pytest scheduling).
+    """
+    import time
+
+    # 40 ``a``s followed by ``!`` — the ``!`` blocks any final ``b``
+    # match so the engine exhausts every grouping permutation before
+    # admitting defeat. Three rows so the timeout has to fire more
+    # than once (single-line timeout could be a happy accident).
+    pathological_subject = "a" * 40 + "!"
+    _write_jsonl(
+        _per_project_log(project_root),
+        [_make_event(subject=pathological_subject) for _ in range(3)],
+    )
+
+    start = time.monotonic()
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={
+            "project": "myproj",
+            "pattern": "(a+)+b",
+            "safe_regex": "true",
+        },
+        headers=auth_headers,
+    )
+    elapsed = time.monotonic() - start
+
+    # 8 s ceiling: per-line timeout is 100 ms but each fresh worker
+    # spawn after a kill adds ~50-1000 ms depending on host load. Three
+    # pathological lines is ~3 s worst case; we double that for slack.
+    # Without the guardrail this query would burn many minutes.
+    assert elapsed < 8.0, f"pattern.search hung; elapsed={elapsed:.3f}s"
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Every line timed out → no events matched.
+    assert body["events"] == []
+    # At least one line should have tripped the timeout — typically all
+    # three do, but we only assert >= 1 to keep the test robust on a
+    # faster future machine where some lines happen to complete in time.
+    assert body.get("_pattern_timeouts", 0) >= 1, body

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -946,6 +946,62 @@ def test_audit_stats_skips_malformed_rows(
     assert body["by_event"] == {"task.created": 2}
 
 
+def test_audit_stats_surfaces_malformed_rows_skipped(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """``/audit/stats`` must surface the walker's malformed-row counter.
+
+    Round-3 routed stats through the parse-gated walker so malformed
+    rows can't inflate totals, but the route dropped the diagnostic.
+    Round-9 (Codex review) surfaces ``_malformed_rows_skipped`` so
+    callers can tell a clean aggregation from one that silently
+    dropped archived rows — same shape grep already exposes.
+
+    Verifies BOTH the live response envelope and the static OpenAPI
+    schema document the field.
+    """
+    log_path = _per_project_log(project_root)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        _make_event(event="task.created", ts="2026-05-21T00:00:00+00:00"),
+        # Non-ISO ``ts`` — the walker bumps malformed_rows_skipped.
+        _make_event(event="task.created", ts="not-a-date"),
+    ]
+    with open(log_path, "w", encoding="utf-8") as fh:
+        for record in rows:
+            fh.write(json.dumps(record) + "\n")
+
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj", "since": "30d"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # The one valid row counts; the malformed one is gated out but
+    # the diagnostic counter MUST surface it on the response envelope.
+    assert body["total"] == 1
+    assert body["_malformed_rows_skipped"] >= 1
+
+    # Static OpenAPI yaml must document the same field so SDK
+    # generators don't strip it.
+    spec_path = (
+        Path(__file__).resolve().parent.parent / "docs" / "api" / "openapi.yaml"
+    )
+    spec_text = spec_path.read_text(encoding="utf-8")
+    stats_idx = spec_text.find("AuditStatsResponse:")
+    assert stats_idx != -1, "AuditStatsResponse schema missing from openapi.yaml"
+    # Look only at the AuditStatsResponse block (cut before the next
+    # top-level schema key).
+    stats_block = spec_text[stats_idx : stats_idx + 4000]
+    assert "_malformed_rows_skipped" in stats_block, (
+        "AuditStatsResponse schema must document _malformed_rows_skipped"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Round-4 guardrails (Codex review on PR #2062): request-level bound for the
 # HTTP regex path. ``limit`` caps matches, not scanned lines, so a no-match

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -252,7 +252,7 @@ def test_grep_regex_pattern_filters_lines(
     project_root: Path,
     audit_home: Path,
 ) -> None:
-    """Pattern is a Python regex (``re.search``) over the raw JSONL line."""
+    """Pattern is a Python regex (``re.search``) when ``safe_regex=true``."""
     _write_jsonl(
         _per_project_log(project_root),
         [
@@ -263,13 +263,43 @@ def test_grep_regex_pattern_filters_lines(
     )
     response = client.get(
         "/api/v1/audit/grep",
-        params={"project": "myproj", "pattern": r"myproj/\d+"},
+        params={
+            "project": "myproj",
+            "pattern": r"myproj/\d+",
+            "safe_regex": "true",
+        },
         headers=auth_headers,
     )
     assert response.status_code == 200
     subjects = [e["subject"] for e in response.json()["events"]]
     # ``myproj/abc`` doesn't match the digit-only suffix regex.
     assert subjects == ["myproj/1", "myproj/12"]
+
+
+def test_grep_default_pattern_is_literal_substring(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Without ``safe_regex=true``, ``pattern`` is matched as a substring."""
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(subject="myproj/1"),
+            _make_event(subject="myproj/12"),
+            _make_event(subject="myproj/abc"),
+        ],
+    )
+    # ``\d+`` is treated as the literal six characters, not a regex —
+    # nothing matches.
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "pattern": r"\d+"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["events"] == []
 
 
 def test_grep_since_shortcut_drops_old_events(
@@ -391,10 +421,10 @@ def test_grep_invalid_regex_returns_400_invalid_request(
     auth_headers: dict[str, str],
     audit_home: Path,
 ) -> None:
-    """Unbalanced group → ``400 invalid_request`` (not a 500)."""
+    """Unbalanced group with ``safe_regex=true`` → ``400 invalid_request``."""
     response = client.get(
         "/api/v1/audit/grep",
-        params={"pattern": "(unbalanced"},
+        params={"pattern": "(unbalanced", "safe_regex": "true"},
         headers=auth_headers,
     )
     assert response.status_code == 400, response.text
@@ -443,7 +473,7 @@ def test_stats_counts_by_event_and_severity(
     )
     response = client.get(
         "/api/v1/audit/stats",
-        params={"project": "myproj"},
+        params={"project": "myproj", "since": "30d"},
         headers=auth_headers,
     )
     assert response.status_code == 200, response.text
@@ -481,7 +511,7 @@ def test_stats_with_project_filter_isolates_one_project(
     )
     response = client.get(
         "/api/v1/audit/stats",
-        params={"project": "myproj"},
+        params={"project": "myproj", "since": "30d"},
         headers=auth_headers,
     )
     assert response.status_code == 200
@@ -528,7 +558,7 @@ def test_stats_empty_log_returns_zero_total(
     """No files at all → ``total=0`` (not a 500)."""
     response = client.get(
         "/api/v1/audit/stats",
-        params={"project": "myproj"},
+        params={"project": "myproj", "since": "24h"},
         headers=auth_headers,
     )
     assert response.status_code == 200
@@ -536,3 +566,114 @@ def test_stats_empty_log_returns_zero_total(
     assert body["total"] == 0
     assert body["by_event"] == {}
     assert body["by_severity"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Round-2 guardrails (Codex review on PR #2062): ReDoS, malformed rows,
+# unbounded stats. See module docstring in
+# ``src/pollypm/web_api/routes/audit.py``.
+# ---------------------------------------------------------------------------
+
+
+def test_audit_grep_pattern_length_capped(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+) -> None:
+    """Patterns longer than 200 chars → ``400 invalid_request``."""
+    long_pattern = "a" * 500
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"pattern": long_pattern},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "pattern" in body["error"]["message"]
+
+
+def test_audit_grep_pathological_pattern_returns_safely(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """ReDoS pattern returns within budget when default literal mode is on.
+
+    ``(a+)+b`` over ``aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!`` is the canonical
+    catastrophic-backtracking demo. The HTTP surface treats ``pattern``
+    as a literal substring by default, so this query must NOT hang —
+    it should complete in well under a second and just return no hits.
+    """
+    import time
+
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(subject=f"myproj/{'a' * 30}!"),
+            _make_event(subject="myproj/normal"),
+        ],
+    )
+    start = time.monotonic()
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "pattern": "(a+)+b"},
+        headers=auth_headers,
+    )
+    elapsed = time.monotonic() - start
+    assert response.status_code == 200, response.text
+    # Literal substring search over a handful of small lines must be
+    # near-instant; a 1 s budget is generous and unambiguously below
+    # what a catastrophic regex would take on the same input.
+    assert elapsed < 1.0, f"literal-mode grep took {elapsed:.3f}s (ReDoS regression?)"
+    # The literal string "(a+)+b" is never present in any line.
+    assert response.json()["events"] == []
+
+
+def test_audit_grep_malformed_row_skipped_not_500(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """A row with a non-ISO ``ts`` must be skipped, not 500 the response."""
+    log_path = _per_project_log(project_root)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    # Mix one valid event with one malformed one (bad ``ts``).
+    good = _make_event(subject="myproj/good", ts="2026-05-21T00:00:00+00:00")
+    bad = _make_event(subject="myproj/bad", ts="not-a-date")
+    with open(log_path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(good) + "\n")
+        fh.write(json.dumps(bad) + "\n")
+
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    subjects = [e["subject"] for e in body["events"]]
+    assert subjects == ["myproj/good"]
+    assert body["_malformed_rows_skipped"] >= 1
+
+
+def test_audit_stats_requires_time_window(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+) -> None:
+    """``/audit/stats`` without ``since`` → ``400 invalid_request`` with hint."""
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "since" in body["error"]["message"]
+    # Hint should mention the CLI escape hatch for unbounded scans.
+    hint = (body["error"].get("hint") or "").lower()
+    assert "since" in hint or "cli" in hint or "pm audit" in hint

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -1,0 +1,538 @@
+"""Integration tests for ``GET /api/v1/audit/{grep,stats}``.
+
+Phase 2 surface #6 (audit query). These tests drive the FastAPI app
+end-to-end against a synthesized audit-log tree so the rotation-aware
+file walker, ``since`` shortcut parsing, and filter chaining are all
+exercised through the HTTP surface.
+
+The harness mirrors ``tests/web_api/conftest.py`` but stays
+``--noconftest``-friendly so the spec's pytest invocation
+(``pytest --noconftest tests/test_audit_endpoint.py``) runs in
+isolation without pulling shared fixtures. Each fixture is declared
+locally; the cost is a bit of duplication, the win is that one
+unrelated failing fixture upstream can't mask regressions in this
+endpoint.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+from pollypm.web_api import create_app, ensure_token
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (self-contained — no shared conftest dependency)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def audit_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``POLLYPM_AUDIT_HOME`` so test logs don't bleed into ``~``."""
+    audit = tmp_path / "audit"
+    audit.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit))
+    return audit
+
+
+@pytest.fixture
+def api_config(
+    tmp_path: Path, project_root: Path, workspace_root: Path
+) -> PollyPMConfig:
+    base_dir = workspace_root / ".pollypm"
+    state_db = base_dir / "state.db"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace_root,
+            tmux_session="pollypm-test",
+            workspace_root=workspace_root,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=state_db,
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def token_path(tmp_path: Path) -> Path:
+    return tmp_path / "api-token"
+
+
+@pytest.fixture
+def token(token_path: Path) -> str:
+    value, _generated = ensure_token(token_path)
+    return value
+
+
+@pytest.fixture
+def app(api_config, token_path, token):  # noqa: ARG001 — token fixture must run
+    return create_app(config=api_config, token_path=token_path)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Log-writing helpers — drive the rotation-aware walker without going
+# through ``audit.log.emit`` (we want deterministic timestamps + the
+# ability to pre-place ``.gz`` archives).
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    *,
+    project: str = "myproj",
+    event: str = "task.created",
+    subject: str = "",
+    ts: str | None = None,
+    status: str = "ok",
+    actor: str = "polly",
+    metadata: dict | None = None,
+) -> dict:
+    return {
+        "schema": 1,
+        "ts": ts or "2026-05-21T00:00:00+00:00",
+        "project": project,
+        "event": event,
+        "subject": subject,
+        "actor": actor,
+        "status": status,
+        "metadata": metadata or {},
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _write_jsonl_gz(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _per_project_log(project_root: Path) -> Path:
+    return project_root / ".pollypm" / "audit.jsonl"
+
+
+def _central_log(audit_home: Path, project: str) -> Path:
+    return audit_home / f"{project}.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_grep_requires_auth(client: TestClient, audit_home: Path) -> None:
+    """No bearer → ``401 unauthorized`` (spec §6 / Phase 1 §3)."""
+    response = client.get("/api/v1/audit/grep")
+    assert response.status_code == 401
+    body = response.json()
+    assert body["error"]["code"] in {"unauthorized", "invalid_token"}
+
+
+def test_stats_requires_auth(client: TestClient, audit_home: Path) -> None:
+    response = client.get("/api/v1/audit/stats")
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Grep happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_grep_happy_path_returns_matching_events(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Filter chain (project + event_type + pattern) returns hits."""
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(event="task.created", subject="myproj/1"),
+            _make_event(event="task.created", subject="myproj/2"),
+            _make_event(event="task.status_changed", subject="myproj/1"),
+        ],
+    )
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "event_type": "task.created", "pattern": "myproj/"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["next_cursor"] is None
+    subjects = [e["subject"] for e in body["events"]]
+    assert subjects == ["myproj/1", "myproj/2"]
+    # Sanity: every event carries the canonical Event shape.
+    assert all("event" in e and "actor" in e for e in body["events"])
+
+
+def test_grep_regex_pattern_filters_lines(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Pattern is a Python regex (``re.search``) over the raw JSONL line."""
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(subject="myproj/1"),
+            _make_event(subject="myproj/12"),
+            _make_event(subject="myproj/abc"),
+        ],
+    )
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "pattern": r"myproj/\d+"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    subjects = [e["subject"] for e in response.json()["events"]]
+    # ``myproj/abc`` doesn't match the digit-only suffix regex.
+    assert subjects == ["myproj/1", "myproj/12"]
+
+
+def test_grep_since_shortcut_drops_old_events(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """``since=1h`` shortcut keeps only the recent event."""
+    now = datetime.now(timezone.utc)
+    old_ts = (now - timedelta(hours=3)).isoformat()
+    fresh_ts = (now - timedelta(minutes=10)).isoformat()
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(subject="myproj/old", ts=old_ts),
+            _make_event(subject="myproj/fresh", ts=fresh_ts),
+        ],
+    )
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "since": "1h"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    subjects = [e["subject"] for e in response.json()["events"]]
+    assert subjects == ["myproj/fresh"]
+
+
+def test_grep_walks_rotated_gz_archives(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Rotation-awareness: events in a ``.gz`` sibling surface in results."""
+    live = _per_project_log(project_root)
+    archive = live.with_name(live.name + ".1700000000.gz")
+    _write_jsonl(live, [_make_event(subject="myproj/live")])
+    _write_jsonl_gz(archive, [_make_event(subject="myproj/archived")])
+    # Pin mtime so the walker's newest-first sort is deterministic.
+    os.utime(archive, (1_700_000_000, 1_700_000_000))
+
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "pattern": "myproj/"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    subjects = [e["subject"] for e in response.json()["events"]]
+    # Live first, then the rotated archive (matches the CLI ordering).
+    assert subjects == ["myproj/live", "myproj/archived"]
+
+
+def test_grep_limit_caps_result_count(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """``limit`` short-circuits the iteration."""
+    _write_jsonl(
+        _per_project_log(project_root),
+        [_make_event(subject=f"myproj/{i}") for i in range(50)],
+    )
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj", "limit": 5},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert len(response.json()["events"]) == 5
+
+
+def test_grep_default_limit_is_100(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """No explicit ``limit`` → default 100 (spec §8.1)."""
+    _write_jsonl(
+        _per_project_log(project_root),
+        [_make_event(subject=f"myproj/{i}") for i in range(250)],
+    )
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"project": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert len(response.json()["events"]) == 100
+
+
+# ---------------------------------------------------------------------------
+# Grep error paths
+# ---------------------------------------------------------------------------
+
+
+def test_grep_invalid_since_returns_400_invalid_request(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+) -> None:
+    """Free-text 'yesterday' is not ISO-8601 → ``400 invalid_request``."""
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"since": "yesterday"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "since" in body["error"]["message"]
+
+
+def test_grep_invalid_regex_returns_400_invalid_request(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+) -> None:
+    """Unbalanced group → ``400 invalid_request`` (not a 500)."""
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"pattern": "(unbalanced"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "pattern" in body["error"]["message"]
+
+
+def test_grep_limit_above_max_rejected_by_validation(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+) -> None:
+    """``limit=5000`` exceeds the 1000 cap (spec §8.3)."""
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={"limit": 5000},
+        headers=auth_headers,
+    )
+    # Pydantic-driven query validation returns ``422 validation_error``
+    # via the spec's reshape handler.
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+
+def test_stats_counts_by_event_and_severity(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Stats aggregates across event names + severity (status)."""
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(event="task.created", status="ok"),
+            _make_event(event="task.created", status="ok"),
+            _make_event(event="task.status_changed", status="warn"),
+            _make_event(event="watchdog.escalation_dispatched", status="error"),
+        ],
+    )
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 4
+    assert body["by_event"] == {
+        "task.created": 2,
+        "task.status_changed": 1,
+        "watchdog.escalation_dispatched": 1,
+    }
+    assert body["by_severity"] == {"ok": 2, "warn": 1, "error": 1}
+
+
+def test_stats_with_project_filter_isolates_one_project(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """``project=myproj`` ignores events sitting in another project's tail."""
+    # myproj's per-project log carries one event.
+    _write_jsonl(
+        _per_project_log(project_root),
+        [_make_event(project="myproj", event="task.created")],
+    )
+    # Central tail for a different project — must NOT show up under
+    # ``project=myproj``. The CLI helper's ``_resolve_target_files``
+    # branch with a project filter scopes to that project's tail only.
+    _write_jsonl(
+        _central_log(audit_home, "otherproj"),
+        [
+            _make_event(project="otherproj", event="task.created"),
+            _make_event(project="otherproj", event="task.created"),
+        ],
+    )
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["by_event"] == {"task.created": 1}
+
+
+def test_stats_with_since_excludes_old_events(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """``since=1h`` cuts off events older than the cutoff."""
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(event="a", ts=(now - timedelta(hours=3)).isoformat()),
+            _make_event(event="b", ts=(now - timedelta(minutes=5)).isoformat()),
+            _make_event(event="c", ts=(now - timedelta(minutes=1)).isoformat()),
+        ],
+    )
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj", "since": "1h"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert body["by_event"] == {"b": 1, "c": 1}
+    # ``since`` echoes back the parsed cutoff so the client can
+    # confirm the server's interpretation.
+    assert body["since"] is not None
+
+
+def test_stats_empty_log_returns_zero_total(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+) -> None:
+    """No files at all → ``total=0`` (not a 500)."""
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["by_event"] == {}
+    assert body["by_severity"] == {}

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -1064,3 +1064,100 @@ def test_audit_grep_deadline_bounds_first_pathological_line(
     # surfaced even though only one or two lines were scanned.
     assert body.get("_truncated_by_deadline") is True, body
     assert body["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# Round-6 guardrail (Codex review on PR #2062): ``/audit/stats`` needs the
+# same request-level wall-clock bound + diagnostic as ``/audit/grep``.
+# Requiring ``since`` is only a semantic bound — the walker still reads
+# every target file/line until it parses ``ts`` and filters, so a large
+# archived history with a small ``since`` window can still monopolize the
+# API worker on a synchronous GET.
+# ---------------------------------------------------------------------------
+def test_audit_stats_request_deadline_truncates_large_scan(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``deadline_seconds`` must bound ``/audit/stats`` scan + diagnose it.
+
+    Round-5 left stats calling ``iter_matching_events(..., deadline_s=None)``
+    without scanned-line/byte caps or any ``truncated`` response field. A
+    large old history can still force a full synchronous walk just to
+    discard rows older than ``since``.
+
+    Deterministic timing: monkeypatch the walker's ``parse_event_ts`` to
+    add ~3 ms per row so 200 archived rows would unbounded-scan for
+    ~600 ms. With ``deadline_seconds=0.5`` the walker MUST stop early,
+    surface ``_truncated_by_deadline=true``, and the whole request must
+    return in well under the un-bounded baseline. Monkeypatching the ts
+    parser (rather than relying on raw row volume) keeps the test fast
+    and immune to CI host speed variation.
+    """
+    import time
+
+    from pollypm.audit import query as audit_query
+
+    # Sentinel old timestamp — every row falls outside the ``since=24h``
+    # window, so the walker exercises the parse → since-filter path on
+    # every row but yields nothing (so the body's ``total`` would be 0
+    # if the scan completed). Mirrors the realistic shape Codex
+    # described: large old history + small since window.
+    old_ts = "2020-01-01T00:00:00+00:00"
+    total_rows = 200
+    archive = _per_project_log(project_root).with_name(
+        "audit.jsonl.1700000000.gz"
+    )
+    _write_jsonl_gz(
+        archive,
+        [
+            _make_event(event="task.created", subject="old", ts=old_ts)
+            for _ in range(total_rows)
+        ],
+    )
+    os.utime(archive, (1_700_000_000, 1_700_000_000))
+
+    # Slow ``parse_event_ts`` so the unbounded baseline is well above the
+    # deadline. Slow ~3 ms per row → 200 rows ≈ 600 ms unbounded.
+    real_parse_event_ts = audit_query.parse_event_ts
+
+    def slow_parse_event_ts(value: object) -> object:
+        time.sleep(0.003)
+        return real_parse_event_ts(value)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(audit_query, "parse_event_ts", slow_parse_event_ts)
+
+    start = time.monotonic()
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={
+            "project": "myproj",
+            "since": "24h",
+            "deadline_seconds": "0.5",
+        },
+        headers=auth_headers,
+    )
+    elapsed = time.monotonic() - start
+
+    # 2 s ceiling: deadline=0.5 s + one in-flight ts-parse (~3 ms) +
+    # FastAPI/TestClient overhead. Un-bounded baseline is ~600 ms over
+    # 200 rows; if the deadline didn't fire, the test would still finish
+    # quickly on a fast host — but the truncation flag below pins the
+    # actual behaviour the contract guarantees.
+    assert elapsed < 2.0, (
+        f"deadline_seconds=0.5 did not bound stats scan; "
+        f"elapsed={elapsed:.3f}s "
+        f"(un-bounded baseline ≈ {total_rows * 0.003:.2f}s)"
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Bounded-truncation diagnostic must be set so the caller can tell
+    # this from a complete empty scan.
+    assert body.get("_truncated_by_deadline") is True, body
+    # The walker must have stopped strictly before the full row set
+    # (otherwise the deadline didn't actually save work).
+    assert 1 <= body.get("_lines_scanned", 0) < total_rows, body
+    # Every row was outside ``since=24h`` so no aggregation is reported.
+    assert body["total"] == 0

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -997,3 +997,70 @@ def test_audit_grep_regex_mode_requires_since(
         headers=auth_headers,
     )
     assert ok_response.status_code == 200, ok_response.text
+
+
+# ---------------------------------------------------------------------------
+# Round-5 guardrail (Codex review on PR #2062): ``deadline_seconds`` must
+# bound the FIRST regex line too. Round-4 wired a request-level deadline
+# but ``_BoundedRegexSession.search`` still waited ``_STARTUP_GRACE_S = 5.0``
+# on the first call, so a caller requesting ``deadline_seconds=0.5`` could
+# still spend ~5 s on a pathological first line. The fix clamps both the
+# steady-state per-line poll AND the first-line startup grace to the
+# remaining request budget.
+# ---------------------------------------------------------------------------
+def test_audit_grep_deadline_bounds_first_pathological_line(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """A small ``deadline_seconds`` must cap the FIRST regex line too.
+
+    Round-4 regression: even one pathological row blocks for
+    ``_STARTUP_GRACE_S`` (5 s) before the walker can truncate, because
+    the first call to the regex worker pays for forkserver warmup. A
+    caller asking for ``deadline_seconds=0.5`` should NOT spend ~5 s.
+
+    Verified to FAIL on round-4 (elapsed ≈ 5.0 s, well above 2 s
+    ceiling) and PASS with the round-5 ``max_wall_clock_s`` plumbing.
+    """
+    import time
+
+    pathological_subject = "a" * 40 + "!"
+    # Just a handful of rows — the bug is on the FIRST line; even one
+    # is enough to reproduce.
+    _write_jsonl(
+        _per_project_log(project_root),
+        [_make_event(subject=pathological_subject) for _ in range(3)],
+    )
+
+    start = time.monotonic()
+    response = client.get(
+        "/api/v1/audit/grep",
+        params={
+            "project": "myproj",
+            "pattern": "(a+)+b",
+            "safe_regex": "true",
+            "since": "30d",
+            "deadline_seconds": "0.5",
+        },
+        headers=auth_headers,
+    )
+    elapsed = time.monotonic() - start
+
+    # 2 s ceiling: deadline=0.5 s + one in-flight line clamped to ≤0.5 s
+    # + worker respawn (~500 ms on macOS) + FastAPI/TestClient overhead.
+    # Round-4 elapsed ≈ 5.0 s (the un-clamped startup grace), so any
+    # ceiling between 2 s and 5 s would catch the bug; 2 s gives clear
+    # signal without flaking on a loaded CI host.
+    assert elapsed < 2.0, (
+        f"deadline_seconds=0.5 did not bound first pathological line; "
+        f"elapsed={elapsed:.3f}s (round-4 bug elapses ~5.0s due to "
+        f"_STARTUP_GRACE_S)"
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # The request was bounded by the deadline, so truncation must be
+    # surfaced even though only one or two lines were scanned.
+    assert body.get("_truncated_by_deadline") is True, body
+    assert body["events"] == []

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -692,6 +692,33 @@ def test_task_reassign_request_schema_forbids_extras() -> None:
         "``model_config = {'extra': 'forbid'}`` on the Pydantic "
         "model so the static YAML and the request validator agree."
     )
+def test_audit_responses_document_corrupt_archives_skipped() -> None:
+    """Pin the round-7 diagnostic field on both audit response schemas.
+
+    Round 7 of #2062 added ``_corrupt_archives_skipped`` to the runtime
+    ``AuditGrepResponse`` / ``AuditStatsResponse`` Pydantic models so
+    the walker can skip truncated/corrupt ``.gz`` archives best-effort
+    instead of raising a 500. Round 8 (Codex) caught that
+    ``docs/api/openapi.yaml`` did not document the new field, so
+    generated clients had no way to read the diagnostic.
+
+    This test fails if either schema drops the field again.
+    """
+    contract = _load_contract()
+    for schema_name in ("AuditGrepResponse", "AuditStatsResponse"):
+        schema = contract["components"]["schemas"][schema_name]
+        properties = schema.get("properties", {})
+        assert "_corrupt_archives_skipped" in properties, (
+            f"{schema_name} must document `_corrupt_archives_skipped` "
+            "(round-7 best-effort gz skip, PR #2062)."
+        )
+        field = properties["_corrupt_archives_skipped"]
+        assert field.get("type") == "integer", (
+            f"{schema_name}._corrupt_archives_skipped must be an integer."
+        )
+        assert field.get("minimum", 0) >= 0, (
+            f"{schema_name}._corrupt_archives_skipped must be non-negative."
+        )
 
 
 def test_implementation_openapi_validates_as_31() -> None:


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/audit/grep` and `GET /api/v1/audit/stats` (Phase 2 surface #6, audit query).
- Reuses the rotation-aware helpers from `pollypm.cli_features.audit` (`_resolve_target_files`, `_iter_matching_events`, `parse_since`) so HTTP results mirror what `pm audit grep` would produce. Streaming counterpart is already shipped at `/api/v1/events`.
- Minor refactor on `_resolve_target_files`: accepts either `config_path` (CLI — loads from disk) or pre-loaded `config` (web API). CLI path is unchanged.

## File:line of each handler

- Grep handler: `src/pollypm/web_api/routes/audit.py:131` (`grep_audit_endpoint`)
- Stats handler: `src/pollypm/web_api/routes/audit.py:194` (`stats_audit_endpoint`)
- Router wired in `src/pollypm/web_api/app.py:127` under `auth_deps`.

## Reused helpers

- `pollypm.cli_features.audit._resolve_target_files` — per-project + central-tail file resolution.
- `pollypm.cli_features.audit._iter_matching_events` — cheap→expensive filter chain (regex → event_type → since).
- `pollypm.cli_features.audit.parse_since` — ISO-8601 / shortcut (`1h`/`24h`/`7d`) parsing.

## Test plan

`tests/test_audit_endpoint.py` — 15 cases, all passing locally.

- [x] Auth required (grep + stats)
- [x] Grep happy path (project + event_type + pattern)
- [x] Grep regex pattern filtering
- [x] Grep `since=1h` shortcut
- [x] Grep walks rotated `.gz` archives
- [x] Grep limit cap + default-100 behaviour
- [x] Grep invalid `since` → `400 invalid_request`
- [x] Grep invalid regex → `400 invalid_request`
- [x] Grep `limit > 1000` → `422 validation_error`
- [x] Stats counts by event + severity
- [x] Stats project filter isolates target project
- [x] Stats `since` cutoff
- [x] Stats empty log → `total=0`

## OpenAPI

- New paths `/audit/grep` + `/audit/stats` under a new `Audit` tag.
- New schemas `AuditGrepResponse` + `AuditStatsResponse` referencing the existing `Event` schema.
- `test_contract_yaml_is_valid_openapi_31` + `test_implementation_openapi_validates_as_31` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)