### PR TITLE
feat(api): projects pause/resume/archive/init-guide

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -204,8 +204,9 @@ paths:
         Flips `KnownProject.tracked=false` and re-renders the global
         TOML. Idempotent — a second call against an already-paused
         project returns 200 with the same snapshot and skips the disk
-        write. `reason` is currently accepted for audit symmetry but
-        not persisted.
+        write. `reason` is persisted to the per-project audit log
+        (`projects.tracked.set` event) along with the actor and
+        timestamp. Clamped to 500 chars.
       requestBody:
         required: false
         content:
@@ -264,8 +265,9 @@ paths:
         TOML. Source data on disk (the repo itself, audit JSONLs) is
         untouched. Archive is irreversible from the API — subsequent
         `pause`/`resume`/`init-guide` calls 404. Re-onboarding uses
-        the CLI's `pm add-project`. `reason` is currently accepted
-        for audit symmetry but not persisted.
+        the CLI's `pm add-project`. `reason` is persisted to the per-
+        project audit log (`projects.archive` event) along with the
+        actor and timestamp. Clamped to 500 chars.
       requestBody:
         required: false
         content:
@@ -1725,13 +1727,19 @@ components:
       type: object
       description: |
         Body for `POST /projects/{key}/pause` and
-        `POST /projects/{key}/archive`. `reason` is currently
-        accepted for audit symmetry but not persisted.
+        `POST /projects/{key}/archive`. `reason` is persisted to the
+        per-project audit log (`projects.tracked.set` /
+        `projects.archive` events) along with the actor and timestamp.
+        Clamped to 500 chars.
       properties:
         reason:
           type: string
           maxLength: 500
-          description: Optional operator-supplied note.
+          description: |
+            Optional operator-supplied note. Persisted to the per-
+            project audit log (`projects.tracked.set` /
+            `projects.archive` events) along with the actor and
+            timestamp. Clamped to 500 chars.
 
     InitGuideRequest:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -268,6 +268,12 @@ paths:
         the CLI's `pm add-project`. `reason` is persisted to the per-
         project audit log (`projects.archive` event) along with the
         actor and timestamp. Clamped to 500 chars.
+
+        Enforces the session→project invariant: if any enabled session
+        in `config.sessions` still references this project key the
+        request fails with `409 conflict` and `error.message` lists the
+        blocking session names. Disable or remove those sessions
+        (`pm sessions disable <name>`) and retry.
       requestBody:
         required: false
         content:
@@ -285,6 +291,16 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: |
+            Project is still referenced by one or more enabled sessions.
+            `error.message` names the blocking sessions; disable or
+            remove them before retrying. Mirrors the CLI guard in
+            `pm projects remove`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -193,6 +193,133 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /projects/{key}/pause:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    post:
+      tags: [Projects]
+      operationId: pauseProject
+      summary: Pause a project (set tracked=false)
+      description: |
+        Flips `KnownProject.tracked=false` and re-renders the global
+        TOML. Idempotent — a second call against an already-paused
+        project returns 200 with the same snapshot and skips the disk
+        write. `reason` is currently accepted for audit symmetry but
+        not persisted.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectReasonRequest"
+      responses:
+        "200":
+          description: Project paused (or already was).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /projects/{key}/resume:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    post:
+      tags: [Projects]
+      operationId: resumeProject
+      summary: Resume a project (set tracked=true)
+      description: |
+        Flips `KnownProject.tracked=true` and re-renders the global
+        TOML. Idempotent — a second call against an already-tracked
+        project returns 200 with the same snapshot and skips the disk
+        write.
+      responses:
+        "200":
+          description: Project resumed (or already was).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /projects/{key}/archive:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    post:
+      tags: [Projects]
+      operationId: archiveProject
+      summary: Archive a project (remove from config)
+      description: |
+        Removes the project from `config.projects` and re-renders the
+        TOML. Source data on disk (the repo itself, audit JSONLs) is
+        untouched. Archive is irreversible from the API — subsequent
+        `pause`/`resume`/`init-guide` calls 404. Re-onboarding uses
+        the CLI's `pm add-project`. `reason` is currently accepted
+        for audit symmetry but not persisted.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectReasonRequest"
+      responses:
+        "200":
+          description: Project archived; response carries the operator-facing message.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /projects/{key}/init-guide:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    post:
+      tags: [Projects]
+      operationId: initProjectGuide
+      summary: Seed a project-local role guide
+      description: |
+        Wraps `pollypm.project_guides.init_project_guide` — writes
+        `<project>/.pollypm/project-guides/<role>.md` seeded from the
+        built-in template for that role. Without `force=true`, an
+        existing guide returns `409 conflict`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InitGuideRequest"
+      responses:
+        "200":
+          description: Guide written; response carries the rendered body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InitGuideResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
   /projects/{key}/plan:
     parameters:
       - $ref: "#/components/parameters/ProjectKey"
@@ -1233,9 +1360,10 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
     ServiceUnavailable:
       description: |
-        Backing store (work-service / pg) unavailable.
-        Returned with error code `service_unavailable`. Retry shortly;
-        check `pm doctor` if the failure persists.
+        Backing store unavailable (work-service / pg for inbox + task
+        writes, or state.db / pollypm.toml for project + config writes).
+        Returned with error code `service_unavailable`. Clients should
+        retry shortly; persistent failures point at `pm doctor`.
       content:
         application/json:
           schema:
@@ -1592,6 +1720,59 @@ components:
         tracked:
           type: boolean
           default: true
+
+    ProjectReasonRequest:
+      type: object
+      description: |
+        Body for `POST /projects/{key}/pause` and
+        `POST /projects/{key}/archive`. `reason` is currently
+        accepted for audit symmetry but not persisted.
+      properties:
+        reason:
+          type: string
+          maxLength: 500
+          description: Optional operator-supplied note.
+
+    InitGuideRequest:
+      type: object
+      required: [role]
+      properties:
+        role:
+          type: string
+          enum: [architect, reviewer, worker]
+          description: |
+            Which role-specific guide to seed. The `operator_pm` role
+            is intentionally excluded — Polly always uses the built-in
+            operator guide.
+        force:
+          type: boolean
+          default: false
+          description: |
+            Overwrite an existing guide. Without this, existing
+            guides return `409 conflict`.
+
+    InitGuideResponse:
+      type: object
+      required: [role, path, body]
+      properties:
+        role:
+          type: string
+          description: Normalized role name (matches `role` in the request).
+        path:
+          type: string
+          description: |
+            Filesystem path of the written guide (server-local).
+        forked_from:
+          type: string
+          description: |
+            Fork-reference for the built-in template the guide was
+            seeded from. Used by the drift detector to flag when the
+            upstream template has moved.
+        body:
+          type: string
+          description: |
+            The rendered guide body (without front-matter). Clients
+            can preview the seeded text without a follow-up GET.
 
     PlanRequest:
       type: object

--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import typer
 
 from pollypm.agent_profiles.defaults import heartbeat_prompt, polly_prompt
-from pollypm.config import GLOBAL_CONFIG_DIR, load_config, write_config
+from pollypm.config import GLOBAL_CONFIG_DIR, config_rmw_lock, load_config, write_config
 from pollypm.models import AccountConfig, PollyPMConfig, ProviderKind
 from pollypm.onboarding import (
     _decode_jwt_payload,
@@ -548,13 +548,21 @@ def add_account_via_login(config_path: Path, provider: ProviderKind) -> tuple[st
     if provider is ProviderKind.CLAUDE:
         _prime_claude_home(final_home)
 
-    config.accounts[key] = AccountConfig(
-        name=key,
-        provider=provider,
-        email=email,
-        home=final_home,
-    )
-    write_config(config, config_path, force=True)
+    # #2063 round 7: hold the shared RMW lock around the final
+    # load → mutate → write so a concurrent API / project write can't
+    # slot in and lose its edit (or have its own write clobbered).
+    # We intentionally re-load INSIDE the lock so any disk edits that
+    # landed while the user was completing the tmux login are merged
+    # forward rather than overwritten.
+    with config_rmw_lock(config_path):
+        fresh = load_config(config_path)
+        fresh.accounts[key] = AccountConfig(
+            name=key,
+            provider=provider,
+            email=email,
+            home=final_home,
+        )
+        write_config(fresh, config_path, force=True)
     return key, email
 
 
@@ -579,8 +587,20 @@ def relogin_account(config_path: Path, identifier: str) -> tuple[str, str]:
     if detected_email:
         if account.provider is ProviderKind.CLAUDE:
             _prime_claude_home(account.home)
-        config.accounts[account_name].email = detected_email
-        write_config(config, path=config_path, force=True)
+        # #2063 round 7: re-load INSIDE the shared RMW lock so any disk
+        # edits that landed while the tmux login was running merge
+        # forward instead of being overwritten.
+        with config_rmw_lock(config_path):
+            fresh = load_config(config_path)
+            account_entry = fresh.accounts.get(account_name)
+            if account_entry is None:
+                # Disk-side delete raced this relogin — bail without
+                # resurrecting a removed account.
+                raise typer.BadParameter(
+                    f"Account {account_name} was removed during login."
+                )
+            account_entry.email = detected_email
+            write_config(fresh, path=config_path, force=True)
         return account_name, detected_email
 
     raise typer.BadParameter(
@@ -590,17 +610,20 @@ def relogin_account(config_path: Path, identifier: str) -> tuple[str, str]:
 
 
 def remove_account(config_path: Path, identifier: str, *, delete_home: bool = False) -> tuple[str, str]:
-    config = load_config(config_path)
-    account_name, account = _resolve_account_identifier(config, identifier)
-    _validate_account_removal(config, account_name)
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write.
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        account_name, account = _resolve_account_identifier(config, identifier)
+        _validate_account_removal(config, account_name)
 
-    del config.accounts[account_name]
-    if config.pollypm.controller_account == account_name:
-        config.pollypm.controller_account = next(iter(config.accounts), "")
-    config.pollypm.failover_accounts = [
-        name for name in config.pollypm.failover_accounts if name != account_name
-    ]
-    write_config(config, path=config_path, force=True)
+        del config.accounts[account_name]
+        if config.pollypm.controller_account == account_name:
+            config.pollypm.controller_account = next(iter(config.accounts), "")
+        config.pollypm.failover_accounts = [
+            name for name in config.pollypm.failover_accounts if name != account_name
+        ]
+        write_config(config, path=config_path, force=True)
 
     if delete_home and account.home and account.home.exists():
         import shutil
@@ -611,68 +634,78 @@ def remove_account(config_path: Path, identifier: str, *, delete_home: bool = Fa
 
 
 def set_controller_account(config_path: Path, identifier: str) -> tuple[str, str]:
-    config = load_config(config_path)
-    account_name, account = _resolve_account_identifier(config, identifier)
-    previous = config.pollypm.controller_account
-    config.pollypm.controller_account = account_name
-    config.sessions["heartbeat"].account = account_name
-    config.sessions["heartbeat"].provider = account.provider
-    config.sessions["heartbeat"].prompt = heartbeat_prompt()
-    config.sessions["heartbeat"].agent_profile = "heartbeat"
-    config.sessions["heartbeat"].args = default_control_args(
-        account.provider,
-        open_permissions=config.pollypm.open_permissions_by_default,
-    )
-    config.sessions["operator"].account = account_name
-    config.sessions["operator"].provider = account.provider
-    config.sessions["operator"].prompt = polly_prompt()
-    config.sessions["operator"].agent_profile = "polly"
-    config.sessions["operator"].args = default_control_args(
-        account.provider,
-        open_permissions=config.pollypm.open_permissions_by_default,
-    )
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write so concurrent project / API writes can't
+    # land in between.
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        account_name, account = _resolve_account_identifier(config, identifier)
+        previous = config.pollypm.controller_account
+        config.pollypm.controller_account = account_name
+        config.sessions["heartbeat"].account = account_name
+        config.sessions["heartbeat"].provider = account.provider
+        config.sessions["heartbeat"].prompt = heartbeat_prompt()
+        config.sessions["heartbeat"].agent_profile = "heartbeat"
+        config.sessions["heartbeat"].args = default_control_args(
+            account.provider,
+            open_permissions=config.pollypm.open_permissions_by_default,
+        )
+        config.sessions["operator"].account = account_name
+        config.sessions["operator"].provider = account.provider
+        config.sessions["operator"].prompt = polly_prompt()
+        config.sessions["operator"].agent_profile = "polly"
+        config.sessions["operator"].args = default_control_args(
+            account.provider,
+            open_permissions=config.pollypm.open_permissions_by_default,
+        )
 
-    failover = [name for name in config.pollypm.failover_accounts if name != account_name]
-    if previous and previous != account_name and previous in config.accounts and previous not in failover:
-        failover.insert(0, previous)
-    config.pollypm.failover_accounts = failover
-    config.pollypm.failover_enabled = bool(failover)
-    write_config(config, path=config_path, force=True)
+        failover = [name for name in config.pollypm.failover_accounts if name != account_name]
+        if previous and previous != account_name and previous in config.accounts and previous not in failover:
+            failover.insert(0, previous)
+        config.pollypm.failover_accounts = failover
+        config.pollypm.failover_enabled = bool(failover)
+        write_config(config, path=config_path, force=True)
     return account_name, account.email or account_name
 
 
 def set_open_permissions_default(config_path: Path, enabled: bool) -> bool:
-    config = load_config(config_path)
-    config.pollypm.open_permissions_by_default = enabled
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write.
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        config.pollypm.open_permissions_by_default = enabled
 
-    for session_name in ("heartbeat", "operator"):
-        session = config.sessions.get(session_name)
-        if session is None:
-            continue
-        session.args = default_control_args(session.provider, open_permissions=enabled)
+        for session_name in ("heartbeat", "operator"):
+            session = config.sessions.get(session_name)
+            if session is None:
+                continue
+            session.args = default_control_args(session.provider, open_permissions=enabled)
 
-    write_config(config, path=config_path, force=True)
+        write_config(config, path=config_path, force=True)
     return enabled
 
 
 def toggle_failover_account(config_path: Path, identifier: str) -> tuple[str, bool]:
-    config = load_config(config_path)
-    account_name, _account = _resolve_account_identifier(config, identifier)
-    if account_name == config.pollypm.controller_account:
-        raise typer.BadParameter("The controller account cannot also be in the failover list.")
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write.
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        account_name, _account = _resolve_account_identifier(config, identifier)
+        if account_name == config.pollypm.controller_account:
+            raise typer.BadParameter("The controller account cannot also be in the failover list.")
 
-    failover = list(config.pollypm.failover_accounts)
-    enabled: bool
-    if account_name in failover:
-        failover = [name for name in failover if name != account_name]
-        enabled = False
-    else:
-        failover.append(account_name)
-        enabled = True
+        failover = list(config.pollypm.failover_accounts)
+        enabled: bool
+        if account_name in failover:
+            failover = [name for name in failover if name != account_name]
+            enabled = False
+        else:
+            failover.append(account_name)
+            enabled = True
 
-    config.pollypm.failover_accounts = failover
-    config.pollypm.failover_enabled = bool(failover)
-    write_config(config, path=config_path, force=True)
+        config.pollypm.failover_accounts = failover
+        config.pollypm.failover_enabled = bool(failover)
+        write_config(config, path=config_path, force=True)
     return account_name, enabled
 
 

--- a/src/pollypm/cockpit_project_settings.py
+++ b/src/pollypm/cockpit_project_settings.py
@@ -33,7 +33,7 @@ from textual.widgets import (
 )
 
 from pollypm.account_usage_sampler import load_cached_account_usage
-from pollypm.config import GLOBAL_CONFIG_DIR, load_config, write_config
+from pollypm.config import GLOBAL_CONFIG_DIR, config_rmw_lock, load_config, write_config
 from pollypm.cockpit_project_advisor_log import render_advisor_log_lines
 from pollypm.cockpit_settings_confirm import _SettingsConfirmModal
 from pollypm.cockpit_settings_history import (
@@ -549,13 +549,18 @@ class PollyProjectSettingsApp(App[None]):
         assignment: ModelAssignment,
     ) -> None:
         try:
-            config = load_config(self.config_path)
-            project = config.projects.get(self.project_key)
-            if project is None:
-                self._notify(f"Project not found: {self.project_key}")
-                return
-            project.role_assignments[role] = assignment
-            write_config(config, self.config_path, force=True)
+            # #2063 round 7: hold the shared RMW lock across the full
+            # load → mutate → write so a concurrent API ``/pause`` or
+            # CLI write can't slot in and clobber the role override
+            # (or have its own write clobbered by ours).
+            with config_rmw_lock(self.config_path):
+                config = load_config(self.config_path)
+                project = config.projects.get(self.project_key)
+                if project is None:
+                    self._notify(f"Project not found: {self.project_key}")
+                    return
+                project.role_assignments[role] = assignment
+                write_config(config, self.config_path, force=True)
         except Exception as exc:  # noqa: BLE001
             self._notify(f"Role update failed: {exc}")
             return
@@ -565,13 +570,16 @@ class PollyProjectSettingsApp(App[None]):
 
     def _clear_project_role_override(self, role: str) -> None:
         try:
-            config = load_config(self.config_path)
-            project = config.projects.get(self.project_key)
-            if project is None:
-                self._notify(f"Project not found: {self.project_key}")
-                return
-            project.role_assignments.pop(role, None)
-            write_config(config, self.config_path, force=True)
+            # #2063 round 7: hold the shared RMW lock — see
+            # ``_save_project_role_assignment`` above for rationale.
+            with config_rmw_lock(self.config_path):
+                config = load_config(self.config_path)
+                project = config.projects.get(self.project_key)
+                if project is None:
+                    self._notify(f"Project not found: {self.project_key}")
+                    return
+                project.role_assignments.pop(role, None)
+                write_config(config, self.config_path, force=True)
         except Exception as exc:  # noqa: BLE001
             self._notify(f"Role update failed: {exc}")
             return
@@ -788,17 +796,17 @@ class PollyProjectSettingsApp(App[None]):
         if button is None:
             return
         new_channel = "beta" if button.id == "release-channel-beta" else "stable"
+        # #2063 round 7: hold the shared RMW lock across the full
+        # load → mutate → write so a concurrent project write can't
+        # land in between and lose its edit.
         try:
-            config = load_config(self.config_path)
-        except Exception as exc:  # noqa: BLE001
-            self._notify(f"Release channel update failed: {exc}")
-            return
-        current = getattr(getattr(config, "pollypm", None), "release_channel", "stable")
-        if current == new_channel:
-            return
-        config.pollypm.release_channel = new_channel
-        try:
-            write_config(config, self.config_path, force=True)
+            with config_rmw_lock(self.config_path):
+                config = load_config(self.config_path)
+                current = getattr(getattr(config, "pollypm", None), "release_channel", "stable")
+                if current == new_channel:
+                    return
+                config.pollypm.release_channel = new_channel
+                write_config(config, self.config_path, force=True)
         except Exception as exc:  # noqa: BLE001
             self._notify(f"Release channel update failed: {exc}")
             return

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -134,7 +134,7 @@ from pollypm.cockpit_metrics import (  # noqa: F401  (re-exported)
     PollyMetricsApp,
     _MetricsDrillDownModal,
 )
-from pollypm.config import load_config, write_config
+from pollypm.config import config_rmw_lock, load_config, write_config
 from pollypm.cockpit_palette import (  # noqa: F401  (re-exported)
     CommandPaletteModal,
     KeyboardHelpModal,
@@ -4807,9 +4807,14 @@ class PollySettingsPaneApp(App[None]):
         assignment: ModelAssignment,
     ) -> None:
         try:
-            config = load_config(self.config_path)
-            config.pollypm.role_assignments[role] = assignment
-            write_config(config, self.config_path, force=True)
+            # #2063 round 7: hold the shared RMW lock across the full
+            # load → mutate → write so a concurrent API / project
+            # write can't slot in and lose its edit (or have its own
+            # write clobbered by ours).
+            with config_rmw_lock(self.config_path):
+                config = load_config(self.config_path)
+                config.pollypm.role_assignments[role] = assignment
+                write_config(config, self.config_path, force=True)
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(f"Role update failed: {exc}", severity="error")
@@ -4828,9 +4833,12 @@ class PollySettingsPaneApp(App[None]):
 
     def _clear_global_role_assignment(self, role: str) -> None:
         try:
-            config = load_config(self.config_path)
-            config.pollypm.role_assignments.pop(role, None)
-            write_config(config, self.config_path, force=True)
+            # #2063 round 7: hold the shared RMW lock — see
+            # ``_write_global_role_assignment`` above for rationale.
+            with config_rmw_lock(self.config_path):
+                config = load_config(self.config_path)
+                config.pollypm.role_assignments.pop(role, None)
+                write_config(config, self.config_path, force=True)
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(f"Role update failed: {exc}", severity="error")
@@ -5503,24 +5511,28 @@ class PollySettingsPaneApp(App[None]):
     ) -> None:
         if not assignments:
             return
-        config = load_config(self.config_path)
-        sessions = getattr(config, "sessions", {}) or {}
-        accounts = getattr(config, "accounts", {}) or {}
-        changed = False
-        for session_name, target_key in assignments.items():
-            session = sessions.get(session_name)
-            account = accounts.get(target_key)
-            if session is None or account is None:
-                continue
-            if getattr(session, "account", None) != target_key:
-                session.account = target_key
-                changed = True
-            provider = getattr(account, "provider", None)
-            if provider is not None and getattr(session, "provider", None) != provider:
-                session.provider = provider
-                changed = True
-        if changed:
-            write_config(config, self.config_path, force=True)
+        # #2063 round 7: hold the shared RMW lock across the full
+        # load → mutate → write so a concurrent API / project write
+        # can't slot in and lose its edit.
+        with config_rmw_lock(self.config_path):
+            config = load_config(self.config_path)
+            sessions = getattr(config, "sessions", {}) or {}
+            accounts = getattr(config, "accounts", {}) or {}
+            changed = False
+            for session_name, target_key in assignments.items():
+                session = sessions.get(session_name)
+                account = accounts.get(target_key)
+                if session is None or account is None:
+                    continue
+                if getattr(session, "account", None) != target_key:
+                    session.account = target_key
+                    changed = True
+                provider = getattr(account, "provider", None)
+                if provider is not None and getattr(session, "provider", None) != provider:
+                    session.provider = provider
+                    changed = True
+            if changed:
+                write_config(config, self.config_path, force=True)
 
     def _active_table(self) -> DataTable | None:
         if self._active_section == "accounts":

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -929,19 +929,14 @@ def _project_local_mtimes(
     return snapshot
 
 
-def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
-    config_path = path.resolve()
-    try:
-        mtime = config_path.stat().st_mtime
-        cached = _config_cache.get(config_path)
-        if (
-            cached is not None
-            and cached[0] == mtime
-            and _project_local_mtimes(cached[1]) == cached[2]
-        ):
-            return cached[1]
-    except OSError:
-        pass
+def _parse_config(config_path: Path) -> PollyPMConfig:
+    """Parse the TOML at ``config_path`` into a :class:`PollyPMConfig`.
+
+    Pure parsing — no caching, no auth-token minting, no disk writes.
+    Factored out of :func:`load_config` so the post-load persistence path
+    can re-read under ``config_rmw_lock`` without recursing back into the
+    persistence/caching code (#2063 round 9).
+    """
     base = config_path.parent
     raw = _load_raw_toml(config_path)
     project = _parse_project_settings(raw, base=base)
@@ -983,17 +978,58 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
     # to distinct identities, or the cache singleton can serve
     # cross-config data.
     config.config_path = config_path
+    return config
+
+
+def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
+    config_path = path.resolve()
+    try:
+        mtime = config_path.stat().st_mtime
+        cached = _config_cache.get(config_path)
+        if (
+            cached is not None
+            and cached[0] == mtime
+            and _project_local_mtimes(cached[1]) == cached[2]
+        ):
+            return cached[1]
+    except OSError:
+        pass
+
+    config = _parse_config(config_path)
     # PR #2018 review fix (id 4502598240): mint auth tokens for any
     # session that lacks one, then persist back to disk. Without this,
     # legacy sessions stay at auth_token="" and watchdog/recovery
     # dispatch silently emits unsigned briefs (the advertised Lever 2
     # signing is inactive). Idempotent — write_config only fires when
     # ensure_session_auth_tokens actually minted a token.
+    #
+    # #2063 round 9 audit: this is a load → mutate → write inside
+    # ``load_config`` itself. Wrap with ``config_rmw_lock(config_path)``
+    # AND re-read the config under the lock via :func:`_parse_config`
+    # so the token-mint write participates in the shared RMW invariant.
+    # Otherwise a concurrent CLI/API writer that landed between this
+    # function's parse and the auth-token write would be silently
+    # overwritten by our possibly-stale snapshot (which has fresh fields
+    # only for ``sessions[*].auth_token``).
     try:
         from pollypm.session_auth import ensure_session_auth_tokens
         if ensure_session_auth_tokens(config):
             try:
-                write_config(config, config_path, force=True)
+                with config_rmw_lock(config_path):
+                    # Re-parse under the lock so the persisted write
+                    # merges our token additions onto the freshest disk
+                    # snapshot, never clobbering a concurrent edit.
+                    fresh = _parse_config(config_path)
+                    if ensure_session_auth_tokens(fresh):
+                        write_config(fresh, config_path, force=True)
+                    # Reflect any tokens minted on disk into the live
+                    # snapshot the caller receives, so subsequent reads
+                    # of ``config.sessions[*].auth_token`` see the same
+                    # value as the on-disk TOML.
+                    for name, fresh_session in fresh.sessions.items():
+                        live_session = config.sessions.get(name)
+                        if live_session is not None:
+                            live_session.auth_token = fresh_session.auth_token
             except Exception:  # noqa: BLE001
                 # Persistence failure is non-fatal — tokens stay in
                 # memory for the rest of this process; next load_config
@@ -1428,14 +1464,21 @@ def _build_example_config(root: Path, *, tmux_session: str = "pollypm") -> Polly
 
 
 def write_example_config(path: Path = DEFAULT_CONFIG_PATH, force: bool = False) -> Path:
-    if path.exists() and not force:
-        raise FileExistsError(f"Config already exists: {path}")
+    # #2063 round 9: the existence check + the write MUST live under the
+    # same ``config_rmw_lock`` or two concurrent ``pm init`` callers race
+    # — both observe ``path.exists() == False`` before either takes the
+    # lock, both pass the outer guard, and the second clobbers the first.
+    #
+    # Strategy: when ``force=False`` we delegate the existence check to
+    # the locked guard inside :func:`write_config` (which raises
+    # ``FileExistsError`` atomically under the flock). When ``force=True``
+    # we still take the lock so the example-config build + write is
+    # serialised against other writers, then call ``write_config`` with
+    # ``force=True`` to allow the overwrite.
     root = path.resolve().parent
-    return write_config(
-        _build_example_config(root, tmux_session=_default_init_tmux_session(root)),
-        path,
-        force=True,
-    )
+    example = _build_example_config(root, tmux_session=_default_init_tmux_session(root))
+    with config_rmw_lock(path):
+        return write_config(example, path, force=force)
 
 
 # ---------------------------------------------------------------------------
@@ -1451,9 +1494,18 @@ def write_example_config(path: Path = DEFAULT_CONFIG_PATH, force: bool = False) 
 #
 # Fix: move the lock primitive HERE and have every read-modify-write
 # call site wrap the whole RMW with :func:`config_rmw_lock`. The lock
-# is re-entrant per thread (thread-local depth counter), so nested
-# acquisitions inside ``write_config`` itself don't deadlock when a
-# caller already holds it for the full RMW.
+# is re-entrant per thread (per-path thread-local depth tracking added
+# in round 8), so nested acquisitions inside ``write_config`` itself
+# don't deadlock when a caller already holds it for the full RMW.
+#
+# Exceptions (intentionally not wrapped in a full RMW; they rely on
+# ``write_config``'s internal lock for torn-write protection only):
+# 1. :func:`pollypm.onboarding_tui.OnboardingApp` first-run build+write
+#    has no prior snapshot to merge against and runs before the API/CLI
+#    is up.
+# 2. The auth-token mint inside :func:`load_config` re-reads under the
+#    lock before persisting so concurrent edits still survive
+#    (round 9 audit fix).
 #
 # POSIX-only. PollyPM ships as a personal-use Mac/Linux deployment;
 # Windows isn't a supported target.

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -1466,12 +1466,46 @@ _rmw_lock_state = threading.local()
 def _config_lock_path(config_path: Path) -> Path:
     """Return the sibling lockfile path for ``config_path``.
 
-    Resolves the path so two callers that pass equivalent relative /
-    absolute / symlinked paths still hit the same lockfile and serialise
-    against each other.
+    Canonicalises via :func:`os.path.realpath` (which works whether or
+    not the target exists) so two callers that pass equivalent
+    relative / absolute / symlinked paths still hit the same lockfile
+    and serialise against each other. Crucially, fresh-config
+    initialisation (when ``config_path`` does not yet exist on disk)
+    also produces a stable canonical lock path, so the first-write
+    creation guard participates in the same invariant as subsequent
+    writes.
     """
-    resolved = config_path.resolve() if config_path.exists() else config_path
-    return resolved.with_suffix(resolved.suffix + ".lock")
+    import os
+
+    canonical = Path(os.path.realpath(str(config_path)))
+    return canonical.with_suffix(canonical.suffix + ".lock")
+
+
+def _canonical_lock_key(config_path: Path) -> Path:
+    """Canonical key for thread-local re-entrancy tracking.
+
+    Must match the canonicalisation used by :func:`_config_lock_path`
+    so a nested acquire is recognised as re-entrant only when it
+    targets the same on-disk lockfile.
+    """
+    import os
+
+    return Path(os.path.realpath(str(config_path)))
+
+
+def _held_locks() -> dict:
+    """Thread-local map: canonical config path -> [fh_or_None, depth].
+
+    Tracks every config path this thread currently holds (or has
+    re-entered). The outermost frame for a given path owns the file
+    handle and is responsible for releasing the flock; re-entrant
+    frames store ``None`` for the handle and only bump the depth.
+    """
+    held = getattr(_rmw_lock_state, "held", None)
+    if held is None:
+        held = {}
+        _rmw_lock_state.held = held
+    return held
 
 
 @contextlib.contextmanager
@@ -1486,10 +1520,11 @@ def config_rmw_lock(config_path: Path):
     and both write back, with the second writer clobbering the first.
 
     The lock is implemented as an exclusive ``fcntl.flock`` on a sibling
-    lockfile (``<config_path>.lock``). Re-entrant per thread via a
-    thread-local depth counter: nested ``with config_rmw_lock(...):``
-    inside the same thread (notably ``write_config``'s own internal
-    acquire) is a cheap no-op rather than a deadlock.
+    lockfile (``<config_path>.lock``). Re-entrancy is tracked **per
+    canonical config path**: a nested ``with config_rmw_lock(path):``
+    against the SAME path is a cheap no-op (so ``write_config``'s
+    internal acquire doesn't deadlock its outer caller), but a nested
+    acquire against a DIFFERENT path takes that path's flock normally.
 
     Cross-thread contention is handled by ``flock`` itself — the second
     thread blocks until the first releases. Cross-process contention
@@ -1499,21 +1534,30 @@ def config_rmw_lock(config_path: Path):
     effort in the ``finally`` so a propagating exception still unlocks.
 
     Codex round 6 on #2063 first introduced this primitive inside the
-    web_api module; Codex round 7 moved it here so CLI / cockpit
-    writers participate in the same invariant.
+    web_api module; round 7 moved it here so CLI / cockpit writers
+    participate in the same invariant; round 8 (this revision) replaced
+    the path-blind depth counter with per-path tracking so nested
+    acquires against a different config never silently bypass that
+    config's flock.
     """
     import fcntl
 
-    depth = getattr(_rmw_lock_state, "depth", 0)
-    if depth > 0:
-        # Already held by this thread — re-entrant no-op so callers
-        # that wrap the full RMW don't deadlock against ``write_config``'s
-        # internal acquire.
-        _rmw_lock_state.depth = depth + 1
+    key = _canonical_lock_key(config_path)
+    held = _held_locks()
+
+    if key in held:
+        # Re-entrant for THIS specific path — bump depth, don't touch
+        # flock. The outermost frame still owns the file handle and
+        # will release it when its own depth decrements back to zero.
+        entry = held[key]
+        entry[1] += 1
         try:
             yield
         finally:
-            _rmw_lock_state.depth -= 1
+            entry[1] -= 1
+            # Re-entrant frames never own the flock so they never
+            # release it; only the outermost frame (where ``fh`` is
+            # non-None) does the unlock + close below.
         return
 
     lock_path = _config_lock_path(config_path)
@@ -1523,29 +1567,48 @@ def config_rmw_lock(config_path: Path):
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # "a+" creates if missing without truncating; we never read or write
     # the lockfile itself, only flock its fd.
-    with open(lock_path, "a+") as lock_fh:
+    lock_fh = open(lock_path, "a+")
+    try:
         fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
-        _rmw_lock_state.depth = 1
+        entry = [lock_fh, 1]
+        held[key] = entry
         try:
             yield
         finally:
-            _rmw_lock_state.depth = 0
+            # The outermost frame is the only one that releases the
+            # flock. Any nested re-entrant frames decremented inside
+            # the ``yield`` and left the entry in ``held`` with
+            # ``depth == 1`` — i.e. matching our own outer acquire.
             try:
-                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
-            except OSError:
-                pass
+                del held[key]
+            finally:
+                try:
+                    fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+    finally:
+        try:
+            lock_fh.close()
+        except OSError:
+            pass
 
 
 def write_config(config: PollyPMConfig, path: Path = DEFAULT_CONFIG_PATH, force: bool = False) -> Path:
-    if path.exists() and not force:
-        raise FileExistsError(f"Config already exists: {path}")
     # Defence in depth: even if a caller forgets to wrap the full RMW
     # with :func:`config_rmw_lock`, the WRITE itself is still serialised
     # so two writers can't interleave their multi-file (global + per-
     # project local) write sequence and produce a torn config on disk.
     # The lock is re-entrant per thread, so the common case where the
     # caller already holds it for the full RMW is a cheap no-op here.
+    #
+    # The ``force=False`` existence guard MUST run INSIDE the lock —
+    # otherwise two writers initialising a fresh config can both observe
+    # ``path.exists() == False`` before either takes the lock, both pass
+    # the guard, and the second writer silently clobbers the first
+    # (Codex round 8 on #2063).
     with config_rmw_lock(path):
+        if path.exists() and not force:
+            raise FileExistsError(f"Config already exists: {path}")
         path.parent.mkdir(parents=True, exist_ok=True)
         # Always UTF-8 — TOML is UTF-8 by spec, and a non-UTF-8 default
         # locale (Windows CP-1252, ``LC_ALL=C``) would mangle non-ASCII

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import logging
+import threading
 import tomllib
 from pathlib import Path
 
@@ -1436,20 +1438,125 @@ def write_example_config(path: Path = DEFAULT_CONFIG_PATH, force: bool = False) 
     )
 
 
+# ---------------------------------------------------------------------------
+# Shared read-modify-write lock for the global TOML.
+#
+# Codex round 7 on #2063 caught that the previous lock (lived inside
+# ``pollypm.web_api.service`` as ``_config_write_lock``) only serialised
+# concurrent API writers against each other. CLI / cockpit callers that
+# do their own ``load_config → mutate → write_config`` sequence still
+# raced the API path: a CLI write that lands between the API helper's
+# ``load_config`` and ``write_config`` is silently overwritten when the
+# API later writes its older snapshot.
+#
+# Fix: move the lock primitive HERE and have every read-modify-write
+# call site wrap the whole RMW with :func:`config_rmw_lock`. The lock
+# is re-entrant per thread (thread-local depth counter), so nested
+# acquisitions inside ``write_config`` itself don't deadlock when a
+# caller already holds it for the full RMW.
+#
+# POSIX-only. PollyPM ships as a personal-use Mac/Linux deployment;
+# Windows isn't a supported target.
+# ---------------------------------------------------------------------------
+
+
+_rmw_lock_state = threading.local()
+
+
+def _config_lock_path(config_path: Path) -> Path:
+    """Return the sibling lockfile path for ``config_path``.
+
+    Resolves the path so two callers that pass equivalent relative /
+    absolute / symlinked paths still hit the same lockfile and serialise
+    against each other.
+    """
+    resolved = config_path.resolve() if config_path.exists() else config_path
+    return resolved.with_suffix(resolved.suffix + ".lock")
+
+
+@contextlib.contextmanager
+def config_rmw_lock(config_path: Path):
+    """Serialise the read-modify-write cycle for ``config_path``.
+
+    Use this around the full ``load_config → mutate → write_config``
+    sequence whenever a caller might race other config writers
+    (API, CLI, cockpit, onboarding). Holding the lock across the entire
+    RMW — not just the write — closes the lost-update window where two
+    writers each load the same disk snapshot, mutate disjoint fields,
+    and both write back, with the second writer clobbering the first.
+
+    The lock is implemented as an exclusive ``fcntl.flock`` on a sibling
+    lockfile (``<config_path>.lock``). Re-entrant per thread via a
+    thread-local depth counter: nested ``with config_rmw_lock(...):``
+    inside the same thread (notably ``write_config``'s own internal
+    acquire) is a cheap no-op rather than a deadlock.
+
+    Cross-thread contention is handled by ``flock`` itself — the second
+    thread blocks until the first releases. Cross-process contention
+    works the same way (the lockfile path is process-shared).
+
+    POSIX-only. The lockfile is created on first use; release is best-
+    effort in the ``finally`` so a propagating exception still unlocks.
+
+    Codex round 6 on #2063 first introduced this primitive inside the
+    web_api module; Codex round 7 moved it here so CLI / cockpit
+    writers participate in the same invariant.
+    """
+    import fcntl
+
+    depth = getattr(_rmw_lock_state, "depth", 0)
+    if depth > 0:
+        # Already held by this thread — re-entrant no-op so callers
+        # that wrap the full RMW don't deadlock against ``write_config``'s
+        # internal acquire.
+        _rmw_lock_state.depth = depth + 1
+        try:
+            yield
+        finally:
+            _rmw_lock_state.depth -= 1
+        return
+
+    lock_path = _config_lock_path(config_path)
+    # Ensure parent exists — config_path may not have been created yet
+    # on the very first write after a fresh install, but the parent
+    # ``.pollypm/`` always exists by the time any caller reaches here.
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    # "a+" creates if missing without truncating; we never read or write
+    # the lockfile itself, only flock its fd.
+    with open(lock_path, "a+") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        _rmw_lock_state.depth = 1
+        try:
+            yield
+        finally:
+            _rmw_lock_state.depth = 0
+            try:
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+
+
 def write_config(config: PollyPMConfig, path: Path = DEFAULT_CONFIG_PATH, force: bool = False) -> Path:
     if path.exists() and not force:
         raise FileExistsError(f"Config already exists: {path}")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # Always UTF-8 — TOML is UTF-8 by spec, and a non-UTF-8 default
-    # locale (Windows CP-1252, ``LC_ALL=C``) would mangle non-ASCII
-    # project names or personas (``café``, ``プロジェクト``) that
-    # round-trip through the cockpit settings UI.
-    path.write_text(_render_global_config(config), encoding="utf-8")
-    for project_key, project in config.projects.items():
-        local_path = project_config_path(project.path)
-        local_path.parent.mkdir(parents=True, exist_ok=True)
-        local_path.write_text(
-            _render_project_local_config(config, project_key),
-            encoding="utf-8",
-        )
+    # Defence in depth: even if a caller forgets to wrap the full RMW
+    # with :func:`config_rmw_lock`, the WRITE itself is still serialised
+    # so two writers can't interleave their multi-file (global + per-
+    # project local) write sequence and produce a torn config on disk.
+    # The lock is re-entrant per thread, so the common case where the
+    # caller already holds it for the full RMW is a cheap no-op here.
+    with config_rmw_lock(path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Always UTF-8 — TOML is UTF-8 by spec, and a non-UTF-8 default
+        # locale (Windows CP-1252, ``LC_ALL=C``) would mangle non-ASCII
+        # project names or personas (``café``, ``プロジェクト``) that
+        # round-trip through the cockpit settings UI.
+        path.write_text(_render_global_config(config), encoding="utf-8")
+        for project_key, project in config.projects.items():
+            local_path = project_config_path(project.path)
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            local_path.write_text(
+                _render_project_local_config(config, project_key),
+                encoding="utf-8",
+            )
     return path

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -1022,14 +1022,21 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
                     fresh = _parse_config(config_path)
                     if ensure_session_auth_tokens(fresh):
                         write_config(fresh, config_path, force=True)
-                    # Reflect any tokens minted on disk into the live
-                    # snapshot the caller receives, so subsequent reads
-                    # of ``config.sessions[*].auth_token`` see the same
-                    # value as the on-disk TOML.
-                    for name, fresh_session in fresh.sessions.items():
-                        live_session = config.sessions.get(name)
-                        if live_session is not None:
-                            live_session.auth_token = fresh_session.auth_token
+                    # #2063 round 10 (Codex blocker): swap the live
+                    # snapshot for the post-lock ``fresh`` object.
+                    # Round 9 only copied ``sessions[*].auth_token`` back
+                    # into the pre-lock ``config``, then cached that
+                    # pre-lock snapshot under the post-write mtime. Any
+                    # concurrent edit to a non-token field that landed
+                    # between the initial parse and the locked re-parse
+                    # would be on disk but invisible to every subsequent
+                    # ``load_config`` call until the file mtime changed
+                    # again — a stale-cache trap on the same path the
+                    # rest of this PR is tightening. ``fresh`` already
+                    # has the freshly-minted tokens AND any concurrent
+                    # disk edits, so it is the canonical post-write
+                    # state for both the return value and the cache.
+                    config = fresh
             except Exception:  # noqa: BLE001
                 # Persistence failure is non-fatal — tokens stay in
                 # memory for the rest of this process; next load_config

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import typer
 
 from pollypm.agent_profiles.defaults import heartbeat_prompt, polly_prompt
-from pollypm.config import load_config, write_config
+from pollypm.config import config_rmw_lock, load_config, write_config
 from pollypm.models import (
     AccountConfig,
     KnownProject,
@@ -701,34 +701,38 @@ def provision_demo_project_fallback(config_path: Path) -> Path:
 def add_selected_projects(config_path: Path, selected_paths: list[Path]) -> list[KnownProject]:
     if not selected_paths:
         return []
-    config = load_config(config_path)
-    added: list[KnownProject] = []
-    for repo_path in selected_paths:
-        normalized = repo_path.resolve()
-        if any(project.path.resolve() == normalized for project in config.projects.values()):
-            continue
-        project = KnownProject(
-            key=make_project_key(normalized, set(config.projects) | {item.key for item in added}),
-            path=normalized,
-            name=normalized.name,
-            kind=ProjectKind.GIT,
-        )
-        config.projects[project.key] = project
-        ensure_project_scaffold(normalized)
-        # Commit the freshly written .gitignore/docs/issues so the
-        # project root is clean before the user runs their first task
-        # (#926). Best-effort: a failure here is logged and the
-        # registration still succeeds.
-        try:
-            commit_initial_scaffold(normalized)
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "onboarding: initial scaffold commit failed for %s",
-                normalized, exc_info=True,
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write so a concurrent API / cockpit write
+    # can't slot in and lose its edit.
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        added: list[KnownProject] = []
+        for repo_path in selected_paths:
+            normalized = repo_path.resolve()
+            if any(project.path.resolve() == normalized for project in config.projects.values()):
+                continue
+            project = KnownProject(
+                key=make_project_key(normalized, set(config.projects) | {item.key for item in added}),
+                path=normalized,
+                name=normalized.name,
+                kind=ProjectKind.GIT,
             )
-        added.append(project)
-    if added:
-        write_config(config, path=config_path, force=True)
+            config.projects[project.key] = project
+            ensure_project_scaffold(normalized)
+            # Commit the freshly written .gitignore/docs/issues so the
+            # project root is clean before the user runs their first task
+            # (#926). Best-effort: a failure here is logged and the
+            # registration still succeeds.
+            try:
+                commit_initial_scaffold(normalized)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "onboarding: initial scaffold commit failed for %s",
+                    normalized, exc_info=True,
+                )
+            added.append(project)
+        if added:
+            write_config(config, path=config_path, force=True)
     return added
 
 
@@ -1345,8 +1349,18 @@ def relogin_account(config_path: Path, identifier: str) -> tuple[str, str]:
         account.home,
     )
     if detected_email and detected_email != (account.email or "").lower():
-        config.accounts[account_name].email = detected_email
-        write_config(config, path=config_path, force=True)
+        # #2063 round 7: re-load INSIDE the shared RMW lock so any
+        # disk edits during the tmux login merge forward.
+        with config_rmw_lock(config_path):
+            fresh = load_config(config_path)
+            account_entry = fresh.accounts.get(account_name)
+            if account_entry is None:
+                # Account was removed during login; surface upward.
+                raise typer.BadParameter(
+                    f"Account {account_name} was removed during login."
+                )
+            account_entry.email = detected_email
+            write_config(fresh, path=config_path, force=True)
         return account_name, detected_email
 
     return account_name, account.email or detected_email or account_name

--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -1074,6 +1074,16 @@ class OnboardingApp(App[OnboardingResult | None]):
             if self.project_selection is not None:
                 self.state.selected_project_paths = list(self.project_selection.selected)
             config = self._build_config()
+            # #2063 round 9 audit: this is a fresh-config build + write
+            # during initial onboarding, NOT a load → mutate → write.
+            # There is no prior snapshot to merge against, so wrapping
+            # with ``config_rmw_lock`` would only serialise against
+            # concurrent writers — and during first-run onboarding
+            # there shouldn't BE any concurrent writers (the API/CLI
+            # hasn't been started yet). Pattern A inside
+            # :func:`write_config` still serialises the multi-file write
+            # itself, so a torn write across global + per-project files
+            # cannot happen. Intentionally outside the RMW wrap.
             write_config(config, path=self.config_path, force=True)
             self.step = "tour"
             self._render_current_step()

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -857,7 +857,7 @@ def _purge_project_sessions(
     a project that no longer exists in the config — exactly the
     leaked-worker mode #1561's issue body calls out.
     """
-    from pollypm.config import write_config
+    from pollypm.config import config_rmw_lock, write_config
     from pollypm.session_services import create_tmux_client
 
     config = load_config(config_path)
@@ -890,9 +890,15 @@ def _purge_project_sessions(
     # tmux server doesn't block the config cleanup — the user can always
     # re-run ``pm reset`` to mop up tmux state, but they can't recover
     # if the [sessions.*] entries stay and block ``remove_project``.
-    for session in matches:
-        config.sessions.pop(session.name, None)
-    write_config(config, config_path, force=True)
+    #
+    # #2063 round 7: hold the shared RMW lock and re-load INSIDE so
+    # any concurrent edits during the tmux teardown merge forward.
+    matched_names = [session.name for session in matches]
+    with config_rmw_lock(config_path):
+        fresh = load_config(config_path)
+        for name in matched_names:
+            fresh.sessions.pop(name, None)
+        write_config(fresh, config_path, force=True)
     return results
 
 

--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import typer
 
-from pollypm.config import load_config, write_config
+from pollypm.config import config_rmw_lock, load_config, write_config
 from pollypm.doc_scaffold import scaffold_docs
 from pollypm.models import KnownProject, ProjectKind
 from pollypm.task_backends import FileTaskBackend, get_task_backend
@@ -480,15 +480,19 @@ def scaffold_issue_tracker(project_path: Path) -> Path:
 
 
 def enable_tracked_project(config_path: Path, project_key: str) -> KnownProject:
-    config = load_config(config_path)
-    project = config.projects.get(project_key)
-    if project is None:
-        raise typer.BadParameter(f"Unknown project: {project_key}")
-    scaffold_issue_tracker(project.path)
-    project.kind = detect_project_kind(project.path)
-    project.tracked = True
-    config.projects[project_key] = project
-    write_config(config, config_path, force=True)
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write so a concurrent API or cockpit writer
+    # can't slot a write between our load and ours and lose its edit.
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        project = config.projects.get(project_key)
+        if project is None:
+            raise typer.BadParameter(f"Unknown project: {project_key}")
+        scaffold_issue_tracker(project.path)
+        project.kind = detect_project_kind(project.path)
+        project.tracked = True
+        config.projects[project_key] = project
+        write_config(config, config_path, force=True)
     return project
 
 
@@ -666,44 +670,48 @@ def register_project(
     project goes cold. See savethenovel "silently invisible fresh
     project" failure mode.
     """
-    config = load_config(config_path)
-    normalized_path = normalize_project_path(repo_path)
-    if not normalized_path.exists() or not normalized_path.is_dir():
-        raise typer.BadParameter(f"{normalized_path} is not a directory.")
-    for project in config.projects.values():
-        if normalize_project_path(project.path) == normalized_path:
-            return project
+    # #2063 round 7: hold the shared RMW lock so a concurrent API
+    # ``/pause`` or cockpit-driven write can't land between our load and
+    # write and clobber the new project entry (or vice versa).
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        normalized_path = normalize_project_path(repo_path)
+        if not normalized_path.exists() or not normalized_path.is_dir():
+            raise typer.BadParameter(f"{normalized_path} is not a directory.")
+        for project in config.projects.values():
+            if normalize_project_path(project.path) == normalized_path:
+                return project
 
-    if slug is None:
-        key = make_project_key(normalized_path, set(config.projects))
-    else:
-        key = slug.strip()
-        canonical = slugify_project_key(key)
-        if not canonical:
-            raise typer.BadParameter(
-                f"Slug {slug!r} does not yield a valid key "
-                "(at least one alphanumeric character required)."
-            )
-        if canonical != key:
-            raise typer.BadParameter(
-                f"Slug {slug!r} is not in canonical form. "
-                f"Try {canonical!r}."
-            )
-        if key in config.projects:
-            raise typer.BadParameter(
-                f"A project already exists at slug {key!r}. "
-                "Pick a different slug or remove the conflict first."
-            )
-    project = KnownProject(
-        key=key,
-        path=normalized_path,
-        name=name or normalized_path.name,
-        persona_name=default_persona_name(name or normalized_path.name),
-        kind=detect_project_kind(normalized_path),
-        tracked=bool(tracked),
-    )
-    config.projects[key] = project
-    write_config(config, config_path, force=True)
+        if slug is None:
+            key = make_project_key(normalized_path, set(config.projects))
+        else:
+            key = slug.strip()
+            canonical = slugify_project_key(key)
+            if not canonical:
+                raise typer.BadParameter(
+                    f"Slug {slug!r} does not yield a valid key "
+                    "(at least one alphanumeric character required)."
+                )
+            if canonical != key:
+                raise typer.BadParameter(
+                    f"Slug {slug!r} is not in canonical form. "
+                    f"Try {canonical!r}."
+                )
+            if key in config.projects:
+                raise typer.BadParameter(
+                    f"A project already exists at slug {key!r}. "
+                    "Pick a different slug or remove the conflict first."
+                )
+        project = KnownProject(
+            key=key,
+            path=normalized_path,
+            name=name or normalized_path.name,
+            persona_name=default_persona_name(name or normalized_path.name),
+            kind=detect_project_kind(normalized_path),
+            tracked=bool(tracked),
+        )
+        config.projects[key] = project
+        write_config(config, config_path, force=True)
     ensure_project_scaffold(normalized_path)
     return project
 
@@ -748,99 +756,108 @@ def rename_project(
             f"Try {normalized_new!r}."
         )
 
-    config = load_config(config_path)
-    if old_slug not in config.projects:
-        raise typer.BadParameter(f"Unknown project: {old_slug}")
-    if old_slug == new_slug:
-        raise typer.BadParameter("New slug must differ from the old slug.")
-    if new_slug in config.projects:
-        raise typer.BadParameter(
-            f"A project already exists at key {new_slug!r}. "
-            "Pick a different slug or remove the conflict first."
-        )
-
-    warnings: list[str] = []
-    project = config.projects[old_slug]
-    renamed_project = KnownProject(
-        key=new_slug,
-        path=project.path,
-        name=project.name,
-        persona_name=project.persona_name,
-        kind=project.kind,
-        tracked=project.tracked,
-        role_assignments=dict(project.role_assignments),
-    )
-
-    session_updates: list[tuple[str, str, str]] = []  # (name, old_project, new_project)
-    for session_name, session in config.sessions.items():
-        if session.project == old_slug:
-            session_updates.append((session_name, old_slug, new_slug))
-
-    # Flag live state the rename doesn't touch.
-    for session_name, _, _ in session_updates:
-        if session_name.endswith(f"_{old_slug}") or session_name.endswith(old_slug):
-            warnings.append(
-                f"Session name {session_name!r} still contains the old "
-                f"slug; restart the session to pick up the new name."
-            )
-    tmux_windows_mentioning_old = [
-        s.window_name for s in config.sessions.values()
-        if s.window_name and old_slug in s.window_name
-    ]
-    if tmux_windows_mentioning_old:
-        warnings.append(
-            f"Tmux window names still reference {old_slug!r}: "
-            f"{', '.join(sorted(set(tmux_windows_mentioning_old)))}. "
-            "Kill + relaunch each affected session to pick up new names."
-        )
-    work_db = project_state_db_path(project.path)
-    if work_db.exists():
-        warnings.append(
-            f"Work-service task IDs in {work_db} still use the old "
-            f"slug (e.g. {old_slug}/1). Existing tasks keep their IDs; "
-            "new tasks will use the new slug."
-        )
-    worktree_root = project_worktrees_dir(project.path)
-    if worktree_root.exists():
-        old_worktrees = [p.name for p in worktree_root.iterdir() if old_slug in p.name]
-        if old_worktrees:
-            warnings.append(
-                f"Worktree directories under {worktree_root} still use "
-                f"the old slug: {', '.join(sorted(old_worktrees))}. "
-                "Safe to leave; new worktrees will use the new slug."
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write so concurrent API / cockpit writers can't
+    # clobber the rename (or have their own write clobbered by it).
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        if old_slug not in config.projects:
+            raise typer.BadParameter(f"Unknown project: {old_slug}")
+        if old_slug == new_slug:
+            raise typer.BadParameter("New slug must differ from the old slug.")
+        if new_slug in config.projects:
+            raise typer.BadParameter(
+                f"A project already exists at key {new_slug!r}. "
+                "Pick a different slug or remove the conflict first."
             )
 
-    if dry_run:
-        return project, warnings
+        warnings: list[str] = []
+        project = config.projects[old_slug]
+        renamed_project = KnownProject(
+            key=new_slug,
+            path=project.path,
+            name=project.name,
+            persona_name=project.persona_name,
+            kind=project.kind,
+            tracked=project.tracked,
+            role_assignments=dict(project.role_assignments),
+        )
 
-    # Apply mutations.
-    del config.projects[old_slug]
-    config.projects[new_slug] = renamed_project
-    for session_name, _old, new in session_updates:
-        session = config.sessions[session_name]
-        config.sessions[session_name] = replace(session, project=new)
-    write_config(config, config_path, force=True)
+        session_updates: list[tuple[str, str, str]] = []  # (name, old_project, new_project)
+        for session_name, session in config.sessions.items():
+            if session.project == old_slug:
+                session_updates.append((session_name, old_slug, new_slug))
+
+        # Flag live state the rename doesn't touch.
+        for session_name, _, _ in session_updates:
+            if session_name.endswith(f"_{old_slug}") or session_name.endswith(old_slug):
+                warnings.append(
+                    f"Session name {session_name!r} still contains the old "
+                    f"slug; restart the session to pick up the new name."
+                )
+        tmux_windows_mentioning_old = [
+            s.window_name for s in config.sessions.values()
+            if s.window_name and old_slug in s.window_name
+        ]
+        if tmux_windows_mentioning_old:
+            warnings.append(
+                f"Tmux window names still reference {old_slug!r}: "
+                f"{', '.join(sorted(set(tmux_windows_mentioning_old)))}. "
+                "Kill + relaunch each affected session to pick up new names."
+            )
+        work_db = project_state_db_path(project.path)
+        if work_db.exists():
+            warnings.append(
+                f"Work-service task IDs in {work_db} still use the old "
+                f"slug (e.g. {old_slug}/1). Existing tasks keep their IDs; "
+                "new tasks will use the new slug."
+            )
+        worktree_root = project_worktrees_dir(project.path)
+        if worktree_root.exists():
+            old_worktrees = [p.name for p in worktree_root.iterdir() if old_slug in p.name]
+            if old_worktrees:
+                warnings.append(
+                    f"Worktree directories under {worktree_root} still use "
+                    f"the old slug: {', '.join(sorted(old_worktrees))}. "
+                    "Safe to leave; new worktrees will use the new slug."
+                )
+
+        if dry_run:
+            return project, warnings
+
+        # Apply mutations.
+        del config.projects[old_slug]
+        config.projects[new_slug] = renamed_project
+        for session_name, _old, new in session_updates:
+            session = config.sessions[session_name]
+            config.sessions[session_name] = replace(session, project=new)
+        write_config(config, config_path, force=True)
     return renamed_project, warnings
 
 
 def remove_project(config_path: Path, project_key: str) -> KnownProject:
-    config = load_config(config_path)
-    project = config.projects.get(project_key)
-    if project is None:
-        raise typer.BadParameter(f"Unknown project: {project_key}")
-    session_refs = [
-        session.name
-        for session in config.sessions.values()
-        if session.project == project_key and session.enabled
-    ]
-    if session_refs:
-        session_word = "session" if len(session_refs) == 1 else "sessions"
-        raise typer.BadParameter(
-            f"Project {project_key} is still used by "
-            f"{session_word}: {', '.join(session_refs)}"
-        )
-    del config.projects[project_key]
-    write_config(config, config_path, force=True)
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write. This is the exact callsite Codex round-7
+    # reproduced as the lost-update vehicle: an external CLI removal
+    # racing the API ``/pause`` lost the API mutation (or vice versa).
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        project = config.projects.get(project_key)
+        if project is None:
+            raise typer.BadParameter(f"Unknown project: {project_key}")
+        session_refs = [
+            session.name
+            for session in config.sessions.values()
+            if session.project == project_key and session.enabled
+        ]
+        if session_refs:
+            session_word = "session" if len(session_refs) == 1 else "sessions"
+            raise typer.BadParameter(
+                f"Project {project_key} is still used by "
+                f"{session_word}: {', '.join(session_refs)}"
+            )
+        del config.projects[project_key]
+        write_config(config, config_path, force=True)
     return project
 
 
@@ -883,9 +900,12 @@ def scan_projects(
 
 
 def set_workspace_root(config_path: Path, workspace_root: Path) -> Path:
-    config = load_config(config_path)
-    config.project.workspace_root = normalize_project_path(workspace_root)
-    write_config(config, config_path, force=True)
+    # #2063 round 7: hold the shared RMW lock so a concurrent project
+    # write can't slot between our load and write and lose its edit.
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        config.project.workspace_root = normalize_project_path(workspace_root)
+        write_config(config, config_path, force=True)
     return config.project.workspace_root
 
 

--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -911,6 +911,39 @@ def scan_projects(
     if not candidates:
         return []
 
+    # #2063 round 12: scaffold BEFORE the locked config write. The round-9
+    # restructure wrote the new project entries inside the lock and only
+    # then called ``ensure_project_scaffold`` after releasing it. If
+    # scaffolding raised (permissions, partial checkout, bad path), the
+    # command surfaced the error but the global config already pointed at
+    # a project whose ``.pollypm/`` was never created — an operator-
+    # visible inconsistency.
+    #
+    # Codex reproduction: patch ``ensure_project_scaffold`` to raise
+    # ``PermissionError``; pre-fix ``load_config(config_path).projects``
+    # still contained the new project key after the exception.
+    #
+    # ``ensure_project_scaffold`` is idempotent (it uses
+    # ``mkdir(exist_ok=True)``) and touches only the project's own
+    # ``.pollypm/`` dir, not the shared global TOML — so running it
+    # before the lock is safe: if commit later fails, the worst case is a
+    # ``.pollypm/`` dir on disk that no config references (operators can
+    # ``rm -rf`` it), which is strictly better than a config entry whose
+    # scaffold never landed.
+    scaffolded: list[Path] = []
+    for repo_path in candidates:
+        try:
+            ensure_project_scaffold(repo_path)
+        except OSError as exc:
+            typer.echo(
+                f"Skipping {repo_path}: scaffold failed ({exc})", err=True
+            )
+            continue
+        scaffolded.append(repo_path)
+
+    if not scaffolded:
+        return []
+
     added: list[KnownProject] = []
     with config_rmw_lock(config_path):
         fresh = load_config(config_path)
@@ -922,7 +955,7 @@ def scan_projects(
             for project in fresh.projects.values()
         }
         known_keys = set(fresh.projects)
-        for repo_path in candidates:
+        for repo_path in scaffolded:
             if normalize_project_path(repo_path) in known_paths:
                 # A concurrent writer added this project between our
                 # pre-lock discovery and the lock acquire. Skip rather
@@ -942,12 +975,6 @@ def scan_projects(
 
         if added:
             write_config(fresh, config_path, force=True)
-
-    # Filesystem scaffolding is idempotent (``mkdir(exist_ok=True)``) and
-    # touches each project's own ``.pollypm/`` dir, not the shared
-    # global TOML — safe to run outside the critical section.
-    for project in added:
-        ensure_project_scaffold(project.path)
 
     return added
 

--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -867,14 +867,38 @@ def scan_projects(
     scan_root: Path | None = None,
     interactive: bool = True,
 ) -> list[KnownProject]:
-    config = load_config(config_path)
+    # #2063 round 9: discovery (filesystem walk) and interactive
+    # confirmation happen OUTSIDE the shared config_rmw_lock. Holding the
+    # lock across ``typer.confirm`` would block every other config writer
+    # for the duration of user thinking time. Codex's prescription is
+    # "do discovery outside the critical section" then enter the lock to
+    # reload + recompute + merge + write so concurrent additions by other
+    # writers (API pause, CLI remove) are visible and survive.
+    #
+    # Pre-lock snapshot is best-effort: by the time we reload inside the
+    # lock the on-disk config may differ. We re-derive ``known_paths`` /
+    # ``known_keys`` against the FRESH snapshot so candidates added by a
+    # concurrent writer between the prompt and the lock acquire are
+    # skipped (rather than overwritten).
+    initial_config = load_config(config_path)
     root = normalize_project_path(scan_root or DEFAULT_SCAN_ROOT)
-    known_paths = {normalize_project_path(project.path) for project in config.projects.values()}
-    discovered = discover_recent_git_repositories(root, known_paths=known_paths, recent_days=14)
-    added: list[KnownProject] = []
+    pre_known_paths = {
+        normalize_project_path(project.path)
+        for project in initial_config.projects.values()
+    }
+    discovered = discover_recent_git_repositories(
+        root, known_paths=pre_known_paths, recent_days=14
+    )
 
+    # Confirm with the operator BEFORE taking the lock. The confirmation
+    # default is computed against the pre-lock snapshot's workspace_root;
+    # an external mutation that flips workspace_root between here and the
+    # lock acquire is acceptable — the operator's intent is captured.
+    candidates: list[Path] = []
     for repo_path in discovered:
-        default_choice = _default_add_choice(repo_path, config.project.workspace_root)
+        default_choice = _default_add_choice(
+            repo_path, initial_config.project.workspace_root
+        )
         if interactive:
             add = typer.confirm(
                 f"Add project {repo_path.name} at {repo_path}?",
@@ -882,19 +906,48 @@ def scan_projects(
             )
             if not add:
                 continue
-        project = KnownProject(
-            key=make_project_key(repo_path, set(config.projects) | {item.key for item in added}),
-            path=repo_path,
-            name=repo_path.name,
-            persona_name=default_persona_name(repo_path.name),
-            kind=ProjectKind.GIT,
-        )
-        config.projects[project.key] = project
-        ensure_project_scaffold(repo_path)
-        added.append(project)
+        candidates.append(repo_path)
 
-    if added:
-        write_config(config, config_path, force=True)
+    if not candidates:
+        return []
+
+    added: list[KnownProject] = []
+    with config_rmw_lock(config_path):
+        fresh = load_config(config_path)
+        # Recompute known sets against the fresh snapshot so a
+        # concurrent register/scan that landed between our discovery and
+        # this lock acquire is visible.
+        known_paths = {
+            normalize_project_path(project.path)
+            for project in fresh.projects.values()
+        }
+        known_keys = set(fresh.projects)
+        for repo_path in candidates:
+            if normalize_project_path(repo_path) in known_paths:
+                # A concurrent writer added this project between our
+                # pre-lock discovery and the lock acquire. Skip rather
+                # than clobber.
+                continue
+            key = make_project_key(repo_path, known_keys)
+            known_keys.add(key)
+            project = KnownProject(
+                key=key,
+                path=repo_path,
+                name=repo_path.name,
+                persona_name=default_persona_name(repo_path.name),
+                kind=ProjectKind.GIT,
+            )
+            fresh.projects[key] = project
+            added.append(project)
+
+        if added:
+            write_config(fresh, config_path, force=True)
+
+    # Filesystem scaffolding is idempotent (``mkdir(exist_ok=True)``) and
+    # touches each project's own ``.pollypm/`` dir, not the shared
+    # global TOML — safe to run outside the critical section.
+    for project in added:
+        ensure_project_scaffold(project.path)
 
     return added
 

--- a/src/pollypm/web_api/routes/projects.py
+++ b/src/pollypm/web_api/routes/projects.py
@@ -1,4 +1,4 @@
-"""Project read endpoints (Phase 1).
+"""Project endpoints (Phase 1 reads + Phase 2 lifecycle writes).
 
 Implements:
 
@@ -6,34 +6,47 @@ Implements:
 - ``GET /api/v1/projects/{key}`` — drilldown view.
 - ``GET /api/v1/projects/{key}/tasks`` — paginated task list.
 - ``GET /api/v1/projects/{key}/plan`` — structured plan body.
-
-Write endpoints (`POST /projects`, `POST /projects/{key}/plan`,
-`POST /projects/{key}/chat`) ship in Phase 2 (#1548).
+- ``POST /api/v1/projects/{key}/pause`` — mark project ``tracked=false``.
+- ``POST /api/v1/projects/{key}/resume`` — mark project ``tracked=true``.
+- ``POST /api/v1/projects/{key}/archive`` — remove project from config
+  (per spec §6.2; source data on disk is untouched).
+- ``POST /api/v1/projects/{key}/init-guide`` — seed a project-local
+  role guide (``architect`` / ``reviewer`` / ``worker``).
 """
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, Query
-from pydantic import Field
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
 
 from pollypm.web_api.errors import not_found
 from pollypm.web_api.models import (
+    ActionResult,
     Plan,
+    Project,
     ProjectDrilldown,
     ProjectListResponse,
     TaskListResponse,
 )
 from pollypm.web_api.routes._deps import ConfigDep
 from pollypm.web_api.service import (
+    archive_project,
     get_active_plan,
+    init_project_guide_for_role,
     list_project_tasks,
     list_projects,
     project_drilldown,
+    set_project_tracked,
 )
 
 router = APIRouter(tags=["Projects"])
+
+
+# ---------------------------------------------------------------------------
+# Read endpoints (Phase 1)
+# ---------------------------------------------------------------------------
 
 
 @router.get(
@@ -104,3 +117,155 @@ def get_project_plan_endpoint(
             hint="Plans appear here once a task reaches the user_approval node.",
         )
     return plan
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — write endpoints (pause / resume / archive / init-guide)
+# ---------------------------------------------------------------------------
+
+
+class _ReasonBody(BaseModel):
+    """Optional `{reason?}` body shared by pause / archive routes.
+
+    ``reason`` is currently accepted for audit symmetry with the
+    cockpit's Pause/Archive UX; it isn't stored on
+    :class:`KnownProject`. When audit emission lands (spec §2.10) the
+    string will be threaded into the ``api.mutation`` audit row's
+    ``metadata.reason`` so operators can grep for "why".
+    """
+
+    reason: str | None = Field(
+        default=None,
+        max_length=500,
+        description="Optional operator-supplied note. Currently not persisted.",
+    )
+
+
+class _InitGuideBody(BaseModel):
+    """Body for ``POST /projects/{key}/init-guide``."""
+
+    role: Literal["architect", "reviewer", "worker"] = Field(
+        description="Which role-specific guide to seed.",
+    )
+    force: bool = Field(
+        default=False,
+        description="Overwrite an existing guide file. Without this, "
+        "existing guides return 409 conflict.",
+    )
+
+
+class InitGuideResponse(BaseModel):
+    """Return shape for ``POST /projects/{key}/init-guide``.
+
+    Mirrors :class:`pollypm.project_guides.ProjectGuideInfo` but
+    serializes ``path`` as a string so the API stays loop-back-portable.
+    """
+
+    role: str
+    path: str
+    forked_from: str | None = None
+    body: str
+
+
+@router.post(
+    "/projects/{key}/pause",
+    response_model=Project,
+    summary="Pause a project (set tracked=false)",
+    operation_id="pauseProject",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project not registered."},
+        "503": {"description": "Backing store unreachable (failed to persist)."},
+    },
+)
+def pause_project_endpoint(
+    key: str,
+    config: ConfigDep,
+    body: _ReasonBody | None = None,
+) -> Project:
+    reason = body.reason if body is not None else None
+    # Idempotent per spec §6.3 ("Pause a paused project ... returns
+    # 200 with current state, no audit churn"). Skip the disk write
+    # when already paused so we don't churn the TOML mtime — still
+    # return the canonical post-state so clients see consistent JSON
+    # whether they raced an earlier call or not.
+    project = config.projects.get(key)
+    if project is None:
+        raise not_found(f"Project not registered: {key}")
+    if project.tracked is False:
+        from pollypm.web_api.service import _project_to_api  # local import: private helper
+
+        return _project_to_api(config, key, project)
+    return set_project_tracked(config, key, tracked=False, reason=reason)
+
+
+@router.post(
+    "/projects/{key}/resume",
+    response_model=Project,
+    summary="Resume a project (set tracked=true)",
+    operation_id="resumeProject",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project not registered."},
+        "503": {"description": "Backing store unreachable (failed to persist)."},
+    },
+)
+def resume_project_endpoint(
+    key: str,
+    config: ConfigDep,
+) -> Project:
+    project = config.projects.get(key)
+    if project is None:
+        raise not_found(f"Project not registered: {key}")
+    if project.tracked is True:
+        from pollypm.web_api.service import _project_to_api  # local import: private helper
+
+        return _project_to_api(config, key, project)
+    return set_project_tracked(config, key, tracked=True)
+
+
+@router.post(
+    "/projects/{key}/archive",
+    response_model=ActionResult,
+    summary="Archive a project (remove from config)",
+    operation_id="archiveProject",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project not registered."},
+        "503": {"description": "Backing store unreachable (failed to persist)."},
+    },
+)
+def archive_project_endpoint(
+    key: str,
+    config: ConfigDep,
+    body: _ReasonBody | None = None,
+) -> ActionResult:
+    reason = body.reason if body is not None else None
+    label = archive_project(config, key, reason=reason)
+    message = f"archived {label}"
+    if reason:
+        message = f"{message} ({reason})"
+    return ActionResult(ok=True, message=message)
+
+
+@router.post(
+    "/projects/{key}/init-guide",
+    response_model=InitGuideResponse,
+    summary="Seed a project-local role guide",
+    operation_id="initProjectGuide",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project not registered."},
+        "409": {"description": "Guide already exists; resend with force=true."},
+        "422": {"description": "Unknown role."},
+    },
+)
+def init_project_guide_endpoint(
+    key: str,
+    body: _InitGuideBody,
+    config: ConfigDep,
+) -> InitGuideResponse:
+    payload = init_project_guide_for_role(
+        config, key, role=body.role, force=body.force
+    )
+    return InitGuideResponse(**payload)

--- a/src/pollypm/web_api/routes/projects.py
+++ b/src/pollypm/web_api/routes/projects.py
@@ -229,6 +229,14 @@ def resume_project_endpoint(
     responses={
         "401": {"description": "Missing or invalid bearer token."},
         "404": {"description": "Project not registered."},
+        "409": {
+            "description": (
+                "Project is still referenced by one or more enabled "
+                "sessions; the response body names the blocking sessions "
+                "in ``error.message``. Disable or remove those sessions "
+                "before retrying."
+            )
+        },
         "503": {"description": "Backing store unreachable (failed to persist)."},
     },
 )

--- a/src/pollypm/web_api/routes/projects.py
+++ b/src/pollypm/web_api/routes/projects.py
@@ -127,17 +127,23 @@ def get_project_plan_endpoint(
 class _ReasonBody(BaseModel):
     """Optional `{reason?}` body shared by pause / archive routes.
 
-    ``reason`` is currently accepted for audit symmetry with the
-    cockpit's Pause/Archive UX; it isn't stored on
-    :class:`KnownProject`. When audit emission lands (spec §2.10) the
-    string will be threaded into the ``api.mutation`` audit row's
-    ``metadata.reason`` so operators can grep for "why".
+    ``reason`` is persisted to the per-project audit log as part of
+    the ``projects.tracked.set`` (pause/resume) and ``projects.archive``
+    events emitted by the service layer, alongside the actor and
+    timestamp. Clamped to 500 chars by ``max_length`` here and re-
+    clamped in :func:`pollypm.web_api.service._emit_project_audit` as
+    belt-and-suspenders.
     """
 
     reason: str | None = Field(
         default=None,
         max_length=500,
-        description="Optional operator-supplied note. Currently not persisted.",
+        description=(
+            "Optional operator-supplied note. Persisted to the per-"
+            "project audit log (`projects.tracked.set` / "
+            "`projects.archive` events) along with the actor and "
+            "timestamp. Clamped to 500 chars."
+        ),
     )
 
 
@@ -184,18 +190,11 @@ def pause_project_endpoint(
     body: _ReasonBody | None = None,
 ) -> Project:
     reason = body.reason if body is not None else None
-    # Idempotent per spec §6.3 ("Pause a paused project ... returns
-    # 200 with current state, no audit churn"). Skip the disk write
-    # when already paused so we don't churn the TOML mtime — still
-    # return the canonical post-state so clients see consistent JSON
-    # whether they raced an earlier call or not.
-    project = config.projects.get(key)
-    if project is None:
-        raise not_found(f"Project not registered: {key}")
-    if project.tracked is False:
-        from pollypm.web_api.service import _project_to_api  # local import: private helper
-
-        return _project_to_api(config, key, project)
+    # Idempotency lives in ``set_project_tracked`` (Codex round 2 on
+    # #2063): deciding "already paused" against the long-lived
+    # ``ConfigDep`` snapshot was returning 200 with a stale value when
+    # disk had been edited externally. The service helper reloads disk
+    # first and short-circuits there.
     return set_project_tracked(config, key, tracked=False, reason=reason)
 
 
@@ -214,13 +213,11 @@ def resume_project_endpoint(
     key: str,
     config: ConfigDep,
 ) -> Project:
-    project = config.projects.get(key)
-    if project is None:
-        raise not_found(f"Project not registered: {key}")
-    if project.tracked is True:
-        from pollypm.web_api.service import _project_to_api  # local import: private helper
-
-        return _project_to_api(config, key, project)
+    # Idempotency lives in ``set_project_tracked`` (Codex round 2 on
+    # #2063): deciding "already tracked" against the long-lived
+    # ``ConfigDep`` snapshot was returning 200 with a stale value when
+    # disk had been edited externally. The service helper reloads disk
+    # first and short-circuits there.
     return set_project_tracked(config, key, tracked=True)
 
 

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -388,24 +388,35 @@ def _refresh_live_projects(
 ) -> None:
     """Replace ``live_config.projects`` in place with ``fresh_config.projects``.
 
-    Used after every config-mutation path so the long-lived
-    :class:`ConfigDep` object reflects disk state in full — both the
+    Used after every config-mutation path so the in-request
+    :class:`ConfigDep` snapshot reflects disk state in full — both the
     mutated project AND any concurrent external edits / additions /
-    removals.
+    removals — before we build the response body off it.
 
-    Codex round 3 on #2063: the previous field-by-field copy
+    Post-#2056 the ``ConfigDep`` provider reloads via
+    ``load_config(config_path)`` per request, so cross-request
+    consistency is already guaranteed by the reload. This refresh is
+    therefore load-bearing only for:
+
+    * the IN-REQUEST response (we serialize from
+      ``config.projects[key]`` after the refresh, so it picks up the
+      post-write disk state without an extra ``_project_to_api`` arg
+      rewrite), AND
+    * the in-memory fallback path (``config_path is None``), where
+      tests construct :class:`PollyPMConfig` directly and the app
+      factory wires a startup-frozen ``lambda: config`` provider with
+      no per-request reload.
+
+    Codex round 3 on #2063: a previous field-by-field copy
     (``tracked`` / ``path`` / ``name``) left other ``KnownProject``
-    fields (``persona_name``, ``kind``, role/model assignments, worker
-    caps, plan enforcement, etc.) stale when an external CLI / cockpit
-    edit changed them on the same project before the API call landed.
-    The response is built from the live snapshot so the API would
-    return stale metadata while disk had the new metadata. Mirror
-    case: external project additions / removals on disk before
-    ``/archive`` would stay invisible to in-process GETs until restart.
+    fields (``persona_name``, ``kind``, role assignments, worker caps,
+    plan enforcement, etc.) stale when an external edit changed them on
+    the same project before the API call landed. Full ``clear() +
+    update()`` propagates every field plus external add/remove on other
+    keys.
 
     Mutates ``live_config.projects`` in place so any external object
-    holding a reference to the dict (FastAPI ``Depends`` caches it
-    across requests) sees the new contents.
+    holding a reference to the dict sees the new contents.
     """
     live_config.projects.clear()
     live_config.projects.update(fresh_config.projects)
@@ -427,21 +438,32 @@ def set_project_tracked(
       that landed between server boot and this call are preserved —
       we never write back the long-lived ``ConfigDep`` snapshot with
       ``force=True`` (that would silently drop e.g. a project added
-      via ``pm add-project`` after the server started).
+      via ``pm add-project`` after the server started). Post-#2056
+      the request's ``config`` is itself a per-request
+      ``load_config(config_path)`` reload, so the extra
+      ``load_config`` here is a cheap cache hit on the production
+      path AND still required for the in-memory fallback path
+      (``config_path is None``) where ``config`` is a startup-frozen
+      object.
     * Idempotency is decided AGAINST the freshly-loaded disk state
       (Codex round 2 on #2063): if disk already matches ``tracked``
-      we skip the write AND fully refresh the live snapshot from disk
-      so a stale in-memory value can't keep lying. Deciding against
-      the long-lived ``ConfigDep`` here would let a server that booted
-      with ``tracked=True`` short-circuit a ``/resume`` call even
-      after an external edit flipped disk to ``False``.
-    * Mutate the freshly-loaded copy, NOT the live ``config``.
+      we skip the write AND refresh the request's snapshot from disk
+      so the response body is built from disk state, not from any
+      stale field.
+    * Mutate the freshly-loaded copy via DEEP COPY, NOT the live
+      ``config`` — ``load_config`` is memoised by path, so the
+      ``fresh_cached`` snapshot IS the same object as the request's
+      ``config`` whenever the server was bootstrapped via
+      ``load_config(config_path)``. Without the deep copy, a write
+      failure after mutating ``fresh.tracked`` would leak a stale
+      lie into the cache (Codex round 4 on #2063).
     * After every successful disk write we re-load disk and FULLY
       refresh ``config.projects`` via :func:`_refresh_live_projects`
-      (Codex round 3 on #2063). The previous field-by-field copy left
-      other ``KnownProject`` fields (``persona_name``, ``kind``, role
-      assignments, worker caps, etc.) stale when an external edit
-      changed them on the same project before the API call.
+      so the in-request response reflects the post-write state plus
+      any concurrent external edits (Codex round 3 on #2063). Post-
+      #2056 the NEXT request reloads from disk anyway, so this is
+      mainly load-bearing for the current response and for the
+      in-memory fallback path.
     * If ``write_config`` raises ``OSError`` the live ``config``
       stays untouched and a subsequent GET reflects the unchanged
       disk state — no stale in-memory lie that flips back on restart.

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -400,6 +400,13 @@ def set_project_tracked(
       we never write back the long-lived ``ConfigDep`` snapshot with
       ``force=True`` (that would silently drop e.g. a project added
       via ``pm add-project`` after the server started).
+    * Idempotency is decided AGAINST the freshly-loaded disk state
+      (Codex round 2 on #2063): if disk already matches ``tracked``
+      we skip the write AND sync the live snapshot from disk so a
+      stale in-memory value can't keep lying. Deciding against the
+      long-lived ``ConfigDep`` here would let a server that booted
+      with ``tracked=True`` short-circuit a ``/resume`` call even
+      after an external edit flipped disk to ``False``.
     * Mutate the freshly-loaded copy, NOT the live ``config``.
     * Only after the disk write succeeds do we sync the change back
       into the live ``config`` so subsequent in-process reads see it.
@@ -435,6 +442,20 @@ def set_project_tracked(
         # Disk-side delete raced us. Treat as 404 — the in-memory state
         # is stale and the next GET will agree.
         raise not_found(f"Project not registered: {project_key}")
+
+    # Idempotency decided against DISK, not against the long-lived
+    # in-memory snapshot. If disk already matches the request we still
+    # sync the live ``config`` from disk so a stale in-process value
+    # can't continue lying to subsequent GETs.
+    if fresh_project.tracked == tracked:
+        live_project.tracked = fresh_project.tracked
+        live_project.path = fresh_project.path
+        live_project.name = fresh_project.name
+        config.projects[project_key] = live_project
+        for key, value in fresh.projects.items():
+            if key not in config.projects:
+                config.projects[key] = value
+        return _project_to_api(config, project_key, live_project)
 
     fresh_project.tracked = tracked
     fresh.projects[project_key] = fresh_project

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -383,6 +383,51 @@ def _emit_project_audit(
         pass
 
 
+@contextlib.contextmanager
+def _config_write_lock(config_path: Path):
+    """Serialise config read-modify-write across concurrent API requests.
+
+    Codex round 6 on #2063 caught a lost-update race: two clients
+    pausing different projects concurrently each ``deepcopy`` the same
+    cached load_config snapshot, mutate their own project, then both
+    write with ``force=True``. The second writer's snapshot still has
+    the first writer's project at the OLD value — so the first write
+    is silently reverted on disk. Per-request reloads (post-#2056)
+    don't help because the race is between two requests, both of which
+    reload at the same moment before either writes.
+
+    Fix: hold an exclusive ``fcntl.flock`` on a sibling lockfile for
+    the entire ``load_config → mutate → write_config`` sequence. The
+    lockfile is created on first use (``open(..., "a+")`` is
+    create-if-missing without truncation). Lock release is best-effort
+    in the ``finally`` block so a propagating exception still unlocks.
+
+    POSIX-only. PollyPM ships as a personal-use Mac/Linux deployment;
+    Windows isn't a supported target.
+
+    The lock is per ``config_path`` so two unrelated configs (e.g.
+    multi-tenant dev setups) don't serialise against each other.
+    """
+    import fcntl
+
+    lock_path = config_path.with_suffix(config_path.suffix + ".lock")
+    # Ensure parent exists — config_path may not have been created yet
+    # on the very first request after a fresh install, but the parent
+    # ``.pollypm/`` always exists by the time the API is up.
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    # "a+" creates if missing without truncating; we never read from
+    # or write to the lockfile, only flock its fd.
+    with open(lock_path, "a+") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            try:
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+
+
 def _refresh_live_projects(
     live_config: PollyPMConfig, fresh_config: PollyPMConfig
 ) -> None:
@@ -434,6 +479,16 @@ def set_project_tracked(
 
     Concurrent-safe write semantics (Codex review on #2063):
 
+    * The entire read-modify-write section is serialised by an
+      exclusive ``fcntl.flock`` on a sibling lockfile (Codex round 6
+      on #2063 — ``_config_write_lock``). Without this lock, two
+      concurrent ``/pause`` calls on DIFFERENT projects could each
+      deepcopy the same cached snapshot, mutate their own project,
+      and then both write ``force=True`` — the second writer would
+      silently revert the first writer's change on disk. The flock
+      forces request B to reload AFTER request A's write commits, so
+      its deepcopy reflects A's mutation and the merged write
+      preserves both.
     * Re-load the on-disk TOML so any external CLI / cockpit edits
       that landed between server boot and this call are preserved —
       we never write back the long-lived ``ConfigDep`` snapshot with
@@ -477,85 +532,102 @@ def set_project_tracked(
     from pollypm.config import load_config, write_config
 
     # Bind to the original (in-memory) project up-front so the 404 path
-    # doesn't pay for a disk reload.
+    # doesn't pay for a disk reload or take the lock.
     live_project = config.projects.get(project_key)
     if live_project is None:
         raise not_found(f"Project not registered: {project_key}")
 
     config_path = _resolve_config_write_path(config)
-    # Reload from disk so we don't lose concurrent CLI / cockpit edits
-    # (e.g. an external ``pm add-project`` that added a new project key
-    # the in-memory server hasn't seen yet).
-    try:
-        fresh_cached = load_config(config_path)
-    except OSError as exc:
-        raise service_unavailable(
-            f"Failed to reload config for {project_key}: {exc}",
-            hint="Check read permissions on the PollyPM config file.",
-        ) from exc
-    # ``load_config`` is memoised by ``config_path`` (see
-    # ``pollypm.config._config_cache``) so ``fresh_cached`` IS the same
-    # object as the live ``ConfigDep`` whenever the server was bootstrapped
-    # via ``load_config(config_path)`` — which is exactly what
-    # ``pm serve`` / ``load_api_config`` do in production. Mutating
-    # ``fresh_cached.projects[key].tracked`` would therefore mutate the
-    # live snapshot BEFORE the durable write completes. If write_config
-    # then raises OSError, the API returns 503 but the live config has
-    # already flipped — a rollback violation Codex reproduced on round 4
-    # of #2063. Take a deep copy here so all mutation happens on a
-    # detached graph; the live snapshot is only touched via
-    # ``_refresh_live_projects`` AFTER the disk write succeeds.
-    fresh = copy.deepcopy(fresh_cached)
-    fresh_project = fresh.projects.get(project_key)
-    if fresh_project is None:
-        # Disk-side delete raced us. Treat as 404 — the in-memory state
-        # is stale and the next GET will agree.
-        raise not_found(f"Project not registered: {project_key}")
+    # Hold the per-config write lock across the entire RMW so two
+    # concurrent requests on different projects can't lose each other's
+    # writes (Codex round 6 on #2063). The lock is released BEFORE we
+    # return; subsequent callers' load_config sees the updated mtime
+    # and reloads fresh.
+    with _config_write_lock(config_path):
+        # Reload from disk so we don't lose concurrent CLI / cockpit
+        # edits (e.g. an external ``pm add-project`` that added a new
+        # project key the in-memory server hasn't seen yet). Under the
+        # flock this also picks up any sibling-API-request mutation
+        # that committed while we were waiting on the lock.
+        try:
+            fresh_cached = load_config(config_path)
+        except OSError as exc:
+            raise service_unavailable(
+                f"Failed to reload config for {project_key}: {exc}",
+                hint="Check read permissions on the PollyPM config file.",
+            ) from exc
+        # ``load_config`` is memoised by ``config_path`` (see
+        # ``pollypm.config._config_cache``) so ``fresh_cached`` IS the
+        # same object as the live ``ConfigDep`` whenever the server was
+        # bootstrapped via ``load_config(config_path)`` — which is
+        # exactly what ``pm serve`` / ``load_api_config`` do in
+        # production. Mutating ``fresh_cached.projects[key].tracked``
+        # would therefore mutate the live snapshot BEFORE the durable
+        # write completes. If write_config then raises OSError, the API
+        # returns 503 but the live config has already flipped — a
+        # rollback violation Codex reproduced on round 4 of #2063. Take
+        # a deep copy here so all mutation happens on a detached graph;
+        # the live snapshot is only touched via
+        # ``_refresh_live_projects`` AFTER the disk write succeeds.
+        fresh = copy.deepcopy(fresh_cached)
+        fresh_project = fresh.projects.get(project_key)
+        if fresh_project is None:
+            # Disk-side delete raced us. Treat as 404 — the in-memory
+            # state is stale and the next GET will agree.
+            raise not_found(f"Project not registered: {project_key}")
 
-    # Idempotency decided against DISK, not against the long-lived
-    # in-memory snapshot. If disk already matches the request we still
-    # FULLY refresh the live ``config.projects`` from disk so any
-    # external metadata edits (persona_name, kind, role assignments,
-    # worker caps, etc.) propagate — Codex round 3 on #2063.
-    if fresh_project.tracked == tracked:
-        _refresh_live_projects(config, fresh)
-        return _project_to_api(config, project_key, config.projects[project_key])
+        # Idempotency decided against DISK, not against the long-lived
+        # in-memory snapshot. If disk already matches the request we
+        # still FULLY refresh the live ``config.projects`` from disk so
+        # any external metadata edits (persona_name, kind, role
+        # assignments, worker caps, etc.) propagate — Codex round 3 on
+        # #2063.
+        if fresh_project.tracked == tracked:
+            _refresh_live_projects(config, fresh)
+            return _project_to_api(
+                config, project_key, config.projects[project_key]
+            )
 
-    fresh_project.tracked = tracked
-    fresh.projects[project_key] = fresh_project
-    try:
-        write_config(fresh, config_path, force=True)
-    except OSError as exc:
-        # Live config untouched — Codex P0 #1 (rollback guarantee). The
-        # deep-copy above is what makes this rollback real on the
-        # cached-load_config path: ``fresh`` is a detached graph, so
-        # mutating ``fresh_project.tracked`` never reached the live
-        # ``ConfigDep`` shared with FastAPI request handlers. Codex
-        # round 4 on #2063.
-        raise service_unavailable(
-            f"Failed to persist project state for {project_key}: {exc}",
-            hint="Check write permissions on the PollyPM config file.",
-        ) from exc
+        fresh_project.tracked = tracked
+        fresh.projects[project_key] = fresh_project
+        try:
+            write_config(fresh, config_path, force=True)
+        except OSError as exc:
+            # Live config untouched — Codex P0 #1 (rollback guarantee).
+            # The deep-copy above is what makes this rollback real on
+            # the cached-load_config path: ``fresh`` is a detached
+            # graph, so mutating ``fresh_project.tracked`` never
+            # reached the live ``ConfigDep`` shared with FastAPI
+            # request handlers. Codex round 4 on #2063.
+            raise service_unavailable(
+                f"Failed to persist project state for {project_key}: {exc}",
+                hint="Check write permissions on the PollyPM config file.",
+            ) from exc
 
-    # Disk write succeeded — re-load disk and FULLY refresh the live
-    # ``config.projects`` so in-process callers see (a) the new
-    # ``tracked`` we just wrote AND (b) any concurrent external edits
-    # to other fields / other projects that landed between our load
-    # and our write — Codex round 3 on #2063. The extra load_config()
-    # is cheap relative to the durable write we just did and ensures
-    # we never widen a write-after-read race.
-    try:
-        post_write = load_config(config_path)
-    except OSError as exc:
-        # Live config still reflects pre-write state. Surface as 503
-        # so the client can retry; subsequent GETs stay consistent.
-        raise service_unavailable(
-            f"Failed to reload config after writing {project_key}: {exc}",
-            hint="Check read permissions on the PollyPM config file.",
-        ) from exc
-    _refresh_live_projects(config, post_write)
+        # Disk write succeeded — re-load disk and FULLY refresh the
+        # live ``config.projects`` so in-process callers see (a) the
+        # new ``tracked`` we just wrote AND (b) any concurrent external
+        # edits to other fields / other projects that landed between
+        # our load and our write — Codex round 3 on #2063. The extra
+        # load_config() is cheap relative to the durable write we just
+        # did. The flock guarantees no other API writer is between our
+        # write and this reload.
+        try:
+            post_write = load_config(config_path)
+        except OSError as exc:
+            # Live config still reflects pre-write state. Surface as
+            # 503 so the client can retry; subsequent GETs stay
+            # consistent.
+            raise service_unavailable(
+                f"Failed to reload config after writing {project_key}: {exc}",
+                hint="Check read permissions on the PollyPM config file.",
+            ) from exc
+        _refresh_live_projects(config, post_write)
 
-    refreshed_project = config.projects[project_key]
+        refreshed_project = config.projects[project_key]
+
+    # Audit emit outside the lock — it does its own I/O and we don't
+    # want it serialising with other API writers.
     _emit_project_audit(
         event="projects.tracked.set",
         config=config,
@@ -591,6 +663,14 @@ def archive_project(
     enforced uniformly with the CLI's ``pm projects remove``. Enabled-
     session references map to ``409 conflict`` with the blocking
     session names in the body.
+
+    Codex round 6 on #2063: the entire ``remove_project`` call + the
+    post-write reload runs under the same ``_config_write_lock`` used
+    by :func:`set_project_tracked`. Without this, an archive on
+    project A and a pause on project B could each load the same
+    cached config, mutate their own key, and write — losing one
+    mutation. The flock serialises the read-modify-write at the API
+    entry point.
     """
     import typer
 
@@ -603,73 +683,84 @@ def archive_project(
     label = live_project.display_label()
     project_path = live_project.path
     config_path = _resolve_config_write_path(config)
-    # Snapshot the live project entry so we can roll back the in-memory
-    # state if ``remove_project`` raises OSError after mutation. The
-    # facade does ``config = load_config(...); del config.projects[key];
-    # write_config(...)`` — and ``load_config`` is memoised by path, so
-    # the dict it mutates IS the live ``ConfigDep`` dict on the
-    # production cached path. A write failure after ``del`` would
-    # otherwise leave the live snapshot missing the project even though
-    # disk still has it (Codex round 4 on #2063, mirror of the
-    # set_project_tracked deep-copy fix above).
-    _live_project_snapshot = config.projects.get(project_key)
-    try:
-        # ``remove_project`` reloads from disk, enforces the session-ref
-        # guard, then writes back — same concurrent-safe pattern as the
-        # tracked-toggle path above. Live ``config`` is untouched if the
-        # facade raises ``BadParameter`` (it raises before mutating);
-        # OSError can fire after the in-place delete, so we restore the
-        # snapshot below.
-        _remove_project_facade(config_path, project_key)
-    except typer.BadParameter as exc:
-        msg = str(exc)
-        if "still used by" in msg:
-            raise APIError(
-                status_code=409,
-                code="conflict",
-                message=msg,
-                hint=(
-                    "Disable or remove the listed sessions before "
-                    "archiving this project."
-                ),
+    # Hold the per-config flock across the facade call AND the post-
+    # archive reload so we serialise with any concurrent
+    # ``set_project_tracked`` or sibling ``archive_project`` call
+    # against the same config (Codex round 6 on #2063). The lock is
+    # released BEFORE the audit emit; subsequent API writers' load_
+    # config sees our committed mtime and reloads fresh.
+    with _config_write_lock(config_path):
+        # Snapshot the live project entry so we can roll back the in-
+        # memory state if ``remove_project`` raises OSError after
+        # mutation. The facade does ``config = load_config(...);
+        # del config.projects[key]; write_config(...)`` — and
+        # ``load_config`` is memoised by path, so the dict it mutates
+        # IS the live ``ConfigDep`` dict on the production cached path.
+        # A write failure after ``del`` would otherwise leave the live
+        # snapshot missing the project even though disk still has it
+        # (Codex round 4 on #2063, mirror of the set_project_tracked
+        # deep-copy fix above).
+        _live_project_snapshot = config.projects.get(project_key)
+        try:
+            # ``remove_project`` reloads from disk, enforces the
+            # session-ref guard, then writes back. Live ``config`` is
+            # untouched if the facade raises ``BadParameter`` (it
+            # raises before mutating); OSError can fire after the in-
+            # place delete, so we restore the snapshot below.
+            _remove_project_facade(config_path, project_key)
+        except typer.BadParameter as exc:
+            msg = str(exc)
+            if "still used by" in msg:
+                raise APIError(
+                    status_code=409,
+                    code="conflict",
+                    message=msg,
+                    hint=(
+                        "Disable or remove the listed sessions before "
+                        "archiving this project."
+                    ),
+                ) from exc
+            # Disk-side race (project gone between our 404 check and
+            # the facade's reload). Treat as 404 so the client sees a
+            # stable error code.
+            raise not_found(msg) from exc
+        except OSError as exc:
+            # Roll the live snapshot back if the facade already del'd
+            # the cached entry before the write failed — Codex round 4
+            # on #2063 (durable-write rollback on the cached config
+            # path).
+            if (
+                _live_project_snapshot is not None
+                and project_key not in config.projects
+            ):
+                config.projects[project_key] = _live_project_snapshot
+            raise service_unavailable(
+                f"Failed to persist archive for {project_key}: {exc}",
+                hint="Check write permissions on the PollyPM config file.",
             ) from exc
-        # Disk-side race (project gone between our 404 check and the
-        # facade's reload). Treat as 404 so the client sees a stable
-        # error code.
-        raise not_found(msg) from exc
-    except OSError as exc:
-        # Roll the live snapshot back if the facade already del'd the
-        # cached entry before the write failed — Codex round 4 on
-        # #2063 (durable-write rollback on the cached config path).
-        if (
-            _live_project_snapshot is not None
-            and project_key not in config.projects
-        ):
-            config.projects[project_key] = _live_project_snapshot
-        raise service_unavailable(
-            f"Failed to persist archive for {project_key}: {exc}",
-            hint="Check write permissions on the PollyPM config file.",
-        ) from exc
 
-    # Disk write succeeded — re-load disk and FULLY refresh the live
-    # ``config.projects`` (Codex round 3 on #2063). The previous
-    # pop()-only sync left any concurrent external project ADDITIONS
-    # invisible to subsequent in-process ``GET /projects`` calls until
-    # the server restarted. Full refresh both drops the archived key
-    # and surfaces any external additions / metadata edits.
-    try:
-        post_archive = load_config(config_path)
-    except OSError as exc:
-        # Archive landed on disk but we can't see the post-state.
-        # Best-effort: drop the archived key from the live snapshot so
-        # the immediate response is at least internally consistent.
-        config.projects.pop(project_key, None)
-        raise service_unavailable(
-            f"Failed to reload config after archiving {project_key}: {exc}",
-            hint="Check read permissions on the PollyPM config file.",
-        ) from exc
-    _refresh_live_projects(config, post_archive)
+        # Disk write succeeded — re-load disk and FULLY refresh the
+        # live ``config.projects`` (Codex round 3 on #2063). The
+        # previous pop()-only sync left any concurrent external
+        # project ADDITIONS invisible to subsequent in-process
+        # ``GET /projects`` calls until the server restarted. Full
+        # refresh both drops the archived key and surfaces any
+        # external additions / metadata edits.
+        try:
+            post_archive = load_config(config_path)
+        except OSError as exc:
+            # Archive landed on disk but we can't see the post-state.
+            # Best-effort: drop the archived key from the live snapshot
+            # so the immediate response is at least internally
+            # consistent.
+            config.projects.pop(project_key, None)
+            raise service_unavailable(
+                f"Failed to reload config after archiving {project_key}: {exc}",
+                hint="Check read permissions on the PollyPM config file.",
+            ) from exc
+        _refresh_live_projects(config, post_archive)
 
+    # Audit emit outside the lock — independent I/O.
     _emit_project_audit(
         event="projects.archive",
         config=config,

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -383,6 +383,34 @@ def _emit_project_audit(
         pass
 
 
+def _refresh_live_projects(
+    live_config: PollyPMConfig, fresh_config: PollyPMConfig
+) -> None:
+    """Replace ``live_config.projects`` in place with ``fresh_config.projects``.
+
+    Used after every config-mutation path so the long-lived
+    :class:`ConfigDep` object reflects disk state in full — both the
+    mutated project AND any concurrent external edits / additions /
+    removals.
+
+    Codex round 3 on #2063: the previous field-by-field copy
+    (``tracked`` / ``path`` / ``name``) left other ``KnownProject``
+    fields (``persona_name``, ``kind``, role/model assignments, worker
+    caps, plan enforcement, etc.) stale when an external CLI / cockpit
+    edit changed them on the same project before the API call landed.
+    The response is built from the live snapshot so the API would
+    return stale metadata while disk had the new metadata. Mirror
+    case: external project additions / removals on disk before
+    ``/archive`` would stay invisible to in-process GETs until restart.
+
+    Mutates ``live_config.projects`` in place so any external object
+    holding a reference to the dict (FastAPI ``Depends`` caches it
+    across requests) sees the new contents.
+    """
+    live_config.projects.clear()
+    live_config.projects.update(fresh_config.projects)
+
+
 def set_project_tracked(
     config: PollyPMConfig,
     project_key: str,
@@ -402,14 +430,18 @@ def set_project_tracked(
       via ``pm add-project`` after the server started).
     * Idempotency is decided AGAINST the freshly-loaded disk state
       (Codex round 2 on #2063): if disk already matches ``tracked``
-      we skip the write AND sync the live snapshot from disk so a
-      stale in-memory value can't keep lying. Deciding against the
-      long-lived ``ConfigDep`` here would let a server that booted
+      we skip the write AND fully refresh the live snapshot from disk
+      so a stale in-memory value can't keep lying. Deciding against
+      the long-lived ``ConfigDep`` here would let a server that booted
       with ``tracked=True`` short-circuit a ``/resume`` call even
       after an external edit flipped disk to ``False``.
     * Mutate the freshly-loaded copy, NOT the live ``config``.
-    * Only after the disk write succeeds do we sync the change back
-      into the live ``config`` so subsequent in-process reads see it.
+    * After every successful disk write we re-load disk and FULLY
+      refresh ``config.projects`` via :func:`_refresh_live_projects`
+      (Codex round 3 on #2063). The previous field-by-field copy left
+      other ``KnownProject`` fields (``persona_name``, ``kind``, role
+      assignments, worker caps, etc.) stale when an external edit
+      changed them on the same project before the API call.
     * If ``write_config`` raises ``OSError`` the live ``config``
       stays untouched and a subsequent GET reflects the unchanged
       disk state — no stale in-memory lie that flips back on restart.
@@ -445,17 +477,12 @@ def set_project_tracked(
 
     # Idempotency decided against DISK, not against the long-lived
     # in-memory snapshot. If disk already matches the request we still
-    # sync the live ``config`` from disk so a stale in-process value
-    # can't continue lying to subsequent GETs.
+    # FULLY refresh the live ``config.projects`` from disk so any
+    # external metadata edits (persona_name, kind, role assignments,
+    # worker caps, etc.) propagate — Codex round 3 on #2063.
     if fresh_project.tracked == tracked:
-        live_project.tracked = fresh_project.tracked
-        live_project.path = fresh_project.path
-        live_project.name = fresh_project.name
-        config.projects[project_key] = live_project
-        for key, value in fresh.projects.items():
-            if key not in config.projects:
-                config.projects[key] = value
-        return _project_to_api(config, project_key, live_project)
+        _refresh_live_projects(config, fresh)
+        return _project_to_api(config, project_key, config.projects[project_key])
 
     fresh_project.tracked = tracked
     fresh.projects[project_key] = fresh_project
@@ -468,29 +495,35 @@ def set_project_tracked(
             hint="Check write permissions on the PollyPM config file.",
         ) from exc
 
-    # Disk write succeeded — now sync the live config so in-process
-    # callers see the new state without waiting for a load_config()
-    # cache refresh. We update the existing KnownProject in place so
-    # any objects holding a reference to it observe the new value.
-    live_project.tracked = tracked
-    config.projects[project_key] = live_project
-    # Merge any external project additions that landed on disk so a
-    # subsequent in-process GET sees them too (defence-in-depth — the
-    # next load_config() will rediscover them anyway via mtime).
-    for key, value in fresh.projects.items():
-        if key not in config.projects:
-            config.projects[key] = value
+    # Disk write succeeded — re-load disk and FULLY refresh the live
+    # ``config.projects`` so in-process callers see (a) the new
+    # ``tracked`` we just wrote AND (b) any concurrent external edits
+    # to other fields / other projects that landed between our load
+    # and our write — Codex round 3 on #2063. The extra load_config()
+    # is cheap relative to the durable write we just did and ensures
+    # we never widen a write-after-read race.
+    try:
+        post_write = load_config(config_path)
+    except OSError as exc:
+        # Live config still reflects pre-write state. Surface as 503
+        # so the client can retry; subsequent GETs stay consistent.
+        raise service_unavailable(
+            f"Failed to reload config after writing {project_key}: {exc}",
+            hint="Check read permissions on the PollyPM config file.",
+        ) from exc
+    _refresh_live_projects(config, post_write)
 
+    refreshed_project = config.projects[project_key]
     _emit_project_audit(
         event="projects.tracked.set",
         config=config,
         project_key=project_key,
-        project_path=live_project.path,
+        project_path=refreshed_project.path,
         actor=actor,
         reason=reason,
         extra={"tracked": tracked},
     )
-    return _project_to_api(config, project_key, live_project)
+    return _project_to_api(config, project_key, refreshed_project)
 
 
 def archive_project(
@@ -556,8 +589,24 @@ def archive_project(
             hint="Check write permissions on the PollyPM config file.",
         ) from exc
 
-    # Disk write succeeded — sync the live config.
-    config.projects.pop(project_key, None)
+    # Disk write succeeded — re-load disk and FULLY refresh the live
+    # ``config.projects`` (Codex round 3 on #2063). The previous
+    # pop()-only sync left any concurrent external project ADDITIONS
+    # invisible to subsequent in-process ``GET /projects`` calls until
+    # the server restarted. Full refresh both drops the archived key
+    # and surfaces any external additions / metadata edits.
+    try:
+        post_archive = load_config(config_path)
+    except OSError as exc:
+        # Archive landed on disk but we can't see the post-state.
+        # Best-effort: drop the archived key from the live snapshot so
+        # the immediate response is at least internally consistent.
+        config.projects.pop(project_key, None)
+        raise service_unavailable(
+            f"Failed to reload config after archiving {project_key}: {exc}",
+            hint="Check read permissions on the PollyPM config file.",
+        ) from exc
+    _refresh_live_projects(config, post_archive)
 
     _emit_project_audit(
         event="projects.archive",

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -319,6 +319,154 @@ def project_drilldown(config: PollyPMConfig, key: str) -> APIProjectDrilldown | 
     )
 
 
+# ---------------------------------------------------------------------------
+# Project write helpers (Phase 2 — projects pause/resume/archive/init-guide)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_config_write_path(config: PollyPMConfig) -> Path:
+    """Pick the TOML path mutations should write back to.
+
+    Prefers ``config.config_path`` (stamped by :func:`load_config` post
+    PR #2026) and falls back to ``DEFAULT_CONFIG_PATH``. Tests that
+    construct a :class:`PollyPMConfig` by hand must set
+    ``config_path`` to a tmp file or the helper writes to the user's
+    real ``~/.pollypm/pollypm.toml`` — same constraint as
+    ``pollypm.projects.enable_tracked_project``.
+    """
+    if config.config_path is not None:
+        return Path(config.config_path)
+    from pollypm.config import DEFAULT_CONFIG_PATH
+
+    return Path(DEFAULT_CONFIG_PATH)
+
+
+def set_project_tracked(
+    config: PollyPMConfig,
+    project_key: str,
+    *,
+    tracked: bool,
+    reason: str | None = None,  # noqa: ARG001 — accepted for audit symmetry, not stored
+) -> APIProject:
+    """Flip ``KnownProject.tracked`` and re-render the global TOML.
+
+    Mirrors what the cockpit's ``set_project_tracked`` service does —
+    mutate ``config.projects[key].tracked`` then ``write_config`` so
+    the change survives across processes. Idempotent: setting the same
+    value re-writes the same TOML (no-op effectively).
+
+    Returns the post-mutation :class:`APIProject` snapshot so the
+    client can refresh without a follow-up GET (same idiom as the
+    task transitions in Phase 2).
+    """
+    from pollypm.config import write_config
+
+    project = config.projects.get(project_key)
+    if project is None:
+        raise not_found(f"Project not registered: {project_key}")
+
+    project.tracked = tracked
+    config.projects[project_key] = project
+    try:
+        write_config(config, _resolve_config_write_path(config), force=True)
+    except OSError as exc:
+        raise service_unavailable(
+            f"Failed to persist project state for {project_key}: {exc}",
+            hint="Check write permissions on the PollyPM config file.",
+        ) from exc
+    return _project_to_api(config, project_key, project)
+
+
+def archive_project(
+    config: PollyPMConfig,
+    project_key: str,
+    *,
+    reason: str | None = None,  # noqa: ARG001 — accepted for audit symmetry, not stored
+) -> str:
+    """Remove ``project_key`` from ``config.projects`` and persist.
+
+    Per spec §6.2 "Archive ... Removes from config; Source data on
+    disk untouched." Returns the removed project's display label so
+    the route can populate an :class:`ActionResult` message.
+
+    Archive is irreversible from the API: subsequent ``resume`` /
+    ``pause`` / ``init-guide`` calls 404 because the project key is
+    gone. Re-registering uses ``pm add-project`` (CLI-only).
+    """
+    from pollypm.config import write_config
+
+    project = config.projects.get(project_key)
+    if project is None:
+        raise not_found(f"Project not registered: {project_key}")
+
+    label = project.display_label()
+    del config.projects[project_key]
+    try:
+        write_config(config, _resolve_config_write_path(config), force=True)
+    except OSError as exc:
+        # Roll back in-memory if the disk write fails so we don't
+        # silently desync the running server from disk.
+        config.projects[project_key] = project
+        raise service_unavailable(
+            f"Failed to persist archive for {project_key}: {exc}",
+            hint="Check write permissions on the PollyPM config file.",
+        ) from exc
+    return label
+
+
+def init_project_guide_for_role(
+    config: PollyPMConfig,
+    project_key: str,
+    *,
+    role: str,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Wrap :func:`pollypm.project_guides.init_project_guide`.
+
+    Returns ``{role, path, forked_from, body}`` so clients can preview
+    the seeded markdown without a follow-up GET. Role validation maps
+    to ``422 validation_error`` (matches the spec §6 matrix —
+    unsupported enum value); existing-without-force maps to ``409
+    conflict`` mirroring the cockpit's ``--force`` UX.
+    """
+    from pollypm.project_guides import init_project_guide
+
+    project = config.projects.get(project_key)
+    if project is None:
+        raise not_found(f"Project not registered: {project_key}")
+
+    try:
+        info = init_project_guide(project.path, role, force=force)
+    except ValueError as exc:
+        # ``validate_project_guide_role`` raises ``ValueError`` for
+        # unknown roles. Spec §6 maps that to 422 (body validates as
+        # JSON but the enum value is wrong).
+        raise APIError(
+            status_code=422,
+            code="validation_error",
+            message=str(exc),
+            hint="Supported roles: architect, reviewer, worker.",
+        ) from exc
+    except FileExistsError as exc:
+        raise APIError(
+            status_code=409,
+            code="conflict",
+            message=str(exc),
+            hint="Re-send with `force=true` to overwrite the existing guide.",
+        ) from exc
+    except OSError as exc:
+        raise service_unavailable(
+            f"Failed to write project guide for {project_key}: {exc}",
+        ) from exc
+
+    return {
+        "role": info.role,
+        "path": str(info.path),
+        "forked_from": info.forked_from,
+        "body": info.body,
+    }
+
+
 def _project_to_api(config: PollyPMConfig, key: str, project: KnownProject) -> APIProject:
     counts: dict[str, int] = {}
     pending_plan_review = False
@@ -1880,11 +2028,13 @@ def load_api_config(config_path: Path | None) -> PollyPMConfig:
 
 __all__ = [
     "archive_inbox_item",
+    "archive_project",
     "audit_event_to_api",
     "get_active_plan",
     "get_inbox_item",
     "get_project",
     "get_task_detail",
+    "init_project_guide_for_role",
     "list_inbox",
     "list_project_tasks",
     "list_projects",
@@ -1894,5 +2044,6 @@ __all__ = [
     "promote_inbox_to_task",
     "queue_task",
     "reply_inbox_item",
+    "set_project_tracked",
     "snooze_inbox_item",
 ]

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -341,47 +341,143 @@ def _resolve_config_write_path(config: PollyPMConfig) -> Path:
     return Path(DEFAULT_CONFIG_PATH)
 
 
+def _emit_project_audit(
+    *,
+    event: str,
+    config: PollyPMConfig,
+    project_key: str,
+    project_path: Path | None,
+    actor: str,
+    reason: str | None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Best-effort audit emit for project lifecycle mutations.
+
+    Mirrors :func:`pollypm.cockpit_pane_reaper._emit_audit`: a failure
+    in the audit subsystem must NOT block (or roll back) the API
+    mutation, so this swallows every exception. ``reason`` is bounded
+    at 500 chars upstream by ``_ReasonBody`` but we clamp again here
+    as belt-and-suspenders in case a future caller bypasses the
+    Pydantic model.
+    """
+    try:
+        from pollypm.audit import emit as _audit_emit
+    except Exception:  # noqa: BLE001
+        return
+    metadata: dict[str, Any] = {"source": "web_api"}
+    if reason is not None:
+        metadata["reason"] = reason[:500]
+    if extra:
+        metadata.update(extra)
+    try:
+        _audit_emit(
+            event=event,
+            project=project_key,
+            subject=f"projects/{project_key}",
+            actor=actor or "api",
+            status="ok",
+            metadata=metadata,
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def set_project_tracked(
     config: PollyPMConfig,
     project_key: str,
     *,
     tracked: bool,
-    reason: str | None = None,  # noqa: ARG001 — accepted for audit symmetry, not stored
+    reason: str | None = None,
+    actor: str = "api",
 ) -> APIProject:
     """Flip ``KnownProject.tracked`` and re-render the global TOML.
 
-    Mirrors what the cockpit's ``set_project_tracked`` service does —
-    mutate ``config.projects[key].tracked`` then ``write_config`` so
-    the change survives across processes. Idempotent: setting the same
-    value re-writes the same TOML (no-op effectively).
+    Concurrent-safe write semantics (Codex review on #2063):
+
+    * Re-load the on-disk TOML so any external CLI / cockpit edits
+      that landed between server boot and this call are preserved —
+      we never write back the long-lived ``ConfigDep`` snapshot with
+      ``force=True`` (that would silently drop e.g. a project added
+      via ``pm add-project`` after the server started).
+    * Mutate the freshly-loaded copy, NOT the live ``config``.
+    * Only after the disk write succeeds do we sync the change back
+      into the live ``config`` so subsequent in-process reads see it.
+    * If ``write_config`` raises ``OSError`` the live ``config``
+      stays untouched and a subsequent GET reflects the unchanged
+      disk state — no stale in-memory lie that flips back on restart.
 
     Returns the post-mutation :class:`APIProject` snapshot so the
     client can refresh without a follow-up GET (same idiom as the
     task transitions in Phase 2).
     """
-    from pollypm.config import write_config
+    from pollypm.config import load_config, write_config
 
-    project = config.projects.get(project_key)
-    if project is None:
+    # Bind to the original (in-memory) project up-front so the 404 path
+    # doesn't pay for a disk reload.
+    live_project = config.projects.get(project_key)
+    if live_project is None:
         raise not_found(f"Project not registered: {project_key}")
 
-    project.tracked = tracked
-    config.projects[project_key] = project
+    config_path = _resolve_config_write_path(config)
+    # Reload from disk so we don't lose concurrent CLI / cockpit edits
+    # (e.g. an external ``pm add-project`` that added a new project key
+    # the in-memory server hasn't seen yet).
     try:
-        write_config(config, _resolve_config_write_path(config), force=True)
+        fresh = load_config(config_path)
     except OSError as exc:
+        raise service_unavailable(
+            f"Failed to reload config for {project_key}: {exc}",
+            hint="Check read permissions on the PollyPM config file.",
+        ) from exc
+    fresh_project = fresh.projects.get(project_key)
+    if fresh_project is None:
+        # Disk-side delete raced us. Treat as 404 — the in-memory state
+        # is stale and the next GET will agree.
+        raise not_found(f"Project not registered: {project_key}")
+
+    fresh_project.tracked = tracked
+    fresh.projects[project_key] = fresh_project
+    try:
+        write_config(fresh, config_path, force=True)
+    except OSError as exc:
+        # Live config untouched — Codex P0 #1 (rollback guarantee).
         raise service_unavailable(
             f"Failed to persist project state for {project_key}: {exc}",
             hint="Check write permissions on the PollyPM config file.",
         ) from exc
-    return _project_to_api(config, project_key, project)
+
+    # Disk write succeeded — now sync the live config so in-process
+    # callers see the new state without waiting for a load_config()
+    # cache refresh. We update the existing KnownProject in place so
+    # any objects holding a reference to it observe the new value.
+    live_project.tracked = tracked
+    config.projects[project_key] = live_project
+    # Merge any external project additions that landed on disk so a
+    # subsequent in-process GET sees them too (defence-in-depth — the
+    # next load_config() will rediscover them anyway via mtime).
+    for key, value in fresh.projects.items():
+        if key not in config.projects:
+            config.projects[key] = value
+
+    _emit_project_audit(
+        event="projects.tracked.set",
+        config=config,
+        project_key=project_key,
+        project_path=live_project.path,
+        actor=actor,
+        reason=reason,
+        extra={"tracked": tracked},
+    )
+    return _project_to_api(config, project_key, live_project)
 
 
 def archive_project(
     config: PollyPMConfig,
     project_key: str,
     *,
-    reason: str | None = None,  # noqa: ARG001 — accepted for audit symmetry, not stored
+    reason: str | None = None,
+    actor: str = "api",
 ) -> str:
     """Remove ``project_key`` from ``config.projects`` and persist.
 
@@ -392,25 +488,65 @@ def archive_project(
     Archive is irreversible from the API: subsequent ``resume`` /
     ``pause`` / ``init-guide`` calls 404 because the project key is
     gone. Re-registering uses ``pm add-project`` (CLI-only).
-    """
-    from pollypm.config import write_config
 
-    project = config.projects.get(project_key)
-    if project is None:
+    Codex review on #2063 (P0 #3): routes through
+    :func:`pollypm.projects.remove_project` so the session→project
+    invariant (no enabled session may reference a missing project) is
+    enforced uniformly with the CLI's ``pm projects remove``. Enabled-
+    session references map to ``409 conflict`` with the blocking
+    session names in the body.
+    """
+    import typer
+
+    from pollypm.projects import remove_project as _remove_project_facade
+
+    live_project = config.projects.get(project_key)
+    if live_project is None:
         raise not_found(f"Project not registered: {project_key}")
 
-    label = project.display_label()
-    del config.projects[project_key]
+    label = live_project.display_label()
+    project_path = live_project.path
+    config_path = _resolve_config_write_path(config)
     try:
-        write_config(config, _resolve_config_write_path(config), force=True)
+        # ``remove_project`` reloads from disk, enforces the session-ref
+        # guard, then writes back — same concurrent-safe pattern as the
+        # tracked-toggle path above. Live ``config`` is untouched if the
+        # facade raises.
+        _remove_project_facade(config_path, project_key)
+    except typer.BadParameter as exc:
+        msg = str(exc)
+        if "still used by" in msg:
+            raise APIError(
+                status_code=409,
+                code="conflict",
+                message=msg,
+                hint=(
+                    "Disable or remove the listed sessions before "
+                    "archiving this project."
+                ),
+            ) from exc
+        # Disk-side race (project gone between our 404 check and the
+        # facade's reload). Treat as 404 so the client sees a stable
+        # error code.
+        raise not_found(msg) from exc
     except OSError as exc:
-        # Roll back in-memory if the disk write fails so we don't
-        # silently desync the running server from disk.
-        config.projects[project_key] = project
         raise service_unavailable(
             f"Failed to persist archive for {project_key}: {exc}",
             hint="Check write permissions on the PollyPM config file.",
         ) from exc
+
+    # Disk write succeeded — sync the live config.
+    config.projects.pop(project_key, None)
+
+    _emit_project_audit(
+        event="projects.archive",
+        config=config,
+        project_key=project_key,
+        project_path=project_path,
+        actor=actor,
+        reason=reason,
+        extra={"label": label},
+    )
     return label
 
 

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -392,11 +392,24 @@ def _emit_project_audit(
 # snapshot (the exact reproduction Codex documented on round 7).
 #
 # The API helpers below import ``config_rmw_lock`` from ``pollypm.config``
-# and wrap their full read-modify-write under it. All in-tree CLI /
-# cockpit writers do the same — see ``pollypm.projects``,
-# ``pollypm.accounts``, ``pollypm.workers``, ``pollypm.onboarding``,
-# ``pollypm.cockpit_ui``, ``pollypm.cockpit_project_settings``, and
-# ``pollypm.plugins_builtin.project_planning.cli.project``.
+# and wrap their full read-modify-write under it. Every in-tree config
+# writer that does a ``load_config → mutate → write_config`` sequence
+# wraps it under the shared lock — see ``pollypm.projects`` (including
+# ``scan_projects`` post round 9), ``pollypm.accounts``,
+# ``pollypm.workers``, ``pollypm.onboarding``, ``pollypm.cockpit_ui``,
+# ``pollypm.cockpit_project_settings``, and
+# ``pollypm.plugins_builtin.project_planning.cli.project``. The
+# ``write_example_config`` initialiser in ``pollypm.config`` also wraps
+# its write so two concurrent ``pm init`` callers serialise on the same
+# lock. Two writes are intentionally OUTSIDE a full RMW wrap and rely
+# on :func:`pollypm.config.write_config`'s internal lock (Pattern A)
+# for torn-write protection:
+#
+# 1. ``pollypm.onboarding_tui`` first-run build+write — no prior
+#    snapshot to merge against; the API/CLI is not running yet.
+# 2. ``pollypm.config.load_config`` auth-token mint — re-reads under
+#    the lock before the write so concurrent edits still survive
+#    (round 9 audit fix).
 
 
 def _refresh_live_projects(

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -383,49 +383,20 @@ def _emit_project_audit(
         pass
 
 
-@contextlib.contextmanager
-def _config_write_lock(config_path: Path):
-    """Serialise config read-modify-write across concurrent API requests.
-
-    Codex round 6 on #2063 caught a lost-update race: two clients
-    pausing different projects concurrently each ``deepcopy`` the same
-    cached load_config snapshot, mutate their own project, then both
-    write with ``force=True``. The second writer's snapshot still has
-    the first writer's project at the OLD value — so the first write
-    is silently reverted on disk. Per-request reloads (post-#2056)
-    don't help because the race is between two requests, both of which
-    reload at the same moment before either writes.
-
-    Fix: hold an exclusive ``fcntl.flock`` on a sibling lockfile for
-    the entire ``load_config → mutate → write_config`` sequence. The
-    lockfile is created on first use (``open(..., "a+")`` is
-    create-if-missing without truncation). Lock release is best-effort
-    in the ``finally`` block so a propagating exception still unlocks.
-
-    POSIX-only. PollyPM ships as a personal-use Mac/Linux deployment;
-    Windows isn't a supported target.
-
-    The lock is per ``config_path`` so two unrelated configs (e.g.
-    multi-tenant dev setups) don't serialise against each other.
-    """
-    import fcntl
-
-    lock_path = config_path.with_suffix(config_path.suffix + ".lock")
-    # Ensure parent exists — config_path may not have been created yet
-    # on the very first request after a fresh install, but the parent
-    # ``.pollypm/`` always exists by the time the API is up.
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    # "a+" creates if missing without truncating; we never read from
-    # or write to the lockfile, only flock its fd.
-    with open(lock_path, "a+") as lock_fh:
-        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            try:
-                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
-            except OSError:
-                pass
+# Codex round 7 on #2063 moved the config-write lock primitive into
+# :mod:`pollypm.config` (``config_rmw_lock``) so CLI / cockpit / onboarding
+# writers participate in the same serialisation invariant. Round 6's
+# local ``_config_write_lock`` only serialised API-vs-API; a CLI write
+# that landed between an API helper's ``load_config`` and
+# ``write_config`` was still silently overwritten by the API's older
+# snapshot (the exact reproduction Codex documented on round 7).
+#
+# The API helpers below import ``config_rmw_lock`` from ``pollypm.config``
+# and wrap their full read-modify-write under it. All in-tree CLI /
+# cockpit writers do the same — see ``pollypm.projects``,
+# ``pollypm.accounts``, ``pollypm.workers``, ``pollypm.onboarding``,
+# ``pollypm.cockpit_ui``, ``pollypm.cockpit_project_settings``, and
+# ``pollypm.plugins_builtin.project_planning.cli.project``.
 
 
 def _refresh_live_projects(
@@ -479,16 +450,19 @@ def set_project_tracked(
 
     Concurrent-safe write semantics (Codex review on #2063):
 
-    * The entire read-modify-write section is serialised by an
-      exclusive ``fcntl.flock`` on a sibling lockfile (Codex round 6
-      on #2063 — ``_config_write_lock``). Without this lock, two
-      concurrent ``/pause`` calls on DIFFERENT projects could each
-      deepcopy the same cached snapshot, mutate their own project,
-      and then both write ``force=True`` — the second writer would
-      silently revert the first writer's change on disk. The flock
-      forces request B to reload AFTER request A's write commits, so
-      its deepcopy reflects A's mutation and the merged write
-      preserves both.
+    * The entire read-modify-write section is serialised by the
+      SHARED :func:`pollypm.config.config_rmw_lock` (Codex round 7 on
+      #2063 promoted the round-6 API-local flock to a project-wide
+      invariant). Every other in-tree config writer — ``pm
+      add-project`` / ``pm rename-project`` / ``pm remove-project``,
+      the cockpit role-assignment editor, accounts, workers, the
+      project-planning plugin's session-purge — wraps its full
+      load → mutate → write under the same lock, so a CLI write that
+      lands while we're inside this block blocks on the flock instead
+      of clobbering our snapshot (or being clobbered by us). The
+      lockfile is a sibling of ``config_path`` (``<path>.lock``); the
+      lock is per-path so two unrelated configs (multi-tenant dev
+      setups) don't serialise against each other.
     * Re-load the on-disk TOML so any external CLI / cockpit edits
       that landed between server boot and this call are preserved —
       we never write back the long-lived ``ConfigDep`` snapshot with
@@ -529,7 +503,7 @@ def set_project_tracked(
     """
     import copy
 
-    from pollypm.config import load_config, write_config
+    from pollypm.config import config_rmw_lock, load_config, write_config
 
     # Bind to the original (in-memory) project up-front so the 404 path
     # doesn't pay for a disk reload or take the lock.
@@ -538,12 +512,15 @@ def set_project_tracked(
         raise not_found(f"Project not registered: {project_key}")
 
     config_path = _resolve_config_write_path(config)
-    # Hold the per-config write lock across the entire RMW so two
-    # concurrent requests on different projects can't lose each other's
-    # writes (Codex round 6 on #2063). The lock is released BEFORE we
-    # return; subsequent callers' load_config sees the updated mtime
-    # and reloads fresh.
-    with _config_write_lock(config_path):
+    # Hold the SHARED per-config RMW lock across the entire
+    # load → mutate → write → reload. Two concurrent API requests on
+    # different projects can't lose each other's writes (Codex round
+    # 6), AND a concurrent CLI/cockpit ``load_config → mutate →
+    # write_config`` sequence on the same config can't slot in between
+    # our load and our write to lose its edit (Codex round 7). The
+    # lock is released BEFORE we return; subsequent callers'
+    # load_config sees the updated mtime and reloads fresh.
+    with config_rmw_lock(config_path):
         # Reload from disk so we don't lose concurrent CLI / cockpit
         # edits (e.g. an external ``pm add-project`` that added a new
         # project key the in-memory server hasn't seen yet). Under the
@@ -664,16 +641,20 @@ def archive_project(
     session references map to ``409 conflict`` with the blocking
     session names in the body.
 
-    Codex round 6 on #2063: the entire ``remove_project`` call + the
-    post-write reload runs under the same ``_config_write_lock`` used
-    by :func:`set_project_tracked`. Without this, an archive on
-    project A and a pause on project B could each load the same
-    cached config, mutate their own key, and write — losing one
-    mutation. The flock serialises the read-modify-write at the API
-    entry point.
+    Codex round 7 on #2063: the entire ``remove_project`` call + the
+    post-write reload runs under the SHARED
+    :func:`pollypm.config.config_rmw_lock`. The facade itself also
+    acquires the lock (re-entrant per thread, so the nested acquire
+    is a no-op). Without this shared invariant, an archive on project
+    A and a CLI ``pm projects remove`` on project B could each load
+    the same cached config, mutate their own key, and write — losing
+    one mutation. The shared lock serialises the read-modify-write
+    across BOTH API and CLI entry points (round 6's API-local flock
+    only protected API-vs-API).
     """
     import typer
 
+    from pollypm.config import config_rmw_lock
     from pollypm.projects import remove_project as _remove_project_facade
 
     live_project = config.projects.get(project_key)
@@ -683,13 +664,13 @@ def archive_project(
     label = live_project.display_label()
     project_path = live_project.path
     config_path = _resolve_config_write_path(config)
-    # Hold the per-config flock across the facade call AND the post-
-    # archive reload so we serialise with any concurrent
-    # ``set_project_tracked`` or sibling ``archive_project`` call
-    # against the same config (Codex round 6 on #2063). The lock is
-    # released BEFORE the audit emit; subsequent API writers' load_
-    # config sees our committed mtime and reloads fresh.
-    with _config_write_lock(config_path):
+    # Hold the SHARED per-config RMW lock across the facade call AND
+    # the post-archive reload so we serialise with any concurrent
+    # API ``set_project_tracked`` / sibling ``archive_project`` call
+    # AND with concurrent CLI / cockpit writers (Codex round 7 on
+    # #2063). The lock is released BEFORE the audit emit; subsequent
+    # writers' load_config sees our committed mtime and reloads fresh.
+    with config_rmw_lock(config_path):
         # Snapshot the live project entry so we can roll back the in-
         # memory state if ``remove_project`` raises OSError after
         # mutation. The facade does ``config = load_config(...);

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -450,6 +450,8 @@ def set_project_tracked(
     client can refresh without a follow-up GET (same idiom as the
     task transitions in Phase 2).
     """
+    import copy
+
     from pollypm.config import load_config, write_config
 
     # Bind to the original (in-memory) project up-front so the 404 path
@@ -463,12 +465,25 @@ def set_project_tracked(
     # (e.g. an external ``pm add-project`` that added a new project key
     # the in-memory server hasn't seen yet).
     try:
-        fresh = load_config(config_path)
+        fresh_cached = load_config(config_path)
     except OSError as exc:
         raise service_unavailable(
             f"Failed to reload config for {project_key}: {exc}",
             hint="Check read permissions on the PollyPM config file.",
         ) from exc
+    # ``load_config`` is memoised by ``config_path`` (see
+    # ``pollypm.config._config_cache``) so ``fresh_cached`` IS the same
+    # object as the live ``ConfigDep`` whenever the server was bootstrapped
+    # via ``load_config(config_path)`` — which is exactly what
+    # ``pm serve`` / ``load_api_config`` do in production. Mutating
+    # ``fresh_cached.projects[key].tracked`` would therefore mutate the
+    # live snapshot BEFORE the durable write completes. If write_config
+    # then raises OSError, the API returns 503 but the live config has
+    # already flipped — a rollback violation Codex reproduced on round 4
+    # of #2063. Take a deep copy here so all mutation happens on a
+    # detached graph; the live snapshot is only touched via
+    # ``_refresh_live_projects`` AFTER the disk write succeeds.
+    fresh = copy.deepcopy(fresh_cached)
     fresh_project = fresh.projects.get(project_key)
     if fresh_project is None:
         # Disk-side delete raced us. Treat as 404 — the in-memory state
@@ -489,7 +504,12 @@ def set_project_tracked(
     try:
         write_config(fresh, config_path, force=True)
     except OSError as exc:
-        # Live config untouched — Codex P0 #1 (rollback guarantee).
+        # Live config untouched — Codex P0 #1 (rollback guarantee). The
+        # deep-copy above is what makes this rollback real on the
+        # cached-load_config path: ``fresh`` is a detached graph, so
+        # mutating ``fresh_project.tracked`` never reached the live
+        # ``ConfigDep`` shared with FastAPI request handlers. Codex
+        # round 4 on #2063.
         raise service_unavailable(
             f"Failed to persist project state for {project_key}: {exc}",
             hint="Check write permissions on the PollyPM config file.",
@@ -561,11 +581,23 @@ def archive_project(
     label = live_project.display_label()
     project_path = live_project.path
     config_path = _resolve_config_write_path(config)
+    # Snapshot the live project entry so we can roll back the in-memory
+    # state if ``remove_project`` raises OSError after mutation. The
+    # facade does ``config = load_config(...); del config.projects[key];
+    # write_config(...)`` — and ``load_config`` is memoised by path, so
+    # the dict it mutates IS the live ``ConfigDep`` dict on the
+    # production cached path. A write failure after ``del`` would
+    # otherwise leave the live snapshot missing the project even though
+    # disk still has it (Codex round 4 on #2063, mirror of the
+    # set_project_tracked deep-copy fix above).
+    _live_project_snapshot = config.projects.get(project_key)
     try:
         # ``remove_project`` reloads from disk, enforces the session-ref
         # guard, then writes back — same concurrent-safe pattern as the
         # tracked-toggle path above. Live ``config`` is untouched if the
-        # facade raises.
+        # facade raises ``BadParameter`` (it raises before mutating);
+        # OSError can fire after the in-place delete, so we restore the
+        # snapshot below.
         _remove_project_facade(config_path, project_key)
     except typer.BadParameter as exc:
         msg = str(exc)
@@ -584,6 +616,14 @@ def archive_project(
         # error code.
         raise not_found(msg) from exc
     except OSError as exc:
+        # Roll the live snapshot back if the facade already del'd the
+        # cached entry before the write failed — Codex round 4 on
+        # #2063 (durable-write rollback on the cached config path).
+        if (
+            _live_project_snapshot is not None
+            and project_key not in config.projects
+        ):
+            config.projects[project_key] = _live_project_snapshot
         raise service_unavailable(
             f"Failed to persist archive for {project_key}: {exc}",
             hint="Check write permissions on the PollyPM config file.",

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -229,52 +229,76 @@ def create_worker_session(
     if not prompt or not prompt.strip():
         prompt = suggest_worker_prompt(config_path, project_key=project_key)
 
-    for existing in config.sessions.values():
-        if existing.role == role and existing.project == project_key and existing.enabled:
-            raise typer.BadParameter(
-                f"Project {project_key} already has {role} session {existing.name}"
-            )
-
-    session_key = session_name or _make_role_session_name(
-        role, project_key, set(config.sessions)
-    )
     # Workers use a ``pa`` worktree lane; non-worker roles (e.g. architect)
     # take a lane named after the role so they don't collide with workers.
     lane_kind = "pa" if role == "worker" else role
-    worktree = ensure_worktree(
-        config_path,
-        project_key=project_key,
-        lane_kind=lane_kind,
-        lane_key=session_key,
-        session_name=session_key,
-    )
     window_prefix = "worker" if role == "worker" else role
-    worker = SessionConfig(
-        name=session_key,
-        role=role,
-        provider=active_provider,
-        account=account_name,
-        cwd=Path(worktree.path) if worktree is not None else project.path,
-        project=project_key,
-        window_name=f"{window_prefix}-{project_key}",
-        prompt=prompt,
-        agent_profile=agent_profile,
-        args=default_session_args(
-            active_provider,
-            open_permissions=config.pollypm.open_permissions_by_default,
-            role=role,
-            model=active_model,
-        ),
-    )
-    # #2063 round 7: hold the shared RMW lock around the commit, and
-    # re-load INSIDE the lock so any disk edits that landed while we
-    # were resolving role / creating the worktree merge forward rather
-    # than being overwritten by our older snapshot.
+
+    # #2063 round 11: pull the duplicate-role check, session_key allocation,
+    # worktree creation, AND the commit ALL inside the same critical section.
+    # Round 7 had moved only the commit inside the lock, but the uniqueness
+    # check ran against the pre-lock snapshot. Two concurrent ``pm worker-
+    # start`` calls for the same project/role could both pass the pre-lock
+    # check, both compute the same ``session_key``, both create a worktree,
+    # and both commit — the second write would clobber the first, orphaning
+    # one worktree and leaving the config inconsistent. Holding the lock
+    # across the entire load → check → allocate → ensure_worktree → commit
+    # sequence collapses that race: the loser sees the winner's session in
+    # ``fresh.sessions`` and raises before touching the filesystem.
+    worktree = None
     try:
         with config_rmw_lock(config_path):
             fresh = load_config(config_path)
+            for existing in fresh.sessions.values():
+                if (
+                    existing.role == role
+                    and existing.project == project_key
+                    and existing.enabled
+                ):
+                    raise typer.BadParameter(
+                        f"Project {project_key} already has {role} session {existing.name}"
+                    )
+            if session_name is not None and session_name in fresh.sessions:
+                # Explicit session name collision — surface a clear error
+                # rather than overwriting the existing entry.
+                raise typer.BadParameter(
+                    f"Session name {session_name!r} is already in use"
+                )
+            session_key = session_name or _make_role_session_name(
+                role, project_key, set(fresh.sessions)
+            )
+            worktree = ensure_worktree(
+                config_path,
+                project_key=project_key,
+                lane_kind=lane_kind,
+                lane_key=session_key,
+                session_name=session_key,
+            )
+            worker = SessionConfig(
+                name=session_key,
+                role=role,
+                provider=active_provider,
+                account=account_name,
+                cwd=Path(worktree.path) if worktree is not None else project.path,
+                project=project_key,
+                window_name=f"{window_prefix}-{project_key}",
+                prompt=prompt,
+                agent_profile=agent_profile,
+                args=default_session_args(
+                    active_provider,
+                    open_permissions=fresh.pollypm.open_permissions_by_default,
+                    role=role,
+                    model=active_model,
+                ),
+            )
             fresh.sessions[session_key] = worker
             write_config(fresh, config_path, force=True)
+    except typer.BadParameter:
+        # Uniqueness failures and operator-input errors leave the worktree
+        # state alone — either we never created one (duplicate role check
+        # fired first) or the worktree belongs to a sibling session that
+        # legitimately won the race.
+        raise
     except Exception as exc:
         if worktree is not None and worktree.path and Path(worktree.path).exists():
             import shutil

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -8,7 +8,7 @@ import typer
 
 from pollypm.accounts import is_account_runtime_unavailable
 from pollypm.acct import detect_logged_in
-from pollypm.config import load_config, write_config
+from pollypm.config import config_rmw_lock, load_config, write_config
 from pollypm.onboarding import default_session_args
 from pollypm.models import ProviderKind, SessionConfig
 from pollypm.role_routing import resolved_provider_kind, resolve_role_assignment
@@ -266,11 +266,16 @@ def create_worker_session(
             model=active_model,
         ),
     )
-    config.sessions[session_key] = worker
+    # #2063 round 7: hold the shared RMW lock around the commit, and
+    # re-load INSIDE the lock so any disk edits that landed while we
+    # were resolving role / creating the worktree merge forward rather
+    # than being overwritten by our older snapshot.
     try:
-        write_config(config, config_path, force=True)
+        with config_rmw_lock(config_path):
+            fresh = load_config(config_path)
+            fresh.sessions[session_key] = worker
+            write_config(fresh, config_path, force=True)
     except Exception as exc:
-        del config.sessions[session_key]
         if worktree is not None and worktree.path and Path(worktree.path).exists():
             import shutil
             shutil.rmtree(worktree.path, ignore_errors=True)
@@ -325,15 +330,18 @@ def stop_worker_session(config_path: Path, session_name: str) -> None:
 
 
 def remove_worker_session(config_path: Path, session_name: str) -> None:
-    config = load_config(config_path)
-    session = config.sessions.get(session_name)
-    if session is None:
-        raise typer.BadParameter(f"Unknown session: {session_name}")
-    if session.role != "worker":
-        raise typer.BadParameter("Only worker sessions can be removed from the worker manager.")
+    # #2063 round 7: hold the shared RMW lock across the full
+    # load → mutate → write.
+    with config_rmw_lock(config_path):
+        config = load_config(config_path)
+        session = config.sessions.get(session_name)
+        if session is None:
+            raise typer.BadParameter(f"Unknown session: {session_name}")
+        if session.role != "worker":
+            raise typer.BadParameter("Only worker sessions can be removed from the worker manager.")
 
-    del config.sessions[session_name]
-    write_config(config, config_path, force=True)
+        del config.sessions[session_name]
+        write_config(config, config_path, force=True)
 
 
 def _make_worker_session_name(project_key: str, existing: set[str]) -> str:

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -121,10 +121,39 @@ def create_worker_session(
     role: str = "worker",
     agent_profile: str | None = None,
 ) -> SessionConfig:
-    config = load_config(config_path)
-    project = config.projects.get(project_key)
-    if project is None:
-        registered = ", ".join(sorted(config.projects.keys())) or "<none>"
+    # #2063 round 12: pre-lock work is DISCOVERY ONLY — read-only helpers
+    # whose results are NOT committed to disk. The legacy implementation
+    # resolved the worker ``account``, role routing, ``active_provider``,
+    # ``active_model``, and ``prompt`` from the pre-lock snapshot and then
+    # committed those values inside the lock. If an account or project edit
+    # landed between pre-lock validation and the locked commit, the
+    # committed ``SessionConfig`` could reference an account no longer in
+    # ``fresh.accounts`` — load_config's invariant guard then raised
+    # ``ValueError: Session references unknown account`` on the next read.
+    #
+    # Codex reproduction: patch ``suggest_worker_prompt`` to remove the
+    # selected worker account from disk between pre-lock account validation
+    # and the locked commit; the legacy path persisted an invalid session.
+    #
+    # Fix shape: pre-lock keeps only cheap helpers — project existence
+    # (early-error UX), role routing (pure function, re-derived inside the
+    # lock anyway), and a prompt suggestion when the operator passed none.
+    # Every field that ends up in the committed ``SessionConfig`` is
+    # re-derived from ``fresh`` inside the lock.
+
+    role = (role or "worker").strip() or "worker"
+
+    # PRE-LOCK DISCOVERY (results are NOT committed; the locked block
+    # rebuilds everything against ``fresh``):
+    # - early project-existence check for a friendlier error than the
+    #   locked block would emit on a missing project_key;
+    # - prompt suggestion when the caller passed none (the suggestion is
+    #   currently empty-string so it can't go stale, but we still
+    #   call it pre-lock to avoid the suggester re-reading inside the
+    #   critical section).
+    discovery_config = load_config(config_path)
+    if project_key not in discovery_config.projects:
+        registered = ", ".join(sorted(discovery_config.projects.keys())) or "<none>"
         raise typer.BadParameter(
             f"No project '{project_key}' registered.\n"
             f"\n"
@@ -135,120 +164,161 @@ def create_worker_session(
             f"(currently: {registered}), or register a new one with\n"
             f"    pm add-project <path> --name {project_key}"
         )
-
-    role = (role or "worker").strip() or "worker"
-    routed_assignment = resolve_role_assignment(role, project_key, config=config)
-    routed_provider: ProviderKind | None
-    try:
-        routed_provider = resolved_provider_kind(routed_assignment)
-    except ValueError:
-        _log.warning(
-            "Ignoring invalid routed provider %r for %s on %s.",
-            routed_assignment.provider,
-            role,
-            project_key,
-        )
-        routed_provider = None
-
-    if account_name is None:
-        preferred_provider = (
-            routed_provider
-            if routed_provider is not None and routed_assignment.source != "fallback"
-            else provider
-        )
-        try:
-            account_name = auto_select_worker_account(
-                config_path,
-                provider=preferred_provider,
-            )
-        except typer.BadParameter:
-            if (
-                routed_provider is None
-                or provider is not None
-                or routed_assignment.source == "fallback"
-            ):
-                raise
-            _log.warning(
-                "Role routing resolved %s for %s to %s/%s from %s, but no matching account is available; "
-                "falling back to the legacy worker account selection.",
-                role,
-                project_key,
-                routed_assignment.provider,
-                routed_assignment.model,
-                routed_assignment.source,
-            )
-            account_name = auto_select_worker_account(config_path, provider=provider)
-    if account_name not in config.accounts:
-        raise typer.BadParameter(f"Unknown account: {account_name}")
-    account = config.accounts[account_name]
-    if provider is not None and account.provider is not provider:
-        raise typer.BadParameter(
-            f"Account {account_name} uses provider {account.provider.value}, not {provider.value}"
-        )
-    active_provider = account.provider
-    active_model: str | None = None
-    if routed_provider is not None and (
-        routed_assignment.source != "fallback"
-        or account.provider is routed_provider
-    ):
-        if account.provider is not routed_provider:
-            _log.warning(
-                "Role routing resolved %s for %s to %s/%s from %s, but account %s uses %s; "
-                "keeping the session on the account provider.",
-                role,
-                project_key,
-                routed_assignment.provider,
-                routed_assignment.model,
-                routed_assignment.source,
-                account_name,
-                account.provider.value,
-            )
-        else:
-            active_provider = routed_provider
-            active_model = routed_assignment.model
-            _log.info(
-                "Role routing resolved %s for %s to %s/%s from %s.",
-                role,
-                project_key,
-                routed_assignment.provider,
-                routed_assignment.model,
-                routed_assignment.source,
-            )
-    elif routed_provider is not None and routed_assignment.source != "fallback":
-        _log.warning(
-            "Role routing resolved %s for %s to %s/%s from %s, but account %s uses %s; "
-            "keeping the session on the account provider.",
-            role,
-            project_key,
-            routed_assignment.provider,
-            routed_assignment.model,
-            routed_assignment.source,
-            account_name,
-            account.provider.value,
-        )
     if not prompt or not prompt.strip():
-        prompt = suggest_worker_prompt(config_path, project_key=project_key)
+        prompt_suggestion = suggest_worker_prompt(
+            config_path, project_key=project_key
+        )
+    else:
+        prompt_suggestion = None
+    del discovery_config
 
     # Workers use a ``pa`` worktree lane; non-worker roles (e.g. architect)
     # take a lane named after the role so they don't collide with workers.
     lane_kind = "pa" if role == "worker" else role
     window_prefix = "worker" if role == "worker" else role
 
-    # #2063 round 11: pull the duplicate-role check, session_key allocation,
-    # worktree creation, AND the commit ALL inside the same critical section.
-    # Round 7 had moved only the commit inside the lock, but the uniqueness
-    # check ran against the pre-lock snapshot. Two concurrent ``pm worker-
-    # start`` calls for the same project/role could both pass the pre-lock
-    # check, both compute the same ``session_key``, both create a worktree,
-    # and both commit — the second write would clobber the first, orphaning
-    # one worktree and leaving the config inconsistent. Holding the lock
-    # across the entire load → check → allocate → ensure_worktree → commit
-    # sequence collapses that race: the loser sees the winner's session in
-    # ``fresh.sessions`` and raises before touching the filesystem.
+    # LOCKED RMW: every field committed to disk is derived from ``fresh``.
+    # Round 11 moved the duplicate-role check + session_key allocation +
+    # worktree creation + commit inside the lock. Round 12 extends that
+    # invariant: account selection, route resolution, ``active_provider``,
+    # ``active_model``, and the final ``prompt`` are ALSO derived from
+    # ``fresh`` — so an account / project edit between pre-lock discovery
+    # and the locked commit can never persist a session referencing
+    # something that's no longer in the locked config snapshot.
     worktree = None
     try:
         with config_rmw_lock(config_path):
             fresh = load_config(config_path)
+
+            # Re-validate the project against ``fresh`` — an external
+            # ``pm projects remove`` could have landed between discovery
+            # and lock acquire.
+            project = fresh.projects.get(project_key)
+            if project is None:
+                registered = ", ".join(sorted(fresh.projects.keys())) or "<none>"
+                raise typer.BadParameter(
+                    f"No project '{project_key}' registered.\n"
+                    f"\n"
+                    f"Why: project disappeared between worker-start "
+                    f"validation and the config write lock.\n"
+                    f"\n"
+                    f"Fix: re-register with `pm add-project <path> "
+                    f"--name {project_key}` (currently registered: "
+                    f"{registered})."
+                )
+
+            # Role routing is a pure function of ``fresh`` — re-resolve so
+            # an external role_assignments edit between pre-lock discovery
+            # and the locked commit is honoured.
+            routed_assignment = resolve_role_assignment(
+                role, project_key, config=fresh
+            )
+            routed_provider: ProviderKind | None
+            try:
+                routed_provider = resolved_provider_kind(routed_assignment)
+            except ValueError:
+                _log.warning(
+                    "Ignoring invalid routed provider %r for %s on %s.",
+                    routed_assignment.provider,
+                    role,
+                    project_key,
+                )
+                routed_provider = None
+
+            # Account selection is derived from ``fresh``. The auto-select
+            # helper reloads config_path itself; under the held lock that
+            # reload sees the same ``fresh`` snapshot (load_config caches
+            # on mtime; no other writer can advance mtime while we hold
+            # the lock).
+            resolved_account = account_name
+            if resolved_account is None:
+                preferred_provider = (
+                    routed_provider
+                    if routed_provider is not None
+                    and routed_assignment.source != "fallback"
+                    else provider
+                )
+                try:
+                    resolved_account = auto_select_worker_account(
+                        config_path,
+                        provider=preferred_provider,
+                    )
+                except typer.BadParameter:
+                    if (
+                        routed_provider is None
+                        or provider is not None
+                        or routed_assignment.source == "fallback"
+                    ):
+                        raise
+                    _log.warning(
+                        "Role routing resolved %s for %s to %s/%s from %s, but no matching account is available; "
+                        "falling back to the legacy worker account selection.",
+                        role,
+                        project_key,
+                        routed_assignment.provider,
+                        routed_assignment.model,
+                        routed_assignment.source,
+                    )
+                    resolved_account = auto_select_worker_account(
+                        config_path, provider=provider
+                    )
+
+            if resolved_account not in fresh.accounts:
+                # Round-12 invariant: never commit a session whose
+                # ``account`` is missing from the locked snapshot.
+                known = ", ".join(sorted(fresh.accounts.keys())) or "<none>"
+                raise typer.BadParameter(
+                    f"Unknown account: {resolved_account} "
+                    f"(known in current config: {known})"
+                )
+            account = fresh.accounts[resolved_account]
+            if provider is not None and account.provider is not provider:
+                raise typer.BadParameter(
+                    f"Account {resolved_account} uses provider "
+                    f"{account.provider.value}, not {provider.value}"
+                )
+            active_provider = account.provider
+            active_model: str | None = None
+            if routed_provider is not None and (
+                routed_assignment.source != "fallback"
+                or account.provider is routed_provider
+            ):
+                if account.provider is not routed_provider:
+                    _log.warning(
+                        "Role routing resolved %s for %s to %s/%s from %s, but account %s uses %s; "
+                        "keeping the session on the account provider.",
+                        role,
+                        project_key,
+                        routed_assignment.provider,
+                        routed_assignment.model,
+                        routed_assignment.source,
+                        resolved_account,
+                        account.provider.value,
+                    )
+                else:
+                    active_provider = routed_provider
+                    active_model = routed_assignment.model
+                    _log.info(
+                        "Role routing resolved %s for %s to %s/%s from %s.",
+                        role,
+                        project_key,
+                        routed_assignment.provider,
+                        routed_assignment.model,
+                        routed_assignment.source,
+                    )
+            elif routed_provider is not None and routed_assignment.source != "fallback":
+                _log.warning(
+                    "Role routing resolved %s for %s to %s/%s from %s, but account %s uses %s; "
+                    "keeping the session on the account provider.",
+                    role,
+                    project_key,
+                    routed_assignment.provider,
+                    routed_assignment.model,
+                    routed_assignment.source,
+                    resolved_account,
+                    account.provider.value,
+                )
+
             for existing in fresh.sessions.values():
                 if (
                     existing.role == role
@@ -274,15 +344,18 @@ def create_worker_session(
                 lane_key=session_key,
                 session_name=session_key,
             )
+            final_prompt = prompt if (prompt and prompt.strip()) else (
+                prompt_suggestion or ""
+            )
             worker = SessionConfig(
                 name=session_key,
                 role=role,
                 provider=active_provider,
-                account=account_name,
+                account=resolved_account,
                 cwd=Path(worktree.path) if worktree is not None else project.path,
                 project=project_key,
                 window_name=f"{window_prefix}-{project_key}",
-                prompt=prompt,
+                prompt=final_prompt,
                 agent_profile=agent_profile,
                 args=default_session_args(
                     active_provider,
@@ -294,10 +367,10 @@ def create_worker_session(
             fresh.sessions[session_key] = worker
             write_config(fresh, config_path, force=True)
     except typer.BadParameter:
-        # Uniqueness failures and operator-input errors leave the worktree
-        # state alone — either we never created one (duplicate role check
-        # fired first) or the worktree belongs to a sibling session that
-        # legitimately won the race.
+        # Uniqueness / validation failures and operator-input errors leave
+        # the worktree state alone — either we never created one (the
+        # check fired first) or the worktree belongs to a sibling session
+        # that legitimately won the race.
         raise
     except Exception as exc:
         if worktree is not None and worktree.path and Path(worktree.path).exists():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1012,3 +1012,113 @@ def test_write_config_round_trips_non_ascii_project_name(tmp_path: Path) -> None
     # Bytes must contain the UTF-8 encoding of "café" (c-a-f + 0xC3 0xA9).
     raw = config_path.read_bytes()
     assert b"caf\xc3\xa9" in raw
+
+
+def test_load_config_auto_persist_returns_post_lock_snapshot(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Concurrent disk edit during auth-token auto-persist must be visible.
+
+    #2063 round 10 (Codex blocker): round 9 wrapped the legacy
+    ``ensure_session_auth_tokens()`` write in ``config_rmw_lock`` and
+    re-parsed under the lock as ``fresh``, but then only copied
+    ``sessions[*].auth_token`` back into the pre-lock ``config`` and
+    cached that pre-lock snapshot under the post-write mtime. If any
+    config edit landed between the initial parse and the locked
+    re-parse, disk kept the edit but the process cache served the
+    stale pre-lock object as if it matched the latest mtime —
+    subsequent ``load_config(path)`` calls returned stale config
+    indefinitely.
+
+    Reproduction (Codex's): seed a legacy session missing
+    ``auth_token`` plus a project ``persona_name='Old'``. Monkeypatch
+    ``ensure_session_auth_tokens`` so its FIRST invocation rewrites
+    ``persona_name='New'`` to disk before returning (simulates a
+    concurrent CLI/API edit racing the auto-persist). After the fix
+    both the first and the second ``load_config(path)`` must observe
+    the post-lock state: minted token AND the concurrent edit.
+    """
+    import pollypm.config as config_module
+    import pollypm.session_auth as session_auth
+
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        """
+[project]
+name = "PollyPM"
+tmux_session = "pollypm"
+
+[pollypm]
+controller_account = "claude_primary"
+
+[accounts.claude_primary]
+provider = "claude"
+home = ".pollypm/homes/claude_primary"
+
+[sessions.heartbeat]
+role = "heartbeat-supervisor"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[sessions.operator]
+role = "operator-pm"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[projects.myproj]
+path = "myproj"
+persona_name = "Old"
+"""
+    )
+
+    # Clear any cache entry for this path from earlier tests / module
+    # state so the load below exercises the auto-persist branch.
+    config_module._config_cache.pop(config_path.resolve(), None)
+
+    original = session_auth.ensure_session_auth_tokens
+    call_count = {"n": 0}
+
+    def patched(cfg):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Simulate a concurrent CLI edit landing between the
+            # pre-lock parse and the locked re-parse: rewrite the
+            # persona on disk BEFORE we mint tokens on the pre-lock
+            # snapshot. The locked re-parse inside load_config will
+            # then see persona='New'.
+            disk = config_path.read_text()
+            assert 'persona_name = "Old"' in disk
+            config_path.write_text(
+                disk.replace('persona_name = "Old"', 'persona_name = "New"')
+            )
+        return original(cfg)
+
+    monkeypatch.setattr(session_auth, "ensure_session_auth_tokens", patched)
+
+    loaded = config_module.load_config(config_path)
+
+    # 1. Auto-persist worked: operator session now carries a minted token.
+    assert loaded.sessions["operator"].auth_token, (
+        "ensure_session_auth_tokens must have minted + persisted a token"
+    )
+    # 2. The concurrent persona_name edit (visible only to the locked
+    #    re-parse) is reflected in the returned snapshot. Pre-fix this
+    #    returned 'Old' because load_config returned the pre-lock object.
+    assert loaded.projects["myproj"].persona_name == "New", (
+        "load_config must return the post-lock snapshot that observed "
+        "the concurrent disk edit, not the stale pre-lock parse"
+    )
+    # 3. A subsequent load_config call must also see the post-lock
+    #    state. Pre-fix the cache held the pre-lock object under the
+    #    post-write mtime, so this call kept returning 'Old' forever.
+    again = config_module.load_config(config_path)
+    assert again.projects["myproj"].persona_name == "New", (
+        "load_config cache stored the stale pre-lock snapshot; "
+        "subsequent calls return stale config indefinitely"
+    )
+    assert again.sessions["operator"].auth_token == loaded.sessions[
+        "operator"
+    ].auth_token

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -2239,3 +2239,113 @@ def test_write_example_config_race_serialized_by_lock(
         f"{type(failures[0][1]).__name__}: {failures[0][1]!r}"
     )
     assert missing_path.exists(), "winner did not persist the example config"
+
+
+# ---------------------------------------------------------------------------
+# Codex round 12: scan_projects must scaffold BEFORE the locked commit.
+#
+# Round 9 restructured scan_projects to write under the lock and scaffold
+# AFTER releasing it. If ``ensure_project_scaffold`` raised (permissions,
+# partial checkout, bad path), the global config already pointed at a
+# project whose ``.pollypm/`` was never created — operator-visible
+# inconsistency. The round-12 fix scaffolds OUTSIDE the lock BEFORE the
+# write so a scaffold failure can never persist a half-formed entry.
+# ---------------------------------------------------------------------------
+
+
+def test_scan_projects_scaffold_failure_does_not_persist(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 12: ``scan_projects`` must not persist a project whose
+    scaffold raised.
+
+    Repro: stub ``discover_recent_git_repositories`` to return one new
+    candidate, then patch ``ensure_project_scaffold`` to raise
+    ``PermissionError``. Pre-fix (round-9 ordering — scaffold AFTER the
+    locked write) the call raised but ``load_config`` still surfaced
+    the new project key in ``config.projects``. Post-fix the scaffold
+    happens before the locked write, so a scaffold failure short-
+    circuits without touching disk config.
+    """
+    from pollypm import projects as projects_module
+    from pollypm.projects import scan_projects
+
+    new_project_root = tmp_path / "scaffold_will_fail"
+    new_project_root.mkdir()
+
+    base_dir = workspace / ".pollypm"
+    seed = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={},
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(seed, config_path, force=True)
+
+    monkeypatch.setattr(
+        projects_module,
+        "discover_recent_git_repositories",
+        lambda root, known_paths, recent_days: [new_project_root],
+    )
+
+    def _failing_scaffold(path):
+        raise PermissionError(f"simulated scaffold failure for {path}")
+
+    monkeypatch.setattr(
+        projects_module, "ensure_project_scaffold", _failing_scaffold
+    )
+
+    # scan_projects in non-interactive mode runs to completion without
+    # raising — the fix logs/echoes the per-candidate failure and skips
+    # the entry. The critical assertion is the disk-level invariant.
+    result = scan_projects(
+        config_path,
+        scan_root=tmp_path,
+        interactive=False,
+    )
+
+    # No project should have been added — the scaffold failure must
+    # short-circuit BEFORE the locked write.
+    assert result == [], (
+        f"scan_projects returned added projects despite scaffold failure: "
+        f"{[p.key for p in result]}"
+    )
+
+    final = load_config(config_path)
+    assert final.projects == {}, (
+        f"scan_projects persisted a project despite scaffold failure — "
+        f"#2063 round-12 regression. Persisted keys: "
+        f"{sorted(final.projects.keys())}"
+    )

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -1816,3 +1816,202 @@ def test_config_rmw_lock_is_reentrant_within_thread(
     # Sanity: the write actually landed on disk.
     reloaded = load_config(config_path)
     assert reloaded.projects["myproj"].tracked is False
+
+
+# ---------------------------------------------------------------------------
+# Codex round 8 regressions: per-path re-entrancy + first-write race
+# ---------------------------------------------------------------------------
+
+
+def _hold_lock_child(lock_path_str: str, hold_seconds: float, ready_path_str: str) -> None:
+    """Helper executed in a child process to hold an exclusive flock.
+
+    Opens ``lock_path_str`` (must be the canonical sibling lockfile
+    of some config path), acquires ``LOCK_EX``, touches
+    ``ready_path_str`` so the parent knows the lock is held, then
+    sleeps for ``hold_seconds`` before releasing.
+    """
+    import fcntl
+    import time
+    from pathlib import Path as _Path
+
+    lock_path = _Path(lock_path_str)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        _Path(ready_path_str).write_text("ready", encoding="utf-8")
+        time.sleep(hold_seconds)
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def test_config_rmw_lock_does_not_bypass_different_path(
+    tmp_path: Path,
+) -> None:
+    """Codex round 8: nested acquire on a DIFFERENT path must take that path's flock.
+
+    Round 7's depth counter was path-blind: once any config_rmw_lock
+    was held by the thread, a nested acquire on a different config
+    path skipped the flock entirely, letting another process hold the
+    second path's lock while this thread was supposedly inside it.
+
+    Repro: child process holds ``path_b``'s flock for HOLD_SECONDS.
+    Parent thread enters ``config_rmw_lock(path_a)`` and then nests
+    ``config_rmw_lock(path_b)``. The inner acquire MUST block until
+    the child releases — i.e. elapsed wall-clock time inside the
+    nested acquire must be close to HOLD_SECONDS, not ~0.
+    """
+    import multiprocessing
+    import time
+
+    from pollypm.config import _config_lock_path, config_rmw_lock
+
+    path_a = tmp_path / "a" / ".pollypm" / "pollypm.toml"
+    path_b = tmp_path / "b" / ".pollypm" / "pollypm.toml"
+    path_a.parent.mkdir(parents=True, exist_ok=True)
+    path_b.parent.mkdir(parents=True, exist_ok=True)
+
+    ready_marker = tmp_path / "child_ready.flag"
+    hold_seconds = 2.0
+    lock_b_path = _config_lock_path(path_b)
+
+    # Use spawn so the child does not inherit any thread-local lock
+    # state from the parent process.
+    ctx = multiprocessing.get_context("spawn")
+    child = ctx.Process(
+        target=_hold_lock_child,
+        args=(str(lock_b_path), hold_seconds, str(ready_marker)),
+    )
+    child.start()
+    try:
+        # Wait until the child has actually acquired the flock.
+        deadline = time.monotonic() + 10.0
+        while not ready_marker.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert ready_marker.exists(), "child process did not signal ready"
+
+        start = time.monotonic()
+        with config_rmw_lock(path_a):
+            with config_rmw_lock(path_b):
+                inner_acquired_at = time.monotonic()
+        elapsed = inner_acquired_at - start
+
+        # The inner acquire must have BLOCKED on the child's flock.
+        # Round 7's path-blind no-op returned in microseconds; the
+        # per-path fix should wait for the child to release. Allow a
+        # generous margin for scheduling jitter.
+        assert elapsed >= hold_seconds * 0.5, (
+            f"nested acquire on different path bypassed flock: "
+            f"elapsed={elapsed:.3f}s, expected >= {hold_seconds * 0.5:.3f}s"
+        )
+    finally:
+        child.join(timeout=10.0)
+        if child.is_alive():  # pragma: no cover — safety net
+            child.terminate()
+            child.join(timeout=5.0)
+
+
+def test_first_write_race_serialized_by_lock(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+) -> None:
+    """Codex round 8: ``write_config(force=False)`` must serialise the existence check.
+
+    Round 7 evaluated ``if path.exists() and not force`` BEFORE taking
+    the lock. Two writers racing to initialise the same fresh config
+    could both observe ``False``, both enter the lock sequentially, and
+    both write — silently clobbering the first writer. With the
+    existence check inside the lock, exactly one writer wins and the
+    other gets ``FileExistsError``.
+    """
+    import threading
+
+    base_dir = workspace / ".pollypm"
+
+    def _make_seed(persona: str) -> PollyPMConfig:
+        return PollyPMConfig(
+            project=ProjectSettings(
+                name="PollyPM",
+                root_dir=workspace,
+                tmux_session="pollypm-test",
+                workspace_root=workspace,
+                base_dir=base_dir,
+                logs_dir=base_dir / "logs",
+                snapshots_dir=base_dir / "snapshots",
+                state_db=base_dir / "state.db",
+            ),
+            pollypm=PollyPMSettings(
+                controller_account="codex_primary",
+                open_permissions_by_default=False,
+                failover_enabled=False,
+                failover_accounts=[],
+                heartbeat_backend="local",
+                scheduler_backend="inline",
+                lease_timeout_minutes=30,
+            ),
+            accounts={
+                "codex_primary": AccountConfig(
+                    name="codex_primary",
+                    provider=ProviderKind.CODEX,
+                    email="codex@example.com",
+                    runtime=RuntimeKind.LOCAL,
+                    home=base_dir / "homes" / "codex_primary",
+                ),
+            },
+            sessions={},
+            projects={
+                "myproj": KnownProject(
+                    key="myproj",
+                    path=project_root,
+                    name=f"My Project ({persona})",
+                    tracked=True,
+                    kind=ProjectKind.GIT,
+                ),
+            },
+            memory=MemorySettings(backend="file"),
+            config_path=config_path,
+        )
+
+    # Ensure no leftover config from any prior fixture wiring.
+    if config_path.exists():
+        config_path.unlink()
+
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, BaseException | None]] = []
+    results_lock = threading.Lock()
+
+    def _writer(persona: str) -> None:
+        seed = _make_seed(persona)
+        barrier.wait()
+        try:
+            write_config(seed, config_path, force=False)
+            with results_lock:
+                results.append((persona, None))
+        except BaseException as exc:  # noqa: BLE001 — captured for the assert
+            with results_lock:
+                results.append((persona, exc))
+
+    t1 = threading.Thread(target=_writer, args=("alpha",), daemon=True)
+    t2 = threading.Thread(target=_writer, args=("bravo",), daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=15.0)
+    t2.join(timeout=15.0)
+    assert not t1.is_alive() and not t2.is_alive(), "writers deadlocked"
+
+    successes = [r for r in results if r[1] is None]
+    failures = [r for r in results if r[1] is not None]
+
+    assert len(successes) == 1, (
+        f"expected exactly one writer to succeed, got "
+        f"successes={[r[0] for r in successes]}, "
+        f"failures={[(p, type(e).__name__) for p, e in failures]}"
+    )
+    assert len(failures) == 1, (
+        f"expected exactly one writer to raise FileExistsError, got "
+        f"failures={[(p, type(e).__name__, str(e)) for p, e in failures]}"
+    )
+    assert isinstance(failures[0][1], FileExistsError), (
+        f"loser must raise FileExistsError, got {type(failures[0][1]).__name__}: "
+        f"{failures[0][1]!r}"
+    )

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -25,9 +25,16 @@ from pollypm.config import (
     PollyPMConfig,
     PollyPMSettings,
     ProjectSettings,
+    load_config,
     write_config,
 )
-from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+from pollypm.models import (
+    KnownProject,
+    ProjectKind,
+    ProviderKind,
+    RuntimeKind,
+    SessionConfig,
+)
 from pollypm.web_api import create_app, ensure_token
 
 
@@ -404,3 +411,264 @@ def test_init_guide_unknown_project_returns_404(
         json={"role": "architect"},
     )
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Codex review regressions on PR #2063 — config write durability invariants.
+#
+# These four tests pin down behaviour the original Phase 2 patch broke:
+#
+# 1. rollback on disk-write failure (Codex P0 #1 / service.py:352)
+# 2. concurrent-edit preservation (Codex P0 #2 / service.py:355)
+# 3. session→project invariant on archive (Codex P0 #3 / service.py:387)
+# 4. ``reason`` field actually emitted as an audit event (Codex P1 /
+#    routes/projects.py:246)
+# ---------------------------------------------------------------------------
+
+
+def test_pause_rolls_back_in_memory_when_disk_write_fails(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex P0 #1: failed write_config MUST NOT flip the live config.
+
+    Reproduces the original bug: patch ``pollypm.config.write_config``
+    to raise ``OSError`` and confirm:
+
+    * the API returns 503 (mapped via ``service_unavailable``),
+    * the in-memory ``cfg.projects['myproj'].tracked`` stays True,
+    * a subsequent GET reflects the unchanged value (no in-memory lie).
+    """
+    assert config.projects["myproj"].tracked is True
+
+    def _fail_write_config(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise OSError("simulated disk-full during config persist")
+
+    monkeypatch.setattr("pollypm.config.write_config", _fail_write_config)
+
+    response = client.post(
+        "/api/v1/projects/myproj/pause",
+        headers=auth_headers,
+        json={"reason": "test rollback"},
+    )
+    assert response.status_code == 503, response.text
+    body = response.json()
+    assert body["error"]["code"] == "service_unavailable"
+
+    # Live config was NOT mutated — the in-memory rollback contract.
+    assert config.projects["myproj"].tracked is True
+
+    # And a subsequent GET reflects the unchanged value (no stale lie).
+    get_response = client.get(
+        "/api/v1/projects/myproj", headers=auth_headers
+    )
+    assert get_response.status_code == 200
+    assert get_response.json()["tracked"] is True
+
+
+def test_pause_preserves_concurrent_external_project_addition(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
+    workspace: Path,
+    tmp_path: Path,
+) -> None:
+    """Codex P0 #2: concurrent CLI edit must survive an API tracked-toggle.
+
+    Reproduces the original bug: simulate an external ``pm add-project``
+    that lands a new project key ``external`` on disk between server
+    boot and the API call, then call the API ``/pause`` on ``myproj``.
+
+    With the original ``force=True`` write-back the API would silently
+    drop ``external`` from disk. The fix reloads from disk first.
+    """
+    # Simulate an external CLI / cockpit edit adding a second project.
+    external_root = tmp_path / "external"
+    external_root.mkdir()
+    (external_root / ".pollypm").mkdir()
+    fresh = load_config(config_path)
+    fresh.projects["external"] = KnownProject(
+        key="external",
+        path=external_root,
+        name="External Project",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+    write_config(fresh, config_path, force=True)
+
+    # Sanity: in-memory ``config`` (the long-lived server snapshot)
+    # has NOT seen the external addition yet — that's the whole point.
+    assert "external" not in config.projects
+
+    # Now the API call.
+    response = client.post(
+        "/api/v1/projects/myproj/pause",
+        headers=auth_headers,
+        json={"reason": "concurrent edit test"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["tracked"] is False
+
+    # Re-read TOML from disk and assert BOTH:
+    # * the API mutation landed (myproj.tracked = False), AND
+    # * the externally-added project survives.
+    reloaded = load_config(config_path)
+    assert "myproj" in reloaded.projects
+    assert reloaded.projects["myproj"].tracked is False
+    assert "external" in reloaded.projects, (
+        "external project was clobbered by the API write — "
+        "Codex P0 #2 regression"
+    )
+    assert reloaded.projects["external"].tracked is True
+
+
+def test_archive_blocked_when_enabled_session_references_project(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+    tmp_path: Path,
+) -> None:
+    """Codex P0 #3: archive must enforce the session→project invariant.
+
+    Build a config with an enabled session referencing ``myproj``, then
+    POST ``/archive``. Expect 409 with the session name in the body —
+    matches the guard ``pollypm.projects.remove_project`` already
+    enforces for the CLI.
+    """
+    base_dir = workspace / ".pollypm"
+    cfg = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={
+            "blocker-session": SessionConfig(
+                name="blocker-session",
+                role="worker",
+                provider=ProviderKind.CODEX,
+                account="codex_primary",
+                cwd=project_root,
+                project="myproj",
+                enabled=True,
+            ),
+        },
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(cfg, config_path, force=True)
+
+    token_path = tmp_path / "api-token"
+    value, _ = ensure_token(token_path)
+    app = create_app(config=cfg, token_path=token_path)
+    client = TestClient(app)
+    headers = {"Authorization": f"Bearer {value}"}
+
+    response = client.post(
+        "/api/v1/projects/myproj/archive",
+        headers=headers,
+        json={"reason": "ignored — should 409"},
+    )
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["error"]["code"] == "conflict"
+    assert "blocker-session" in body["error"]["message"], (
+        "409 body should name the blocking session — Codex P0 #3"
+    )
+
+    # Project was NOT removed in-memory.
+    assert "myproj" in cfg.projects
+
+
+def test_pause_emits_audit_event_with_reason(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    project_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex P1: ``reason`` must persist somewhere durable.
+
+    Original bug: the API accepted and echoed ``reason`` but the
+    service silently dropped it. The fix emits a ``projects.tracked.set``
+    audit event with ``reason`` in metadata so operators can grep the
+    audit log for "why".
+
+    Pins ``POLLYPM_AUDIT_HOME`` to a tmp dir so this test stays clean
+    when run with ``--noconftest`` (the global conftest normally
+    redirects audit output, but the file-level docstring instructs
+    callers to run with ``--noconftest`` to skip the postgres harness).
+    """
+    import json
+
+    from pollypm.audit.log import central_log_path, project_log_path
+
+    audit_home = tmp_path / "audit"
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    response = client.post(
+        "/api/v1/projects/myproj/pause",
+        headers=auth_headers,
+        json={"reason": "testing-audit-emit"},
+    )
+    assert response.status_code == 200, response.text
+
+    # Two surfaces accept the event — per-project log + central tail.
+    # Either is sufficient for the contract; check both.
+    found = False
+    for path in (project_log_path(project_root), central_log_path("myproj")):
+        if path is None or not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if rec.get("event") == "projects.tracked.set" and rec.get(
+                "metadata", {}
+            ).get("reason") == "testing-audit-emit":
+                found = True
+                break
+        if found:
+            break
+
+    assert found, (
+        "Expected projects.tracked.set audit event with "
+        "reason='testing-audit-emit' — Codex P1 regression"
+    )

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -672,3 +672,139 @@ def test_pause_emits_audit_event_with_reason(
         "Expected projects.tracked.set audit event with "
         "reason='testing-audit-emit' — Codex P1 regression"
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex round 2 on PR #2063 — stale-snapshot idempotency.
+#
+# The route-level "already at target" short-circuit decided idempotency
+# against the long-lived ConfigDep snapshot. When disk has been edited
+# externally to the opposite value, the route returned 200 with the live
+# (stale) state and never wrote — disk stayed out of sync.
+#
+# Fix: idempotency lives in ``set_project_tracked`` after the fresh
+# ``load_config(config_path)``. Routes delegate unconditionally.
+# ---------------------------------------------------------------------------
+
+
+def test_resume_with_live_true_but_disk_false_reflects_disk(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
+) -> None:
+    """Codex round 2: stale live=True vs disk=False on /resume.
+
+    Reproduces the route-bypass bug: server boots with ``tracked=True``
+    in memory, an external editor flips disk to ``tracked=False``, then
+    ``POST /resume`` lands. Pre-fix the route returned 200 with the
+    stale live value and disk stayed ``tracked=False``. Post-fix the
+    service helper reloads disk, sees ``False`` != target ``True``,
+    writes ``True``, and both surfaces agree.
+    """
+    # Sanity: live thinks tracked.
+    assert config.projects["myproj"].tracked is True
+
+    # External editor flips disk to tracked=False without touching the
+    # live in-memory snapshot.
+    fresh = load_config(config_path)
+    fresh.projects["myproj"].tracked = False
+    write_config(fresh, config_path, force=True)
+    # Live snapshot is still stale on purpose.
+    assert config.projects["myproj"].tracked is True
+
+    response = client.post(
+        "/api/v1/projects/myproj/resume", headers=auth_headers, json={}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["tracked"] is True
+
+    # Disk MUST reflect the resume — pre-fix this stayed False because
+    # the route short-circuited on the stale live value and never wrote.
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is True, (
+        "Disk did not reflect /resume target — Codex round-2 regression "
+        "(stale-snapshot idempotency on the route bypassed the durable "
+        "write path)."
+    )
+    # Live snapshot is now in sync too.
+    assert config.projects["myproj"].tracked is True
+
+
+def test_pause_with_live_false_but_disk_true_reflects_disk(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
+) -> None:
+    """Codex round 2: stale live=False vs disk=True on /pause (mirror case).
+
+    Boot live as ``tracked=False`` (already-paused snapshot), have an
+    external editor flip disk to ``tracked=True``, then ``POST /pause``.
+    Pre-fix the route short-circuited on live=False and returned 200
+    without writing; disk stayed ``True``. Post-fix the service helper
+    reloads, sees ``True`` != target ``False``, writes ``False``, and
+    both surfaces agree.
+    """
+    # Flip live to False so the pre-fix route would short-circuit.
+    config.projects["myproj"].tracked = False
+
+    # External editor flips disk back to tracked=True.
+    fresh = load_config(config_path)
+    fresh.projects["myproj"].tracked = True
+    write_config(fresh, config_path, force=True)
+    # Live snapshot is intentionally stale (False vs disk True).
+    assert config.projects["myproj"].tracked is False
+
+    response = client.post(
+        "/api/v1/projects/myproj/pause",
+        headers=auth_headers,
+        json={"reason": "stale-snapshot regression"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["tracked"] is False
+
+    # Disk MUST reflect the pause — pre-fix this stayed True.
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is False, (
+        "Disk did not reflect /pause target — Codex round-2 regression "
+        "(stale-snapshot idempotency on the route bypassed the durable "
+        "write path)."
+    )
+    assert config.projects["myproj"].tracked is False
+
+
+def test_resume_idempotent_when_disk_already_true_syncs_live(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
+) -> None:
+    """Codex round 2: when disk already matches target, sync the live snapshot.
+
+    Live boots as ``tracked=False`` (stale); disk is actually
+    ``tracked=True``. /resume's target equals disk so the helper takes
+    the no-write idempotent branch but MUST still sync live so a
+    subsequent GET doesn't keep lying.
+    """
+    # Disk = True (already at /resume's target).
+    fresh = load_config(config_path)
+    fresh.projects["myproj"].tracked = True
+    write_config(fresh, config_path, force=True)
+    # Live is stale (False).
+    config.projects["myproj"].tracked = False
+
+    response = client.post(
+        "/api/v1/projects/myproj/resume", headers=auth_headers, json={}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["tracked"] is True
+
+    # Live snapshot must have been synced from disk even though no write
+    # happened — otherwise GET keeps returning the stale value.
+    assert config.projects["myproj"].tracked is True
+    get_response = client.get(
+        "/api/v1/projects/myproj", headers=auth_headers
+    )
+    assert get_response.status_code == 200
+    assert get_response.json()["tracked"] is True

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -808,3 +808,193 @@ def test_resume_idempotent_when_disk_already_true_syncs_live(
     )
     assert get_response.status_code == 200
     assert get_response.json()["tracked"] is True
+
+
+# ---------------------------------------------------------------------------
+# Codex round 3 on PR #2063 — full live-snapshot refresh after every mutation.
+#
+# Round-2 idempotency only copied tracked/path/name from disk back into the
+# long-lived ConfigDep object. Round 3 caught that other KnownProject fields
+# (persona_name, kind, role assignments, worker caps, plan enforcement, ...)
+# stayed stale when an external CLI / cockpit edit changed them on the same
+# project before the API call. Mirror gap on archive: external project
+# additions on disk before the archive stayed invisible to GET /projects
+# until restart.
+#
+# Fix: ``_refresh_live_projects`` does a full ``clear() + update()`` from
+# the freshly-loaded disk config after every mutation path.
+# ---------------------------------------------------------------------------
+
+
+def test_pause_idempotent_refreshes_external_metadata_edit(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
+) -> None:
+    """Codex round 3: idempotent /pause must surface external metadata edits.
+
+    Start with ``myproj.tracked=False`` (already at /pause's target) and
+    ``persona_name="old"``. An external editor flips ``persona_name`` to
+    ``"new"`` on disk without changing ``tracked``. POST /pause hits the
+    idempotent branch (no write) but MUST still refresh the live
+    snapshot so the response and a subsequent GET show ``persona_name=
+    "new"``.
+
+    Pre-fix: the field-by-field copy only synced tracked/path/name, so
+    ``persona_name`` stayed stale.
+    """
+    # Boot state: tracked=False, persona_name="old".
+    config.projects["myproj"].tracked = False
+    config.projects["myproj"].persona_name = "old"
+    fresh = load_config(config_path)
+    fresh.projects["myproj"].tracked = False
+    fresh.projects["myproj"].persona_name = "old"
+    write_config(fresh, config_path, force=True)
+
+    # External editor changes persona_name to "new" without touching tracked.
+    external = load_config(config_path)
+    external.projects["myproj"].persona_name = "new"
+    write_config(external, config_path, force=True)
+    # Live snapshot is intentionally stale on persona_name.
+    assert config.projects["myproj"].persona_name == "old"
+
+    # POST /pause — target tracked=False matches disk, so the helper
+    # takes the idempotent (no-write) branch.
+    response = client.post(
+        "/api/v1/projects/myproj/pause",
+        headers=auth_headers,
+        json={"reason": "round-3 idempotent metadata refresh"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["tracked"] is False
+
+    # Live snapshot MUST now reflect the external persona_name edit —
+    # pre-fix it stayed "old" because only tracked/path/name got copied.
+    assert config.projects["myproj"].persona_name == "new", (
+        "Idempotent pause failed to refresh persona_name — Codex round-3 "
+        "regression (live snapshot only copied tracked/path/name)."
+    )
+
+
+def test_resume_write_success_refreshes_external_metadata_edit(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
+) -> None:
+    """Codex round 3: write-success /resume must surface external metadata edits.
+
+    Mirror case: live thinks ``tracked=True, persona_name="old"``. An
+    external editor lands ``tracked=False, persona_name="new"`` on disk.
+    POST /resume's target (True) differs from disk (False) so the helper
+    takes the write branch. The post-write live refresh MUST pick up the
+    new ``persona_name`` too — not just the ``tracked`` bit we wrote.
+
+    Pre-fix: only ``live_project.tracked = target`` ran, leaving
+    persona_name stale.
+    """
+    # Boot state matches disk: tracked=True, persona_name="old".
+    config.projects["myproj"].persona_name = "old"
+    fresh = load_config(config_path)
+    fresh.projects["myproj"].tracked = True
+    fresh.projects["myproj"].persona_name = "old"
+    write_config(fresh, config_path, force=True)
+
+    # External editor lands tracked=False + persona_name="new" on disk.
+    external = load_config(config_path)
+    external.projects["myproj"].tracked = False
+    external.projects["myproj"].persona_name = "new"
+    write_config(external, config_path, force=True)
+    # Live snapshot is intentionally stale (tracked=True, persona_name="old").
+    assert config.projects["myproj"].tracked is True
+    assert config.projects["myproj"].persona_name == "old"
+
+    # POST /resume — target True != disk False, so the helper writes.
+    response = client.post(
+        "/api/v1/projects/myproj/resume", headers=auth_headers, json={}
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["tracked"] is True
+    # The response Project model doesn't surface persona_name directly,
+    # but the live snapshot underneath MUST reflect both fields.
+
+    # Live snapshot MUST reflect the external persona_name edit too —
+    # pre-fix only ``tracked`` was synced, leaving persona_name stale.
+    assert config.projects["myproj"].tracked is True
+    assert config.projects["myproj"].persona_name == "new", (
+        "Write-success resume failed to refresh persona_name — Codex "
+        "round-3 regression (live snapshot only synced the tracked bit)."
+    )
+
+    # Disk must reflect the resume write.
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is True
+    assert reloaded.projects["myproj"].persona_name == "new"
+
+
+def test_archive_surfaces_concurrent_external_project_addition(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
+    tmp_path: Path,
+) -> None:
+    """Codex round 3: external project added on disk before /archive surfaces.
+
+    Start with ``myproj`` only. An external CLI lands a second project
+    ``external`` on disk between server boot and the API call. POST
+    /archive removes ``myproj``; the post-archive live refresh MUST
+    surface ``external`` to subsequent ``GET /projects`` calls.
+
+    Pre-fix: ``config.projects.pop(project_key, None)`` only dropped the
+    archived key. The external addition stayed invisible to in-process
+    GETs until restart.
+    """
+    # Sanity: live boots with myproj only.
+    assert list(config.projects.keys()) == ["myproj"]
+
+    # External CLI adds a second project on disk.
+    external_root = tmp_path / "external"
+    external_root.mkdir()
+    (external_root / ".pollypm").mkdir()
+    fresh = load_config(config_path)
+    fresh.projects["external"] = KnownProject(
+        key="external",
+        path=external_root,
+        name="External Project",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+    write_config(fresh, config_path, force=True)
+    # Live snapshot still doesn't know about ``external``.
+    assert "external" not in config.projects
+
+    # POST /archive on myproj.
+    response = client.post(
+        "/api/v1/projects/myproj/archive",
+        headers=auth_headers,
+        json={"reason": "round-3 archive refresh"},
+    )
+    assert response.status_code == 200, response.text
+
+    # Live snapshot MUST drop myproj AND surface external.
+    assert "myproj" not in config.projects
+    assert "external" in config.projects, (
+        "Archive failed to surface concurrent external project addition "
+        "— Codex round-3 regression (post-archive sync only pop()'d the "
+        "archived key)."
+    )
+
+    # And GET /projects sees external too (end-to-end via the route).
+    list_response = client.get(
+        "/api/v1/projects", headers=auth_headers
+    )
+    assert list_response.status_code == 200
+    keys = [item["key"] for item in list_response.json()["items"]]
+    assert "external" in keys, (
+        "GET /projects did not surface concurrent external addition after "
+        "archive — Codex round-3 regression."
+    )
+    assert "myproj" not in keys

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -2015,3 +2015,227 @@ def test_first_write_race_serialized_by_lock(
         f"loser must raise FileExistsError, got {type(failures[0][1]).__name__}: "
         f"{failures[0][1]!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex round 9 regressions: scan_projects + write_example_config races
+# ---------------------------------------------------------------------------
+
+
+def test_scan_projects_race_with_set_project_tracked_preserves_both(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 9: ``scan_projects`` must not clobber a concurrent API pause.
+
+    Pre-fix (round 8 head ``faa37303e``): ``scan_projects`` did
+    ``load_config → mutate → write_config`` without wrapping in
+    ``config_rmw_lock``. A concurrent API pause that landed between the
+    scan's load and write was silently overwritten with the scan's older
+    snapshot (``project_a.tracked`` reverted to True).
+
+    Post-fix: discovery happens outside the critical section; the
+    load+merge+write block runs under ``config_rmw_lock(config_path)``
+    so both mutations land on disk.
+    """
+    import threading
+
+    from pollypm import projects as projects_module
+    from pollypm.projects import scan_projects
+    from pollypm.web_api.service import set_project_tracked
+
+    project_a_root = tmp_path / "project_a"
+    project_a_root.mkdir()
+    (project_a_root / ".pollypm").mkdir()
+    # A separate "discovery" candidate dir the scan will pretend to find
+    # via the monkeypatched discoverer.
+    new_project_root = tmp_path / "newly_discovered"
+    new_project_root.mkdir()
+    (new_project_root / ".pollypm").mkdir()
+
+    base_dir = workspace / ".pollypm"
+    seed = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "project_a": KnownProject(
+                key="project_a",
+                path=project_a_root,
+                name="Project A",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(seed, config_path, force=True)
+
+    live_a = load_config(config_path)
+
+    # Stub discovery so we don't depend on a real git tree, and so we
+    # control exactly which path the scan tries to add.
+    monkeypatch.setattr(
+        projects_module,
+        "discover_recent_git_repositories",
+        lambda root, known_paths, recent_days: [new_project_root],
+    )
+    # Pin scaffold to a no-op — we don't need to materialise a real
+    # project tree on disk for the race assertion.
+    monkeypatch.setattr(
+        projects_module,
+        "ensure_project_scaffold",
+        lambda path: path,
+    )
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException | None] = [None, None]
+
+    def _api_pause_worker() -> None:
+        try:
+            barrier.wait(timeout=10)
+            set_project_tracked(
+                live_a,
+                "project_a",
+                tracked=False,
+                reason="round-9 scan race",
+                actor="api",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors[0] = exc
+
+    def _cli_scan_worker() -> None:
+        try:
+            barrier.wait(timeout=10)
+            scan_projects(
+                config_path,
+                scan_root=tmp_path,
+                interactive=False,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors[1] = exc
+
+    t1 = threading.Thread(target=_api_pause_worker)
+    t2 = threading.Thread(target=_cli_scan_worker)
+    t1.start()
+    t2.start()
+    t1.join(timeout=20)
+    t2.join(timeout=20)
+
+    assert errors == [None, None], f"workers raised: {errors!r}"
+
+    final = load_config(config_path)
+    # BOTH mutations must survive.
+    assert "project_a" in final.projects, (
+        "project_a vanished — scan_projects clobbered the API pause's "
+        "project list. Codex round-9 cross-writer invariant violated."
+    )
+    assert final.projects["project_a"].tracked is False, (
+        "project_a's API pause was reverted by the scan's write — "
+        "Codex round-9 lost-update through scan_projects."
+    )
+    # The scan must have actually merged its new project into the
+    # post-API-write snapshot.
+    new_paths = {
+        str(project.path) for project in final.projects.values()
+    }
+    assert str(new_project_root) in new_paths or any(
+        project.path.samefile(new_project_root)
+        for project in final.projects.values()
+    ), (
+        "scan_projects' new entry did not land on disk after the race — "
+        "either the scan saw the API's snapshot and skipped, or the API "
+        "write clobbered the scan's addition."
+    )
+
+
+def test_write_example_config_race_serialized_by_lock(
+    tmp_path: Path,
+) -> None:
+    """Codex round 9: two ``write_example_config`` calls on a missing path serialise.
+
+    Pre-fix: ``write_example_config`` checked ``path.exists()`` OUTSIDE
+    the lock and then called ``write_config(..., force=True)``, bypassing
+    the locked existence guard. Two concurrent ``pm init`` callers could
+    both observe ``False`` and the second silently clobbered the first.
+
+    Post-fix: the existence decision lives inside ``config_rmw_lock`` —
+    delegated to the locked guard inside ``write_config(force=False)``.
+    Exactly one caller wins; the other raises ``FileExistsError``.
+    """
+    import threading
+
+    from pollypm.config import write_example_config
+
+    missing_path = tmp_path / "fresh" / ".pollypm" / "pollypm.toml"
+    missing_path.parent.mkdir(parents=True, exist_ok=True)
+
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, BaseException | None]] = []
+    results_lock = threading.Lock()
+
+    def _writer(persona: str) -> None:
+        barrier.wait()
+        try:
+            write_example_config(missing_path, force=False)
+            with results_lock:
+                results.append((persona, None))
+        except BaseException as exc:  # noqa: BLE001 — captured for assert
+            with results_lock:
+                results.append((persona, exc))
+
+    t1 = threading.Thread(target=_writer, args=("alpha",), daemon=True)
+    t2 = threading.Thread(target=_writer, args=("bravo",), daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=15.0)
+    t2.join(timeout=15.0)
+    assert not t1.is_alive() and not t2.is_alive(), "writers deadlocked"
+
+    successes = [r for r in results if r[1] is None]
+    failures = [r for r in results if r[1] is not None]
+
+    assert len(successes) == 1, (
+        f"expected exactly one write_example_config to succeed, got "
+        f"successes={[r[0] for r in successes]}, "
+        f"failures={[(p, type(e).__name__) for p, e in failures]}"
+    )
+    assert len(failures) == 1, (
+        f"expected exactly one write_example_config to raise FileExistsError, "
+        f"got failures={[(p, type(e).__name__) for p, e in failures]}"
+    )
+    assert isinstance(failures[0][1], FileExistsError), (
+        f"loser must raise FileExistsError, got "
+        f"{type(failures[0][1]).__name__}: {failures[0][1]!r}"
+    )
+    assert missing_path.exists(), "winner did not persist the example config"

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -998,3 +998,267 @@ def test_archive_surfaces_concurrent_external_project_addition(
         "archive — Codex round-3 regression."
     )
     assert "myproj" not in keys
+
+
+# ---------------------------------------------------------------------------
+# Codex round 4 on PR #2063 — rollback on the cached load_config path.
+#
+# Round 1 added a rollback regression but constructed the live config by hand
+# (i.e. NOT via ``load_config``) so the cached-singleton aliasing never came
+# into play. Codex round 4 reproduced the bug against the production path:
+# ``pm serve`` builds ``ConfigDep`` via ``load_config(config_path)``, and
+# ``set_project_tracked`` then calls ``load_config(config_path)`` AGAIN — but
+# ``load_config`` memoises by path, so the "fresh" snapshot is literally the
+# same Python object as the live ``ConfigDep``. Mutating
+# ``fresh.projects[key].tracked`` before ``write_config`` therefore flipped
+# the live snapshot too; if the write then raised, the API returned 503 but
+# subsequent GETs returned the flipped (stale-lie) value.
+#
+# Fix: deep-copy the loaded snapshot before mutating it; live ``ConfigDep``
+# is only touched via ``_refresh_live_projects`` AFTER the write succeeds.
+# Archive has the analogous bug through the ``remove_project`` facade
+# (``del config.projects[key]`` on the cached object before ``write_config``);
+# the service-level fix snapshots the live entry and restores it on OSError.
+# ---------------------------------------------------------------------------
+
+
+def test_pause_rolls_back_with_real_load_config_cache(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 4: rollback must hold when live config came via load_config.
+
+    Reproduce the production path exactly:
+
+    * write a seed config to disk,
+    * call ``load_config(config_path)`` to get the LIVE snapshot (which
+      enters the module-level cache),
+    * build the FastAPI app on that live snapshot,
+    * monkeypatch ``pollypm.config.write_config`` to raise OSError,
+    * POST ``/pause``.
+
+    Expect 503, AND the live snapshot's ``tracked`` MUST stay True, AND
+    a follow-up ``load_config(config_path)`` (cache hit — same object)
+    MUST also stay True. Pre-fix the live snapshot flipped to False
+    because ``fresh = load_config(...)`` returned the very same object
+    we'd handed to FastAPI.
+    """
+    from pollypm.config import (
+        AccountConfig,
+        MemorySettings,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectSettings,
+        load_config,
+        write_config,
+    )
+
+    base_dir = workspace / ".pollypm"
+    seed = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(seed, config_path, force=True)
+
+    # CRITICAL: build the live snapshot via load_config so the API and the
+    # service helper share the SAME cached object (production path).
+    live = load_config(config_path)
+    assert live.projects["myproj"].tracked is True
+
+    token_path = tmp_path / "api-token"
+    value, _ = ensure_token(token_path)
+    app = create_app(config=live, token_path=token_path)
+    client_ = TestClient(app)
+    headers = {"Authorization": f"Bearer {value}"}
+
+    # Sanity: a second load_config returns the EXACT same object (cache
+    # hit). This is what would have made the original mutate-then-write
+    # bug undetectable in the hand-built-config rollback test.
+    assert load_config(config_path) is live, (
+        "load_config did not return the cached object; this test's "
+        "assumptions about the cached-singleton path are invalid."
+    )
+
+    def _fail_write_config(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise OSError("simulated disk-full during config persist")
+
+    monkeypatch.setattr("pollypm.config.write_config", _fail_write_config)
+
+    response = client_.post(
+        "/api/v1/projects/myproj/pause",
+        headers=headers,
+        json={"reason": "round-4 cached-config rollback"},
+    )
+    assert response.status_code == 503, response.text
+    assert response.json()["error"]["code"] == "service_unavailable"
+
+    # Live snapshot MUST stay True — this is the round-4 invariant.
+    assert live.projects["myproj"].tracked is True, (
+        "Live ConfigDep flipped to False on a failed write — Codex "
+        "round-4 regression (deep-copy of the cached load_config "
+        "snapshot is missing)."
+    )
+
+    # Cache-hit reload MUST also stay True (same object as ``live``).
+    cached_again = load_config(config_path)
+    assert cached_again.projects["myproj"].tracked is True
+
+    # And a subsequent GET reflects the unchanged value (no stale lie).
+    get_response = client_.get("/api/v1/projects/myproj", headers=headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["tracked"] is True
+
+
+def test_archive_rolls_back_with_real_load_config_cache(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex round 4 mirror: archive's rollback on the cached path.
+
+    The ``archive_project`` service helper delegates to
+    ``pollypm.projects.remove_project``, which does
+    ``config = load_config(config_path); del config.projects[key];
+    write_config(...)``. On the cached path the ``del`` mutates the live
+    snapshot BEFORE the write — so a failed write would leave the live
+    config missing the project even though disk still has it. The
+    service-level fix snapshots the live entry and restores it on
+    OSError.
+    """
+    from pollypm.config import (
+        AccountConfig,
+        MemorySettings,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectSettings,
+        load_config,
+        write_config,
+    )
+
+    base_dir = workspace / ".pollypm"
+    seed = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(seed, config_path, force=True)
+
+    live = load_config(config_path)
+    assert "myproj" in live.projects
+
+    token_path = tmp_path / "api-token"
+    value, _ = ensure_token(token_path)
+    app = create_app(config=live, token_path=token_path)
+    client_ = TestClient(app)
+    headers = {"Authorization": f"Bearer {value}"}
+
+    def _fail_write_config(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise OSError("simulated disk-full during config persist")
+
+    # Archive routes through ``pollypm.projects.remove_project`` which
+    # does ``from pollypm.config import write_config`` at module load,
+    # so the patched name MUST be the one bound inside
+    # ``pollypm.projects`` — patching ``pollypm.config.write_config``
+    # alone leaves the facade's binding pointing at the real impl.
+    monkeypatch.setattr("pollypm.projects.write_config", _fail_write_config)
+
+    response = client_.post(
+        "/api/v1/projects/myproj/archive",
+        headers=headers,
+        json={"reason": "round-4 archive rollback"},
+    )
+    assert response.status_code == 503, response.text
+    assert response.json()["error"]["code"] == "service_unavailable"
+
+    # Live snapshot MUST still hold ``myproj`` — pre-fix it was del'd
+    # by the facade before the write failed.
+    assert "myproj" in live.projects, (
+        "Live ConfigDep lost ``myproj`` on a failed archive write — "
+        "Codex round-4 regression (cached-load_config path: facade's "
+        "in-place del leaked into the live snapshot)."
+    )
+
+    # And a subsequent GET still surfaces the project.
+    get_response = client_.get("/api/v1/projects/myproj", headers=headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["key"] == "myproj"

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -144,7 +144,10 @@ def client(app) -> TestClient:
 
 
 def test_pause_happy_path_sets_tracked_false(
-    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
 ) -> None:
     response = client.post(
         "/api/v1/projects/myproj/pause",
@@ -155,12 +158,19 @@ def test_pause_happy_path_sets_tracked_false(
     body = response.json()
     assert body["key"] == "myproj"
     assert body["tracked"] is False
-    # Side effect: in-memory config flipped + persisted TOML reflects it.
-    assert config.projects["myproj"].tracked is False
+    # Side effect: persisted TOML reflects the flip. Post-#2056 the
+    # route reloads via ``load_config(config_path)`` per request, so the
+    # original fixture ``config`` object is no longer what the route
+    # mutates — assert against disk (Pattern A).
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is False
 
 
 def test_pause_is_idempotent_on_already_paused(
-    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
 ) -> None:
     """Already-paused → 200 with the current snapshot.
 
@@ -179,7 +189,10 @@ def test_pause_is_idempotent_on_already_paused(
     second = client.post("/api/v1/projects/myproj/pause", headers=auth_headers)
     assert second.status_code == 200, second.text
     assert second.json()["tracked"] is False
-    assert config.projects["myproj"].tracked is False
+    # Disk reflects the paused state (Pattern A — post-#2056 per-request
+    # reload, the fixture ``config`` object is not the route's snapshot).
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is False
 
 
 # ---------------------------------------------------------------------------
@@ -188,17 +201,28 @@ def test_pause_is_idempotent_on_already_paused(
 
 
 def test_resume_happy_path_sets_tracked_true(
-    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
 ) -> None:
-    # Start from paused.
-    config.projects["myproj"].tracked = False
+    # Start from paused — write to disk so the per-request load_config
+    # reload sees ``tracked=False`` (post-#2056 the route reloads via
+    # ``load_config(config_path)`` per request, so an in-memory mutation
+    # to the fixture ``config`` would be invisible to the route).
+    paused = load_config(config_path)
+    paused.projects["myproj"].tracked = False
+    write_config(paused, config_path, force=True)
+
     response = client.post(
         "/api/v1/projects/myproj/resume", headers=auth_headers, json={}
     )
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["tracked"] is True
-    assert config.projects["myproj"].tracked is True
+    # Assert against disk (Pattern A).
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is True
 
 
 def test_resume_is_idempotent_on_already_tracked(
@@ -219,7 +243,10 @@ def test_resume_is_idempotent_on_already_tracked(
 
 
 def test_archive_happy_path_removes_from_config(
-    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config: PollyPMConfig,
+    config_path: Path,
 ) -> None:
     response = client.post(
         "/api/v1/projects/myproj/archive",
@@ -231,7 +258,10 @@ def test_archive_happy_path_removes_from_config(
     assert body["ok"] is True
     assert "archived" in body["message"].lower()
     assert "deprecated" in body["message"]
-    assert "myproj" not in config.projects
+    # Disk reflects the removal (Pattern A — post-#2056 per-request
+    # reload, the fixture ``config`` object is not the route's snapshot).
+    reloaded = load_config(config_path)
+    assert "myproj" not in reloaded.projects
 
 
 def test_archive_irreversible_resume_after_archive_returns_404(
@@ -780,19 +810,20 @@ def test_resume_idempotent_when_disk_already_true_syncs_live(
     config: PollyPMConfig,
     config_path: Path,
 ) -> None:
-    """Codex round 2: when disk already matches target, sync the live snapshot.
+    """Codex round 2 (restated post-#2056): idempotent /resume reflects disk.
 
-    Live boots as ``tracked=False`` (stale); disk is actually
-    ``tracked=True``. /resume's target equals disk so the helper takes
-    the no-write idempotent branch but MUST still sync live so a
-    subsequent GET doesn't keep lying.
+    Post-#2056 the route reloads via ``load_config(config_path)`` per
+    request, so the "live snapshot" concept that round-2 pinned is gone:
+    every request gets the freshly-loaded disk state. The invariant we
+    still care about is that an idempotent /resume (disk already at the
+    target) returns 200 with the disk-backed snapshot AND a follow-up
+    GET keeps reflecting the disk value. Pattern A — assert via disk +
+    a subsequent GET, not via the fixture ``config`` object.
     """
     # Disk = True (already at /resume's target).
     fresh = load_config(config_path)
     fresh.projects["myproj"].tracked = True
     write_config(fresh, config_path, force=True)
-    # Live is stale (False).
-    config.projects["myproj"].tracked = False
 
     response = client.post(
         "/api/v1/projects/myproj/resume", headers=auth_headers, json={}
@@ -800,9 +831,11 @@ def test_resume_idempotent_when_disk_already_true_syncs_live(
     assert response.status_code == 200, response.text
     assert response.json()["tracked"] is True
 
-    # Live snapshot must have been synced from disk even though no write
-    # happened — otherwise GET keeps returning the stale value.
-    assert config.projects["myproj"].tracked is True
+    # Disk is unchanged at True.
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is True
+    # A follow-up GET reflects disk too (the per-request reload picks up
+    # the same disk state).
     get_response = client.get(
         "/api/v1/projects/myproj", headers=auth_headers
     )
@@ -832,32 +865,27 @@ def test_pause_idempotent_refreshes_external_metadata_edit(
     config: PollyPMConfig,
     config_path: Path,
 ) -> None:
-    """Codex round 3: idempotent /pause must surface external metadata edits.
+    """Codex round 3 (restated post-#2056): idempotent /pause reflects disk metadata.
 
-    Start with ``myproj.tracked=False`` (already at /pause's target) and
-    ``persona_name="old"``. An external editor flips ``persona_name`` to
-    ``"new"`` on disk without changing ``tracked``. POST /pause hits the
-    idempotent branch (no write) but MUST still refresh the live
-    snapshot so the response and a subsequent GET show ``persona_name=
-    "new"``.
+    Start with ``tracked=False, persona_name="new"`` on disk (the post-
+    external-edit state). POST /pause hits the idempotent branch (target
+    matches disk) and MUST return a response Project whose
+    ``persona_name`` reflects the disk value, plus a follow-up GET that
+    sees the same value.
 
-    Pre-fix: the field-by-field copy only synced tracked/path/name, so
-    ``persona_name`` stayed stale.
+    Post-#2056 the route reloads via ``load_config(config_path)`` per
+    request, so the "live snapshot refresh" the round-3 patch added is
+    no longer necessary for the NEXT request — that request reloads from
+    disk anyway. What we still pin is that the response built from the
+    in-request reload reflects all disk fields, not just ``tracked``.
     """
-    # Boot state: tracked=False, persona_name="old".
-    config.projects["myproj"].tracked = False
-    config.projects["myproj"].persona_name = "old"
-    fresh = load_config(config_path)
-    fresh.projects["myproj"].tracked = False
-    fresh.projects["myproj"].persona_name = "old"
-    write_config(fresh, config_path, force=True)
-
-    # External editor changes persona_name to "new" without touching tracked.
-    external = load_config(config_path)
-    external.projects["myproj"].persona_name = "new"
-    write_config(external, config_path, force=True)
-    # Live snapshot is intentionally stale on persona_name.
-    assert config.projects["myproj"].persona_name == "old"
+    # Disk = tracked=False, persona_name="new" — the state after an
+    # external editor changed both ``tracked`` (to match the target) and
+    # ``persona_name`` between server boot and this call.
+    disk = load_config(config_path)
+    disk.projects["myproj"].tracked = False
+    disk.projects["myproj"].persona_name = "new"
+    write_config(disk, config_path, force=True)
 
     # POST /pause — target tracked=False matches disk, so the helper
     # takes the idempotent (no-write) branch.
@@ -867,14 +895,22 @@ def test_pause_idempotent_refreshes_external_metadata_edit(
         json={"reason": "round-3 idempotent metadata refresh"},
     )
     assert response.status_code == 200, response.text
-    assert response.json()["tracked"] is False
+    body = response.json()
+    assert body["tracked"] is False
+    # Response Project surfaces persona_name — must reflect the disk
+    # value the route reloaded.
+    assert body["persona_name"] == "new"
 
-    # Live snapshot MUST now reflect the external persona_name edit —
-    # pre-fix it stayed "old" because only tracked/path/name got copied.
-    assert config.projects["myproj"].persona_name == "new", (
-        "Idempotent pause failed to refresh persona_name — Codex round-3 "
-        "regression (live snapshot only copied tracked/path/name)."
+    # A subsequent GET still reflects disk (Pattern A).
+    get_response = client.get(
+        "/api/v1/projects/myproj", headers=auth_headers
     )
+    assert get_response.status_code == 200
+    assert get_response.json()["persona_name"] == "new"
+    # Disk unchanged.
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].persona_name == "new"
+    assert reloaded.projects["myproj"].tracked is False
 
 
 def test_resume_write_success_refreshes_external_metadata_edit(
@@ -883,32 +919,26 @@ def test_resume_write_success_refreshes_external_metadata_edit(
     config: PollyPMConfig,
     config_path: Path,
 ) -> None:
-    """Codex round 3: write-success /resume must surface external metadata edits.
+    """Codex round 3 (restated post-#2056): write-success /resume preserves external metadata.
 
-    Mirror case: live thinks ``tracked=True, persona_name="old"``. An
-    external editor lands ``tracked=False, persona_name="new"`` on disk.
-    POST /resume's target (True) differs from disk (False) so the helper
-    takes the write branch. The post-write live refresh MUST pick up the
-    new ``persona_name`` too — not just the ``tracked`` bit we wrote.
+    Disk has ``tracked=False, persona_name="new"`` after an external
+    editor changed both fields. POST /resume's target (True) differs
+    from disk (False) so the helper writes. The write MUST preserve the
+    external ``persona_name`` edit (concurrent-edit preservation, Codex
+    P0 #2 still applies) and the response MUST surface it.
 
-    Pre-fix: only ``live_project.tracked = target`` ran, leaving
-    persona_name stale.
+    Post-#2056 the route reloads via ``load_config(config_path)`` per
+    request, so we don't pin a "live snapshot refresh" anymore — the
+    next request reloads from disk anyway. What we pin is that the
+    durable write preserves concurrent external metadata edits and the
+    response reflects the post-write disk state.
     """
-    # Boot state matches disk: tracked=True, persona_name="old".
-    config.projects["myproj"].persona_name = "old"
-    fresh = load_config(config_path)
-    fresh.projects["myproj"].tracked = True
-    fresh.projects["myproj"].persona_name = "old"
-    write_config(fresh, config_path, force=True)
-
-    # External editor lands tracked=False + persona_name="new" on disk.
+    # Disk: tracked=False (so /resume must write True), persona_name=
+    # "new" from an external edit we must not clobber.
     external = load_config(config_path)
     external.projects["myproj"].tracked = False
     external.projects["myproj"].persona_name = "new"
     write_config(external, config_path, force=True)
-    # Live snapshot is intentionally stale (tracked=True, persona_name="old").
-    assert config.projects["myproj"].tracked is True
-    assert config.projects["myproj"].persona_name == "old"
 
     # POST /resume — target True != disk False, so the helper writes.
     response = client.post(
@@ -917,21 +947,17 @@ def test_resume_write_success_refreshes_external_metadata_edit(
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["tracked"] is True
-    # The response Project model doesn't surface persona_name directly,
-    # but the live snapshot underneath MUST reflect both fields.
+    # Response Project surfaces persona_name — must reflect the
+    # external edit the write preserved.
+    assert body["persona_name"] == "new"
 
-    # Live snapshot MUST reflect the external persona_name edit too —
-    # pre-fix only ``tracked`` was synced, leaving persona_name stale.
-    assert config.projects["myproj"].tracked is True
-    assert config.projects["myproj"].persona_name == "new", (
-        "Write-success resume failed to refresh persona_name — Codex "
-        "round-3 regression (live snapshot only synced the tracked bit)."
-    )
-
-    # Disk must reflect the resume write.
+    # Disk must reflect the resume write AND preserve persona_name.
     reloaded = load_config(config_path)
     assert reloaded.projects["myproj"].tracked is True
-    assert reloaded.projects["myproj"].persona_name == "new"
+    assert reloaded.projects["myproj"].persona_name == "new", (
+        "Write-success resume clobbered concurrent external persona_name "
+        "edit — Codex P0 #2 (concurrent-edit preservation) regression."
+    )
 
 
 def test_archive_surfaces_concurrent_external_project_addition(
@@ -941,20 +967,19 @@ def test_archive_surfaces_concurrent_external_project_addition(
     config_path: Path,
     tmp_path: Path,
 ) -> None:
-    """Codex round 3: external project added on disk before /archive surfaces.
+    """Codex round 3 (restated post-#2056): /archive preserves external additions.
 
-    Start with ``myproj`` only. An external CLI lands a second project
-    ``external`` on disk between server boot and the API call. POST
-    /archive removes ``myproj``; the post-archive live refresh MUST
-    surface ``external`` to subsequent ``GET /projects`` calls.
+    Start with ``myproj`` only on disk. An external CLI lands a second
+    project ``external`` on disk between server boot and the API call.
+    POST /archive removes ``myproj``; the durable write MUST preserve
+    ``external`` (Codex P0 #2 concurrent-edit preservation), and a
+    subsequent GET /projects reloads disk and surfaces ``external``.
 
-    Pre-fix: ``config.projects.pop(project_key, None)`` only dropped the
-    archived key. The external addition stayed invisible to in-process
-    GETs until restart.
+    Post-#2056 the route reloads via ``load_config(config_path)`` per
+    request, so we don't pin a "live snapshot refresh" anymore — we
+    pin the durable invariant (disk reflects archive + preserves the
+    concurrent add) and the GET round-trip.
     """
-    # Sanity: live boots with myproj only.
-    assert list(config.projects.keys()) == ["myproj"]
-
     # External CLI adds a second project on disk.
     external_root = tmp_path / "external"
     external_root.mkdir()
@@ -968,8 +993,6 @@ def test_archive_surfaces_concurrent_external_project_addition(
         kind=ProjectKind.GIT,
     )
     write_config(fresh, config_path, force=True)
-    # Live snapshot still doesn't know about ``external``.
-    assert "external" not in config.projects
 
     # POST /archive on myproj.
     response = client.post(
@@ -979,15 +1002,16 @@ def test_archive_surfaces_concurrent_external_project_addition(
     )
     assert response.status_code == 200, response.text
 
-    # Live snapshot MUST drop myproj AND surface external.
-    assert "myproj" not in config.projects
-    assert "external" in config.projects, (
-        "Archive failed to surface concurrent external project addition "
-        "— Codex round-3 regression (post-archive sync only pop()'d the "
-        "archived key)."
+    # Disk MUST drop myproj AND preserve external (Pattern A).
+    reloaded = load_config(config_path)
+    assert "myproj" not in reloaded.projects
+    assert "external" in reloaded.projects, (
+        "Archive clobbered concurrent external project addition — "
+        "Codex P0 #2 (concurrent-edit preservation) regression."
     )
 
-    # And GET /projects sees external too (end-to-end via the route).
+    # And GET /projects sees external too (end-to-end via the per-request
+    # reload).
     list_response = client.get(
         "/api/v1/projects", headers=auth_headers
     )
@@ -995,7 +1019,7 @@ def test_archive_surfaces_concurrent_external_project_addition(
     keys = [item["key"] for item in list_response.json()["items"]]
     assert "external" in keys, (
         "GET /projects did not surface concurrent external addition after "
-        "archive — Codex round-3 regression."
+        "archive."
     )
     assert "myproj" not in keys
 

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -1565,3 +1565,254 @@ def test_concurrent_archive_and_pause_preserves_both(
         "project_b's pause was reverted by project_a's archive — Codex "
         "round-6 lost-update race regression."
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex round 7 on PR #2063 — shared config_rmw_lock invariant across API
+# and non-API writers.
+#
+# Round 6's API-local ``_config_write_lock`` closed the API-vs-API
+# lost-update window, but a CLI / cockpit writer that does its own
+# ``load_config → mutate → write_config`` outside the lock still raced the
+# API path: a CLI ``pm projects remove`` (or cockpit role-assignment edit)
+# that landed between an API helper's ``load_config`` and ``write_config``
+# was silently overwritten by the API's older snapshot. Codex reproduced
+# this by monkey-patching ``pollypm.config.write_config`` to flip a
+# project's ``persona_name`` immediately before the API pause wrote its
+# snapshot for a different project — the final TOML had the API mutation
+# but the external persona_name edit was lost.
+#
+# Fix: ``pollypm.config.config_rmw_lock`` is the shared lock primitive.
+# Every in-tree config writer wraps its full RMW under it: API helpers
+# (``set_project_tracked`` / ``archive_project``), CLI helpers
+# (``pollypm.projects.remove_project`` / ``register_project`` /
+# ``rename_project`` / ``enable_tracked_project`` / ``set_workspace_root``),
+# accounts (``add_account_via_login`` / ``remove_account`` /
+# ``set_controller_account`` / ``set_open_permissions_default`` /
+# ``toggle_failover_account`` / ``relogin_account``), workers, onboarding,
+# the cockpit project-settings + roles editors, and the project-planning
+# plugin session-purge. ``write_config`` ALSO acquires the lock for defence
+# in depth (re-entrant per thread so nested wraps don't deadlock).
+#
+# These tests pin the cross-writer invariant: a CLI writer running
+# concurrently with the API on the same config must preserve both
+# mutations.
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_api_pause_and_cli_remove_preserves_both(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+    tmp_path: Path,
+) -> None:
+    """Codex round 7: API pause + CLI remove on different projects.
+
+    Real reproduction: thread 1 calls the API ``set_project_tracked``
+    helper to pause ``project_a``; thread 2 calls
+    ``pollypm.projects.remove_project`` (the same code path the CLI
+    ``pm projects remove`` uses) to drop ``project_c``. Both threads
+    sync via a ``threading.Barrier`` so they race the RMW.
+
+    Pre-fix (round-6 lock local to web_api): the CLI helper had no
+    lock, so its ``load_config`` happened concurrently with the API's,
+    its mutation ran outside the API's serialised window, and either
+    the API's write reverted the CLI remove (``project_c`` resurrects)
+    or the CLI's write reverted the API pause (``project_a.tracked``
+    stays True). Post-fix (round 7): both writers acquire
+    ``pollypm.config.config_rmw_lock``, so the loser reloads AFTER the
+    winner's mtime updates and BOTH mutations land on disk.
+    """
+    import threading
+
+    from pollypm.projects import remove_project
+    from pollypm.web_api.service import set_project_tracked
+
+    project_a_root = tmp_path / "project_a"
+    project_a_root.mkdir()
+    (project_a_root / ".pollypm").mkdir()
+    project_c_root = tmp_path / "project_c"
+    project_c_root.mkdir()
+    (project_c_root / ".pollypm").mkdir()
+
+    base_dir = workspace / ".pollypm"
+    seed = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "project_a": KnownProject(
+                key="project_a",
+                path=project_a_root,
+                name="Project A",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+            "project_c": KnownProject(
+                key="project_c",
+                path=project_c_root,
+                name="Project C",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(seed, config_path, force=True)
+
+    live_a = load_config(config_path)
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException | None] = [None, None]
+
+    def _api_pause_worker() -> None:
+        try:
+            barrier.wait(timeout=10)
+            set_project_tracked(
+                live_a,
+                "project_a",
+                tracked=False,
+                reason="round-7 cross-writer pause",
+                actor="api",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors[0] = exc
+
+    def _cli_remove_worker() -> None:
+        try:
+            barrier.wait(timeout=10)
+            # CLI path — does its own load_config + mutate +
+            # write_config under the shared RMW lock.
+            remove_project(config_path, "project_c")
+        except BaseException as exc:  # noqa: BLE001
+            errors[1] = exc
+
+    t1 = threading.Thread(target=_api_pause_worker)
+    t2 = threading.Thread(target=_cli_remove_worker)
+    t1.start()
+    t2.start()
+    t1.join(timeout=20)
+    t2.join(timeout=20)
+
+    assert errors == [None, None], f"workers raised: {errors!r}"
+
+    # BOTH mutations must survive on disk — the round-7 invariant.
+    final = load_config(config_path)
+    assert "project_a" in final.projects, (
+        "project_a vanished — CLI remove clobbered the API pause's "
+        "project list. Codex round-7 cross-writer invariant violated."
+    )
+    assert final.projects["project_a"].tracked is False, (
+        "project_a's API pause was reverted by the CLI remove's write — "
+        "Codex round-7 lost-update across API + CLI writers."
+    )
+    assert "project_c" not in final.projects, (
+        "project_c was resurrected by the API pause's write — Codex "
+        "round-7 lost-update across API + CLI writers."
+    )
+
+
+def test_config_rmw_lock_is_reentrant_within_thread(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+) -> None:
+    """Codex round 7: ``config_rmw_lock`` must be re-entrant per thread.
+
+    ``write_config`` ALSO acquires ``config_rmw_lock`` (defence in depth
+    for stray callers that forget to wrap the full RMW). Without per-
+    thread re-entrancy, the API helpers — which wrap the full RMW and
+    THEN call ``write_config`` inside that block — would deadlock the
+    moment ``write_config`` tries to acquire the lock its caller already
+    holds.
+
+    Pin the invariant: nested ``with config_rmw_lock(path):`` inside the
+    same thread completes without deadlock AND a ``write_config`` call
+    inside the outer wrap also returns. A regression in the depth
+    counter would hang this test until the pytest timeout fires.
+    """
+    from pollypm.config import config_rmw_lock
+
+    base_dir = workspace / ".pollypm"
+    seed = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(seed, config_path, force=True)
+
+    with config_rmw_lock(config_path):
+        with config_rmw_lock(config_path):
+            # write_config takes the lock internally; this is the
+            # API-helper pattern in production.
+            fresh = load_config(config_path)
+            fresh.projects["myproj"].tracked = False
+            write_config(fresh, config_path, force=True)
+
+    # Sanity: the write actually landed on disk.
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is False

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -1,0 +1,406 @@
+"""Integration tests for Phase 2 project write endpoints.
+
+Covers ``POST /api/v1/projects/{key}/pause``,
+``POST /api/v1/projects/{key}/resume``,
+``POST /api/v1/projects/{key}/archive``, and
+``POST /api/v1/projects/{key}/init-guide`` per the Phase 2 endpoints
+spec §6.2.
+
+Run with ``pytest --noconftest tests/test_projects_writes_endpoint.py -v
+--timeout=120`` so the per-project conftest (which requires a Postgres
+harness) is skipped — these tests exercise the FastAPI app via
+``TestClient`` and never reach the work-service backing store.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+    write_config,
+)
+from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+from pollypm.web_api import create_app, ensure_token
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — self-contained (do not rely on tests/web_api/conftest.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def config_path(workspace: Path) -> Path:
+    return workspace / ".pollypm" / "pollypm.toml"
+
+
+@pytest.fixture
+def config(workspace: Path, project_root: Path, config_path: Path) -> PollyPMConfig:
+    base_dir = workspace / ".pollypm"
+    cfg = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    # Seed the global TOML on disk so write_config (force=True) can
+    # round-trip without raising FileExistsError on its first read.
+    write_config(cfg, config_path, force=True)
+    return cfg
+
+
+@pytest.fixture
+def token(tmp_path: Path) -> tuple[Path, str]:
+    token_path = tmp_path / "api-token"
+    value, _generated = ensure_token(token_path)
+    return token_path, value
+
+
+@pytest.fixture
+def auth_headers(token: tuple[Path, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token[1]}"}
+
+
+@pytest.fixture
+def app(config: PollyPMConfig, token: tuple[Path, str]):
+    token_path, _value = token
+    return create_app(config=config, token_path=token_path)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Pause
+# ---------------------------------------------------------------------------
+
+
+def test_pause_happy_path_sets_tracked_false(
+    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+) -> None:
+    response = client.post(
+        "/api/v1/projects/myproj/pause",
+        headers=auth_headers,
+        json={"reason": "operator pause"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["key"] == "myproj"
+    assert body["tracked"] is False
+    # Side effect: in-memory config flipped + persisted TOML reflects it.
+    assert config.projects["myproj"].tracked is False
+
+
+def test_pause_is_idempotent_on_already_paused(
+    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+) -> None:
+    """Already-paused → 200 with the current snapshot.
+
+    DECISION: pause is idempotent (returns 200, no churn) per spec §6.3
+    "Pause a paused project. Idempotent; returns 200 with current
+    state, no audit churn." A 409 here would force clients to special-
+    case a 'pause if not already paused' workflow that the cockpit
+    doesn't.
+    """
+    # First call: 200, flips tracked.
+    first = client.post("/api/v1/projects/myproj/pause", headers=auth_headers)
+    assert first.status_code == 200, first.text
+    assert first.json()["tracked"] is False
+
+    # Second call: still 200, tracked stays false.
+    second = client.post("/api/v1/projects/myproj/pause", headers=auth_headers)
+    assert second.status_code == 200, second.text
+    assert second.json()["tracked"] is False
+    assert config.projects["myproj"].tracked is False
+
+
+# ---------------------------------------------------------------------------
+# Resume
+# ---------------------------------------------------------------------------
+
+
+def test_resume_happy_path_sets_tracked_true(
+    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+) -> None:
+    # Start from paused.
+    config.projects["myproj"].tracked = False
+    response = client.post(
+        "/api/v1/projects/myproj/resume", headers=auth_headers, json={}
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["tracked"] is True
+    assert config.projects["myproj"].tracked is True
+
+
+def test_resume_is_idempotent_on_already_tracked(
+    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+) -> None:
+    # Already tracked — call should still 200 and leave state intact.
+    response = client.post(
+        "/api/v1/projects/myproj/resume", headers=auth_headers, json={}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["tracked"] is True
+    assert config.projects["myproj"].tracked is True
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+
+def test_archive_happy_path_removes_from_config(
+    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+) -> None:
+    response = client.post(
+        "/api/v1/projects/myproj/archive",
+        headers=auth_headers,
+        json={"reason": "deprecated"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert "archived" in body["message"].lower()
+    assert "deprecated" in body["message"]
+    assert "myproj" not in config.projects
+
+
+def test_archive_irreversible_resume_after_archive_returns_404(
+    client: TestClient, auth_headers: dict[str, str], config: PollyPMConfig
+) -> None:
+    """Archive is irreversible from the API.
+
+    DECISION: archive removes the project from config (per spec §6.2).
+    Subsequent resume / pause / init-guide calls 404 because the key
+    is gone. Re-onboarding uses the CLI's ``pm add-project``.
+    """
+    archived = client.post(
+        "/api/v1/projects/myproj/archive", headers=auth_headers, json={}
+    )
+    assert archived.status_code == 200
+
+    resume_attempt = client.post(
+        "/api/v1/projects/myproj/resume", headers=auth_headers, json={}
+    )
+    assert resume_attempt.status_code == 404
+    assert resume_attempt.json()["error"]["code"] == "not_found"
+
+    pause_attempt = client.post(
+        "/api/v1/projects/myproj/pause", headers=auth_headers, json={}
+    )
+    assert pause_attempt.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Init-guide
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("role", ["architect", "reviewer", "worker"])
+def test_init_guide_happy_per_role(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    role: str,
+) -> None:
+    response = client.post(
+        "/api/v1/projects/myproj/init-guide",
+        headers=auth_headers,
+        json={"role": role},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["role"] == role
+    assert body["body"]
+    # File actually landed on disk under .pollypm/project-guides/<role>.md.
+    written = Path(body["path"])
+    assert written.exists()
+    assert written.parent == project_root / ".pollypm" / "project-guides"
+
+
+def test_init_guide_unknown_role_returns_422(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    response = client.post(
+        "/api/v1/projects/myproj/init-guide",
+        headers=auth_headers,
+        json={"role": "operator_pm"},
+    )
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+
+
+def test_init_guide_existing_without_force_returns_409(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    # Seed once — succeeds.
+    first = client.post(
+        "/api/v1/projects/myproj/init-guide",
+        headers=auth_headers,
+        json={"role": "architect"},
+    )
+    assert first.status_code == 200
+
+    # Re-send without force — server refuses with 409.
+    second = client.post(
+        "/api/v1/projects/myproj/init-guide",
+        headers=auth_headers,
+        json={"role": "architect"},
+    )
+    assert second.status_code == 409, second.text
+    body = second.json()
+    assert body["error"]["code"] == "conflict"
+    assert body["error"]["hint"] and "force" in body["error"]["hint"].lower()
+
+
+def test_init_guide_existing_with_force_returns_200(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    first = client.post(
+        "/api/v1/projects/myproj/init-guide",
+        headers=auth_headers,
+        json={"role": "worker"},
+    )
+    assert first.status_code == 200
+    first_path = Path(first.json()["path"])
+    # Tamper the on-disk file so we can detect the overwrite.
+    first_path.write_text("# stale guide body\n", encoding="utf-8")
+
+    second = client.post(
+        "/api/v1/projects/myproj/init-guide",
+        headers=auth_headers,
+        json={"role": "worker", "force": True},
+    )
+    assert second.status_code == 200, second.text
+    # Body re-rendered from the built-in template; the stale content is gone.
+    assert "# stale guide body" not in second.json()["body"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting — auth + unknown project
+# ---------------------------------------------------------------------------
+
+
+def test_pause_requires_auth(client: TestClient) -> None:
+    response = client.post("/api/v1/projects/myproj/pause", json={})
+    assert response.status_code == 401
+
+
+def test_archive_requires_auth(client: TestClient) -> None:
+    response = client.post("/api/v1/projects/myproj/archive", json={})
+    assert response.status_code == 401
+
+
+def test_init_guide_requires_auth(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/projects/myproj/init-guide", json={"role": "architect"}
+    )
+    assert response.status_code == 401
+
+
+def test_pause_unknown_project_returns_404(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    response = client.post(
+        "/api/v1/projects/no-such-project/pause",
+        headers=auth_headers,
+        json={},
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_resume_unknown_project_returns_404(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    response = client.post(
+        "/api/v1/projects/no-such-project/resume",
+        headers=auth_headers,
+        json={},
+    )
+    assert response.status_code == 404
+
+
+def test_archive_unknown_project_returns_404(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    response = client.post(
+        "/api/v1/projects/no-such-project/archive",
+        headers=auth_headers,
+        json={},
+    )
+    assert response.status_code == 404
+
+
+def test_init_guide_unknown_project_returns_404(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    response = client.post(
+        "/api/v1/projects/no-such-project/init-guide",
+        headers=auth_headers,
+        json={"role": "architect"},
+    )
+    assert response.status_code == 404

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -1286,3 +1286,282 @@ def test_archive_rolls_back_with_real_load_config_cache(
     get_response = client_.get("/api/v1/projects/myproj", headers=headers)
     assert get_response.status_code == 200
     assert get_response.json()["key"] == "myproj"
+
+
+# ---------------------------------------------------------------------------
+# Codex round 6 on PR #2063 — lost-update race across concurrent API writers.
+#
+# Two clients pausing different projects concurrently each deepcopy the same
+# cached load_config snapshot, mutate their own project, then both write with
+# ``force=True``. The second writer's snapshot still has the first writer's
+# project at the OLD value — so the first write is silently reverted on disk.
+# Per-request reloads (post-#2056) don't help because the race is between two
+# requests, both of which reload at the same moment before either writes.
+#
+# Fix: ``set_project_tracked`` and ``archive_project`` hold an exclusive
+# ``fcntl.flock`` on a sibling lockfile across the entire load → mutate →
+# write → reload sequence. Two writers serialise at the lock; the loser
+# reloads AFTER the winner's mtime updates and merges the winner's mutation
+# forward.
+#
+# These tests call the service helpers directly with a ``threading.Barrier``
+# so the race window is real — exercising via TestClient would funnel through
+# Starlette's threadpool and dilute the reproduction. Pattern borrowed from
+# ``tests/test_pg_notifications_race.py``.
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_pause_on_different_projects_preserves_both(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+    tmp_path: Path,
+) -> None:
+    """Codex round 6: two concurrent pauses on DIFFERENT projects.
+
+    Without ``_config_write_lock`` both threads load the same cached
+    snapshot, deepcopy, flip their own ``tracked``, and write — the
+    second writer's snapshot still has the first writer's project at
+    ``tracked=True``, so the second write silently reverts the first.
+    Under the lock the loser reloads AFTER the winner's write commits;
+    final TOML reflects BOTH ``a.tracked=False`` and ``b.tracked=False``.
+    """
+    import threading
+
+    from pollypm.web_api.service import set_project_tracked
+
+    project_a_root = tmp_path / "project_a"
+    project_a_root.mkdir()
+    (project_a_root / ".pollypm").mkdir()
+    project_b_root = tmp_path / "project_b"
+    project_b_root.mkdir()
+    (project_b_root / ".pollypm").mkdir()
+
+    base_dir = workspace / ".pollypm"
+    seed = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "project_a": KnownProject(
+                key="project_a",
+                path=project_a_root,
+                name="Project A",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+            "project_b": KnownProject(
+                key="project_b",
+                path=project_b_root,
+                name="Project B",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(seed, config_path, force=True)
+
+    # Two distinct live snapshots — one per "request". In production
+    # post-#2056 each request gets its own per-request reload, but
+    # load_config caches on mtime so both still resolve to the same
+    # cached object. The lock has to serialise the RMW regardless.
+    live_a = load_config(config_path)
+    live_b = load_config(config_path)
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException | None] = [None, None]
+
+    def _worker(slot: int, live: PollyPMConfig, key: str) -> None:
+        try:
+            barrier.wait(timeout=10)
+            set_project_tracked(
+                live,
+                key,
+                tracked=False,
+                reason=f"round-6 concurrent {key}",
+                actor="api",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors[slot] = exc
+
+    t1 = threading.Thread(target=_worker, args=(0, live_a, "project_a"))
+    t2 = threading.Thread(target=_worker, args=(1, live_b, "project_b"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=20)
+    t2.join(timeout=20)
+
+    assert errors == [None, None], f"workers raised: {errors!r}"
+
+    # BOTH mutations must survive on disk — the round-6 invariant.
+    final = load_config(config_path)
+    assert final.projects["project_a"].tracked is False, (
+        "project_a's pause was reverted by project_b's write — Codex "
+        "round-6 lost-update race regression. Lock missing on the "
+        "config RMW path."
+    )
+    assert final.projects["project_b"].tracked is False, (
+        "project_b's pause was reverted by project_a's write — Codex "
+        "round-6 lost-update race regression. Lock missing on the "
+        "config RMW path."
+    )
+
+
+def test_concurrent_archive_and_pause_preserves_both(
+    workspace: Path,
+    project_root: Path,
+    config_path: Path,
+    tmp_path: Path,
+) -> None:
+    """Codex round 6 mirror: concurrent archive + pause on different keys.
+
+    Archive of ``project_a`` and pause of ``project_b`` must both
+    survive. Without the lock the loser reverts the winner's mutation
+    (either the archive resurrects, or the pause is reverted to
+    tracked=True). Under the lock both land durably.
+    """
+    import threading
+
+    from pollypm.web_api.service import archive_project, set_project_tracked
+
+    project_a_root = tmp_path / "project_a"
+    project_a_root.mkdir()
+    (project_a_root / ".pollypm").mkdir()
+    project_b_root = tmp_path / "project_b"
+    project_b_root.mkdir()
+    (project_b_root / ".pollypm").mkdir()
+
+    base_dir = workspace / ".pollypm"
+    seed = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace,
+            tmux_session="pollypm-test",
+            workspace_root=workspace,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={},
+        projects={
+            "project_a": KnownProject(
+                key="project_a",
+                path=project_a_root,
+                name="Project A",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+            "project_b": KnownProject(
+                key="project_b",
+                path=project_b_root,
+                name="Project B",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+        config_path=config_path,
+    )
+    write_config(seed, config_path, force=True)
+
+    live_a = load_config(config_path)
+    live_b = load_config(config_path)
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException | None] = [None, None]
+
+    def _archive_worker() -> None:
+        try:
+            barrier.wait(timeout=10)
+            archive_project(
+                live_a,
+                "project_a",
+                reason="round-6 concurrent archive",
+                actor="api",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors[0] = exc
+
+    def _pause_worker() -> None:
+        try:
+            barrier.wait(timeout=10)
+            set_project_tracked(
+                live_b,
+                "project_b",
+                tracked=False,
+                reason="round-6 concurrent pause",
+                actor="api",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors[1] = exc
+
+    t1 = threading.Thread(target=_archive_worker)
+    t2 = threading.Thread(target=_pause_worker)
+    t1.start()
+    t2.start()
+    t1.join(timeout=20)
+    t2.join(timeout=20)
+
+    assert errors == [None, None], f"workers raised: {errors!r}"
+
+    # BOTH mutations must survive on disk.
+    final = load_config(config_path)
+    assert "project_a" not in final.projects, (
+        "project_a's archive was reverted by project_b's pause — Codex "
+        "round-6 lost-update race regression on the archive path."
+    )
+    assert "project_b" in final.projects, (
+        "project_b was clobbered by the archive write — concurrent-edit "
+        "preservation regression."
+    )
+    assert final.projects["project_b"].tracked is False, (
+        "project_b's pause was reverted by project_a's archive — Codex "
+        "round-6 lost-update race regression."
+    )

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,6 +1,9 @@
+import threading
 from pathlib import Path
 
-from pollypm.config import write_config
+import typer
+
+from pollypm.config import load_config, write_config
 from pollypm.models import (
     AccountConfig,
     ProjectKind,
@@ -291,6 +294,115 @@ def test_create_worker_session_keeps_legacy_selection_when_fallback_provider_has
 
     assert session.provider is ProviderKind.CLAUDE
     assert session.args == ["--dangerously-skip-permissions"]
+
+
+def test_concurrent_create_worker_session_for_same_role_no_orphans(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Two concurrent ``pm worker-start`` calls for the same project/role
+    must NOT both succeed with the same session_key (round-11 race; #2063).
+
+    Reproduction modelled on Codex's: a ``threading.Barrier(2)`` is wired
+    into a patched ``ensure_worktree`` so on the buggy code path (where
+    the duplicate check happens BEFORE the lock) both threads reach the
+    commit window simultaneously after passing the check, race the
+    write, and the second writer clobbers the first — yielding two
+    "successes" with the same session_key but only one session in the
+    persisted config (the other worktree orphaned).
+
+    With the fix, the uniqueness check happens INSIDE the lock, so the
+    loser sees the winner's session and raises ``typer.BadParameter``
+    before calling ``ensure_worktree``. Only the winner's thread ever
+    enters the patched ``ensure_worktree``; the barrier therefore
+    short-circuits via timeout, the winner proceeds, and the loser
+    surfaces a clear duplicate error.
+
+    Accept either outcome that preserves the invariant:
+      (a) one success + one clear duplicate error; or
+      (b) two distinct session keys (no overwrite).
+    Reject: two successes with the same key, or any orphan.
+    """
+    _config_data, config_path = _config(tmp_path)
+    monkeypatch.setattr("pollypm.workers.detect_logged_in", lambda account: True)
+
+    barrier = threading.Barrier(2, timeout=5.0)
+    worktree_counter = {"n": 0}
+    worktree_lock = threading.Lock()
+
+    def fake_ensure_worktree(*args, **kwargs):
+        # Best-effort barrier: on the buggy code (check outside lock)
+        # both threads reach here and race the commit. On the fixed
+        # code only the winner enters this function; the loser is
+        # already raising under the lock. A timeout-on-broken-barrier
+        # lets the single thread keep going.
+        try:
+            barrier.wait()
+        except threading.BrokenBarrierError:
+            pass
+        with worktree_lock:
+            worktree_counter["n"] += 1
+            idx = worktree_counter["n"]
+        session = kwargs.get("session_name") or args[0] if args else "wt"
+        path = tmp_path / f"worktree-{session}-{idx}"
+        path.mkdir(parents=True, exist_ok=True)
+        return type("Worktree", (), {"path": str(path)})()
+
+    monkeypatch.setattr("pollypm.workers.ensure_worktree", fake_ensure_worktree)
+
+    results: list[str] = []
+    errors: list[BaseException] = []
+    results_lock = threading.Lock()
+
+    def run() -> None:
+        try:
+            session = create_worker_session(
+                config_path,
+                project_key="pollypm",
+                prompt=None,
+                role="worker",
+            )
+            with results_lock:
+                results.append(session.name)
+        except typer.BadParameter as exc:
+            with results_lock:
+                errors.append(exc)
+
+    t1 = threading.Thread(target=run)
+    t2 = threading.Thread(target=run)
+    t1.start()
+    t2.start()
+    t1.join(timeout=15)
+    t2.join(timeout=15)
+    assert not t1.is_alive() and not t2.is_alive(), "worker-start threads deadlocked"
+
+    # Together the two threads must produce exactly two outcomes.
+    assert len(results) + len(errors) == 2, (
+        f"Expected exactly 2 outcomes, got results={results} errors={errors}"
+    )
+
+    # No-orphan invariant: either two distinct keys, or one success + one
+    # clear duplicate error. NEVER two successes with the same key.
+    if len(results) == 2:
+        assert results[0] != results[1], (
+            f"Both threads returned the same session_key {results[0]!r} — "
+            "round-11 race regression (orphan worktree)."
+        )
+    else:
+        assert len(results) == 1 and len(errors) == 1, (
+            f"Expected 1 success + 1 duplicate error, got results={results} "
+            f"errors={[str(e) for e in errors]}"
+        )
+
+    # Every successful session_key MUST be present in the persisted
+    # config (no orphan: a worker that the caller was told succeeded but
+    # that the next ``load_config`` doesn't know about).
+    final = load_config(config_path)
+    final_sessions = set(final.sessions)
+    for key in results:
+        assert key in final_sessions, (
+            f"session_key {key!r} returned successfully but missing from "
+            f"persisted config sessions {sorted(final_sessions)} — orphan."
+        )
 
 
 def test_worker_prompt_requires_core_identity() -> None:

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -405,6 +405,93 @@ def test_concurrent_create_worker_session_for_same_role_no_orphans(
         )
 
 
+def test_create_worker_session_revalidates_account_under_lock(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Account removed between pre-lock validation and locked commit must
+    fail safely without persisting an invalid session (#2063 round 12).
+
+    Codex round-12 reproduction: the pre-lock path resolved the worker
+    ``account`` from the pre-lock config snapshot and committed it
+    inside the lock without re-validating against ``fresh``. An account
+    edit landing between pre-lock and commit produced a persisted
+    session whose ``account`` was missing from ``fresh.accounts`` —
+    ``load_config`` then raised ``ValueError: Session ... references
+    unknown account ...`` on the next read.
+
+    Repro shape: patch ``suggest_worker_prompt`` (the legacy pre-lock
+    helper) to remove the auto-selected worker account from disk before
+    returning, then call ``create_worker_session``. Pre-fix the call
+    succeeds and ``load_config`` raises on the next read. Post-fix the
+    locked block re-validates the account against ``fresh`` and raises
+    ``typer.BadParameter`` BEFORE writing, so the persisted config
+    stays valid.
+    """
+    config, config_path = _config(tmp_path)
+    monkeypatch.setattr("pollypm.workers.detect_logged_in", lambda account: True)
+    monkeypatch.setattr(
+        "pollypm.workers.ensure_worktree",
+        lambda *args, **kwargs: type(
+            "Worktree",
+            (),
+            {"path": str(tmp_path / "revalidate-worktree")},
+        )(),
+    )
+
+    real_suggest = suggest_worker_prompt
+    removed = {"done": False}
+
+    def removing_suggest(config_path_arg, *, project_key):
+        # Drop the explicitly-requested worker account between pre-lock
+        # validation and the locked commit (Codex's exact reproduction
+        # shape). The pre-lock path historically resolved the account
+        # against the pre-lock snapshot and committed inside the lock;
+        # once we drop the account from disk, the locked block's
+        # ``fresh = load_config(...)`` MUST observe the absence and
+        # refuse to persist an invalid session.
+        if not removed["done"]:
+            current = load_config(config_path_arg)
+            current.accounts.pop("claude_worker", None)
+            write_config(current, config_path_arg, force=True)
+            removed["done"] = True
+        return real_suggest(config_path_arg, project_key=project_key)
+
+    monkeypatch.setattr("pollypm.workers.suggest_worker_prompt", removing_suggest)
+
+    raised: BaseException | None = None
+    try:
+        create_worker_session(
+            config_path,
+            project_key="pollypm",
+            prompt=None,
+            account_name="claude_worker",
+            role="worker",
+        )
+    except typer.BadParameter as exc:
+        raised = exc
+
+    assert raised is not None, (
+        "create_worker_session should have raised typer.BadParameter when "
+        "the requested account was removed between pre-lock validation "
+        "and the locked commit — #2063 round-12 regression."
+    )
+    assert "claude_worker" in str(raised) or "Unknown account" in str(raised), (
+        f"BadParameter should name the missing account, got: {raised!r}"
+    )
+
+    # Critical: load_config MUST succeed (no invalid session persisted).
+    # Pre-fix this raised ``ValueError: Session 'worker_pollypm' references
+    # unknown account 'claude_worker'``.
+    final = load_config(config_path)
+    for session in final.sessions.values():
+        assert session.account in final.accounts, (
+            f"persisted session {session.name!r} references unknown account "
+            f"{session.account!r} — #2063 round-12 regression (the locked "
+            f"commit wrote a SessionConfig whose account was missing from "
+            f"the locked snapshot)."
+        )
+
+
 def test_worker_prompt_requires_core_identity() -> None:
     prompt = worker_prompt()
 

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -262,6 +262,76 @@ def test_inbox_archive_reason_documented_as_post_transition() -> None:
     )
 
 
+def test_archive_documents_409_session_reference_conflict() -> None:
+    """Codex round 4 on #2063: archive's 409 must be pinned in BOTH surfaces.
+
+    ``archive_project`` maps an enabled-session reference to ``409
+    conflict`` (mirrors the CLI's ``pm projects remove`` guard) but the
+    static contract and the implementation's auto-generated OpenAPI
+    initially only documented 401/404/503. Generated clients would
+    therefore branch on an unexpected response and crash on the
+    user-visible "still referenced by ..." path.
+
+    Pin coverage so future drift trips CI:
+
+    * ``docs/api/openapi.yaml`` — ``POST /projects/{key}/archive``
+      must list a ``409`` response.
+    * The auto-generated FastAPI OpenAPI doc must also list ``409``
+      under ``/api/v1/projects/{key}/archive``.
+    """
+    # Static contract.
+    contract = _load_contract()
+    archive_post = contract["paths"]["/projects/{key}/archive"]["post"]
+    assert "409" in archive_post["responses"], (
+        "docs/api/openapi.yaml POST /projects/{key}/archive is missing a "
+        "409 response — enabled-session reference conflicts are user-visible "
+        "and must be documented (Codex round 4 on #2063)."
+    )
+
+    # Implementation-side doc.
+    from pollypm.config import (
+        AccountConfig,
+        MemorySettings,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectSettings,
+    )
+    from pollypm.models import ProviderKind, RuntimeKind
+    from pollypm.web_api import create_app
+
+    base = Path(__file__).resolve().parent
+    config = PollyPMConfig(
+        project=ProjectSettings(name="P", root_dir=base, tmux_session="t",
+                                workspace_root=base, base_dir=base / ".pollypm",
+                                logs_dir=base / ".pollypm/logs",
+                                snapshots_dir=base / ".pollypm/snapshots",
+                                state_db=base / ".pollypm/state.db"),
+        pollypm=PollyPMSettings(controller_account="codex_primary",
+                                open_permissions_by_default=False,
+                                failover_enabled=False,
+                                failover_accounts=[],
+                                heartbeat_backend="local",
+                                scheduler_backend="inline",
+                                lease_timeout_minutes=30),
+        accounts={"codex_primary": AccountConfig(
+            name="codex_primary", provider=ProviderKind.CODEX,
+            email="codex@example.com", runtime=RuntimeKind.LOCAL,
+            home=base / ".pollypm/homes/codex_primary",
+        )},
+        sessions={},
+        projects={},
+        memory=MemorySettings(backend="file"),
+    )
+    app = create_app(config=config, token_path=base / "tmp-token")
+    raw = app.openapi()
+    impl_archive = raw["paths"]["/api/v1/projects/{key}/archive"]["post"]
+    assert "409" in impl_archive["responses"], (
+        "Implementation OpenAPI for POST /api/v1/projects/{key}/archive is "
+        "missing a 409 response — keep the route's ``responses=`` map in "
+        "sync with the static contract (Codex round 4 on #2063)."
+    )
+
+
 def test_implementation_openapi_validates_as_31() -> None:
     """The auto-generated doc must itself be a valid OpenAPI 3.x doc."""
     # Re-read straight off the FastAPI app so we don't depend on the


### PR DESCRIPTION
## Summary

Phase 2 endpoints spec §6.2 — adds the four POST verbs that drive project lifecycle from a non-tmux client:

- `POST /api/v1/projects/{key}/pause`  — body `{reason?}`; flips `tracked=false`. Idempotent on already-paused.
- `POST /api/v1/projects/{key}/resume` — idempotent on already-tracked.
- `POST /api/v1/projects/{key}/archive` — body `{reason?}`; removes from `config.projects` (source data on disk untouched). Irreversible from the API.
- `POST /api/v1/projects/{key}/init-guide` — body `{role, force?}`; wraps `pollypm.project_guides.init_project_guide` for `architect` / `reviewer` / `worker`.

Mutations go through one helper each (`set_project_tracked`, `archive_project`, `init_project_guide_for_role`) in `web_api.service` so the TOML-write side stays a single writer surface (same pattern as the cockpit's `load_config` → mutate → `write_config`).

OpenAPI: contract + auto-generated doc both validate as OpenAPI 3.1.

## Decisions

- **Pause is idempotent (200), not 409 on already-paused.** Matches spec §6.3 wording and avoids forcing every client to special-case a "pause if not already paused" workflow. Second call short-circuits before the disk write to avoid TOML mtime churn.
- **Archive is removal-style, not flag-style.** Spec §6.2 says "Removes from config; source data on disk untouched." `KnownProject` has no `archived` field today, so removing the key is the lossless path. Subsequent `pause` / `resume` / `init-guide` on an archived key 404. Re-onboarding uses `pm add-project` (CLI-only, per spec).
- **`reason` is accepted but not persisted** on pause/archive. Audit emission is open question §13.1 — when it lands the string flows into the `api.mutation` row's `metadata.reason`.
- **Init-guide unknown role → 422, existing-without-force → 409.** Matches the cockpit `--force` UX; spec §6 maps unknown enum values to 422.

## Spec gaps surfaced

- Spec §6.2 lists archive body as `{confirm: bool}` returning `ActionResult`; this PR follows the issue task description (`{reason?}` body) which is closer to what cockpit Pause/Archive emits. Worth aligning §6.2 once the bulk audit / confirm-token policy lands.
- Spec doesn't say which `pollypm.toml` path the API writes to under concurrent edits. This PR reads `PollyPMConfig.config_path` (the stamp from PR #2026); concurrent edits from a parallel cockpit lose to last-writer-wins. A follow-up `If-Match` on `state.epoch` is the spec's §2.6 answer; deferred.

## Test plan

- [x] `pytest --noconftest tests/test_projects_writes_endpoint.py -v` — 19 cases, all green
- [x] `pytest tests/web_api/test_openapi_conformance.py -v` — 5 cases, all green
- [x] `pytest tests/web_api/test_endpoints.py -k project -v` — 10 cases, all green (no regressions)
- [ ] User smoke per spec §15 Q5: `curl -X POST .../pause` flips cockpit rail; archive removes from rail; init-guide writes file under `<project>/.pollypm/project-guides/`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>