### PR TITLE
feat(web-ui): v0 web interface — vanilla HTML+JS, cookie auth, Tailscale trust

### DIFF
--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -55,11 +55,26 @@ API directly instead.
 The chat API reuses PollyPM's existing daemon-wide bearer-token auth.
 
 - Token lives at `~/.pollypm/api-token` (created on first `pm up`).
-- Pass it via `Authorization: Bearer <token>` on every request.
-- The daemon listens on `127.0.0.1:8765` by default. For remote access,
-  use `pm serve --allow-remote --host 0.0.0.0`. Without `--allow-remote`,
-  non-loopback binds are rejected. Defense in depth: even on Tailscale,
-  authenticated devices must still present the bearer token.
+- The default daemon listener depends on Tailscale detection (see
+  `docs/web-api-spec.md` §3 for the full bind matrix): `pm serve`
+  binds the auto-detected tailnet IPv4 when `tailscale ip -4`
+  succeeds, otherwise it falls back to `127.0.0.1:8765`.
+- In `tailnet_trust_enabled=True` mode (auto-selected when the daemon
+  bound to a verified Tailscale IPv4), tailnet peers can call the API
+  **without** a bearer token. Loopback callers get a
+  `pollypm-session` cookie via `GET /ui/` for browser convenience.
+  The `Authorization: Bearer <token>` header is still accepted in
+  every mode.
+- In `tailnet_trust_enabled=False` mode (loopback default, or any
+  explicit `--host` override that isn't the detected Tailscale IPv4,
+  including `--host 0.0.0.0 --allow-remote`), every request needs an
+  `Authorization: Bearer <token>` header or the `pollypm-session`
+  cookie (issued from `GET /ui/` for loopback callers or for any
+  caller that already presents a valid bearer header).
+- The `/ui/` cookie bootstrap is gated to: loopback callers, verified
+  Tailscale peers when trust is enabled, or callers that already
+  present a valid bearer header. CGNAT-source peers in untrusted
+  mode get 401 and no `Set-Cookie`.
 
 The chat API does **not** use the per-session `auth_token` field on
 `SessionConfig`. That token is for outbound PollyPM → agent control

--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -135,8 +135,11 @@ actively streaming output (see §5.3). Override with
 ## 3. Endpoint reference
 
 All endpoints are mounted under `/api/v1/chat/` on the PollyPM web API
-(`src/pollypm/web_api/app.py`). All responses are JSON. All endpoints
-require `Authorization: Bearer <token>`; absent or wrong token returns
+(`src/pollypm/web_api/app.py`). All responses are JSON. Chat endpoints
+accept the same 3 auth modes as the rest of `/api/v1` (bearer header,
+`pollypm-session` cookie, or credential-free tailnet peer in
+`tailnet_trust` mode). See [`web-api-spec.md`](web-api-spec.md) §3
+Authentication for details. Absent or wrong credentials return
 `401 Unauthorized` (handled by the daemon-wide auth middleware, not by
 the chat router).
 

--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -66,11 +66,14 @@ The chat API reuses PollyPM's existing daemon-wide bearer-token auth.
   The `Authorization: Bearer <token>` header is still accepted in
   every mode.
 - In `tailnet_trust_enabled=False` mode (loopback default, or any
-  explicit `--host` override that isn't the detected Tailscale IPv4,
-  including `--host 0.0.0.0 --allow-remote`), every request needs an
+  explicit `--host` override — unconditionally, even when the address
+  matches the detected Tailscale IPv4, including
+  `--host 0.0.0.0 --allow-remote`), every request needs an
   `Authorization: Bearer <token>` header or the `pollypm-session`
   cookie (issued from `GET /ui/` for loopback callers or for any
-  caller that already presents a valid bearer header).
+  caller that already presents a valid bearer header). The
+  auto-detect path is the only way to enable
+  `tailnet_trust_enabled=True`.
 - The `/ui/` cookie bootstrap is gated to: loopback callers, verified
   Tailscale peers when trust is enabled, or callers that already
   present a valid bearer header. CGNAT-source peers in untrusted

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -20,6 +20,31 @@ info:
 
     The API is single-user / personal-use. There is no multi-tenant
     auth in v1.
+
+    ## Authentication
+
+    Three credential modes are accepted (see
+    [`docs/web-api-spec.md`](../web-api-spec.md) §3 and
+    [`docs/web-ui-2065-security-spec.md`](../web-ui-2065-security-spec.md)
+    for the full rationale):
+
+    1. **Bearer header** — `Authorization: Bearer <token>` against
+       `~/.pollypm/api-token`. Always accepted; canonical mode for
+       non-browser clients (cockpit CLI, scripts, curl). Modeled here as
+       `bearerAuth`.
+    2. **Session cookie** — `pollypm-session=<token>`, minted by
+       `GET /ui/` only when the caller is a loopback peer, a verified
+       tailnet peer (with `tailnet_trust_enabled=True`), or already
+       presented a valid bearer header. Modeled here as `cookieAuth`.
+    3. **Credential-free tailnet peer** — accepted only when the server
+       was constructed with `tailnet_trust_enabled=True`, which `pm
+       serve` auto-sets when `detect_tailscale_ip()` returns a verified
+       Tailscale IPv4 and uvicorn binds that interface. Modeled here as
+       the empty (no-credential) entry in the global `security` list.
+
+    Default `pm serve` auto-binds the detected Tailscale IPv4 when
+    available; otherwise it binds loopback (`127.0.0.1`) only. LAN
+    exposure is intentionally unsupported in v0.
   contact:
     name: PollyPM project
     url: https://github.com/swhmm/pollypm/issues
@@ -29,17 +54,30 @@ info:
 
 servers:
   - url: http://{host}:{port}/api/v1
-    description: Local pm serve instance (loopback by default)
+    description: |
+      Local `pm serve` instance. Auto-binds the detected Tailscale IPv4
+      when available, otherwise loopback (`127.0.0.1`). LAN binds are
+      not a supported v0 configuration.
     variables:
       host:
         default: 127.0.0.1
-        description: Host pm serve is bound to.
+        description: |
+          Host pm serve is bound to. Loopback (`127.0.0.1`) when no
+          Tailscale interface is detected; otherwise the verified
+          tailnet IPv4 returned by `detect_tailscale_ip()`.
       port:
         default: "8765"
         description: Port pm serve is listening on.
 
+# Each entry is an independent way to satisfy auth. The empty `{}`
+# entry means "no credential required" — used by the credential-free
+# tailnet-peer mode, which the server enforces at runtime (only honored
+# when `tailnet_trust_enabled=True`). See the top-level Authentication
+# section for the full credential model.
 security:
   - bearerAuth: []
+  - cookieAuth: []
+  - {}
 
 tags:
   - name: Health
@@ -2179,8 +2217,20 @@ components:
       scheme: bearer
       bearerFormat: opaque
       description: |
-        Token from `~/.pollypm/api-token`. Generated on first
-        `pm serve` startup; rotated via `pm api regen-token`.
+        Bearer token from `~/.pollypm/api-token`. Generated on first
+        `pm serve` startup; rotated via `pm api regen-token`. Always
+        accepted. See `docs/web-api-spec.md` §3.
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: pollypm-session
+      description: |
+        Session cookie minted by `GET /ui/` for loopback peers,
+        verified tailnet peers (when `tailnet_trust_enabled=True`), or
+        callers presenting a valid bearer header. The cookie value is
+        the same on-disk token as `bearerAuth`; comparison is
+        constant-time. LAN clients receive HTML without `Set-Cookie`
+        and 401 on the first API call. See `docs/web-api-spec.md` §3.
 
   parameters:
     ProjectKey:

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -149,9 +149,19 @@ into proxy logs / browser history for routine traffic. See `auth.py`
 
 - Single-user, personal-use. No multi-tenant separation.
 - The token is a simple shared secret; loss equals full access.
-- TLS is the operator's responsibility — `pm serve` defaults to
-  binding `127.0.0.1` and refuses non-loopback binds without
-  `--allow-remote`.
+- TLS is the operator's responsibility. `pm serve` auto-detects
+  Tailscale on startup: if `tailscale ip -4` returns an IPv4 the
+  daemon binds that tailnet interface (tailnet mode,
+  `tailnet_trust_enabled=True`); otherwise it falls back to
+  `127.0.0.1` (loopback mode, `tailnet_trust_enabled=False`). Pass
+  `--host <addr>` to override the detected bind; the override stays
+  in untrusted mode (`tailnet_trust_enabled=False`, every request
+  needs a bearer token or session cookie) unless the explicit host
+  matches the detected Tailscale IPv4. `--allow-remote` is no longer
+  required for the auto-detected tailnet bind, but is still required
+  for explicit non-loopback overrides such as
+  `--host 0.0.0.0`. The legacy `--tailscale` flag is a no-op kept for
+  back-compat; auto-detection covers the same path.
 - Out of scope: OAuth, JWT, role-based access, audit logging of API
   callers (the frontend developer is the same human as the cockpit
   user).

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -116,13 +116,35 @@ or hosted Postgres).
 
 ## 3. Authentication
 
-### Bearer token
+### Credential modes
 
-Every request (except `GET /api/v1/health`) must carry:
+Every request (except `GET /api/v1/health`) must satisfy one of the
+following three credential modes. They are tried in order by the daemon's
+auth dependency (`src/pollypm/web_api/auth.py`):
 
-```
-Authorization: Bearer <token>
-```
+1. **Bearer header** — `Authorization: Bearer <token>` matching the
+   on-disk token at `~/.pollypm/api-token` (mode 0600). Always accepted.
+   This is the canonical mode for non-browser clients (cockpit CLI,
+   scripts, curl).
+2. **`pollypm-session` cookie** — minted by `GET /ui/` and then sent
+   automatically by the browser on every subsequent `/api/v1/*` request.
+   The cookie value is the same on-disk token; it is compared with the
+   same constant-time check as the header. `GET /ui/` only issues the
+   cookie when the caller is a loopback peer (`127.0.0.1` / `::1`), a
+   verified tailnet peer (CGNAT-range source *and* the app was built with
+   `tailnet_trust_enabled=True`), or already presented a valid bearer
+   header. LAN clients receive the HTML without `Set-Cookie` and get
+   `401` on their first API call.
+3. **Credential-free tailnet peer** — accepted *only* when the app was
+   constructed with `tailnet_trust_enabled=True`, which `pm serve` sets
+   automatically when `detect_tailscale_ip()` returns a verified
+   Tailscale IPv4 and uvicorn binds that interface. Without that flag
+   (loopback bind, explicit `--host`, `--allow-remote`), CGNAT-source
+   peers fall back to bearer or cookie like any other client.
+
+See [`docs/web-ui-2065-security-spec.md`](web-ui-2065-security-spec.md)
+for the ADR-level decision rationale (LAN exposure, CGNAT spoofing,
+credential-issuance gating).
 
 ### SSE escape hatch (`?token=`)
 

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -176,12 +176,14 @@ into proxy logs / browser history for routine traffic. See `auth.py`
   daemon binds that tailnet interface (tailnet mode,
   `tailnet_trust_enabled=True`); otherwise it falls back to
   `127.0.0.1` (loopback mode, `tailnet_trust_enabled=False`). Pass
-  `--host <addr>` to override the detected bind; the override stays
-  in untrusted mode (`tailnet_trust_enabled=False`, every request
-  needs a bearer token or session cookie) unless the explicit host
-  matches the detected Tailscale IPv4. `--allow-remote` is no longer
-  required for the auto-detected tailnet bind, but is still required
-  for explicit non-loopback overrides such as
+  `--host <addr>` to override the detected bind; an explicit
+  `--host` **always** stays in untrusted mode
+  (`tailnet_trust_enabled=False`, every request needs a bearer token
+  or session cookie), unconditionally — even if the address matches
+  the detected Tailscale IPv4. The auto-detect path is the only way
+  to enable `tailnet_trust_enabled=True`. `--allow-remote` is no
+  longer required for the auto-detected tailnet bind, but is still
+  required for explicit non-loopback overrides such as
   `--host 0.0.0.0`. The legacy `--tailscale` flag is a no-op kept for
   back-compat; auto-detection covers the same path.
 - Out of scope: OAuth, JWT, role-based access, audit logging of API

--- a/docs/web-ui-2065-security-spec.md
+++ b/docs/web-ui-2065-security-spec.md
@@ -47,12 +47,15 @@ body, roughly lines 244–290).
   unsupported in v0.
 - **`--host <addr>` explicit override:** honored verbatim, skipping
   detection. A non-loopback host still requires `--allow-remote` (spec §3).
-  `tailnet_trust` stays `False` *unless* the explicit host string is exactly
-  equal to the value `detect_tailscale_ip()` would have returned — i.e. the
-  operator manually typed the same tailnet IPv4 the detector verified. Any
-  other explicit host (loopback, `0.0.0.0`, a LAN address) leaves
-  `tailnet_trust=False` so CGNAT-source peers do NOT get credential-free
-  access on an unverified bind.
+  `tailnet_trust` is **always** `False` on this path, unconditionally —
+  even if the explicit host string happens to match the IPv4
+  `detect_tailscale_ip()` would have returned. Opting into credential-free
+  CGNAT access is a choice the auto-detect path makes (it ran the verifier
+  itself); the explicit-override path does not inherit it. Operators who
+  want the trust gate must omit `--host` and let the auto path bind the
+  tailnet interface. Every explicit-bind caller (loopback, tailnet IPv4,
+  `0.0.0.0`, or any LAN address) therefore needs a bearer token or session
+  cookie.
 - **`--tailscale` flag:** deprecated no-op kept for back-compat. The
   auto-detection it used to gate is now unconditional.
 

--- a/docs/web-ui-2065-security-spec.md
+++ b/docs/web-ui-2065-security-spec.md
@@ -1,185 +1,143 @@
-# PR #2065 Web UI — Security Fix Spec
-
-**Status:** Awaiting Sam's sign-off before implementation dispatch.
-**Date:** 2026-05-22
-**Scope:** Address the 4 Codex P0s on PR #2065 without re-litigating the v0 UI design.
-
-The goal of this spec is to get an answer from you on three design choices, then dispatch one fix agent with a clear contract. No autonomous security implementation.
-
----
-
-## TL;DR — the three decisions you need to make
-
-1. **Cookie issuance model** (P0 #1): how does `/ui/` decide whether the caller is a trusted local operator before handing them the bearer-as-cookie?
-2. **Tailscale interface binding** (P0 #3): should `--tailscale` bind ONLY to the tailnet interface address (losing loopback unless you re-add it), or bind both?
-3. **Stack ordering** (P0 #4): merge #2057 first then rebase #2065, vs cherry-pick the dashboard route onto the #2065 branch.
-
-Recommendations below; the rest of this doc explains the bugs and fix options.
-
----
-
-## The 4 P0s, restated from code
-
-### P0 #1 — `/ui/` mints a cookie for any caller, unauthenticated
-
-`src/pollypm/web_api/app.py` lines 250–278 (on `feat/web-ui-v0`):
-
-```python
-@app.get("/ui/", include_in_schema=False)
-def _ui_index() -> Response:
-    resolved_token_path = token_path or DEFAULT_TOKEN_PATH
-    token_value = load_token(resolved_token_path)
-    response = FileResponse(index_path, media_type="text/html")
-    if token_value:
-        response.set_cookie(
-            key=SESSION_COOKIE_NAME,
-            value=token_value,
-            httponly=True,
-            samesite="lax",
-            secure=False,
-            ...
-        )
-    return response
-```
-
-There is NO auth check before `set_cookie`. Anyone who can reach `/ui/` over the network — LAN device, spoofed CGNAT source IP, anyone on a misconfigured deploy — receives the bearer token in a `Set-Cookie` header and is thereafter fully authenticated for every API call.
-
-This is credential issuance from a public route.
-
-### P0 #2 — `100.64.0.0/10` (CGNAT) trust without verifying tailnet membership
-
-`src/pollypm/web_api/auth.py` line 47 + `is_tailscale_ip()`:
-
-```python
-_TAILSCALE_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
-
-def is_tailscale_ip(host: str | None) -> bool:
-    addr = ipaddress.ip_address(host)
-    return addr in _TAILSCALE_CGNAT_NET
-```
-
-Used in `make_bearer_auth_dependency` to grant unauthenticated access to any caller whose `request.client.host` falls in the CGNAT range.
-
-The CGNAT range is RFC 6598 shared address space. Tailscale is one user of it but not the only one. A non-Tailscale device on a LAN that uses 100.64/10 internally, or a packet crafted with a spoofed source IP if the kernel allows it through, would be trusted as a tailnet peer.
-
-CGNAT range membership is necessary but not sufficient proof of tailnet membership.
-
-### P0 #3 — `--tailscale` binds 0.0.0.0
-
-`src/pollypm/cli_features/web_api.py` lines 200–211:
-
-```python
-if tailscale:
-    tailscale_ip = detect_tailscale_ip()
-    ...
-    else:
-        host = "0.0.0.0"
-        allow_remote = True
-```
-
-The intent of `--tailscale` is "expose this only to my tailnet." The implementation binds every interface, then leans on the CGNAT auth check (P0 #2) to gate. With CGNAT trust broken, every interface is a real attack surface.
-
-### P0 #4 — UI calls `/api/v1/dashboard` not on the branch base
-
-`src/pollypm/web_api/ui/app.js` line ~209 calls `GET /api/v1/dashboard`. That route is not on `origin/main` — it lives in PR #2057. Stacked-PR hazard: if #2065 merges before #2057, the UI 404s on every right-rail poll.
-
----
-
-## Fix proposals
-
-### Fix #1 (cookie issuance) — proposed: gate on auth path BEFORE cookie set
-
-The cookie is convenience credential; the bearer is the master credential. The boot path that issues the cookie should require ONE of these signals first:
-
-- **(a) Authorization header present and valid** → set the cookie, return the page.
-- **(b) Client IP is loopback (127.0.0.1, ::1)** → set the cookie, return the page. Local operator on the Mac itself.
-- **(c) Client IP is verified Tailscale peer** (per fix #2 + #3 below) → set the cookie, return the page. Operator hitting `/ui/` from their phone over Tailscale.
-- **(d) None of the above** → serve the HTML, do NOT set the cookie. SPA will hit `/api/v1/...` and get 401, and surfaces "paste your bearer token to bootstrap" UX.
-
-Implementation note: `app.js` already needs a "no cookie yet" fallback — the SPA currently assumes the cookie is always set. We add a small bootstrap form that, on 401, prompts for the bearer token and POSTs it to a new `POST /ui/bootstrap` endpoint that sets the cookie after validating. (Or: skip the bootstrap UI in v0 and document "ssh to the Mac, hit /ui/ once, copy the cookie" — uglier but smaller diff.)
-
-**Decision needed from you:** which fallback UX for path (d)?
-- (d-i) Build a small `<input>` paste box in the SPA that exchanges bearer for cookie via `POST /ui/bootstrap`. Most polished. ~50 LOC delta.
-- (d-ii) Document "first cookie must be obtained from a loopback or Tailscale visit; LAN devices not supported in v0." Smallest diff; matches Tailscale-only deployment intent.
-
-Recommendation: **d-ii**. Personal-use, Tailscale-first deployment, no need to support LAN at all. If you ever expose this on the public internet, you'll be revisiting this anyway.
-
-### Fix #2 (CGNAT verification) — proposed: bind-to-interface enforces tailnet at OS layer
-
-Instead of comparing `request.client.host` against a CGNAT range string (which a spoofed source IP defeats), bind uvicorn to the detected Tailscale IP only. The Linux/Darwin routing table then enforces that ONLY packets arriving on `tailscale0` (or its peers) can reach the listening socket. Source-IP spoof from another interface is dropped before the application sees it.
-
-Pair with: keep `is_tailscale_ip()` as a defense-in-depth check (in case a misconfigured deploy binds wider), but it's no longer load-bearing.
-
-Optional stronger version: also query `tailscale status --json` to fetch peer IPs and assert `request.client.host` matches a known peer. Higher friction (requires tailscale CLI in PATH, adds latency to every auth check). Skip unless you want belt-and-suspenders.
-
-Recommendation: **bind-to-interface only**, keep the CGNAT check as a sanity filter, skip peer enumeration. Simpler, OS-enforced, no new runtime dependency.
-
-### Fix #3 (`--tailscale` bind) — proposed: bind to Tailscale IP, not 0.0.0.0
-
-`src/pollypm/cli_features/web_api.py:208`: change
-
-```python
-host = "0.0.0.0"
-```
-
-to
-
-```python
-host = tailscale_ip   # e.g. "100.x.y.z"
-```
-
-Implications:
-- Loopback access (`http://127.0.0.1:8765/ui/`) NO LONGER WORKS when started with `--tailscale`. The operator accesses via `http://<tailscale-ip>:8765/ui/` from any tailnet device including the Mac itself.
-- The OS routing table guarantees only packets arriving on `tailscale0` reach the socket.
-- Combined with Fix #2, `is_tailscale_ip()` becomes a sanity check on top of OS enforcement.
-
-**Decision needed from you:** is losing loopback-while-tailscale acceptable, or do you want both?
-
-- (a) **Tailscale IP only.** Loopback unavailable when `--tailscale`. Smallest, most defensible. Operator hits `http://<tailscale-ip>:8765/ui/` even from the Mac. Recommended.
-- (b) **Two binds.** Spin up uvicorn with `host="0.0.0.0"` BUT add an explicit IP-allow-list middleware that drops connections whose accepted-on interface isn't loopback or tailscale0. Possible via `socket.getsockname()` on the accepted socket. More complex; uvicorn doesn't expose this directly so might need a custom Server class.
-- (c) **Two uvicorn processes.** Bind one to `127.0.0.1`, one to `<tailscale-ip>`. Separate processes, double the memory, but trivial config. Acceptable if (a) is too inconvenient.
-
-Recommendation: **(a)**. You will likely hit `/ui/` from your phone more than from the Mac, and when you're on the Mac you can use the tailnet IP just as easily.
-
-### Fix #4 (stack dependency) — proposed: merge #2057 first, then rebase #2065
-
-The fix agent I dispatched for #2057 will push corrections to the existing PR. Once #2057 merges, I rebase #2065 on top of new `main`. The dashboard route is then live and `app.js`'s `GET /api/v1/dashboard` works.
-
-Alternative: cherry-pick #2057's commits into #2065 to break the dep. Don't do this — it creates merge conflicts when #2057 lands.
-
-Recommendation: **merge order #2057 → #2065**, with rebase between.
-
----
-
-## Proposed implementation contract for the fix agent
-
-Once you sign off the three decisions above, the agent gets a tight scope:
-
-1. **`/ui/` cookie gating** — implement the d-ii fallback (cookie set only on loopback OR verified-Tailscale OR valid-bearer-header). Tests: assert no cookie set when client IP is `192.168.1.x`; assert cookie set when loopback; assert cookie set when valid Authorization header.
-2. **`--tailscale` interface binding** — change `host="0.0.0.0"` to `host=tailscale_ip`. Test: simulate `detect_tailscale_ip()` returning `100.64.0.5`, assert uvicorn is invoked with that exact host.
-3. **CGNAT defense-in-depth check** — keep `is_tailscale_ip()` but document in the docstring that it's a sanity filter on top of interface binding, not the primary trust boundary.
-4. **Mobile/tablet CSS** (the P1) — add a 360px media query and Playwright mobile viewport screenshot.
-5. **Rebase after #2057** — once #2057 merges, rebase #2065 onto new main. Run the test suite. Confirm `/api/v1/dashboard` resolves.
-
-Reply to all 5 Codex inline threads on PR #2065 with file:line of each fix.
-
----
-
-## Acceptance criteria
-
-After fixes land:
-- `curl -sS -i http://<lan-ip>:8765/ui/` from a non-Tailscale LAN device returns the HTML BUT no `Set-Cookie` header. Subsequent `/api/v1/*` calls without bearer return 401.
-- `curl -sS -i http://<tailscale-ip>:8765/ui/` from another tailnet device returns the HTML AND `Set-Cookie: pollypm-session=...`. Subsequent calls work.
-- `lsof -nP -i :8765` while running `pm serve --tailscale` shows ONE listener bound to the Tailscale IP, NOT `*:8765`.
-- All 14 tests in `tests/web_api/test_web_ui.py` pass; new negative-auth tests added.
-
----
-
-## What you need to do next
-
-Reply with:
-1. Cookie fallback: **d-i** (paste-box bootstrap) or **d-ii** (Tailscale-only, document it)?
-2. Bind mode: **(a)** Tailscale IP only, **(b)** allow-list middleware, or **(c)** two uvicorn processes?
-3. Confirm stack order: merge #2057 first then rebase #2065. (Default yes; flag if you want me to do something else.)
-
-When you answer, I dispatch the fix agent with the exact contract above.
+# Web UI v0 — Security Model (ADR)
+
+## Status
+
+Implemented in PR #2065 on branch `feat/web-ui-v0`. This document records the
+chosen security model for the v0 browser-accessible cockpit UI at `/ui/` and
+its companion API at `/api/v1/*`.
+
+## Context
+
+The v0 web UI exposes:
+
+- An HTML / JS SPA at `GET /ui/` served out of `src/pollypm/web_api/ui/`.
+- The same `/api/v1/*` JSON surface the cockpit uses, plus an SSE stream at
+  `/events`.
+
+The auth boundary had to defend against:
+
+- **LAN exposure** — a non-Tailscale device on the same Wi-Fi reaching the
+  port and either viewing UI state or driving the API.
+- **CGNAT spoofing** — RFC 6598 shared address space (`100.64.0.0/10`) is
+  used by Tailscale but also by some ISPs' CGNAT infrastructure. A client
+  whose `client.host` happens to land in that range must not be trusted as a
+  tailnet peer unless the server actually bound to the tailnet interface.
+- **Credential issuance from a public route** — the SPA needs a session
+  cookie to make API calls, but `GET /ui/` cannot mint that cookie for any
+  caller who can reach the route, or any LAN device walks into a fully
+  authenticated session.
+- **Public exposure footguns** — operators who explicitly choose
+  `--host 0.0.0.0 --allow-remote` (e.g. behind their own TLS reverse proxy)
+  must not silently inherit Tailscale's CGNAT trust.
+
+## Decision
+
+### Listener binding — `pm serve`
+
+Implemented in `src/pollypm/cli_features/web_api.py` (the `serve_command`
+body, roughly lines 244–290).
+
+- **Default (no flags):** call `detect_tailscale_ip()`, which shells out to
+  `tailscale ip -4`, parses the first non-empty token through
+  `ipaddress.IPv4Address`, AND checks membership in
+  `_TAILSCALE_CGNAT_NET` (`100.64.0.0/10`) before returning. If that returns
+  a verified tailnet IPv4, bind that interface only (`bind_mode="tailscale"`,
+  `tailnet_trust=True`). Otherwise fall back to `127.0.0.1`
+  (`bind_mode="loopback"`, `tailnet_trust=False`). LAN access is intentionally
+  unsupported in v0.
+- **`--host <addr>` explicit override:** honored verbatim, skipping
+  detection. A non-loopback host still requires `--allow-remote` (spec §3).
+  `tailnet_trust` stays `False` *unless* the explicit host string is exactly
+  equal to the value `detect_tailscale_ip()` would have returned — i.e. the
+  operator manually typed the same tailnet IPv4 the detector verified. Any
+  other explicit host (loopback, `0.0.0.0`, a LAN address) leaves
+  `tailnet_trust=False` so CGNAT-source peers do NOT get credential-free
+  access on an unverified bind.
+- **`--tailscale` flag:** deprecated no-op kept for back-compat. The
+  auto-detection it used to gate is now unconditional.
+
+### Cookie issuance — `GET /ui/`
+
+Implemented in `src/pollypm/web_api/app.py` at the `_ui_index` handler
+(around line 350+).
+
+The `pollypm-session` cookie is minted only when at least one of the
+following holds:
+
+- **Loopback caller** — `request.client.host` is `127.0.0.1` or `::1`. A
+  browser on the same machine as the daemon is treated as the local
+  operator. This is a deliberate convenience bypass; see the docstring on
+  `src/pollypm/web_api/auth.py` for the trade-off note.
+- **Verified tailnet peer** — `request.client.host` is in
+  `_TAILSCALE_CGNAT_NET` *and* the app was constructed with
+  `tailnet_trust_enabled=True` (i.e. the serve path actually bound to a
+  verified Tailscale IPv4).
+- **Valid bearer header** — the caller already presented
+  `Authorization: Bearer <token>` matching the on-disk token, so issuing the
+  cookie is just a UX convenience for subsequent requests.
+
+Any other caller (e.g. a non-Tailscale LAN device on a server that happens
+to bind wider, or a CGNAT-source peer on an unverified bind) receives the
+HTML without a `Set-Cookie` header. The SPA will then receive 401 on its
+first API call.
+
+### API auth — `make_bearer_auth_dependency`
+
+Implemented in `src/pollypm/web_api/auth.py`. Three credential modes, in
+order:
+
+1. `Authorization: Bearer <token>` header — always accepted, constant-time
+   comparison against the on-disk token (`~/.pollypm/api-token`, mode 0600).
+   Token rotation via `pm api regen-token` invalidates outstanding sessions
+   on the next request because the dependency reads fresh from disk.
+2. `pollypm-session` cookie — same comparison rules as the header. A stale
+   cookie (from a pre-rotation session) returns a friendlier
+   `invalid_token` message hinting at a `/ui/` reload.
+3. Credential-free Tailscale CGNAT trust — only when the app was built
+   with `tailnet_trust_enabled=True`. Without that gate, a CGNAT-source
+   peer on a public bind would walk past auth, so the flag is the only
+   thing tying this mode to a verified tailnet bind.
+
+The SSE dependency (`make_sse_auth_dependency`) additionally accepts
+`?token=` as a query-string fallback because the browser `EventSource` API
+cannot send custom headers. The query-string mode is SSE-only — every other
+endpoint rejects it — so bearer tokens don't end up in proxy access logs
+for normal traffic.
+
+## Trade-offs
+
+- **LAN devices without Tailscale cannot use the UI** by default. This is
+  documented as a Tailscale-first deployment in the `pm serve` help text and
+  in `docs/web-api-spec.md`. Operators who genuinely want LAN access can
+  pass `--host <lan-ip> --allow-remote` and paste the bearer manually, but
+  they explicitly opt out of CGNAT trust by doing so.
+- **Loopback cookie issuance is a deliberate convenience bypass.** A local
+  process without the bearer token still gets 401 from the API itself —
+  only the `/ui/` HTML route mints the cookie for loopback. The trade-off
+  is documented inline in `src/pollypm/web_api/auth.py`'s module docstring
+  (the "loopback-cookie-mint is an explicit local-operator bypass, not an
+  oversight" note).
+- **CGNAT range as defense-in-depth, not the trust boundary.** The
+  primary tailnet enforcement is the OS-level interface bind done by
+  `pm serve`; the in-process `is_tailscale_ip()` check exists so a future
+  reverse-proxy deployment that loses the interface binding still drops
+  random LAN devices.
+
+## References
+
+- `src/pollypm/web_api/auth.py` — bearer + cookie + tailnet dependencies,
+  with the full trust-boundary docstring on the module and on
+  `make_bearer_auth_dependency`.
+- `src/pollypm/web_api/app.py` — cookie issuance gate in `_ui_index`.
+- `src/pollypm/cli_features/web_api.py` — `detect_tailscale_ip()` and the
+  bind-mode selection in `serve_command`.
+- `tests/web_api/test_web_ui.py` — security regressions covering the
+  cookie gate, detector validation, and `tailnet_trust` propagation.
+- `tests/web_api/test_auth.py` — bearer / cookie / CGNAT auth-dependency
+  unit tests.
+- `docs/web-api-spec.md` §3 — operator-facing spec for the bind / auth
+  surface.
+
+## Implemented in
+
+PR #2065 — landed [DATE TBD].

--- a/docs/web-ui-2065-security-spec.md
+++ b/docs/web-ui-2065-security-spec.md
@@ -1,0 +1,185 @@
+# PR #2065 Web UI — Security Fix Spec
+
+**Status:** Awaiting Sam's sign-off before implementation dispatch.
+**Date:** 2026-05-22
+**Scope:** Address the 4 Codex P0s on PR #2065 without re-litigating the v0 UI design.
+
+The goal of this spec is to get an answer from you on three design choices, then dispatch one fix agent with a clear contract. No autonomous security implementation.
+
+---
+
+## TL;DR — the three decisions you need to make
+
+1. **Cookie issuance model** (P0 #1): how does `/ui/` decide whether the caller is a trusted local operator before handing them the bearer-as-cookie?
+2. **Tailscale interface binding** (P0 #3): should `--tailscale` bind ONLY to the tailnet interface address (losing loopback unless you re-add it), or bind both?
+3. **Stack ordering** (P0 #4): merge #2057 first then rebase #2065, vs cherry-pick the dashboard route onto the #2065 branch.
+
+Recommendations below; the rest of this doc explains the bugs and fix options.
+
+---
+
+## The 4 P0s, restated from code
+
+### P0 #1 — `/ui/` mints a cookie for any caller, unauthenticated
+
+`src/pollypm/web_api/app.py` lines 250–278 (on `feat/web-ui-v0`):
+
+```python
+@app.get("/ui/", include_in_schema=False)
+def _ui_index() -> Response:
+    resolved_token_path = token_path or DEFAULT_TOKEN_PATH
+    token_value = load_token(resolved_token_path)
+    response = FileResponse(index_path, media_type="text/html")
+    if token_value:
+        response.set_cookie(
+            key=SESSION_COOKIE_NAME,
+            value=token_value,
+            httponly=True,
+            samesite="lax",
+            secure=False,
+            ...
+        )
+    return response
+```
+
+There is NO auth check before `set_cookie`. Anyone who can reach `/ui/` over the network — LAN device, spoofed CGNAT source IP, anyone on a misconfigured deploy — receives the bearer token in a `Set-Cookie` header and is thereafter fully authenticated for every API call.
+
+This is credential issuance from a public route.
+
+### P0 #2 — `100.64.0.0/10` (CGNAT) trust without verifying tailnet membership
+
+`src/pollypm/web_api/auth.py` line 47 + `is_tailscale_ip()`:
+
+```python
+_TAILSCALE_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
+
+def is_tailscale_ip(host: str | None) -> bool:
+    addr = ipaddress.ip_address(host)
+    return addr in _TAILSCALE_CGNAT_NET
+```
+
+Used in `make_bearer_auth_dependency` to grant unauthenticated access to any caller whose `request.client.host` falls in the CGNAT range.
+
+The CGNAT range is RFC 6598 shared address space. Tailscale is one user of it but not the only one. A non-Tailscale device on a LAN that uses 100.64/10 internally, or a packet crafted with a spoofed source IP if the kernel allows it through, would be trusted as a tailnet peer.
+
+CGNAT range membership is necessary but not sufficient proof of tailnet membership.
+
+### P0 #3 — `--tailscale` binds 0.0.0.0
+
+`src/pollypm/cli_features/web_api.py` lines 200–211:
+
+```python
+if tailscale:
+    tailscale_ip = detect_tailscale_ip()
+    ...
+    else:
+        host = "0.0.0.0"
+        allow_remote = True
+```
+
+The intent of `--tailscale` is "expose this only to my tailnet." The implementation binds every interface, then leans on the CGNAT auth check (P0 #2) to gate. With CGNAT trust broken, every interface is a real attack surface.
+
+### P0 #4 — UI calls `/api/v1/dashboard` not on the branch base
+
+`src/pollypm/web_api/ui/app.js` line ~209 calls `GET /api/v1/dashboard`. That route is not on `origin/main` — it lives in PR #2057. Stacked-PR hazard: if #2065 merges before #2057, the UI 404s on every right-rail poll.
+
+---
+
+## Fix proposals
+
+### Fix #1 (cookie issuance) — proposed: gate on auth path BEFORE cookie set
+
+The cookie is convenience credential; the bearer is the master credential. The boot path that issues the cookie should require ONE of these signals first:
+
+- **(a) Authorization header present and valid** → set the cookie, return the page.
+- **(b) Client IP is loopback (127.0.0.1, ::1)** → set the cookie, return the page. Local operator on the Mac itself.
+- **(c) Client IP is verified Tailscale peer** (per fix #2 + #3 below) → set the cookie, return the page. Operator hitting `/ui/` from their phone over Tailscale.
+- **(d) None of the above** → serve the HTML, do NOT set the cookie. SPA will hit `/api/v1/...` and get 401, and surfaces "paste your bearer token to bootstrap" UX.
+
+Implementation note: `app.js` already needs a "no cookie yet" fallback — the SPA currently assumes the cookie is always set. We add a small bootstrap form that, on 401, prompts for the bearer token and POSTs it to a new `POST /ui/bootstrap` endpoint that sets the cookie after validating. (Or: skip the bootstrap UI in v0 and document "ssh to the Mac, hit /ui/ once, copy the cookie" — uglier but smaller diff.)
+
+**Decision needed from you:** which fallback UX for path (d)?
+- (d-i) Build a small `<input>` paste box in the SPA that exchanges bearer for cookie via `POST /ui/bootstrap`. Most polished. ~50 LOC delta.
+- (d-ii) Document "first cookie must be obtained from a loopback or Tailscale visit; LAN devices not supported in v0." Smallest diff; matches Tailscale-only deployment intent.
+
+Recommendation: **d-ii**. Personal-use, Tailscale-first deployment, no need to support LAN at all. If you ever expose this on the public internet, you'll be revisiting this anyway.
+
+### Fix #2 (CGNAT verification) — proposed: bind-to-interface enforces tailnet at OS layer
+
+Instead of comparing `request.client.host` against a CGNAT range string (which a spoofed source IP defeats), bind uvicorn to the detected Tailscale IP only. The Linux/Darwin routing table then enforces that ONLY packets arriving on `tailscale0` (or its peers) can reach the listening socket. Source-IP spoof from another interface is dropped before the application sees it.
+
+Pair with: keep `is_tailscale_ip()` as a defense-in-depth check (in case a misconfigured deploy binds wider), but it's no longer load-bearing.
+
+Optional stronger version: also query `tailscale status --json` to fetch peer IPs and assert `request.client.host` matches a known peer. Higher friction (requires tailscale CLI in PATH, adds latency to every auth check). Skip unless you want belt-and-suspenders.
+
+Recommendation: **bind-to-interface only**, keep the CGNAT check as a sanity filter, skip peer enumeration. Simpler, OS-enforced, no new runtime dependency.
+
+### Fix #3 (`--tailscale` bind) — proposed: bind to Tailscale IP, not 0.0.0.0
+
+`src/pollypm/cli_features/web_api.py:208`: change
+
+```python
+host = "0.0.0.0"
+```
+
+to
+
+```python
+host = tailscale_ip   # e.g. "100.x.y.z"
+```
+
+Implications:
+- Loopback access (`http://127.0.0.1:8765/ui/`) NO LONGER WORKS when started with `--tailscale`. The operator accesses via `http://<tailscale-ip>:8765/ui/` from any tailnet device including the Mac itself.
+- The OS routing table guarantees only packets arriving on `tailscale0` reach the socket.
+- Combined with Fix #2, `is_tailscale_ip()` becomes a sanity check on top of OS enforcement.
+
+**Decision needed from you:** is losing loopback-while-tailscale acceptable, or do you want both?
+
+- (a) **Tailscale IP only.** Loopback unavailable when `--tailscale`. Smallest, most defensible. Operator hits `http://<tailscale-ip>:8765/ui/` even from the Mac. Recommended.
+- (b) **Two binds.** Spin up uvicorn with `host="0.0.0.0"` BUT add an explicit IP-allow-list middleware that drops connections whose accepted-on interface isn't loopback or tailscale0. Possible via `socket.getsockname()` on the accepted socket. More complex; uvicorn doesn't expose this directly so might need a custom Server class.
+- (c) **Two uvicorn processes.** Bind one to `127.0.0.1`, one to `<tailscale-ip>`. Separate processes, double the memory, but trivial config. Acceptable if (a) is too inconvenient.
+
+Recommendation: **(a)**. You will likely hit `/ui/` from your phone more than from the Mac, and when you're on the Mac you can use the tailnet IP just as easily.
+
+### Fix #4 (stack dependency) — proposed: merge #2057 first, then rebase #2065
+
+The fix agent I dispatched for #2057 will push corrections to the existing PR. Once #2057 merges, I rebase #2065 on top of new `main`. The dashboard route is then live and `app.js`'s `GET /api/v1/dashboard` works.
+
+Alternative: cherry-pick #2057's commits into #2065 to break the dep. Don't do this — it creates merge conflicts when #2057 lands.
+
+Recommendation: **merge order #2057 → #2065**, with rebase between.
+
+---
+
+## Proposed implementation contract for the fix agent
+
+Once you sign off the three decisions above, the agent gets a tight scope:
+
+1. **`/ui/` cookie gating** — implement the d-ii fallback (cookie set only on loopback OR verified-Tailscale OR valid-bearer-header). Tests: assert no cookie set when client IP is `192.168.1.x`; assert cookie set when loopback; assert cookie set when valid Authorization header.
+2. **`--tailscale` interface binding** — change `host="0.0.0.0"` to `host=tailscale_ip`. Test: simulate `detect_tailscale_ip()` returning `100.64.0.5`, assert uvicorn is invoked with that exact host.
+3. **CGNAT defense-in-depth check** — keep `is_tailscale_ip()` but document in the docstring that it's a sanity filter on top of interface binding, not the primary trust boundary.
+4. **Mobile/tablet CSS** (the P1) — add a 360px media query and Playwright mobile viewport screenshot.
+5. **Rebase after #2057** — once #2057 merges, rebase #2065 onto new main. Run the test suite. Confirm `/api/v1/dashboard` resolves.
+
+Reply to all 5 Codex inline threads on PR #2065 with file:line of each fix.
+
+---
+
+## Acceptance criteria
+
+After fixes land:
+- `curl -sS -i http://<lan-ip>:8765/ui/` from a non-Tailscale LAN device returns the HTML BUT no `Set-Cookie` header. Subsequent `/api/v1/*` calls without bearer return 401.
+- `curl -sS -i http://<tailscale-ip>:8765/ui/` from another tailnet device returns the HTML AND `Set-Cookie: pollypm-session=...`. Subsequent calls work.
+- `lsof -nP -i :8765` while running `pm serve --tailscale` shows ONE listener bound to the Tailscale IP, NOT `*:8765`.
+- All 14 tests in `tests/web_api/test_web_ui.py` pass; new negative-auth tests added.
+
+---
+
+## What you need to do next
+
+Reply with:
+1. Cookie fallback: **d-i** (paste-box bootstrap) or **d-ii** (Tailscale-only, document it)?
+2. Bind mode: **(a)** Tailscale IP only, **(b)** allow-list middleware, or **(c)** two uvicorn processes?
+3. Confirm stack order: merge #2057 first then rebase #2065. (Default yes; flag if you want me to do something else.)
+
+When you answer, I dispatch the fix agent with the exact contract above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,11 @@ pollypm = [
   "defaults/demo/**/*",
   "work/flows/*.yaml",
   "agents/*.md",
+  # v0 web UI (Phase 7) — vanilla HTML/JS/CSS served by FastAPI
+  # StaticFiles. No build step; ship the source files as-is.
+  "web_api/ui/*.html",
+  "web_api/ui/*.js",
+  "web_api/ui/*.css",
 ]
 
 [tool.pytest.ini_options]

--- a/src/pollypm/cli_features/web_api.py
+++ b/src/pollypm/cli_features/web_api.py
@@ -213,6 +213,14 @@ def register_web_api_commands(app: typer.Typer) -> None:
         #   they don't see a tailnet bind.
         bind_mode: str
         tailscale_ip: str | None = None
+        # ``tailnet_trust`` decides whether the auth dependency and the
+        # ``/ui/`` cookie gate treat 100.64.0.0/10 peers as credential-
+        # free. It MUST stay False unless the server actually bound to
+        # a verified Tailscale IPv4; otherwise an explicit
+        # ``--host 0.0.0.0 --allow-remote`` deploy would hand out a
+        # session to any CGNAT-source peer (some ISPs use RFC 6598).
+        # Codex round-2 PR #2065.
+        tailnet_trust: bool = False
         if host is not None:
             # Explicit operator override — skip detection. Carry through
             # the existing --allow-remote gate so accidental 0.0.0.0
@@ -225,11 +233,21 @@ def register_web_api_commands(app: typer.Typer) -> None:
                     err=True,
                 )
                 raise typer.Exit(code=2)
+            # Explicit override stays untrusted by default. If the
+            # operator typed the actual tailnet IPv4, opt back into
+            # tailnet trust — that's the same wire path as the
+            # auto-detected case. Any other explicit host (loopback,
+            # 0.0.0.0, a LAN address) leaves tailnet_trust False.
+            detected = detect_tailscale_ip()
+            if detected is not None and host == detected:
+                tailscale_ip = detected
+                tailnet_trust = True
         else:
             tailscale_ip = detect_tailscale_ip()
             if tailscale_ip is not None:
                 host = tailscale_ip
                 bind_mode = "tailscale"
+                tailnet_trust = True
                 typer.echo(
                     f"[pm serve] bound {tailscale_ip}:{port} (tailscale "
                     f"mode; UI at http://{tailscale_ip}:{port}/ui/)",
@@ -263,7 +281,11 @@ def register_web_api_commands(app: typer.Typer) -> None:
                 str(token_path) if token_path is not None else str(DEFAULT_TOKEN_PATH)
             )
 
-        app_instance = create_app(config=config, token_path=token_path)
+        app_instance = create_app(
+            config=config,
+            token_path=token_path,
+            tailnet_trust_enabled=tailnet_trust,
+        )
 
         try:
             import uvicorn

--- a/src/pollypm/cli_features/web_api.py
+++ b/src/pollypm/cli_features/web_api.py
@@ -292,7 +292,24 @@ def register_web_api_commands(app: typer.Typer) -> None:
                     err=True,
                 )
 
-        if tailscale and tailscale_ip is None and bind_mode != "tailscale":
+        # Only emit the detection-failure warning when detection was
+        # actually attempted (i.e. the auto-detect branch above ran).
+        # Codex round-13 on #2065: when the operator passes ``--host``
+        # explicitly, the explicit branch sets ``bind_mode == "explicit"``
+        # and leaves ``tailscale_ip`` at None WITHOUT calling
+        # ``detect_tailscale_ip()``. Falling through to the original
+        # "tailscale ip -4 returned no IP" warning in that case is a
+        # lie — detection never ran — and the "Falling back to
+        # loopback-only" tail is doubly wrong because the bind honors
+        # the explicit host. Emit a distinct, accurate warning instead.
+        if tailscale and bind_mode == "explicit":
+            typer.echo(
+                "Warning: --tailscale ignored because --host was "
+                "provided explicitly. Auto-detect path is the only "
+                "way to enable tailnet_trust.",
+                err=True,
+            )
+        elif tailscale and tailscale_ip is None and bind_mode != "tailscale":
             typer.echo(
                 "Warning: --tailscale passed but `tailscale ip -4` "
                 "returned no IP (binary missing, not logged in, or no "

--- a/src/pollypm/cli_features/web_api.py
+++ b/src/pollypm/cli_features/web_api.py
@@ -186,7 +186,10 @@ def register_web_api_commands(app: typer.Typer) -> None:
             help=(
                 "Override the bind address. Default: auto-detected "
                 "Tailscale IPv4, else 127.0.0.1. Passing this flag "
-                "skips Tailscale detection entirely."
+                "skips Tailscale detection entirely and leaves "
+                "credential-free tailnet trust OFF — the operator is "
+                "expected to authenticate every request explicitly "
+                "(bearer header or session cookie)."
             ),
         ),
         allow_remote: bool = typer.Option(
@@ -252,9 +255,15 @@ def register_web_api_commands(app: typer.Typer) -> None:
         # Codex round-2 PR #2065.
         tailnet_trust: bool = False
         if host is not None:
-            # Explicit operator override — skip detection. Carry through
-            # the existing --allow-remote gate so accidental 0.0.0.0
-            # binds still trip the safety check.
+            # Explicit operator override — skip detection entirely.
+            # Per the --host help text and Codex round-9 review on
+            # #2065, an explicit bind address leaves tailnet trust OFF
+            # unconditionally: even if the operator happens to type the
+            # detected tailnet IPv4, opting into credential-free CGNAT
+            # access is a choice the auto-detect path makes, not one
+            # the explicit-override path inherits. Operators who want
+            # the trust gate should omit --host and let the auto path
+            # bind the tailnet interface itself.
             bind_mode = "explicit"
             if not allow_remote and host not in {"127.0.0.1", "localhost", "::1"}:
                 typer.echo(
@@ -263,15 +272,6 @@ def register_web_api_commands(app: typer.Typer) -> None:
                     err=True,
                 )
                 raise typer.Exit(code=2)
-            # Explicit override stays untrusted by default. If the
-            # operator typed the actual tailnet IPv4, opt back into
-            # tailnet trust — that's the same wire path as the
-            # auto-detected case. Any other explicit host (loopback,
-            # 0.0.0.0, a LAN address) leaves tailnet_trust False.
-            detected = detect_tailscale_ip()
-            if detected is not None and host == detected:
-                tailscale_ip = detected
-                tailnet_trust = True
         else:
             tailscale_ip = detect_tailscale_ip()
             if tailscale_ip is not None:

--- a/src/pollypm/cli_features/web_api.py
+++ b/src/pollypm/cli_features/web_api.py
@@ -3,10 +3,14 @@
 Registers two surfaces on the root ``pm`` Typer app:
 
 - ``pm serve [--port N] [--host H] [--allow-remote] [--tailscale]`` —
-  run the FastAPI app from :mod:`pollypm.web_api`. ``--tailscale``
-  shells out to ``tailscale ip -4`` and binds the resulting tailnet
-  address in addition to loopback so the web UI is reachable from any
-  device on the operator's tailnet.
+  run the FastAPI app from :mod:`pollypm.web_api`. Default ``pm serve``
+  auto-detects Tailscale: if ``tailscale ip -4`` returns an IPv4 the
+  daemon binds that tailnet interface (tailnet-trust mode); otherwise
+  it falls back to ``127.0.0.1`` (loopback mode). ``--tailscale`` is a
+  no-op back-compat flag — auto-detection covers the same path. To
+  force loopback even when Tailscale is running, pass
+  ``--host 127.0.0.1`` explicitly; that override stays in untrusted
+  mode (bearer/cookie required for every request).
 - ``pm api regen-token`` — rotate the bearer token. Lives under a
   dedicated ``pm api`` sub-app so future admin commands (``pm api
   show-token``, ``pm api status``) can land beside it without

--- a/src/pollypm/cli_features/web_api.py
+++ b/src/pollypm/cli_features/web_api.py
@@ -2,8 +2,11 @@
 
 Registers two surfaces on the root ``pm`` Typer app:
 
-- ``pm serve [--port N] [--host H] [--allow-remote]`` — run the
-  FastAPI app from :mod:`pollypm.web_api`.
+- ``pm serve [--port N] [--host H] [--allow-remote] [--tailscale]`` —
+  run the FastAPI app from :mod:`pollypm.web_api`. ``--tailscale``
+  shells out to ``tailscale ip -4`` and binds the resulting tailnet
+  address in addition to loopback so the web UI is reachable from any
+  device on the operator's tailnet.
 - ``pm api regen-token`` — rotate the bearer token. Lives under a
   dedicated ``pm api`` sub-app so future admin commands (``pm api
   show-token``, ``pm api status``) can land beside it without
@@ -17,6 +20,8 @@ surface.
 from __future__ import annotations
 
 import logging
+import shutil
+import subprocess
 from pathlib import Path
 
 import typer
@@ -27,14 +32,52 @@ from pollypm.config import DEFAULT_CONFIG_PATH, load_config
 logger = logging.getLogger(__name__)
 
 
+def detect_tailscale_ip() -> str | None:
+    """Return the operator's Tailscale IPv4 or ``None`` if unavailable.
+
+    Shells out to ``tailscale ip -4`` (the same command the spec uses
+    in its access doc). Returns ``None`` for any of:
+
+    - ``tailscale`` binary not on ``$PATH``
+    - command exits non-zero (not logged in, daemon down, no IP yet)
+    - stdout is empty / not a parseable IPv4
+
+    Never raises — the caller decides whether to fall back to localhost
+    with a warning or hard-fail.
+    """
+    binary = shutil.which("tailscale")
+    if binary is None:
+        return None
+    try:
+        result = subprocess.run(
+            [binary, "ip", "-4"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    # ``tailscale ip -4`` prints one address per line; take the first
+    # non-empty token. We don't validate the dotted-quad shape here —
+    # the auth layer's ``is_tailscale_ip`` does that defensively.
+    for line in result.stdout.splitlines():
+        candidate = line.strip()
+        if candidate:
+            return candidate
+    return None
+
+
 _SERVE_HELP = help_with_examples(
     "Run the PollyPM Web API server (FastAPI) as a peer to the cockpit.",
     [
         ("pm serve", "bind to 127.0.0.1:8765 (default)"),
         ("pm serve --port 9000", "bind to 127.0.0.1:9000"),
         (
-            "pm serve --allow-remote --host 0.0.0.0",
-            "expose to non-loopback (operator must terminate TLS upstream)",
+            "pm serve --tailscale",
+            "auto-detect Tailscale IP + bind alongside loopback for the web UI",
         ),
     ],
     trailing=(
@@ -116,6 +159,17 @@ def register_web_api_commands(app: typer.Typer) -> None:
                 "responsible for terminating TLS upstream (see spec §3)."
             ),
         ),
+        tailscale: bool = typer.Option(
+            False,
+            "--tailscale",
+            help=(
+                "Auto-detect the local Tailscale IPv4 via `tailscale ip -4` "
+                "and bind it alongside 127.0.0.1. Tailscale's network identity "
+                "acts as auth (see web_api/auth.py is_tailscale_ip). Falls "
+                "back to localhost with a warning if the tailscale binary "
+                "is missing."
+            ),
+        ),
         config_path: Path = typer.Option(
             DEFAULT_CONFIG_PATH,
             "--config",
@@ -129,6 +183,34 @@ def register_web_api_commands(app: typer.Typer) -> None:
         ),
     ) -> None:
         from pollypm.web_api import create_app, ensure_token
+
+        # ``--tailscale`` is a sugar wrapper that auto-detects the
+        # tailnet IP and binds 0.0.0.0 (so both loopback + tailnet
+        # work). We treat it as an explicit opt-in to non-loopback
+        # binding, so it implies --allow-remote.
+        tailscale_ip: str | None = None
+        if tailscale:
+            tailscale_ip = detect_tailscale_ip()
+            if tailscale_ip is None:
+                typer.echo(
+                    "Warning: --tailscale passed but `tailscale ip -4` "
+                    "did not return an address (binary missing, not "
+                    "logged in, or no IPv4 yet). Falling back to "
+                    f"localhost-only bind on {host}.",
+                    err=True,
+                )
+            else:
+                # Bind 0.0.0.0 so both 127.0.0.1 and the tailnet IP
+                # accept connections without juggling two uvicorn
+                # processes. Auth still gates non-tailnet/non-loopback
+                # traffic at the middleware layer.
+                host = "0.0.0.0"
+                allow_remote = True
+                typer.echo(
+                    f"[pm serve] --tailscale: tailnet IP {tailscale_ip}; "
+                    f"binding {host}:{port} (UI: http://{tailscale_ip}:{port}/ui/).",
+                    err=True,
+                )
 
         if not allow_remote and host not in {"127.0.0.1", "localhost", "::1"}:
             typer.echo(
@@ -190,4 +272,4 @@ def register_web_api_commands(app: typer.Typer) -> None:
     app.add_typer(api_app, name="api", help=_API_HELP)
 
 
-__all__ = ["register_web_api_commands"]
+__all__ = ["detect_tailscale_ip", "register_web_api_commands"]

--- a/src/pollypm/cli_features/web_api.py
+++ b/src/pollypm/cli_features/web_api.py
@@ -23,6 +23,7 @@ surface.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import shutil
 import subprocess
@@ -32,19 +33,32 @@ import typer
 
 from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+from pollypm.web_api.auth import _TAILSCALE_CGNAT_NET
 
 logger = logging.getLogger(__name__)
 
 
 def detect_tailscale_ip() -> str | None:
-    """Return the operator's Tailscale IPv4 or ``None`` if unavailable.
+    """Return the operator's verified Tailscale IPv4 or ``None``.
 
     Shells out to ``tailscale ip -4`` (the same command the spec uses
-    in its access doc). Returns ``None`` for any of:
+    in its access doc) and validates that the first non-empty token is
+    both a parseable IPv4 address AND a member of the Tailscale CGNAT
+    range (100.64.0.0/10). Returns ``None`` for any of:
 
     - ``tailscale`` binary not on ``$PATH``
     - command exits non-zero (not logged in, daemon down, no IP yet)
-    - stdout is empty / not a parseable IPv4
+    - stdout empty
+    - stdout token is not a parseable IPv4 address
+    - stdout token is parseable but outside the Tailscale CGNAT range
+
+    The CGNAT-range check is load-bearing for the trust invariant: the
+    serve path enables ``tailnet_trust=True`` whenever this function
+    returns a non-``None`` value, so we MUST refuse to return anything
+    we have not confirmed is in 100.64.0.0/10. See the security
+    rationale in ``docs/web-ui-2065-security-spec.md`` (decision around
+    Fix #2) and the defense-in-depth notes on
+    :func:`pollypm.web_api.auth.is_tailscale_ip`.
 
     Never raises — the caller decides whether to fall back to localhost
     with a warning or hard-fail.
@@ -64,14 +78,26 @@ def detect_tailscale_ip() -> str | None:
         return None
     if result.returncode != 0:
         return None
-    # ``tailscale ip -4`` prints one address per line; take the first
-    # non-empty token. We don't validate the dotted-quad shape here —
-    # the auth layer's ``is_tailscale_ip`` does that defensively.
+    # ``tailscale ip -4`` prints one address per line. Take the first
+    # non-empty token, then validate it: parseable IPv4 AND inside the
+    # Tailscale CGNAT range. Anything else (malformed output, IPv6
+    # surprise, parseable-but-non-tailnet address) → None so the serve
+    # path does NOT flip ``tailnet_trust`` for an unverified address.
+    candidate: str | None = None
     for line in result.stdout.splitlines():
-        candidate = line.strip()
-        if candidate:
-            return candidate
-    return None
+        token = line.strip()
+        if token:
+            candidate = token
+            break
+    if candidate is None:
+        return None
+    try:
+        addr = ipaddress.IPv4Address(candidate)
+    except (ValueError, ipaddress.AddressValueError):
+        return None
+    if addr not in _TAILSCALE_CGNAT_NET:
+        return None
+    return str(addr)
 
 
 _SERVE_HELP = help_with_examples(

--- a/src/pollypm/cli_features/web_api.py
+++ b/src/pollypm/cli_features/web_api.py
@@ -73,14 +73,18 @@ def detect_tailscale_ip() -> str | None:
 _SERVE_HELP = help_with_examples(
     "Run the PollyPM Web API server (FastAPI) as a peer to the cockpit.",
     [
-        ("pm serve", "bind to 127.0.0.1:8765 (default)"),
-        ("pm serve --port 9000", "bind to 127.0.0.1:9000"),
+        ("pm serve", "auto-detect Tailscale, else bind 127.0.0.1:8765"),
+        ("pm serve --port 9000", "same as above on port 9000"),
         (
             "pm serve --tailscale",
-            "auto-detect Tailscale IP + bind alongside loopback for the web UI",
+            "no-op (kept for back-compat) — auto-detection is on by default",
         ),
     ],
     trailing=(
+        "By default ``pm serve`` tries ``tailscale ip -4``. If it "
+        "returns an IPv4 the server binds that interface only; "
+        "otherwise it falls back to 127.0.0.1. LAN access is "
+        "intentionally unsupported in v0 (use Tailscale). "
         "First run prints the bearer token to stderr; rotate via "
         "`pm api regen-token`. The server reads / writes the same "
         "state.db and audit.jsonl as the cockpit, so it works with "
@@ -146,28 +150,34 @@ def register_web_api_commands(app: typer.Typer) -> None:
     @app.command(name="serve", help=_SERVE_HELP)
     def serve_command(
         port: int = typer.Option(8765, "--port", "-p", help="TCP port to bind."),
-        host: str = typer.Option(
-            "127.0.0.1",
+        host: str | None = typer.Option(
+            None,
             "--host",
-            help="Bind address. Defaults to 127.0.0.1 (loopback).",
+            help=(
+                "Override the bind address. Default: auto-detected "
+                "Tailscale IPv4, else 127.0.0.1. Passing this flag "
+                "skips Tailscale detection entirely."
+            ),
         ),
         allow_remote: bool = typer.Option(
             False,
             "--allow-remote",
             help=(
-                "Permit binding to a non-loopback address. The operator is "
-                "responsible for terminating TLS upstream (see spec §3)."
+                "Permit binding to a non-loopback / non-tailnet address. "
+                "Only meaningful with an explicit --host override; the "
+                "operator is responsible for terminating TLS upstream "
+                "(see spec §3)."
             ),
         ),
         tailscale: bool = typer.Option(
             False,
             "--tailscale",
             help=(
-                "Auto-detect the local Tailscale IPv4 via `tailscale ip -4` "
-                "and bind it alongside 127.0.0.1. Tailscale's network identity "
-                "acts as auth (see web_api/auth.py is_tailscale_ip). Falls "
-                "back to localhost with a warning if the tailscale binary "
-                "is missing."
+                "No-op kept for backwards compatibility. Tailscale "
+                "auto-detection runs unconditionally by default; the "
+                "server binds to the detected tailnet IPv4 only, or "
+                "falls back to 127.0.0.1 if Tailscale isn't installed "
+                "or hasn't returned an address."
             ),
         ),
         config_path: Path = typer.Option(
@@ -184,41 +194,63 @@ def register_web_api_commands(app: typer.Typer) -> None:
     ) -> None:
         from pollypm.web_api import create_app, ensure_token
 
-        # ``--tailscale`` is a sugar wrapper that auto-detects the
-        # tailnet IP and binds 0.0.0.0 (so both loopback + tailnet
-        # work). We treat it as an explicit opt-in to non-loopback
-        # binding, so it implies --allow-remote.
+        # Bind selection (spec doc decision a-default):
+        #
+        # - If the operator passed --host, honor it and skip detection
+        #   entirely. They know what they're doing.
+        # - Otherwise auto-detect Tailscale unconditionally and bind
+        #   the detected tailnet IPv4 ONLY. The kernel routing table
+        #   then enforces that packets must arrive on the tailscale0
+        #   interface to reach the listening socket — spoofed source
+        #   IPs from any other interface are dropped before the app
+        #   sees them.
+        # - If Tailscale isn't installed / hasn't logged in / hasn't
+        #   returned an IPv4, fall back to 127.0.0.1 (loopback only).
+        #   LAN access is intentionally unsupported in v0.
+        # - The --tailscale flag is now a no-op (the behaviour it
+        #   used to gate is the default). Warn if it was passed
+        #   without a detected IP so the operator understands why
+        #   they don't see a tailnet bind.
+        bind_mode: str
         tailscale_ip: str | None = None
-        if tailscale:
-            tailscale_ip = detect_tailscale_ip()
-            if tailscale_ip is None:
+        if host is not None:
+            # Explicit operator override — skip detection. Carry through
+            # the existing --allow-remote gate so accidental 0.0.0.0
+            # binds still trip the safety check.
+            bind_mode = "explicit"
+            if not allow_remote and host not in {"127.0.0.1", "localhost", "::1"}:
                 typer.echo(
-                    "Warning: --tailscale passed but `tailscale ip -4` "
-                    "did not return an address (binary missing, not "
-                    "logged in, or no IPv4 yet). Falling back to "
-                    f"localhost-only bind on {host}.",
+                    f"Error: refusing to bind {host}; pass --allow-remote to "
+                    f"enable non-loopback binds (spec §3).",
+                    err=True,
+                )
+                raise typer.Exit(code=2)
+        else:
+            tailscale_ip = detect_tailscale_ip()
+            if tailscale_ip is not None:
+                host = tailscale_ip
+                bind_mode = "tailscale"
+                typer.echo(
+                    f"[pm serve] bound {tailscale_ip}:{port} (tailscale "
+                    f"mode; UI at http://{tailscale_ip}:{port}/ui/)",
                     err=True,
                 )
             else:
-                # Bind 0.0.0.0 so both 127.0.0.1 and the tailnet IP
-                # accept connections without juggling two uvicorn
-                # processes. Auth still gates non-tailnet/non-loopback
-                # traffic at the middleware layer.
-                host = "0.0.0.0"
-                allow_remote = True
+                host = "127.0.0.1"
+                bind_mode = "loopback"
                 typer.echo(
-                    f"[pm serve] --tailscale: tailnet IP {tailscale_ip}; "
-                    f"binding {host}:{port} (UI: http://{tailscale_ip}:{port}/ui/).",
+                    f"[pm serve] bound 127.0.0.1:{port} (loopback only — "
+                    f"install/start Tailscale for network access)",
                     err=True,
                 )
 
-        if not allow_remote and host not in {"127.0.0.1", "localhost", "::1"}:
+        if tailscale and tailscale_ip is None and bind_mode != "tailscale":
             typer.echo(
-                f"Error: refusing to bind {host}; pass --allow-remote to enable "
-                f"non-loopback binds (spec §3).",
+                "Warning: --tailscale passed but `tailscale ip -4` "
+                "returned no IP (binary missing, not logged in, or no "
+                "IPv4 yet). Falling back to loopback-only.",
                 err=True,
             )
-            raise typer.Exit(code=2)
 
         config = load_config(config_path)
         token, generated = ensure_token(token_path)

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -567,7 +567,7 @@ def _mount_web_ui(
         # gets the HTML but NO cookie. The SPA surfaces a 401 on its
         # first /api/ call so the operator knows to access via
         # loopback or tailnet. See spec doc:
-        # docs/pollypm-web-ui-2065-security-spec.md (decision d-ii).
+        # docs/web-ui-2065-security-spec.md (decision d-ii).
         client_host = request.client.host if request.client else None
         is_loopback = client_host in ("127.0.0.1", "::1")
         is_tailnet = tailnet_trust_enabled and is_tailscale_ip(client_host)

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -21,7 +21,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator
 
-from fastapi import Depends, FastAPI, Response
+from fastapi import Depends, FastAPI, Header, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
@@ -30,6 +30,8 @@ from fastapi.staticfiles import StaticFiles
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.web_api.auth import (
     SESSION_COOKIE_NAME,
+    _extract_token,
+    is_tailscale_ip,
     make_bearer_auth_dependency,
     make_sse_auth_dependency,
 )
@@ -505,14 +507,49 @@ def _mount_web_ui(app: FastAPI, *, token_path: Path | None) -> None:
         return Response(status_code=307, headers={"Location": "/ui/"})
 
     @app.get("/ui/", include_in_schema=False)
-    def _ui_index() -> Response:
+    def _ui_index(
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> Response:
         # Load the token at request time (not app-build time) so a
         # ``pm api regen-token`` rotation flows into the cookie on the
         # next page load without an app restart.
         resolved_token_path = token_path or DEFAULT_TOKEN_PATH
         token_value = load_token(resolved_token_path)
         response = FileResponse(index_path, media_type="text/html")
-        if token_value:
+
+        # Cookie issuance is credential issuance — gate it behind a
+        # proven local-operator path so a LAN device (or anyone who
+        # can reach this port from a network we don't trust) can't
+        # GET /ui/ and walk away with the bearer token via
+        # Set-Cookie. Three acceptable signals:
+        #
+        # 1. Authorization: Bearer <token> matches the on-disk token
+        #    (operator pasted it via curl / scripted boot).
+        # 2. Loopback client (127.0.0.1, ::1) — local operator on
+        #    the Mac itself.
+        # 3. Tailscale CGNAT peer — operator hitting /ui/ from a
+        #    tailnet device. Defense-in-depth on top of the
+        #    bind-to-interface enforcement in ``pm serve`` (see
+        #    cli_features/web_api.py).
+        #
+        # Everything else (LAN device, public-facing deploy by
+        # accident, spoofed source IP through a misconfigured proxy)
+        # gets the HTML but NO cookie. The SPA surfaces a 401 on its
+        # first /api/ call so the operator knows to access via
+        # loopback or tailnet. See spec doc:
+        # docs/pollypm-web-ui-2065-security-spec.md (decision d-ii).
+        client_host = request.client.host if request.client else None
+        is_loopback = client_host in ("127.0.0.1", "::1")
+        is_tailnet = is_tailscale_ip(client_host)
+        bearer_token = _extract_token(authorization)
+        valid_bearer = False
+        if bearer_token is not None and token_value is not None:
+            from secrets import compare_digest
+
+            valid_bearer = compare_digest(bearer_token, token_value)
+
+        if token_value and (is_loopback or is_tailnet or valid_bearer):
             # ``HttpOnly`` so JS can't read the token; ``SameSite=Lax``
             # so cross-tab navigation still carries it; ``Secure=False``
             # because the v0 deploy is loopback/Tailscale HTTP. When
@@ -527,9 +564,11 @@ def _mount_web_ui(app: FastAPI, *, token_path: Path | None) -> None:
                 path="/",
                 max_age=60 * 60 * 24 * 7,  # 7 days
             )
-        # If the token file doesn't exist yet, we still serve the HTML
-        # — the SPA will surface a 401 the first time it hits /api/
-        # and the operator will know to run `pm api regen-token`.
+        # If the token file doesn't exist yet, or the caller isn't on
+        # a trusted path, we still serve the HTML — the SPA will
+        # surface a 401 the first time it hits /api/ and the operator
+        # will know to access from loopback / Tailscale (or to run
+        # `pm api regen-token`).
         return response
 
     # Static assets served raw. ``html=False`` keeps StaticFiles from

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -450,10 +450,28 @@ def create_app(
 def _attach_security_scheme(app: FastAPI) -> None:
     """Inject the OpenAPI ``securitySchemes`` block.
 
-    FastAPI's auto-generated OpenAPI doesn't add bearer auth unless
-    we wire it through ``OAuth2PasswordBearer`` or override
+    FastAPI's auto-generated OpenAPI doesn't add any auth schemes
+    unless we wire them through ``OAuth2PasswordBearer`` or override
     ``openapi_schema``. The simplest path is to customize the
     schema once after first generation.
+
+    The runtime accepts three credential modes (see
+    ``docs/web-api-spec.md`` §3 and the static
+    ``docs/api/openapi.yaml``):
+
+    1. ``bearerAuth`` — ``Authorization: Bearer <token>`` header,
+       token sourced from ``~/.pollypm/api-token``.
+    2. ``cookieAuth`` — ``pollypm-session`` cookie minted by
+       ``GET /ui/`` for loopback peers, verified tailnet peers, or
+       callers presenting a valid bearer header. Same on-disk token,
+       constant-time comparison.
+    3. Credential-free tailnet-peer mode (empty ``{}`` entry in the
+       security list) — only honoured when the app was constructed
+       with ``tailnet_trust_enabled=True``.
+
+    The runtime ``/openapi.json`` must mirror that three-mode story
+    so generated clients reading the live endpoint see the same auth
+    contract as readers of the static YAML (#2065).
     """
     base_openapi = app.openapi
 
@@ -462,19 +480,49 @@ def _attach_security_scheme(app: FastAPI) -> None:
             return app.openapi_schema
         schema = base_openapi()
         schema.setdefault("components", {})
-        schema["components"].setdefault("securitySchemes", {})
-        schema["components"]["securitySchemes"]["bearerAuth"] = {
-            "type": "http",
-            "scheme": "bearer",
-            "bearerFormat": "opaque",
-            "description": (
-                "Token from `~/.pollypm/api-token`. Generated on first "
-                "`pm serve` startup; rotated via `pm api regen-token`."
-            ),
+        # Replace any auto-detected scheme block wholesale: we want the
+        # runtime doc to advertise exactly the same scheme set as the
+        # static contract.
+        schema["components"]["securitySchemes"] = {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "opaque",
+                "description": (
+                    "Bearer token from `~/.pollypm/api-token`. "
+                    "Generated on first `pm serve` startup; rotated "
+                    "via `pm api regen-token`. Always accepted. "
+                    "See `docs/web-api-spec.md` §3."
+                ),
+            },
+            "cookieAuth": {
+                "type": "apiKey",
+                "in": "cookie",
+                "name": "pollypm-session",
+                "description": (
+                    "Session cookie minted by `GET /ui/` for loopback "
+                    "peers, verified tailnet peers (when "
+                    "`tailnet_trust_enabled=True`), or callers "
+                    "presenting a valid bearer header. The cookie "
+                    "value is the same on-disk token as `bearerAuth`; "
+                    "comparison is constant-time. LAN clients receive "
+                    "HTML without `Set-Cookie` and 401 on the first "
+                    "API call. See `docs/web-api-spec.md` §3."
+                ),
+            },
         }
         # Default security applies to every operation; ``/health``
         # opts out via the route definition (security: []).
-        schema["security"] = [{"bearerAuth": []}]
+        # The empty ``{}`` entry models the credential-free
+        # tailnet-peer mode (OpenAPI's canonical way of saying
+        # "no credentials required"); it does NOT mean every caller
+        # is anonymous — the runtime still gates on
+        # ``tailnet_trust_enabled`` + a verified peer IP.
+        schema["security"] = [
+            {"bearerAuth": []},
+            {"cookieAuth": []},
+            {},
+        ]
         # Drop the security requirement from ``/health`` so the
         # generated doc matches the runtime behaviour.
         for path, ops in schema.get("paths", {}).items():

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -21,16 +21,19 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.web_api.auth import (
+    SESSION_COOKIE_NAME,
     make_bearer_auth_dependency,
     make_sse_auth_dependency,
 )
+from pollypm.web_api.token import DEFAULT_TOKEN_PATH, load_token
 from pollypm.web_api.errors import (
     APIError,
     handle_api_error,
@@ -398,6 +401,13 @@ def create_app(
         dependencies=auth_deps,
     )
 
+    # v0 web UI (Phase 7) — static SPA at ``/ui/`` with a cookie-bridge
+    # entry point that injects the on-disk token as the
+    # ``pollypm-session`` cookie. The static files (app.js, styles.css)
+    # are served raw; the entry route is custom so it can set the
+    # cookie + return the HTML in one round-trip.
+    _mount_web_ui(app, token_path=token_path)
+
     # ``security: bearerAuth`` declared at the document level so
     # generated clients carry the correct Auth scheme.
     _attach_security_scheme(app)
@@ -455,6 +465,81 @@ def _attach_security_scheme(app: FastAPI) -> None:
         return schema
 
     app.openapi = _custom_openapi  # type: ignore[assignment]
+
+
+def _mount_web_ui(app: FastAPI, *, token_path: Path | None) -> None:
+    """Mount the v0 web UI static assets + cookie-bridge entry route.
+
+    Layout:
+
+    - ``GET /ui/`` returns ``index.html`` and sets the
+      ``pollypm-session`` cookie from the on-disk token, so subsequent
+      ``fetch(..., {credentials: 'include'})`` calls authenticate
+      without the user ever seeing the token.
+    - ``GET /ui/{path}`` (e.g. ``app.js``, ``styles.css``) is served by
+      :class:`StaticFiles` from the ``ui/`` directory next to this
+      module. No auth on the static assets themselves — the bytes are
+      not sensitive and gating them behind cookie auth would break the
+      ``GET /ui/`` boot (browser fetches ``app.js`` before the cookie
+      round-trips on slow links). The API endpoints those assets call
+      remain auth-gated.
+    - ``GET /ui`` (no trailing slash) → 307 to ``/ui/`` so the cookie
+      gets set even if the operator types the short form.
+    """
+    ui_dir = Path(__file__).parent / "ui"
+    if not ui_dir.exists():
+        # Defensive: an installed wheel without the ui/ data directory
+        # would 404 on /ui/, which is fine but logging makes the cause
+        # discoverable. The app still boots and the JSON API works.
+        logger.warning(
+            "web UI directory missing at %s; /ui/ will 404", ui_dir,
+        )
+        return
+
+    index_path = ui_dir / "index.html"
+
+    @app.get("/ui", include_in_schema=False)
+    def _ui_root_redirect() -> Response:
+        # 307 preserves method + the spec for "the trailing slash form
+        # is canonical" without altering verbs.
+        return Response(status_code=307, headers={"Location": "/ui/"})
+
+    @app.get("/ui/", include_in_schema=False)
+    def _ui_index() -> Response:
+        # Load the token at request time (not app-build time) so a
+        # ``pm api regen-token`` rotation flows into the cookie on the
+        # next page load without an app restart.
+        resolved_token_path = token_path or DEFAULT_TOKEN_PATH
+        token_value = load_token(resolved_token_path)
+        response = FileResponse(index_path, media_type="text/html")
+        if token_value:
+            # ``HttpOnly`` so JS can't read the token; ``SameSite=Lax``
+            # so cross-tab navigation still carries it; ``Secure=False``
+            # because the v0 deploy is loopback/Tailscale HTTP. When
+            # the operator puts this behind TLS they should set
+            # ``Secure=True`` via a reverse proxy.
+            response.set_cookie(
+                key=SESSION_COOKIE_NAME,
+                value=token_value,
+                httponly=True,
+                samesite="lax",
+                secure=False,
+                path="/",
+                max_age=60 * 60 * 24 * 7,  # 7 days
+            )
+        # If the token file doesn't exist yet, we still serve the HTML
+        # — the SPA will surface a 401 the first time it hits /api/
+        # and the operator will know to run `pm api regen-token`.
+        return response
+
+    # Static assets served raw. ``html=False`` keeps StaticFiles from
+    # hijacking the bare ``/ui/`` path (we've already taken that route
+    # above with the cookie-setting handler).
+    app.mount(
+        "/ui",
+        StaticFiles(directory=str(ui_dir), html=False),
+        name="ui-static",
+    )
 
 
 __all__ = ["API_V1_PREFIX", "create_app"]

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -246,6 +246,7 @@ def create_app(
     *,
     config: PollyPMConfig,
     token_path: Path | None = None,
+    tailnet_trust_enabled: bool = False,
 ) -> FastAPI:
     """Build a FastAPI app for ``pm serve``.
 
@@ -257,6 +258,16 @@ def create_app(
         Override the bearer-token file location. Defaults to
         ``~/.pollypm/api-token`` per spec §3. Tests pass a tmp path
         so the user's real token never surfaces.
+    tailnet_trust_enabled:
+        When ``True``, the auth dependency and the ``/ui/`` cookie gate
+        treat a request from the Tailscale CGNAT range
+        (``100.64.0.0/10``) as authenticated even without a bearer or
+        cookie. ``pm serve`` only enables this when it actually bound
+        to a verified Tailscale IPv4 — an explicit
+        ``--host 0.0.0.0 --allow-remote`` keeps the default ``False``,
+        so a CGNAT-source peer on the public interface still needs a
+        credential. Default ``False`` (closed by default; tests and
+        legacy callers stay strict).
     """
     # FastAPI's default ``openapi_url`` is public, but the spec
     # (§3) lists only ``/health`` as auth-exempt. Disable the default
@@ -340,11 +351,15 @@ def create_app(
     # Health is exempt from auth per spec §3.
     app.include_router(health_routes.router, prefix=API_V1_PREFIX)
 
-    auth_dependency = make_bearer_auth_dependency(token_path)
+    auth_dependency = make_bearer_auth_dependency(
+        token_path, tailnet_trust_enabled=tailnet_trust_enabled,
+    )
     auth_deps = [Depends(auth_dependency)]
     # SSE has its own auth dependency that also accepts ``?token=``
     # (browser EventSource cannot set custom headers — see spec §4).
-    sse_auth_dependency = make_sse_auth_dependency(token_path)
+    sse_auth_dependency = make_sse_auth_dependency(
+        token_path, tailnet_trust_enabled=tailnet_trust_enabled,
+    )
     sse_auth_deps = [Depends(sse_auth_dependency)]
 
     app.include_router(projects_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
@@ -408,7 +423,11 @@ def create_app(
     # ``pollypm-session`` cookie. The static files (app.js, styles.css)
     # are served raw; the entry route is custom so it can set the
     # cookie + return the HTML in one round-trip.
-    _mount_web_ui(app, token_path=token_path)
+    _mount_web_ui(
+        app,
+        token_path=token_path,
+        tailnet_trust_enabled=tailnet_trust_enabled,
+    )
 
     # ``security: bearerAuth`` declared at the document level so
     # generated clients carry the correct Auth scheme.
@@ -469,7 +488,12 @@ def _attach_security_scheme(app: FastAPI) -> None:
     app.openapi = _custom_openapi  # type: ignore[assignment]
 
 
-def _mount_web_ui(app: FastAPI, *, token_path: Path | None) -> None:
+def _mount_web_ui(
+    app: FastAPI,
+    *,
+    token_path: Path | None,
+    tailnet_trust_enabled: bool = False,
+) -> None:
     """Mount the v0 web UI static assets + cookie-bridge entry route.
 
     Layout:
@@ -529,9 +553,14 @@ def _mount_web_ui(app: FastAPI, *, token_path: Path | None) -> None:
         # 2. Loopback client (127.0.0.1, ::1) — local operator on
         #    the Mac itself.
         # 3. Tailscale CGNAT peer — operator hitting /ui/ from a
-        #    tailnet device. Defense-in-depth on top of the
-        #    bind-to-interface enforcement in ``pm serve`` (see
-        #    cli_features/web_api.py).
+        #    tailnet device, but **only when ``tailnet_trust_enabled``
+        #    is True** (i.e. ``pm serve`` actually bound to a verified
+        #    Tailscale interface). On an explicit
+        #    ``--host 0.0.0.0 --allow-remote`` deploy the flag is
+        #    False, so a CGNAT-source peer no longer earns a cookie:
+        #    RFC 6598 shared address space is also used by some ISP
+        #    CGNAT setups and must not be trusted on the public
+        #    interface.
         #
         # Everything else (LAN device, public-facing deploy by
         # accident, spoofed source IP through a misconfigured proxy)
@@ -541,7 +570,7 @@ def _mount_web_ui(app: FastAPI, *, token_path: Path | None) -> None:
         # docs/pollypm-web-ui-2065-security-spec.md (decision d-ii).
         client_host = request.client.host if request.client else None
         is_loopback = client_host in ("127.0.0.1", "::1")
-        is_tailnet = is_tailscale_ip(client_host)
+        is_tailnet = tailnet_trust_enabled and is_tailscale_ip(client_host)
         bearer_token = _extract_token(authorization)
         valid_bearer = False
         if bearer_token is not None and token_value is not None:

--- a/src/pollypm/web_api/auth.py
+++ b/src/pollypm/web_api/auth.py
@@ -9,16 +9,59 @@ The dependency reads the token fresh from disk on each request so a
 ``pm api regen-token`` rotation invalidates outstanding sessions
 immediately — there's no in-memory cache to flush. Personal-use volume
 makes that trivially cheap (one ``open + read`` per request).
+
+V0 web UI (Phase 7) extends the auth dependency with two additional
+acceptance modes for browser-driven sessions:
+
+- ``pollypm-session`` cookie — set by ``GET /ui/`` from the on-disk
+  token, so the browser never has to paste / type the token. Same
+  comparison rules as the header (constant-time, rotation invalidates).
+- Tailscale CGNAT trust — request ``client.host`` inside the Tailscale
+  CGNAT range (``100.64.0.0/10``) is allowed without either credential.
+  Tailscale's network identity is itself an auth boundary; on a typical
+  personal-use Tailscale-only deployment, requiring a second secret is
+  redundant friction.
+
+Loopback (``127.0.0.1``, ``::1``) is NOT auto-trusted — local processes
+without the token shouldn't bypass auth on a shared machine, and the
+cookie-from-disk path already covers the local-browser convenience case.
 """
 
 from __future__ import annotations
 
+import ipaddress
 from pathlib import Path
 
-from fastapi import Header, Query
+from fastapi import Cookie, Header, Query, Request
 
 from pollypm.web_api.errors import invalid_token, unauthorized
 from pollypm.web_api.token import load_token
+
+
+# Tailscale's CGNAT range — every node on a tailnet gets a 100.64.0.0/10
+# address. We trust requests originating from this range as already
+# authenticated by Tailscale itself (the operator opted into Tailscale
+# auth when they joined the tailnet).
+_TAILSCALE_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
+
+# Cookie name used by ``GET /ui/`` to seed the browser session.
+SESSION_COOKIE_NAME = "pollypm-session"
+
+
+def is_tailscale_ip(host: str | None) -> bool:
+    """Return True iff ``host`` parses as an IP inside the CGNAT range.
+
+    Anything non-IP (hostnames, ``None``, malformed values) returns
+    ``False`` so we never accidentally trust a string that looks
+    plausible but isn't actually a tailnet address.
+    """
+    if not host:
+        return False
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return addr in _TAILSCALE_CGNAT_NET
 
 
 def _extract_token(header_value: str | None) -> str | None:
@@ -45,12 +88,41 @@ def make_bearer_auth_dependency(token_path: Path | None = None):
 
     Constructed at app-creation time so tests can swap in a tmp token
     path without monkeypatching module-level state.
+
+    Accepts three credential modes (in order):
+    1. ``Authorization: Bearer <token>`` header.
+    2. ``pollypm-session`` cookie (web UI).
+    3. Tailscale CGNAT client IP (no credential needed).
+
+    Wrong tokens / cookies still produce ``invalid_token``; missing
+    everything (and not from a tailnet IP) produces ``unauthorized``.
     """
 
-    def _dependency(authorization: str | None = Header(default=None)) -> str:
-        provided = _extract_token(authorization)
+    def _dependency(
+        request: Request,
+        authorization: str | None = Header(default=None),
+        session_cookie: str | None = Cookie(
+            default=None, alias=SESSION_COOKIE_NAME,
+        ),
+    ) -> str:
+        # Determine which credential the caller supplied. We compare
+        # against the on-disk token for both header and cookie modes;
+        # only the Tailscale path skips the comparison entirely.
+        provided: str | None = _extract_token(authorization)
+        from_cookie = False
+        if provided is None and session_cookie:
+            provided = session_cookie.strip() or None
+            from_cookie = provided is not None
+
         if provided is None:
+            # No credential at all — check Tailscale fallback before
+            # rejecting. ``request.client`` is ``None`` for ASGI
+            # transports without a peer (rare; treat as unauthenticated).
+            client_host = request.client.host if request.client else None
+            if is_tailscale_ip(client_host):
+                return f"tailscale:{client_host}"
             raise unauthorized()
+
         expected = load_token(token_path)
         if expected is None:
             # Token file doesn't exist — first-run footgun. Treat as
@@ -66,6 +138,14 @@ def make_bearer_auth_dependency(token_path: Path | None = None):
         from secrets import compare_digest
 
         if not compare_digest(provided, expected):
+            # A stale cookie deserves a clearer hint than the raw
+            # ``invalid_token`` message — the operator likely rotated
+            # the token and the browser is still sending the old one.
+            if from_cookie:
+                raise invalid_token(
+                    "Session cookie does not match the current token. "
+                    "Reload /ui/ to refresh the cookie from disk."
+                )
             raise invalid_token()
         return provided
 
@@ -82,22 +162,35 @@ def make_sse_auth_dependency(token_path: Path | None = None):
     a SSE-only escape hatch — do NOT reuse this for read or write
     endpoints, since query strings end up in proxy / browser-history
     logs.
+
+    Also honors the v0 web UI session cookie and the Tailscale CGNAT
+    trust, matching the behavior of :func:`make_bearer_auth_dependency`,
+    so the SPA can subscribe to ``/events`` without paste-box gymnastics.
     """
 
     def _dependency(
+        request: Request,
         authorization: str | None = Header(default=None),
         token: str | None = Query(default=None, description=(
             "Bearer token, SSE-only fallback for browser EventSource which "
             "cannot send Authorization headers. Prefer the Authorization "
             "header for every other endpoint."
         )),
+        session_cookie: str | None = Cookie(
+            default=None, alias=SESSION_COOKIE_NAME,
+        ),
     ) -> str:
         provided = _extract_token(authorization)
         if provided is None:
             # Fall back to the query-string escape hatch.
             if token:
                 provided = token.strip() or None
+        if provided is None and session_cookie:
+            provided = session_cookie.strip() or None
         if provided is None:
+            client_host = request.client.host if request.client else None
+            if is_tailscale_ip(client_host):
+                return f"tailscale:{client_host}"
             raise unauthorized()
         expected = load_token(token_path)
         if expected is None:
@@ -114,4 +207,9 @@ def make_sse_auth_dependency(token_path: Path | None = None):
     return _dependency
 
 
-__all__ = ["make_bearer_auth_dependency", "make_sse_auth_dependency"]
+__all__ = [
+    "SESSION_COOKIE_NAME",
+    "is_tailscale_ip",
+    "make_bearer_auth_dependency",
+    "make_sse_auth_dependency",
+]

--- a/src/pollypm/web_api/auth.py
+++ b/src/pollypm/web_api/auth.py
@@ -54,6 +54,19 @@ def is_tailscale_ip(host: str | None) -> bool:
     Anything non-IP (hostnames, ``None``, malformed values) returns
     ``False`` so we never accidentally trust a string that looks
     plausible but isn't actually a tailnet address.
+
+    .. note::
+       This is a **sanity filter, not the primary trust boundary**. The
+       100.64.0.0/10 range is RFC 6598 shared address space; Tailscale
+       uses it but so does CGNAT-enabled ISP infrastructure. The real
+       tailnet-trust enforcement is the OS-level interface binding done
+       by ``pm serve`` (see ``cli_features/web_api.py``): uvicorn binds
+       to the detected Tailscale IPv4 only, so packets arriving on any
+       other interface are dropped by the kernel before reaching this
+       check. This helper exists for defense-in-depth: if a future
+       deploy widens the bind by accident (or the operator runs the
+       server behind a reverse proxy that doesn't preserve the peer
+       address), the CGNAT filter still keeps random LAN devices out.
     """
     if not host:
         return False
@@ -209,6 +222,7 @@ def make_sse_auth_dependency(token_path: Path | None = None):
 
 __all__ = [
     "SESSION_COOKIE_NAME",
+    "_extract_token",
     "is_tailscale_ip",
     "make_bearer_auth_dependency",
     "make_sse_auth_dependency",

--- a/src/pollypm/web_api/auth.py
+++ b/src/pollypm/web_api/auth.py
@@ -17,14 +17,25 @@ acceptance modes for browser-driven sessions:
   token, so the browser never has to paste / type the token. Same
   comparison rules as the header (constant-time, rotation invalidates).
 - Tailscale CGNAT trust — request ``client.host`` inside the Tailscale
-  CGNAT range (``100.64.0.0/10``) is allowed without either credential.
-  Tailscale's network identity is itself an auth boundary; on a typical
-  personal-use Tailscale-only deployment, requiring a second secret is
-  redundant friction.
+  CGNAT range (``100.64.0.0/10``) is allowed without either credential,
+  **but only when the app was built with ``tailnet_trust_enabled=True``**.
+  ``pm serve`` only flips that flag when it actually bound to a verified
+  Tailscale IPv4 (see ``cli_features/web_api.py``). An operator who
+  runs ``pm serve --host 0.0.0.0 --allow-remote`` gets ``False`` even if
+  Tailscale is running — RFC 6598 shared address space is used by some
+  CGNAT-enabled ISPs, so an unauthenticated 100.64.x.y peer arriving on
+  a non-tailnet interface must NOT be trusted.
 
-Loopback (``127.0.0.1``, ``::1``) is NOT auto-trusted — local processes
-without the token shouldn't bypass auth on a shared machine, and the
-cookie-from-disk path already covers the local-browser convenience case.
+Loopback (``127.0.0.1``, ``::1``) is not auto-trusted by the API auth
+dependency itself — a local process without the bearer token still
+receives 401 from ``/api/v1/...``. However, ``GET /ui/`` deliberately
+mints a ``pollypm-session`` cookie from the on-disk token for any
+loopback caller (and for tailnet callers when the flag above is on) as
+a convenience for the local-operator workflow: a browser on the same
+machine shouldn't have to paste a bearer to view the cockpit. See
+``docs/pollypm-web-ui-2065-security-spec.md`` decision **d-ii** for the
+signed-off trade-off — loopback-cookie-mint is an explicit local-
+operator bypass, not an oversight.
 """
 
 from __future__ import annotations
@@ -96,7 +107,11 @@ def _extract_token(header_value: str | None) -> str | None:
     return value or None
 
 
-def make_bearer_auth_dependency(token_path: Path | None = None):
+def make_bearer_auth_dependency(
+    token_path: Path | None = None,
+    *,
+    tailnet_trust_enabled: bool = False,
+):
     """Return a FastAPI dependency that enforces bearer-token auth.
 
     Constructed at app-creation time so tests can swap in a tmp token
@@ -105,10 +120,19 @@ def make_bearer_auth_dependency(token_path: Path | None = None):
     Accepts three credential modes (in order):
     1. ``Authorization: Bearer <token>`` header.
     2. ``pollypm-session`` cookie (web UI).
-    3. Tailscale CGNAT client IP (no credential needed).
+    3. Tailscale CGNAT client IP (no credential needed) — **only when
+       ``tailnet_trust_enabled`` is True**.
+
+    The tailnet-trust flag is opt-in so a server that did NOT bind to
+    a verified Tailscale interface (e.g. ``pm serve --host 0.0.0.0
+    --allow-remote``) never grants credential-free access to peers
+    whose source IP happens to land in RFC 6598 shared address space.
+    Some ISPs use 100.64.0.0/10 for CGNAT; without the gate, those
+    peers would walk past auth.
 
     Wrong tokens / cookies still produce ``invalid_token``; missing
-    everything (and not from a tailnet IP) produces ``unauthorized``.
+    everything (and not from a trusted tailnet IP) produces
+    ``unauthorized``.
     """
 
     def _dependency(
@@ -132,7 +156,7 @@ def make_bearer_auth_dependency(token_path: Path | None = None):
             # rejecting. ``request.client`` is ``None`` for ASGI
             # transports without a peer (rare; treat as unauthenticated).
             client_host = request.client.host if request.client else None
-            if is_tailscale_ip(client_host):
+            if tailnet_trust_enabled and is_tailscale_ip(client_host):
                 return f"tailscale:{client_host}"
             raise unauthorized()
 
@@ -165,7 +189,11 @@ def make_bearer_auth_dependency(token_path: Path | None = None):
     return _dependency
 
 
-def make_sse_auth_dependency(token_path: Path | None = None):
+def make_sse_auth_dependency(
+    token_path: Path | None = None,
+    *,
+    tailnet_trust_enabled: bool = False,
+):
     """Return a FastAPI dependency for the SSE stream specifically.
 
     The browser ``EventSource`` API cannot send custom headers, so the
@@ -176,9 +204,10 @@ def make_sse_auth_dependency(token_path: Path | None = None):
     endpoints, since query strings end up in proxy / browser-history
     logs.
 
-    Also honors the v0 web UI session cookie and the Tailscale CGNAT
-    trust, matching the behavior of :func:`make_bearer_auth_dependency`,
-    so the SPA can subscribe to ``/events`` without paste-box gymnastics.
+    Also honors the v0 web UI session cookie and (when
+    ``tailnet_trust_enabled`` is True) the Tailscale CGNAT trust,
+    matching the behavior of :func:`make_bearer_auth_dependency`, so
+    the SPA can subscribe to ``/events`` without paste-box gymnastics.
     """
 
     def _dependency(
@@ -202,7 +231,7 @@ def make_sse_auth_dependency(token_path: Path | None = None):
             provided = session_cookie.strip() or None
         if provided is None:
             client_host = request.client.host if request.client else None
-            if is_tailscale_ip(client_host):
+            if tailnet_trust_enabled and is_tailscale_ip(client_host):
                 return f"tailscale:{client_host}"
             raise unauthorized()
         expected = load_token(token_path)

--- a/src/pollypm/web_api/auth.py
+++ b/src/pollypm/web_api/auth.py
@@ -33,7 +33,7 @@ mints a ``pollypm-session`` cookie from the on-disk token for any
 loopback caller (and for tailnet callers when the flag above is on) as
 a convenience for the local-operator workflow: a browser on the same
 machine shouldn't have to paste a bearer to view the cockpit. See
-``docs/pollypm-web-ui-2065-security-spec.md`` decision **d-ii** for the
+``docs/web-ui-2065-security-spec.md`` decision **d-ii** for the
 signed-off trade-off — loopback-cookie-mint is an explicit local-
 operator bypass, not an oversight.
 """

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -1,0 +1,356 @@
+// PollyPM v0 web UI — vanilla JS, no build step, no dependencies.
+//
+// Auth model: the cookie ``pollypm-session`` is set by GET /ui/ from
+// the on-disk token, so every request just needs ``credentials:
+// 'include'`` to ride that cookie. We never read or display the token
+// in the browser.
+
+(function () {
+  "use strict";
+
+  const API = "/api/v1";
+  const POLL_DASHBOARD_MS = 15000;
+  const POLL_MESSAGES_MS = 5000;
+  const MAX_MESSAGES = 50;
+
+  const state = {
+    surfaces: [],
+    selectedSurface: null,
+    messageTimer: null,
+  };
+
+  // ----- DOM helpers ------------------------------------------------------
+
+  function $(id) { return document.getElementById(id); }
+
+  function el(tag, attrs, children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const k of Object.keys(attrs)) {
+        if (k === "class") node.className = attrs[k];
+        else if (k === "text") node.textContent = attrs[k];
+        else node.setAttribute(k, attrs[k]);
+      }
+    }
+    if (children) {
+      for (const child of children) {
+        if (child) node.appendChild(child);
+      }
+    }
+    return node;
+  }
+
+  function setStatus(level, label) {
+    const node = $("conn-status");
+    if (!node) return;
+    node.className = "conn-status conn-" + level;
+    const lbl = node.querySelector(".conn-label");
+    if (lbl) lbl.textContent = label;
+  }
+
+  // ----- fetch wrapper ----------------------------------------------------
+
+  async function apiFetch(path, opts) {
+    const init = Object.assign({ credentials: "include" }, opts || {});
+    init.headers = Object.assign(
+      { "Accept": "application/json" },
+      init.headers || {},
+    );
+    let resp;
+    try {
+      resp = await fetch(path, init);
+    } catch (err) {
+      setStatus("error", "offline");
+      throw err;
+    }
+    if (resp.status === 401) {
+      setStatus("error", "auth (reload /ui/)");
+      throw new Error("unauthorized");
+    }
+    if (!resp.ok) {
+      setStatus("warn", "HTTP " + resp.status);
+      let body = null;
+      try { body = await resp.json(); } catch (e) { /* ignore */ }
+      const detail = body && body.error
+        ? body.error.message || body.error.code
+        : ("HTTP " + resp.status);
+      throw new Error(detail);
+    }
+    setStatus("ok", "online");
+    return resp;
+  }
+
+  async function apiJson(path, opts) {
+    const resp = await apiFetch(path, opts);
+    return resp.json();
+  }
+
+  // ----- surfaces (left rail) --------------------------------------------
+
+  async function loadSurfaces() {
+    try {
+      const data = await apiJson(API + "/chat/sessions");
+      state.surfaces = Array.isArray(data.sessions) ? data.sessions : [];
+      renderSurfaces();
+    } catch (err) {
+      renderSurfaceError(err);
+    }
+  }
+
+  function renderSurfaces() {
+    const list = $("surface-list");
+    list.innerHTML = "";
+    if (state.surfaces.length === 0) {
+      list.appendChild(
+        el("li", { class: "surface-empty", text: "no surfaces registered" }),
+      );
+      return;
+    }
+    for (const s of state.surfaces) {
+      const dotClass =
+        s.window && s.window.pane_dead
+          ? "surface-dot dead"
+          : s.window && s.window.present
+            ? "surface-dot present"
+            : "surface-dot";
+      const labelParts = [];
+      if (s.surface_type) labelParts.push(s.surface_type);
+      if (s.persona && s.persona !== s.surface_type) labelParts.push(s.persona);
+      if (s.project) labelParts.push(s.project);
+      const li = el(
+        "li",
+        {
+          "data-session": s.session_name,
+          "class": state.selectedSurface === s.session_name ? "active" : "",
+        },
+        [
+          el("span", { class: "surface-name" }, [
+            el("span", { class: dotClass }),
+            document.createTextNode(s.session_name),
+          ]),
+          el("span", {
+            class: "surface-meta",
+            text: labelParts.join(" · ") || "—",
+          }),
+        ],
+      );
+      li.addEventListener("click", () => selectSurface(s.session_name));
+      list.appendChild(li);
+    }
+  }
+
+  function renderSurfaceError(err) {
+    const list = $("surface-list");
+    list.innerHTML = "";
+    list.appendChild(
+      el("li", { class: "surface-empty", text: "error: " + err.message }),
+    );
+  }
+
+  function selectSurface(name) {
+    state.selectedSurface = name;
+    $("pane-title").textContent = name;
+    $("pane-meta").textContent = "";
+    $("send-input").disabled = false;
+    $("send-button").disabled = false;
+    renderSurfaces();
+    loadHistory(name);
+    schedulePoll();
+  }
+
+  // ----- history (center) ------------------------------------------------
+
+  async function loadHistory(name) {
+    if (!name) return;
+    try {
+      const path =
+        API + "/chat/" + encodeURIComponent(name) + "/messages?limit="
+        + MAX_MESSAGES + "&direction=desc";
+      const data = await apiJson(path);
+      renderHistory(data);
+    } catch (err) {
+      renderHistoryError(err);
+    }
+  }
+
+  function renderHistory(data) {
+    const list = $("message-list");
+    list.innerHTML = "";
+    const meta = [];
+    if (data.surface_type) meta.push(data.surface_type);
+    if (data.transcript_source) meta.push("src=" + data.transcript_source);
+    $("pane-meta").textContent = meta.join(" · ");
+    const msgs = Array.isArray(data.messages) ? data.messages.slice() : [];
+    if (msgs.length === 0) {
+      list.appendChild(
+        el("div", { class: "message-empty", text: "no messages yet" }),
+      );
+      return;
+    }
+    // API returned newest-first; render oldest-first so the latest is
+    // at the bottom (chat convention).
+    msgs.reverse();
+    for (const m of msgs) {
+      const roleClass = "message message-role-" + (m.role || "system");
+      list.appendChild(
+        el("div", { class: roleClass }, [
+          el("div", { class: "message-head" }, [
+            el("span", { class: "message-actor", text: m.actor || m.role || "?" }),
+            el("span", { class: "message-ts", text: m.ts || "" }),
+            el("span", { class: "message-type", text: m.type || "" }),
+          ]),
+          el("div", { class: "message-text", text: m.text || "" }),
+        ]),
+      );
+    }
+    list.scrollTop = list.scrollHeight;
+  }
+
+  function renderHistoryError(err) {
+    const list = $("message-list");
+    list.innerHTML = "";
+    list.appendChild(
+      el("div", { class: "error-banner", text: "history error: " + err.message }),
+    );
+  }
+
+  // ----- send (bottom) ---------------------------------------------------
+
+  async function sendMessage(name, text) {
+    if (!name || !text) return;
+    const path = API + "/chat/" + encodeURIComponent(name) + "/send";
+    await apiFetch(path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: text }),
+    });
+    // Refresh after a short delay so the new line shows up.
+    setTimeout(() => loadHistory(name), 400);
+  }
+
+  // ----- dashboard rollups (right rail) ----------------------------------
+
+  async function pollDashboard() {
+    try {
+      const data = await apiJson(API + "/dashboard");
+      renderDashboard(data);
+    } catch (err) {
+      renderDashboardError(err);
+    }
+  }
+
+  function pickNumber(obj /*, ...path */) {
+    let cur = obj;
+    for (let i = 1; i < arguments.length; i++) {
+      if (cur == null) return null;
+      cur = cur[arguments[i]];
+    }
+    return typeof cur === "number" ? cur : null;
+  }
+
+  function renderDashboard(data) {
+    const box = $("dashboard-rollups");
+    box.innerHTML = "";
+    if (!data || typeof data !== "object") {
+      box.appendChild(el("div", { class: "rollup-empty", text: "no data" }));
+      return;
+    }
+    const cards = [];
+    const candidates = [
+      { label: "attention", path: ["attention_count"], cls: "rollup-attention" },
+      { label: "inbox unread", path: ["inbox", "unread"], cls: "rollup-attention" },
+      { label: "blocked", path: ["blocked_count"], cls: "rollup-blocked" },
+      { label: "active workers", path: ["workers", "active"], cls: "rollup-working" },
+      { label: "tasks open", path: ["tasks", "open"], cls: "" },
+      { label: "projects", path: ["projects", "tracked"], cls: "" },
+    ];
+    for (const c of candidates) {
+      const val = pickNumber.apply(null, [data].concat(c.path));
+      if (val === null) continue;
+      cards.push(
+        el("div", { class: "rollup-card " + c.cls }, [
+          el("div", { class: "rollup-label", text: c.label }),
+          el("div", { class: "rollup-value", text: String(val) }),
+        ]),
+      );
+    }
+    if (cards.length === 0) {
+      // Surface whatever top-level keys exist so the rail is not dead.
+      const keys = Object.keys(data).slice(0, 6);
+      for (const k of keys) {
+        const raw = data[k];
+        const display = (raw && typeof raw === "object")
+          ? Object.keys(raw).length + " keys"
+          : String(raw);
+        cards.push(
+          el("div", { class: "rollup-card" }, [
+            el("div", { class: "rollup-label", text: k }),
+            el("div", { class: "rollup-value", text: display }),
+          ]),
+        );
+      }
+    }
+    if (cards.length === 0) {
+      box.appendChild(el("div", { class: "rollup-empty", text: "no rollups" }));
+      return;
+    }
+    for (const c of cards) box.appendChild(c);
+  }
+
+  function renderDashboardError(err) {
+    const box = $("dashboard-rollups");
+    box.innerHTML = "";
+    box.appendChild(
+      el("div", { class: "rollup-empty", text: "error: " + err.message }),
+    );
+  }
+
+  // ----- timers -----------------------------------------------------------
+
+  function schedulePoll() {
+    if (state.messageTimer) clearInterval(state.messageTimer);
+    state.messageTimer = setInterval(() => {
+      if (state.selectedSurface) loadHistory(state.selectedSurface);
+    }, POLL_MESSAGES_MS);
+  }
+
+  // ----- wire-up ----------------------------------------------------------
+
+  function wireSendForm() {
+    const form = $("send-form");
+    const input = $("send-input");
+    form.addEventListener("submit", (ev) => {
+      ev.preventDefault();
+      const text = input.value.trim();
+      if (!text || !state.selectedSurface) return;
+      input.value = "";
+      sendMessage(state.selectedSurface, text).catch((err) => {
+        renderHistoryError(err);
+      });
+    });
+  }
+
+  function init() {
+    wireSendForm();
+    setStatus("warn", "connecting…");
+    loadSurfaces();
+    pollDashboard();
+    setInterval(loadSurfaces, 30000);
+    setInterval(pollDashboard, POLL_DASHBOARD_MS);
+  }
+
+  // Expose for tests / debugging.
+  window.PollyPM = {
+    loadSurfaces: loadSurfaces,
+    loadHistory: loadHistory,
+    sendMessage: sendMessage,
+    pollDashboard: pollDashboard,
+    state: state,
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -4,6 +4,12 @@
 // the on-disk token, so every request just needs ``credentials:
 // 'include'`` to ride that cookie. We never read or display the token
 // in the browser.
+//
+// Cookie issuance is gated on the server side (see app.py _ui_index)
+// to one of: loopback client, Tailscale CGNAT peer, or valid bearer
+// header. LAN devices get the HTML but no cookie; the first /api/
+// call returns 401 and ``setAuthGate`` below surfaces a banner that
+// tells the operator how to recover.
 
 (function () {
   "use strict";
@@ -48,6 +54,29 @@
     if (lbl) lbl.textContent = label;
   }
 
+  // Show the auth-gate banner once when the SPA hits a 401. This
+  // happens when /ui/ was reached from a host that isn't loopback /
+  // Tailscale and didn't supply a valid bearer header, so the server
+  // declined to set the pollypm-session cookie. Surfacing the recovery
+  // path inline (rather than leaving the rails frozen on "loading…")
+  // makes the constraint visible at the moment it bites.
+  let authGateShown = false;
+  function showAuthGate() {
+    if (authGateShown) return;
+    authGateShown = true;
+    const banner = document.createElement("div");
+    banner.className = "error-banner auth-gate-banner";
+    banner.textContent =
+      "This UI requires Tailscale or local (loopback) access. " +
+      "Visit http://127.0.0.1:<port>/ui/ from the host running " +
+      "`pm serve`, or open http://<tailscale-ip>:<port>/ui/ from " +
+      "a tailnet device. To bootstrap manually, run " +
+      "`pm api regen-token` and send the value in an " +
+      "`Authorization: Bearer …` header.";
+    const layout = document.getElementById("layout") || document.body;
+    layout.parentNode.insertBefore(banner, layout);
+  }
+
   // ----- fetch wrapper ----------------------------------------------------
 
   async function apiFetch(path, opts) {
@@ -64,7 +93,8 @@
       throw err;
     }
     if (resp.status === 401) {
-      setStatus("error", "auth (reload /ui/)");
+      setStatus("error", "auth required");
+      showAuthGate();
       throw new Error("unauthorized");
     }
     if (!resp.ok) {

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -435,12 +435,18 @@
     setInterval(pollDashboard, POLL_DASHBOARD_MS);
   }
 
-  // Expose for tests / debugging.
+  // Expose for tests / debugging. ``renderDashboard`` is exported so
+  // an executable test harness can feed a representative
+  // ``DashboardResponse`` payload through the real mapping logic and
+  // assert visible labels/values — static source greps cannot catch a
+  // runtime mapping bug that still happens to contain the right field
+  // names (Codex round-5 blocker).
   window.PollyPM = {
     loadSurfaces: loadSurfaces,
     loadHistory: loadHistory,
     sendMessage: sendMessage,
     pollDashboard: pollDashboard,
+    renderDashboard: renderDashboard,
     state: state,
   };
 

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -269,13 +269,25 @@
     }
   }
 
-  function pickNumber(obj /*, ...path */) {
-    let cur = obj;
-    for (let i = 1; i < arguments.length; i++) {
-      if (cur == null) return null;
-      cur = cur[arguments[i]];
-    }
-    return typeof cur === "number" ? cur : null;
+  // Map a server-side ``scoped_fields`` entry (e.g. ``rollups.open_inbox_count``)
+  // to a small ``(filtered)`` tag on the corresponding card. ``scoped_fields``
+  // is set by the dashboard route whenever ``?project=`` narrows the
+  // response so the client can distinguish a workspace counter from a
+  // project-scoped one without having to know the gather pipeline's rules.
+  // We currently never poll with ``?project=`` from the v0 UI, but reading
+  // the field keeps the rail honest if the URL is ever crafted by hand
+  // and makes the contract self-documenting in the DOM.
+  function isScoped(scopedFields, key) {
+    if (!Array.isArray(scopedFields)) return false;
+    return scopedFields.indexOf(key) !== -1;
+  }
+
+  function buildCard(label, value, cls, scoped) {
+    const labelText = scoped ? label + " (filtered)" : label;
+    return el("div", { class: "rollup-card " + (cls || "") }, [
+      el("div", { class: "rollup-label", text: labelText }),
+      el("div", { class: "rollup-value", text: String(value) }),
+    ]);
   }
 
   function renderDashboard(data) {
@@ -285,41 +297,95 @@
       box.appendChild(el("div", { class: "rollup-empty", text: "no data" }));
       return;
     }
+    // The dashboard envelope matches ``DashboardResponse`` in
+    // ``src/pollypm/web_api/routes/dashboard.py`` — counters live under
+    // ``rollups``, list fields (``active_sessions``, ``recent_messages``,
+    // ``projects``) sit at the top level, and ``daemon_status`` is a
+    // string ("up" | "down"). ``scoped_fields`` enumerates which
+    // sub-fields got narrowed by a ``?project=`` filter so the UI can
+    // mark them as filtered rather than mis-presenting them as global.
+    const rollups = (data && typeof data.rollups === "object" && data.rollups)
+      || {};
+    const scopedFields = Array.isArray(data.scoped_fields)
+      ? data.scoped_fields : [];
     const cards = [];
-    const candidates = [
-      { label: "attention", path: ["attention_count"], cls: "rollup-attention" },
-      { label: "inbox unread", path: ["inbox", "unread"], cls: "rollup-attention" },
-      { label: "blocked", path: ["blocked_count"], cls: "rollup-blocked" },
-      { label: "active workers", path: ["workers", "active"], cls: "rollup-working" },
-      { label: "tasks open", path: ["tasks", "open"], cls: "" },
-      { label: "projects", path: ["projects", "tracked"], cls: "" },
-    ];
-    for (const c of candidates) {
-      const val = pickNumber.apply(null, [data].concat(c.path));
-      if (val === null) continue;
-      cards.push(
-        el("div", { class: "rollup-card " + c.cls }, [
-          el("div", { class: "rollup-label", text: c.label }),
-          el("div", { class: "rollup-value", text: String(val) }),
-        ]),
-      );
+
+    // --- counters from rollups ------------------------------------------
+    if (typeof rollups.open_inbox_count === "number") {
+      cards.push(buildCard(
+        "inbox",
+        rollups.open_inbox_count + " items",
+        "rollup-attention",
+        isScoped(scopedFields, "rollups.open_inbox_count"),
+      ));
     }
-    if (cards.length === 0) {
-      // Surface whatever top-level keys exist so the rail is not dead.
-      const keys = Object.keys(data).slice(0, 6);
-      for (const k of keys) {
-        const raw = data[k];
-        const display = (raw && typeof raw === "object")
-          ? Object.keys(raw).length + " keys"
-          : String(raw);
-        cards.push(
-          el("div", { class: "rollup-card" }, [
-            el("div", { class: "rollup-label", text: k }),
-            el("div", { class: "rollup-value", text: display }),
-          ]),
-        );
-      }
+    if (typeof rollups.pending_plan_reviews === "number") {
+      cards.push(buildCard(
+        "plan reviews",
+        rollups.pending_plan_reviews + " waiting",
+        "rollup-attention",
+        isScoped(scopedFields, "rollups.pending_plan_reviews"),
+      ));
     }
+    if (typeof rollups.alert_count === "number") {
+      cards.push(buildCard(
+        "alerts",
+        rollups.alert_count,
+        rollups.alert_count > 0 ? "rollup-blocked" : "",
+        // alert_count is intentionally global per DashboardRollups
+        // docstring — never appears in scoped_fields, so no tag.
+        false,
+      ));
+    }
+
+    // --- activity (24h) -------------------------------------------------
+    if (
+      typeof rollups.sweep_count_24h === "number"
+      || typeof rollups.message_count_24h === "number"
+    ) {
+      const sweeps = typeof rollups.sweep_count_24h === "number"
+        ? rollups.sweep_count_24h : 0;
+      const msgs = typeof rollups.message_count_24h === "number"
+        ? rollups.message_count_24h : 0;
+      cards.push(buildCard(
+        "activity (24h)",
+        sweeps + " sweeps / " + msgs + " msgs",
+        "rollup-working",
+        false,
+      ));
+    }
+
+    // --- daemon health --------------------------------------------------
+    if (typeof data.daemon_status === "string") {
+      const up = data.daemon_status === "up";
+      cards.push(buildCard(
+        "daemon",
+        data.daemon_status,
+        up ? "rollup-working" : "rollup-blocked",
+        false,
+      ));
+    }
+
+    // --- active sessions (list length) ----------------------------------
+    if (Array.isArray(data.active_sessions)) {
+      cards.push(buildCard(
+        "active sessions",
+        data.active_sessions.length,
+        "",
+        isScoped(scopedFields, "active_sessions"),
+      ));
+    }
+
+    // --- tracked projects ----------------------------------------------
+    if (typeof rollups.tracked_count === "number") {
+      cards.push(buildCard(
+        "projects tracked",
+        rollups.tracked_count,
+        "",
+        isScoped(scopedFields, "rollups.tracked_count"),
+      ));
+    }
+
     if (cards.length === 0) {
       box.appendChild(el("div", { class: "rollup-empty", text: "no rollups" }));
       return;

--- a/src/pollypm/web_api/ui/index.html
+++ b/src/pollypm/web_api/ui/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>PollyPM</title>
+<link rel="stylesheet" href="/ui/styles.css" />
+</head>
+<body>
+<header id="topbar">
+  <div class="brand">
+    <span class="brand-mark">◆</span>
+    <span class="brand-name">PollyPM</span>
+    <span class="brand-tag">v0 web</span>
+  </div>
+  <div id="conn-status" class="conn-status conn-unknown" title="Connection status">
+    <span class="conn-dot"></span>
+    <span class="conn-label">connecting…</span>
+  </div>
+</header>
+
+<main id="layout">
+  <aside id="surface-rail" aria-label="Chat surfaces">
+    <h2 class="rail-title">Surfaces</h2>
+    <ul id="surface-list" class="surface-list">
+      <li class="surface-empty">loading…</li>
+    </ul>
+  </aside>
+
+  <section id="message-pane" aria-label="Messages">
+    <header class="pane-header">
+      <h2 id="pane-title">Select a surface</h2>
+      <span id="pane-meta" class="pane-meta"></span>
+    </header>
+    <div id="message-list" class="message-list" aria-live="polite">
+      <div class="message-empty">No surface selected.</div>
+    </div>
+    <form id="send-form" class="send-form" autocomplete="off">
+      <input
+        id="send-input"
+        class="send-input"
+        type="text"
+        name="text"
+        placeholder="Message the selected surface…"
+        disabled
+        aria-label="Send message"
+      />
+      <button id="send-button" class="send-button" type="submit" disabled>Send</button>
+    </form>
+  </section>
+
+  <aside id="dashboard-rail" aria-label="Dashboard">
+    <h2 class="rail-title">Dashboard</h2>
+    <div id="dashboard-rollups" class="dashboard-rollups">
+      <div class="rollup-empty">loading…</div>
+    </div>
+  </aside>
+</main>
+
+<script src="/ui/app.js" defer></script>
+</body>
+</html>

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -337,3 +337,84 @@ section#message-pane {
   color: var(--blocked);
   font-size: 12.5px;
 }
+
+.auth-gate-banner {
+  margin: 12px 16px;
+  border-color: var(--attention);
+  background: rgba(240, 160, 48, 0.10);
+  color: var(--attention);
+  line-height: 1.5;
+}
+
+/* Mobile / tablet — collapse the three-column grid into a single
+ * stacked column so 360–768px viewports (phones in portrait, small
+ * tablets) don't horizontally overflow. The cockpit-tinted message
+ * pane keeps the most vertical space; the rails become full-width
+ * scrollable sections above (surfaces) and below (dashboard) the
+ * conversation. Sam's intent is Tailscale-from-phone first, so this
+ * is the primary read surface and the rails are reference panels.
+ */
+@media (max-width: 768px) {
+  #layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    height: calc(100vh - var(--topbar-h));
+  }
+  aside#surface-rail {
+    border-right: none;
+    border-bottom: 1px solid var(--border-line);
+    max-height: 30vh;
+  }
+  aside#dashboard-rail {
+    border-left: none;
+    border-top: 1px solid var(--border-line);
+    max-height: 28vh;
+  }
+  .rail-title {
+    padding: 10px 14px 6px;
+  }
+  .pane-header {
+    padding: 10px 14px;
+  }
+  .message-list {
+    padding: 10px 14px;
+  }
+  .send-form {
+    padding: 10px 14px;
+  }
+  .dashboard-rollups {
+    /* Lay rollup cards out horizontally so the rail stays short on
+     * a narrow phone viewport. */
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 12px 12px;
+  }
+  .rollup-card {
+    margin: 0;
+    min-width: 110px;
+    flex: 1 1 auto;
+  }
+  #topbar {
+    padding: 0 12px;
+  }
+  .brand-tag {
+    /* Free up a little horizontal room — the brand mark + name are
+     * enough on a phone. */
+    display: none;
+  }
+}
+
+/* Very narrow phones — keep dot indicators visible but tighten
+ * paddings further so the input still fits the row. */
+@media (max-width: 380px) {
+  .surface-list li {
+    padding: 6px 8px;
+  }
+  .message {
+    padding: 6px 8px;
+  }
+  .send-button {
+    padding: 8px 12px;
+  }
+}

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -1,0 +1,339 @@
+/* PollyPM v0 web UI — dark theme tuned to the cockpit palette
+ * (see cockpit_theme.State for the source-of-truth values).
+ *
+ * Hex constants below mirror the cockpit:
+ *   --waiting   #f0c45a  amber / decision pending
+ *   --working   #3ddc84  green / agent active / done
+ *   --blocked   #ff5f6d  red / stuck / error
+ *   --idle      #4a5568  slate / at-rest
+ *   --info      #5b8aff  blue / active marker
+ *   --muted     #6b7a88  warm gray / metadata
+ *   --attention #f0a030  orange / needs decision
+ *   --heading   #eef2f4  bright neutral / heading
+ *   --label     #b8c4cf  body label
+ *   --body      #c8d2da  body text
+ */
+
+:root {
+  --bg-page: #0f1418;
+  --bg-panel: #161c22;
+  --bg-elevated: #1d242c;
+  --bg-row: #1a2128;
+  --bg-row-hover: #222b34;
+  --bg-row-active: #2a3540;
+  --border-line: #2a323b;
+
+  --waiting: #f0c45a;
+  --working: #3ddc84;
+  --blocked: #ff5f6d;
+  --idle: #4a5568;
+  --info: #5b8aff;
+  --muted: #6b7a88;
+  --attention: #f0a030;
+
+  --text-heading: #eef2f4;
+  --text-heading-bright: #eef6ff;
+  --text-label: #b8c4cf;
+  --text-body: #c8d2da;
+  --text-muted: var(--muted);
+
+  --topbar-h: 44px;
+  --rail-w: 240px;
+  --rail-w-right: 260px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--bg-page);
+  color: var(--text-body);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text",
+    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+#topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--topbar-h);
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border-line);
+  background: var(--bg-panel);
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.brand-mark {
+  color: var(--info);
+  font-size: 16px;
+}
+.brand-name {
+  color: var(--text-heading-bright);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.brand-tag {
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.conn-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.conn-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--idle);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
+}
+.conn-ok    .conn-dot { background: var(--working); }
+.conn-ok    .conn-label { color: var(--working); }
+.conn-warn  .conn-dot { background: var(--waiting); }
+.conn-warn  .conn-label { color: var(--waiting); }
+.conn-error .conn-dot { background: var(--blocked); }
+.conn-error .conn-label { color: var(--blocked); }
+
+#layout {
+  display: grid;
+  grid-template-columns: var(--rail-w) 1fr var(--rail-w-right);
+  height: calc(100vh - var(--topbar-h));
+  min-height: 0;
+}
+
+aside#surface-rail,
+aside#dashboard-rail {
+  background: var(--bg-panel);
+  overflow-y: auto;
+  border-right: 1px solid var(--border-line);
+}
+aside#dashboard-rail {
+  border-right: none;
+  border-left: 1px solid var(--border-line);
+}
+
+.rail-title {
+  margin: 0;
+  padding: 14px 16px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.surface-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 8px 16px;
+}
+.surface-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  margin: 2px 0;
+  border-radius: 6px;
+  cursor: pointer;
+  background: var(--bg-row);
+  border: 1px solid transparent;
+}
+.surface-list li:hover {
+  background: var(--bg-row-hover);
+}
+.surface-list li.active {
+  background: var(--bg-row-active);
+  border-color: var(--info);
+}
+.surface-list li.surface-empty {
+  background: transparent;
+  color: var(--text-muted);
+  cursor: default;
+  font-style: italic;
+}
+.surface-name {
+  color: var(--text-heading);
+  font-weight: 500;
+  font-size: 13px;
+}
+.surface-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.surface-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--idle);
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.surface-dot.present { background: var(--working); }
+.surface-dot.dead    { background: var(--blocked); }
+
+section#message-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg-page);
+}
+.pane-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border-line);
+  background: var(--bg-panel);
+}
+#pane-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-heading-bright);
+}
+.pane-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 18px;
+}
+.message-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 24px 0;
+  text-align: center;
+}
+.message {
+  margin: 0 0 10px;
+  padding: 8px 12px;
+  background: var(--bg-row);
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+}
+.message-head {
+  display: flex;
+  gap: 10px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+.message-actor {
+  color: var(--text-label);
+  font-weight: 500;
+}
+.message-role-user   .message-actor { color: var(--info); }
+.message-role-agent  .message-actor { color: var(--working); }
+.message-role-system .message-actor { color: var(--attention); }
+.message-text {
+  color: var(--text-body);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+    Monaco, Consolas, monospace;
+  font-size: 12.5px;
+}
+
+.send-form {
+  display: flex;
+  gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--border-line);
+  background: var(--bg-panel);
+}
+.send-input {
+  flex: 1;
+  padding: 8px 10px;
+  background: var(--bg-elevated);
+  color: var(--text-body);
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+}
+.send-input:focus {
+  outline: none;
+  border-color: var(--info);
+}
+.send-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.send-button {
+  padding: 8px 16px;
+  background: var(--info);
+  color: var(--text-heading-bright);
+  border: none;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+.send-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.send-button:not(:disabled):hover {
+  background: #4a78e0;
+}
+
+.dashboard-rollups {
+  padding: 0 12px 16px;
+}
+.rollup-card {
+  background: var(--bg-row);
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin: 0 0 8px;
+}
+.rollup-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 8px;
+}
+.rollup-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.rollup-value {
+  font-size: 22px;
+  color: var(--text-heading-bright);
+  font-weight: 600;
+  margin-top: 4px;
+}
+.rollup-attention .rollup-value { color: var(--attention); }
+.rollup-blocked   .rollup-value { color: var(--blocked); }
+.rollup-working   .rollup-value { color: var(--working); }
+
+.error-banner {
+  margin: 12px 18px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--blocked);
+  background: rgba(255, 95, 109, 0.08);
+  color: var(--blocked);
+  font-size: 12.5px;
+}

--- a/tests/web_api/conftest.py
+++ b/tests/web_api/conftest.py
@@ -105,7 +105,26 @@ def token(token_path: Path) -> str:
 
 @pytest.fixture
 def app(api_config, token_path, token):  # noqa: ARG001 — token fixture must run
+    # Default app is built with ``tailnet_trust_enabled=False`` to
+    # match the safest ``pm serve`` mode (loopback fallback or explicit
+    # ``--host`` override). Tests that exercise the credential-free
+    # CGNAT path should use the ``tailnet_app`` fixture below.
     return create_app(config=api_config, token_path=token_path)
+
+
+@pytest.fixture
+def tailnet_app(api_config, token_path, token):  # noqa: ARG001
+    """An app built as if ``pm serve`` bound to a verified tailnet IPv4.
+
+    Use this for tests that need credential-free CGNAT trust (the auth
+    bypass and the ``/ui/`` cookie mint from 100.64.x.y peers). Mirrors
+    the ``tailnet_trust=True`` branch in ``cli_features/web_api.py``.
+    """
+    return create_app(
+        config=api_config,
+        token_path=token_path,
+        tailnet_trust_enabled=True,
+    )
 
 
 @pytest.fixture

--- a/tests/web_api/conftest.py
+++ b/tests/web_api/conftest.py
@@ -9,7 +9,6 @@ exercise the same code path ``pm serve`` uses at runtime.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -810,6 +810,126 @@ def test_openapi_documents_three_auth_modes() -> None:
         )
 
 
+def test_runtime_openapi_documents_three_auth_modes() -> None:
+    """Pin the round-11 (#2065) runtime-side auth-contract fix.
+
+    Round 8 fixed the static ``docs/api/openapi.yaml`` to enumerate
+    three credential modes (bearer / cookie / credential-free tailnet
+    peer). Round 11 (Codex 03:48 UTC) caught that the runtime
+    ``/openapi.json`` still only advertised ``bearerAuth`` because
+    ``_attach_security_scheme()`` in ``src/pollypm/web_api/app.py``
+    overwrote ``components.securitySchemes`` with a bearer-only
+    block and ``security`` with ``[{"bearerAuth": []}]``.
+
+    Generated clients that hit the live ``/api/v1/openapi.json`` for
+    discovery would therefore not know the cookie or tailnet-trust
+    modes existed — exactly the drift the round-8 fix was supposed
+    to close.
+
+    Mirrors :func:`test_openapi_documents_three_auth_modes` on the
+    auto-generated FastAPI doc.
+    """
+    from pollypm.config import (
+        AccountConfig,
+        MemorySettings,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectSettings,
+    )
+    from pollypm.models import ProviderKind, RuntimeKind
+    from pollypm.web_api import create_app
+
+    base = Path(__file__).resolve().parent
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            name="P", root_dir=base, tmux_session="t",
+            workspace_root=base, base_dir=base / ".pollypm",
+            logs_dir=base / ".pollypm/logs",
+            snapshots_dir=base / ".pollypm/snapshots",
+            state_db=base / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={"codex_primary": AccountConfig(
+            name="codex_primary", provider=ProviderKind.CODEX,
+            email="codex@example.com", runtime=RuntimeKind.LOCAL,
+            home=base / ".pollypm/homes/codex_primary",
+        )},
+        sessions={},
+        projects={},
+        memory=MemorySettings(backend="file"),
+    )
+    app = create_app(config=config, token_path=base / "tmp-token")
+    schema = app.openapi()
+
+    # 1. Both bearerAuth AND cookieAuth must be declared on the
+    #    runtime doc.
+    schemes = schema.get("components", {}).get("securitySchemes", {})
+    assert "bearerAuth" in schemes, (
+        "Runtime /openapi.json missing bearerAuth scheme "
+        "(#2065 round-11)."
+    )
+    cookie_scheme = schemes.get("cookieAuth")
+    assert cookie_scheme is not None, (
+        "Runtime /openapi.json missing cookieAuth scheme — "
+        "_attach_security_scheme() must mirror the static YAML "
+        "(#2065 round-11)."
+    )
+    assert cookie_scheme.get("type") == "apiKey", (
+        "cookieAuth must be type apiKey, got "
+        f"{cookie_scheme.get('type')!r}"
+    )
+    assert cookie_scheme.get("in") == "cookie", (
+        f"cookieAuth must be in=cookie, got {cookie_scheme.get('in')!r}"
+    )
+    assert cookie_scheme.get("name") == "pollypm-session", (
+        "cookieAuth name must match the runtime cookie "
+        "(pollypm-session); got "
+        f"{cookie_scheme.get('name')!r}"
+    )
+
+    # 2. Top-level security list must enumerate all three modes:
+    #    bearer, cookie, AND a credential-free entry for the
+    #    tailnet-trust path.
+    security = schema.get("security", [])
+    assert isinstance(security, list), (
+        "Runtime security must be a list"
+    )
+    requires_bearer = any(
+        isinstance(entry, dict) and "bearerAuth" in entry
+        for entry in security
+    )
+    requires_cookie = any(
+        isinstance(entry, dict) and "cookieAuth" in entry
+        for entry in security
+    )
+    allows_anonymous = any(
+        isinstance(entry, dict) and len(entry) == 0
+        for entry in security
+    )
+    assert requires_bearer, (
+        "Runtime security list must offer bearerAuth "
+        "(#2065 round-11)."
+    )
+    assert requires_cookie, (
+        "Runtime security list must offer cookieAuth — "
+        "_attach_security_scheme() previously set bearer-only "
+        "(#2065 round-11)."
+    )
+    assert allows_anonymous, (
+        "Runtime security list must include an empty {} entry to "
+        "model the credential-free tailnet-peer mode "
+        "(#2065 round-11)."
+    )
+
+
 def test_implementation_openapi_validates_as_31() -> None:
     """The auto-generated doc must itself be a valid OpenAPI 3.x doc."""
     # Re-read straight off the FastAPI app so we don't depend on the

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -721,6 +721,95 @@ def test_audit_responses_document_corrupt_archives_skipped() -> None:
         )
 
 
+def test_openapi_documents_three_auth_modes() -> None:
+    """Pin the round-8 (#2065) auth-contract fix.
+
+    The static OpenAPI contract previously advertised the API as
+    ``loopback by default`` with only ``bearerAuth`` declared at the
+    document level. The shipped runtime accepts three credential
+    modes: bearer header, ``pollypm-session`` cookie, and a
+    credential-free tailnet-peer mode (only when the server was
+    constructed with ``tailnet_trust_enabled=True``).
+
+    This test fails if anyone reverts the contract back to a
+    bearer-only / loopback-default story.
+    """
+    contract = _load_contract()
+
+    # 1. cookieAuth security scheme exists and is an apiKey-in-cookie
+    #    named pollypm-session (matching the runtime cookie name).
+    schemes = (
+        contract.get("components", {}).get("securitySchemes", {})
+    )
+    assert "bearerAuth" in schemes, "bearerAuth scheme missing"
+    cookie_scheme = schemes.get("cookieAuth")
+    assert cookie_scheme is not None, (
+        "cookieAuth security scheme missing — round-8 #2065 fix."
+    )
+    assert cookie_scheme.get("type") == "apiKey", (
+        f"cookieAuth must be type apiKey, got {cookie_scheme.get('type')!r}"
+    )
+    assert cookie_scheme.get("in") == "cookie", (
+        f"cookieAuth must be in=cookie, got {cookie_scheme.get('in')!r}"
+    )
+    assert cookie_scheme.get("name") == "pollypm-session", (
+        "cookieAuth name must match the runtime cookie "
+        "(pollypm-session); got "
+        f"{cookie_scheme.get('name')!r}"
+    )
+
+    # 2. Global security list allows ANY of: bearer, cookie, or
+    #    credential-free (empty entry — OpenAPI's way of marking
+    #    anonymous access for the tailnet-trust mode).
+    security = contract.get("security", [])
+    assert isinstance(security, list), "top-level security must be a list"
+    requires_bearer = any(
+        isinstance(entry, dict) and "bearerAuth" in entry
+        for entry in security
+    )
+    requires_cookie = any(
+        isinstance(entry, dict) and "cookieAuth" in entry
+        for entry in security
+    )
+    allows_anonymous = any(
+        isinstance(entry, dict) and len(entry) == 0
+        for entry in security
+    )
+    assert requires_bearer, "security list must offer bearerAuth"
+    assert requires_cookie, (
+        "security list must offer cookieAuth (round-8 #2065 fix)."
+    )
+    assert allows_anonymous, (
+        "security list must include an empty {} entry to model the "
+        "credential-free tailnet-peer mode (round-8 #2065 fix)."
+    )
+
+    # 3. Top-level description must enumerate all three modes so
+    #    generated-client readers see the full auth story.
+    description = (contract.get("info", {}).get("description") or "").lower()
+    assert "bearer" in description, (
+        "info.description must mention the bearer mode."
+    )
+    assert "cookie" in description or "pollypm-session" in description, (
+        "info.description must mention the session-cookie mode."
+    )
+    assert "tailnet" in description or "tailscale" in description, (
+        "info.description must mention the tailnet-trust mode."
+    )
+
+    # 4. The old "loopback by default" / bearer-only framing must NOT
+    #    survive — that was the round-7 → round-8 regression Codex
+    #    flagged.
+    servers = contract.get("servers", [])
+    for server in servers:
+        server_desc = (server.get("description") or "").lower()
+        assert "loopback by default" not in server_desc, (
+            "server description still says 'loopback by default' — "
+            "the runtime auto-binds Tailscale when available "
+            "(round-8 #2065 fix)."
+        )
+
+
 def test_implementation_openapi_validates_as_31() -> None:
     """The auto-generated doc must itself be a valid OpenAPI 3.x doc."""
     # Re-read straight off the FastAPI app so we don't depend on the

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1,0 +1,209 @@
+"""V0 web UI tests (Phase 7).
+
+Covers:
+
+- ``GET /ui/`` returns 200 + sets the ``pollypm-session`` cookie from
+  the on-disk token.
+- ``GET /ui/`` HTML carries the anchors the SPA needs
+  (surface-list, message-list, send-input).
+- Static assets ``app.js`` / ``styles.css`` are served.
+- Auth-via-cookie works (no Authorization header).
+- Auth-via-Tailscale-CGNAT works (no header, no cookie).
+- Auth without anything still returns 401.
+- ``pm serve --tailscale`` warns + falls back to localhost when the
+  tailscale binary is missing.
+
+Tests use the shared fixtures in ``conftest.py``; the ``client``
+fixture builds the FastAPI app via ``create_app`` so the UI mount
+flows through the same code path ``pm serve`` uses at runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.cli_features.web_api import detect_tailscale_ip
+from pollypm.web_api.auth import SESSION_COOKIE_NAME, is_tailscale_ip
+
+
+def test_ui_root_returns_html_and_sets_session_cookie(client: TestClient, token: str) -> None:
+    """``GET /ui/`` returns the SPA HTML and seeds the session cookie."""
+    response = client.get("/ui/")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    cookie = response.cookies.get(SESSION_COOKIE_NAME)
+    assert cookie == token, "session cookie should mirror on-disk token"
+
+
+def test_ui_index_contains_required_anchors(client: TestClient) -> None:
+    """The HTML must carry the IDs ``app.js`` queries for."""
+    html = client.get("/ui/").text
+    for anchor in ("surface-list", "message-list", "send-input", "send-button"):
+        assert f'id="{anchor}"' in html, f"missing anchor #{anchor} in index.html"
+    # The cookie-based credentials assumption is baked into app.js; the
+    # HTML must reference it so cache-busting / rename doesn't silently
+    # break the SPA.
+    assert "/ui/app.js" in html
+    assert "/ui/styles.css" in html
+
+
+def test_ui_static_js_served(client: TestClient) -> None:
+    """``GET /ui/app.js`` returns the vanilla JS app."""
+    response = client.get("/ui/app.js")
+    assert response.status_code == 200
+    body = response.text
+    assert "credentials" in body, "app.js must use credentials:'include'"
+    assert "loadSurfaces" in body
+    assert "loadHistory" in body
+    assert "sendMessage" in body
+
+
+def test_ui_static_css_served(client: TestClient) -> None:
+    """``GET /ui/styles.css`` returns the dark-theme stylesheet."""
+    response = client.get("/ui/styles.css")
+    assert response.status_code == 200
+    body = response.text
+    # Sanity-check that the palette wired through (not an empty file).
+    assert "--info" in body or "#5b8aff" in body
+
+
+def test_auth_via_cookie_works(client: TestClient, token: str) -> None:
+    """A request that carries only the session cookie authenticates."""
+    # Boot through /ui/ so the cookie is set on the TestClient's jar,
+    # then call a JSON endpoint with no Authorization header.
+    boot = client.get("/ui/")
+    assert boot.status_code == 200
+    response = client.get("/api/v1/projects")  # no headers — cookie only
+    assert response.status_code == 200
+
+
+def test_auth_via_tailscale_cgnat_ip_works(api_config, token_path: Path) -> None:
+    """A request from a 100.64.0.0/10 client IP bypasses cred checks."""
+    from pollypm.web_api import create_app
+
+    app = create_app(config=api_config, token_path=token_path)
+    # FastAPI's TestClient lets us spoof the client host via
+    # ``base_url`` only at TLS level; the cleaner path is to override
+    # the ``Request.client`` host through the ``client`` arg of
+    # ``TestClient``.
+    tail_client = TestClient(app, base_url="http://testserver")
+    # ``TestClient`` honors ``client=("host", port)`` so the ASGI
+    # scope reports the simulated peer.
+    tail_client.headers.clear()
+    resp = tail_client.get(
+        "/api/v1/projects",
+        headers={},
+        # No bearer, no cookie — Tailscale-only.
+    )
+    # Without the override the default test client uses ``testclient``
+    # as the peer, which is NOT a tailnet IP, so this 401s. Use a
+    # manual ASGI call to set the peer.
+    assert resp.status_code == 401  # baseline: no creds, no tailnet IP
+
+    # Now do it properly through a custom transport. ``ASGITransport``
+    # accepts a ``client`` tuple that flows into the ASGI scope as
+    # ``client=("100.64.0.5", port)``, which is what
+    # ``request.client.host`` reads inside the auth dependency.
+    import asyncio
+
+    import httpx
+
+    async def _probe() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app, client=("100.64.0.5", 12345))
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver",
+        ) as ac:
+            return await ac.get("/api/v1/projects")
+
+    resp2 = asyncio.run(_probe())
+    assert resp2.status_code == 200, (
+        "Tailscale CGNAT IP (100.64.0.5) should bypass credential check; "
+        f"got {resp2.status_code} {resp2.text}"
+    )
+
+
+def test_auth_without_any_credentials_returns_401(client: TestClient) -> None:
+    """No cookie, no header, non-tailnet peer → 401 unauthorized."""
+    # TestClient defaults to client=('testclient', 50000) which is not
+    # a CGNAT IP, so this exercises the rejection path.
+    response = client.get("/api/v1/projects")
+    assert response.status_code == 401
+    body = response.json()
+    assert body["error"]["code"] == "unauthorized"
+
+
+def test_is_tailscale_ip_helper() -> None:
+    """``is_tailscale_ip`` accepts 100.64.0.0/10 and rejects everything else."""
+    assert is_tailscale_ip("100.64.0.5") is True
+    assert is_tailscale_ip("100.127.255.254") is True
+    assert is_tailscale_ip("127.0.0.1") is False
+    assert is_tailscale_ip("192.168.1.5") is False
+    assert is_tailscale_ip("10.0.0.1") is False
+    assert is_tailscale_ip(None) is False
+    assert is_tailscale_ip("") is False
+    assert is_tailscale_ip("not-an-ip") is False
+    # IPv6 outside CGNAT (CGNAT is IPv4-only) → False.
+    assert is_tailscale_ip("::1") is False
+
+
+def test_detect_tailscale_ip_returns_none_when_binary_missing() -> None:
+    """``detect_tailscale_ip`` collapses missing-binary to None."""
+    with patch(
+        "pollypm.cli_features.web_api.shutil.which",
+        return_value=None,
+    ):
+        assert detect_tailscale_ip() is None
+
+
+def test_pm_serve_tailscale_warns_when_binary_missing(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """``pm serve --tailscale`` without tailscale prints a warning + falls back.
+
+    Drives the CLI command via Typer's runner so the user-visible
+    stderr matches what the operator will see in their terminal.
+    """
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features.web_api import register_web_api_commands
+
+    root = typer.Typer()
+    register_web_api_commands(root)
+
+    # Stub uvicorn so the test doesn't actually open a socket. The
+    # serve command imports uvicorn inside the function body, so we
+    # monkeypatch the module attribute at import time.
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: None)
+    # Force ``shutil.which("tailscale")`` to miss.
+    monkeypatch.setattr(
+        "pollypm.cli_features.web_api.shutil.which",
+        lambda name: None,
+    )
+    # Stub config + token machinery so we don't depend on the user's
+    # real ~/.pollypm/.
+    monkeypatch.setattr(
+        "pollypm.cli_features.web_api.load_config",
+        lambda _path: api_config,
+    )
+    monkeypatch.setattr(
+        "pollypm.web_api.ensure_token",
+        lambda _path: ("test-token", False),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        root,
+        ["serve", "--tailscale", "--token-path", str(token_path)],
+    )
+    assert result.exit_code == 0, result.output
+    # CliRunner merges stderr into ``output`` by default; the
+    # ``[pm serve]`` banner + warning land in stderr via typer.echo.
+    assert "--tailscale" in result.output
+    assert "tailscale ip -4" in result.output or "Falling back" in result.output

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -684,6 +684,83 @@ def test_pm_serve_disables_tailnet_trust_on_loopback_fallback(
     )
 
 
+def test_pm_serve_with_explicit_host_skips_tailscale_detection(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit ``--host`` must skip ``detect_tailscale_ip`` entirely.
+
+    Round-9 Codex blocker on #2065: the ``--host`` help text promises
+    "Passing this flag skips Tailscale detection entirely", but the
+    earlier round-5 implementation still re-called
+    ``detect_tailscale_ip()`` in the explicit-host branch to
+    opportunistically enable ``tailnet_trust_enabled`` when the typed
+    host matched the detected IPv4. Help/code drift like that is the
+    exact contract bug Codex flagged.
+
+    This test wires ``detect_tailscale_ip`` to raise; if the explicit
+    branch ever re-introduces the call, the ``RuntimeError`` propagates
+    and the CLI exits non-zero, tripping this assertion.
+    """
+    import typer
+    import uvicorn
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features.web_api import register_web_api_commands
+
+    root = typer.Typer()
+    register_web_api_commands(root)
+
+    captured: dict[str, object] = {}
+
+    def _fake_uvicorn_run(*args, **kwargs):
+        captured["kwargs"] = kwargs
+
+    def _exploding_detect():
+        raise RuntimeError(
+            "detect_tailscale_ip must not be called in the explicit "
+            "--host branch (round-9 #2065)."
+        )
+
+    monkeypatch.setattr(uvicorn, "run", _fake_uvicorn_run)
+    monkeypatch.setattr(
+        "pollypm.cli_features.web_api.detect_tailscale_ip",
+        _exploding_detect,
+    )
+    monkeypatch.setattr(
+        "pollypm.cli_features.web_api.load_config",
+        lambda _path: api_config,
+    )
+    monkeypatch.setattr(
+        "pollypm.web_api.ensure_token",
+        lambda _path: ("test-token", False),
+    )
+
+    import pollypm.web_api as web_api_pkg
+
+    real_create_app = web_api_pkg.create_app
+
+    def _capturing_create_app(**kwargs):
+        captured["create_app_kwargs"] = dict(kwargs)
+        return real_create_app(**kwargs)
+
+    monkeypatch.setattr(web_api_pkg, "create_app", _capturing_create_app)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        root,
+        ["serve", "--token-path", str(token_path), "--host", "127.0.0.1"],
+    )
+    assert result.exit_code == 0, (
+        f"detect_tailscale_ip was called in the explicit --host branch — "
+        f"help-text/code drift regressed (round-9 #2065). Output: "
+        f"{result.output}"
+    )
+    assert captured["kwargs"]["host"] == "127.0.0.1"
+    # And the explicit branch never opts into tailnet trust, even for
+    # a host that happens to look loopback.
+    assert captured["create_app_kwargs"]["tailnet_trust_enabled"] is False
+
+
 # -------- P1: mobile CSS -----------------------------------------------
 
 

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -3,15 +3,20 @@
 Covers:
 
 - ``GET /ui/`` returns 200 + sets the ``pollypm-session`` cookie from
-  the on-disk token.
+  the on-disk token **only** for trusted callers (loopback / Tailscale
+  / valid bearer).
+- ``GET /ui/`` from a LAN client gets the HTML but no cookie, and a
+  subsequent ``/api/`` call returns 401.
 - ``GET /ui/`` HTML carries the anchors the SPA needs
   (surface-list, message-list, send-input).
 - Static assets ``app.js`` / ``styles.css`` are served.
 - Auth-via-cookie works (no Authorization header).
 - Auth-via-Tailscale-CGNAT works (no header, no cookie).
 - Auth without anything still returns 401.
-- ``pm serve --tailscale`` warns + falls back to localhost when the
-  tailscale binary is missing.
+- ``pm serve`` (default) binds the detected Tailscale IPv4 only;
+  ``--tailscale`` is a no-op compat flag; falls back to loopback when
+  the tailscale binary is missing.
+- Mobile CSS media query exists.
 
 Tests use the shared fixtures in ``conftest.py``; the ``client``
 fixture builds the FastAPI app via ``create_app`` so the UI mount
@@ -20,9 +25,11 @@ flows through the same code path ``pm serve`` uses at runtime.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -30,13 +37,107 @@ from pollypm.cli_features.web_api import detect_tailscale_ip
 from pollypm.web_api.auth import SESSION_COOKIE_NAME, is_tailscale_ip
 
 
+def _ui_get_with_peer(app, peer_ip: str, *, headers: dict[str, str] | None = None) -> httpx.Response:
+    """Fetch ``GET /ui/`` with a simulated ``request.client.host``.
+
+    The default ``TestClient`` uses ``("testclient", 50000)`` as the
+    peer, which doesn't exercise the loopback / Tailscale gate. We
+    use ``httpx.ASGITransport(client=…)`` to push a real-looking peer
+    tuple into the ASGI scope.
+    """
+
+    async def _probe() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app, client=(peer_ip, 12345))
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver",
+        ) as ac:
+            return await ac.get("/ui/", headers=headers or {})
+
+    return asyncio.run(_probe())
+
+
+def _api_get_with_peer(app, peer_ip: str, *, headers: dict[str, str] | None = None) -> httpx.Response:
+    """Same as ``_ui_get_with_peer`` but for the JSON API."""
+
+    async def _probe() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app, client=(peer_ip, 12345))
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver",
+        ) as ac:
+            return await ac.get("/api/v1/projects", headers=headers or {})
+
+    return asyncio.run(_probe())
+
+
 def test_ui_root_returns_html_and_sets_session_cookie(client: TestClient, token: str) -> None:
-    """``GET /ui/`` returns the SPA HTML and seeds the session cookie."""
-    response = client.get("/ui/")
+    """``GET /ui/`` returns the SPA HTML and seeds the session cookie.
+
+    The ``TestClient`` default peer is ``testclient`` which our gate
+    accepts as ``request.client.host == "testclient"`` is neither
+    loopback nor tailnet — but FastAPI's TestClient actually sets the
+    scope client to ``("testclient", 50000)``. To keep this baseline
+    test green we explicitly supply the Authorization header so the
+    cookie is issued via the valid-bearer path.
+    """
+    response = client.get("/ui/", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     cookie = response.cookies.get(SESSION_COOKIE_NAME)
     assert cookie == token, "session cookie should mirror on-disk token"
+
+
+# -------- P0 #1: cookie issuance gating ---------------------------------
+
+
+def test_ui_no_cookie_from_lan_client(app, token: str) -> None:
+    """A LAN client (non-loopback, non-tailnet, no bearer) gets the
+    HTML but no Set-Cookie header — and the next /api/ call 401s.
+    """
+    resp = _ui_get_with_peer(app, "192.168.1.100")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert SESSION_COOKIE_NAME not in resp.cookies, (
+        f"LAN client must NOT receive Set-Cookie; got cookies: {dict(resp.cookies)}"
+    )
+    # And the SPA's first /api/ call should hit 401.
+    api_resp = _api_get_with_peer(app, "192.168.1.100")
+    assert api_resp.status_code == 401
+
+
+def test_ui_cookie_set_from_loopback(app, token: str) -> None:
+    """Loopback peer is trusted — cookie is issued."""
+    resp = _ui_get_with_peer(app, "127.0.0.1")
+    assert resp.status_code == 200
+    assert resp.cookies.get(SESSION_COOKIE_NAME) == token
+
+
+def test_ui_cookie_set_from_tailscale_peer(app, token: str) -> None:
+    """Tailscale CGNAT peer is trusted — cookie is issued."""
+    resp = _ui_get_with_peer(app, "100.64.0.5")
+    assert resp.status_code == 200
+    assert resp.cookies.get(SESSION_COOKIE_NAME) == token
+
+
+def test_ui_cookie_set_with_valid_bearer_header(app, token: str) -> None:
+    """A valid Authorization header from any peer gets the cookie."""
+    resp = _ui_get_with_peer(
+        app,
+        "192.168.1.100",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.cookies.get(SESSION_COOKIE_NAME) == token
+
+
+def test_ui_no_cookie_with_invalid_bearer(app, token: str) -> None:
+    """A bogus bearer header from an untrusted peer does NOT issue."""
+    resp = _ui_get_with_peer(
+        app,
+        "192.168.1.100",
+        headers={"Authorization": "Bearer not-the-real-token"},
+    )
+    assert resp.status_code == 200
+    assert SESSION_COOKIE_NAME not in resp.cookies
 
 
 def test_ui_index_contains_required_anchors(client: TestClient) -> None:
@@ -72,11 +173,16 @@ def test_ui_static_css_served(client: TestClient) -> None:
 
 
 def test_auth_via_cookie_works(client: TestClient, token: str) -> None:
-    """A request that carries only the session cookie authenticates."""
-    # Boot through /ui/ so the cookie is set on the TestClient's jar,
-    # then call a JSON endpoint with no Authorization header.
-    boot = client.get("/ui/")
+    """A request that carries only the session cookie authenticates.
+
+    Bootstrap with a valid bearer header (TestClient's default peer
+    is ``("testclient", 50000)``, neither loopback nor tailnet, so
+    only the bearer path issues a cookie). Then drop the header and
+    confirm the cookie alone keeps the session live.
+    """
+    boot = client.get("/ui/", headers={"Authorization": f"Bearer {token}"})
     assert boot.status_code == 200
+    assert boot.cookies.get(SESSION_COOKIE_NAME) == token
     response = client.get("/api/v1/projects")  # no headers — cookie only
     assert response.status_code == 200
 
@@ -86,32 +192,16 @@ def test_auth_via_tailscale_cgnat_ip_works(api_config, token_path: Path) -> None
     from pollypm.web_api import create_app
 
     app = create_app(config=api_config, token_path=token_path)
-    # FastAPI's TestClient lets us spoof the client host via
-    # ``base_url`` only at TLS level; the cleaner path is to override
-    # the ``Request.client`` host through the ``client`` arg of
-    # ``TestClient``.
-    tail_client = TestClient(app, base_url="http://testserver")
-    # ``TestClient`` honors ``client=("host", port)`` so the ASGI
-    # scope reports the simulated peer.
-    tail_client.headers.clear()
-    resp = tail_client.get(
-        "/api/v1/projects",
-        headers={},
-        # No bearer, no cookie — Tailscale-only.
-    )
-    # Without the override the default test client uses ``testclient``
-    # as the peer, which is NOT a tailnet IP, so this 401s. Use a
-    # manual ASGI call to set the peer.
-    assert resp.status_code == 401  # baseline: no creds, no tailnet IP
+    # Baseline: TestClient default peer is ``testclient`` (not a
+    # tailnet IP), so without creds we expect 401.
+    baseline_client = TestClient(app, base_url="http://testserver")
+    baseline_client.headers.clear()
+    baseline_resp = baseline_client.get("/api/v1/projects", headers={})
+    assert baseline_resp.status_code == 401  # baseline: no creds, no tailnet IP
 
-    # Now do it properly through a custom transport. ``ASGITransport``
-    # accepts a ``client`` tuple that flows into the ASGI scope as
-    # ``client=("100.64.0.5", port)``, which is what
-    # ``request.client.host`` reads inside the auth dependency.
-    import asyncio
-
-    import httpx
-
+    # Now spoof a tailnet peer through an explicit ASGITransport
+    # client tuple. ``request.client.host`` inside the auth dependency
+    # reads this value.
     async def _probe() -> httpx.Response:
         transport = httpx.ASGITransport(app=app, client=("100.64.0.5", 12345))
         async with httpx.AsyncClient(
@@ -159,15 +249,22 @@ def test_detect_tailscale_ip_returns_none_when_binary_missing() -> None:
         assert detect_tailscale_ip() is None
 
 
-def test_pm_serve_tailscale_warns_when_binary_missing(
-    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
-) -> None:
-    """``pm serve --tailscale`` without tailscale prints a warning + falls back.
+def _run_serve_command(
+    api_config,
+    token_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    detect_result: str | None,
+    extra_args: list[str] | None = None,
+) -> tuple[object, dict[str, object]]:
+    """Drive ``pm serve`` through Typer's runner with all I/O stubbed.
 
-    Drives the CLI command via Typer's runner so the user-visible
-    stderr matches what the operator will see in their terminal.
+    Returns ``(CliRunner.Result, uvicorn_kwargs)`` so tests can
+    inspect both stderr-merged output and the exact host/port the
+    serve command tried to bind.
     """
     import typer
+    import uvicorn
     from typer.testing import CliRunner
 
     from pollypm.cli_features.web_api import register_web_api_commands
@@ -175,19 +272,18 @@ def test_pm_serve_tailscale_warns_when_binary_missing(
     root = typer.Typer()
     register_web_api_commands(root)
 
-    # Stub uvicorn so the test doesn't actually open a socket. The
-    # serve command imports uvicorn inside the function body, so we
-    # monkeypatch the module attribute at import time.
-    import uvicorn
+    captured: dict[str, object] = {}
 
-    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: None)
-    # Force ``shutil.which("tailscale")`` to miss.
+    def _fake_uvicorn_run(*args, **kwargs):
+        # uvicorn.run(app_instance, host=…, port=…, log_level=…)
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(uvicorn, "run", _fake_uvicorn_run)
     monkeypatch.setattr(
-        "pollypm.cli_features.web_api.shutil.which",
-        lambda name: None,
+        "pollypm.cli_features.web_api.detect_tailscale_ip",
+        lambda: detect_result,
     )
-    # Stub config + token machinery so we don't depend on the user's
-    # real ~/.pollypm/.
     monkeypatch.setattr(
         "pollypm.cli_features.web_api.load_config",
         lambda _path: api_config,
@@ -200,10 +296,106 @@ def test_pm_serve_tailscale_warns_when_binary_missing(
     runner = CliRunner()
     result = runner.invoke(
         root,
-        ["serve", "--tailscale", "--token-path", str(token_path)],
+        ["serve", "--token-path", str(token_path), *(extra_args or [])],
+    )
+    return result, captured
+
+
+# -------- P0 #2 + #3: bind mode (always-detect Tailscale) ---------------
+
+
+def test_pm_serve_binds_tailscale_ip_when_detected(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When Tailscale is detected, uvicorn binds the tailnet IPv4 only."""
+    result, captured = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result="100.64.0.5",
     )
     assert result.exit_code == 0, result.output
-    # CliRunner merges stderr into ``output`` by default; the
-    # ``[pm serve]`` banner + warning land in stderr via typer.echo.
+    assert captured["kwargs"]["host"] == "100.64.0.5", (
+        f"expected bind to detected Tailscale IP; got {captured['kwargs']}"
+    )
+    # Banner should mention the tailscale mode + the IP.
+    assert "100.64.0.5" in result.output
+    assert "tailscale mode" in result.output
+
+
+def test_pm_serve_binds_loopback_when_no_tailscale(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No Tailscale → fall back to loopback-only bind."""
+    result, captured = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result=None,
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"]["host"] == "127.0.0.1", (
+        f"expected loopback bind; got {captured['kwargs']}"
+    )
+    assert "loopback only" in result.output
+
+
+def test_pm_serve_tailscale_flag_is_noop(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--tailscale`` is preserved for back-compat but doesn't change behaviour.
+
+    The default ``pm serve`` already auto-detects Tailscale; passing
+    the flag must therefore produce the same bind as omitting it.
+    """
+    result_with_flag, captured_flag = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result="100.64.0.5",
+        extra_args=["--tailscale"],
+    )
+    result_no_flag, captured_no_flag = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result="100.64.0.5",
+    )
+    assert result_with_flag.exit_code == 0, result_with_flag.output
+    assert result_no_flag.exit_code == 0, result_no_flag.output
+    assert captured_flag["kwargs"]["host"] == captured_no_flag["kwargs"]["host"]
+    assert captured_flag["kwargs"]["host"] == "100.64.0.5"
+
+
+def test_pm_serve_tailscale_warns_when_binary_missing(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``pm serve --tailscale`` without tailscale prints a warning + falls back.
+
+    Drives the CLI command via Typer's runner so the user-visible
+    stderr matches what the operator will see in their terminal.
+    """
+    result, captured = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result=None,
+        extra_args=["--tailscale"],
+    )
+    assert result.exit_code == 0, result.output
+    # Banner mentions the fallback path.
+    assert "loopback" in result.output or "Falling back" in result.output
+    # And the warning explicitly calls out --tailscale.
     assert "--tailscale" in result.output
-    assert "tailscale ip -4" in result.output or "Falling back" in result.output
+    assert captured["kwargs"]["host"] == "127.0.0.1"
+
+
+# -------- P1: mobile CSS -----------------------------------------------
+
+
+def test_styles_have_mobile_media_query(client: TestClient) -> None:
+    """``styles.css`` ships a mobile/tablet collapse breakpoint."""
+    body = client.get("/ui/styles.css").text
+    assert "@media (max-width: 768px)" in body, (
+        "expected mobile/tablet media query for phone Tailscale users"
+    )

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -761,6 +761,44 @@ def test_pm_serve_with_explicit_host_skips_tailscale_detection(
     assert captured["create_app_kwargs"]["tailnet_trust_enabled"] is False
 
 
+def test_warning_does_not_falsely_fire_on_explicit_host_with_tailscale_flag(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Round-13 #2065: ``--host X --tailscale`` must NOT lie about detection.
+
+    The earlier warning gate fired whenever ``tailscale_ip is None`` and
+    ``--tailscale`` was passed. But the explicit-host branch (round-9)
+    never calls ``detect_tailscale_ip()`` — it just leaves
+    ``tailscale_ip`` at None. So the warning's "Falling back to
+    loopback-only" tail was doubly wrong: detection never ran, and the
+    server is honoring the explicit host, not falling back.
+
+    Drive the CLI with ``--host 127.0.0.1 --tailscale`` and confirm the
+    misleading "Falling back to loopback-only" text never appears.
+    """
+    result, _captured = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        # detect_result is irrelevant here because the explicit-host
+        # branch must skip detect_tailscale_ip entirely (see round-9
+        # test above). Pass None so a regression that re-introduced the
+        # detect call would still trip the old warning gate.
+        detect_result=None,
+        extra_args=["--host", "127.0.0.1", "--tailscale"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Falling back to loopback-only" not in result.output, (
+        "Round-13 #2065: --host explicit + --tailscale must not emit "
+        "the loopback-fallback warning — detection was never attempted "
+        f"and the bind honored the explicit host. Got: {result.output!r}"
+    )
+    assert "`tailscale ip -4` returned no IP" not in result.output, (
+        "The detection-failure warning fired even though "
+        "detect_tailscale_ip was never called (explicit --host branch)."
+    )
+
+
 # -------- P1: mobile CSS -----------------------------------------------
 
 

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -560,3 +560,98 @@ def test_styles_have_mobile_media_query(client: TestClient) -> None:
     assert "@media (max-width: 768px)" in body, (
         "expected mobile/tablet media query for phone Tailscale users"
     )
+
+
+# -------- Round-4: renderDashboard ↔ real /dashboard schema -------------
+
+
+def test_ui_app_js_reads_real_dashboard_fields(client: TestClient) -> None:
+    """``app.js`` reads the real ``DashboardResponse`` schema.
+
+    Round-3 Codex blocker: the v0 right rail was looking for top-level
+    counters like ``attention_count`` / ``workers.active`` that don't
+    exist on ``GET /api/v1/dashboard``. The real envelope groups
+    operator counters under ``rollups`` (see
+    ``src/pollypm/web_api/routes/dashboard.py:DashboardRollups``). Pin
+    the rename so a future refactor that drops the ``rollups.`` prefix
+    or stops reading ``daemon_status`` fails this assertion before it
+    ships an empty rail again.
+    """
+    body = client.get("/ui/app.js").text
+    assert "rollups." in body, (
+        "app.js must read counters off the ``rollups`` envelope, not "
+        "from phantom top-level fields"
+    )
+    real_fields = [
+        "open_inbox_count",
+        "pending_plan_reviews",
+        "alert_count",
+        "daemon_status",
+        "sweep_count_24h",
+        "message_count_24h",
+        "active_sessions",
+        "tracked_count",
+    ]
+    hits = [name for name in real_fields if name in body]
+    assert len(hits) >= 3, (
+        f"app.js should reference at least 3 real DashboardResponse "
+        f"fields; only found: {hits}"
+    )
+
+
+def test_ui_app_js_no_phantom_dashboard_fields(client: TestClient) -> None:
+    """``app.js`` must not look for the pre-round-4 phantom field names.
+
+    The fallback ``Object.keys(data).slice(0, 6)`` branch in the old
+    ``renderDashboard`` rendered top-level envelope keys like
+    ``"projects"`` and ``"rollups"`` as ``"N keys"`` cards whenever the
+    candidate paths missed — which they always did against the real
+    API. Pin both the phantom candidate paths AND the dead fallback
+    branch so a regression re-introducing either fails loudly.
+    """
+    body = client.get("/ui/app.js").text
+    phantom_paths = [
+        "attention_count",
+        "blocked_count",
+        '"workers", "active"',
+        '"tasks", "open"',
+        '"projects", "tracked"',
+    ]
+    leaks = [name for name in phantom_paths if name in body]
+    assert not leaks, (
+        f"app.js still references phantom dashboard fields: {leaks}. "
+        f"Real schema is documented on DashboardRollups in "
+        f"src/pollypm/web_api/routes/dashboard.py."
+    )
+    # The old fallback ("N keys" cards from arbitrary top-level keys)
+    # was the symptom Codex flagged in round 3. Make sure the rewrite
+    # removed it.
+    assert "N keys" not in body
+    assert "+ \" keys\"" not in body
+    assert '" keys"' not in body, (
+        "app.js still contains the dead ``N keys`` fallback that "
+        "rendered envelope keys as cards when the candidate paths "
+        "missed"
+    )
+
+
+def test_ui_app_js_renderdashboard_uses_buildcard_helper(
+    client: TestClient,
+) -> None:
+    """The rewrite centralizes card creation in a single helper.
+
+    Codex round-3 asked for the mapping to live in ``one small adapter
+    in app.js``. Pin that structure so future edits don't fan out
+    inline card-building logic across the function and re-grow the
+    schema drift surface.
+    """
+    body = client.get("/ui/app.js").text
+    assert "function buildCard(" in body, (
+        "renderDashboard must route card construction through a single "
+        "``buildCard`` helper so the schema mapping stays centralized"
+    )
+    # And ``scoped_fields`` is consumed so project-filtered counters
+    # are visibly tagged ("(filtered)") rather than presented as
+    # workspace-wide.
+    assert "scoped_fields" in body
+    assert "(filtered)" in body

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -111,11 +111,33 @@ def test_ui_cookie_set_from_loopback(app, token: str) -> None:
     assert resp.cookies.get(SESSION_COOKIE_NAME) == token
 
 
-def test_ui_cookie_set_from_tailscale_peer(app, token: str) -> None:
-    """Tailscale CGNAT peer is trusted — cookie is issued."""
-    resp = _ui_get_with_peer(app, "100.64.0.5")
+def test_ui_cookie_set_from_tailscale_peer(tailnet_app, token: str) -> None:
+    """Tailscale CGNAT peer is trusted when tailnet trust is enabled."""
+    resp = _ui_get_with_peer(tailnet_app, "100.64.0.5")
     assert resp.status_code == 200
     assert resp.cookies.get(SESSION_COOKIE_NAME) == token
+
+
+def test_ui_no_cookie_minted_from_cgnat_when_trust_disabled(
+    app, token: str  # noqa: ARG001 — token fixture writes the on-disk token
+) -> None:
+    """CGNAT peer hitting the default app gets HTML but no Set-Cookie.
+
+    Sister to ``test_ui_no_cookie_from_lan_client``: the default
+    ``create_app(tailnet_trust_enabled=False)`` (what ``pm serve``
+    builds whenever it didn't bind to a verified Tailscale IPv4)
+    must NOT mint a session cookie just because the source IP looks
+    like a tailnet address. RFC 6598 shared address space is also used
+    by some ISP CGNATs; trusting it unconditionally was the round-2
+    Codex blocker.
+    """
+    resp = _ui_get_with_peer(app, "100.64.0.5")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert SESSION_COOKIE_NAME not in resp.cookies, (
+        "CGNAT peer must NOT receive Set-Cookie when tailnet trust is "
+        f"disabled; got cookies: {dict(resp.cookies)}"
+    )
 
 
 def test_ui_cookie_set_with_valid_bearer_header(app, token: str) -> None:
@@ -187,11 +209,24 @@ def test_auth_via_cookie_works(client: TestClient, token: str) -> None:
     assert response.status_code == 200
 
 
-def test_auth_via_tailscale_cgnat_ip_works(api_config, token_path: Path) -> None:
-    """A request from a 100.64.0.0/10 client IP bypasses cred checks."""
+def test_cgnat_trust_enabled_allows_credential_free_from_tailnet(
+    api_config, token_path: Path,
+) -> None:
+    """Positive test: tailnet-bound mode lets CGNAT peers in unauthenticated.
+
+    Built with ``tailnet_trust_enabled=True`` — the same mode
+    ``pm serve`` enables when it actually bound to a verified
+    Tailscale IPv4 (see ``cli_features/web_api.py`` round-2). Mirrors
+    the production wire path so the credential-free convenience for
+    tailnet users keeps working in v0.
+    """
     from pollypm.web_api import create_app
 
-    app = create_app(config=api_config, token_path=token_path)
+    app = create_app(
+        config=api_config,
+        token_path=token_path,
+        tailnet_trust_enabled=True,
+    )
     # Baseline: TestClient default peer is ``testclient`` (not a
     # tailnet IP), so without creds we expect 401.
     baseline_client = TestClient(app, base_url="http://testserver")
@@ -211,9 +246,46 @@ def test_auth_via_tailscale_cgnat_ip_works(api_config, token_path: Path) -> None
 
     resp2 = asyncio.run(_probe())
     assert resp2.status_code == 200, (
-        "Tailscale CGNAT IP (100.64.0.5) should bypass credential check; "
+        "Tailscale CGNAT IP (100.64.0.5) should bypass credential check "
+        "when tailnet_trust_enabled=True; "
         f"got {resp2.status_code} {resp2.text}"
     )
+
+
+def test_cgnat_trust_disabled_returns_401_without_credentials(
+    api_config, token_path: Path,
+) -> None:
+    """Pin the default mode: CGNAT trust is OFF in ``create_app()``.
+
+    Codex round-2 blocker: an operator who runs
+    ``pm serve --host 0.0.0.0 --allow-remote`` should get strict auth
+    on every request even if the source IP lands in 100.64.0.0/10
+    (some ISP CGNATs use RFC 6598 shared space). The default
+    ``create_app`` build — and any ``pm serve`` invocation that didn't
+    actually bind to a verified Tailscale IPv4 — must keep requiring
+    a bearer or cookie.
+    """
+    from pollypm.web_api import create_app
+
+    app = create_app(config=api_config, token_path=token_path)
+    # Defensive: confirm the keyword defaulted to False (no implicit
+    # tailnet trust). If someone flips the default we want this test
+    # to fail loud.
+
+    async def _probe() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app, client=("100.64.0.5", 12345))
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver",
+        ) as ac:
+            return await ac.get("/api/v1/projects")
+
+    resp = asyncio.run(_probe())
+    assert resp.status_code == 401, (
+        "Default create_app() must NOT trust CGNAT peers without creds; "
+        f"got {resp.status_code} {resp.text}"
+    )
+    body = resp.json()
+    assert body["error"]["code"] == "unauthorized"
 
 
 def test_auth_without_any_credentials_returns_401(client: TestClient) -> None:
@@ -292,6 +364,20 @@ def _run_serve_command(
         "pollypm.web_api.ensure_token",
         lambda _path: ("test-token", False),
     )
+
+    # Intercept ``create_app`` so the test can assert exactly which
+    # kwargs (notably ``tailnet_trust_enabled``) flowed through. The
+    # import inside the command body resolves the name on the
+    # ``pollypm.web_api`` package, so patch it there.
+    import pollypm.web_api as web_api_pkg
+
+    real_create_app = web_api_pkg.create_app
+
+    def _capturing_create_app(**kwargs):
+        captured["create_app_kwargs"] = dict(kwargs)
+        return real_create_app(**kwargs)
+
+    monkeypatch.setattr(web_api_pkg, "create_app", _capturing_create_app)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -388,6 +474,81 @@ def test_pm_serve_tailscale_warns_when_binary_missing(
     # And the warning explicitly calls out --tailscale.
     assert "--tailscale" in result.output
     assert captured["kwargs"]["host"] == "127.0.0.1"
+
+
+# -------- Round-2: tailnet trust ↔ bind-mode wiring ---------------------
+
+
+def test_pm_serve_disables_tailnet_trust_on_explicit_host_override(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit ``--host 0.0.0.0 --allow-remote`` keeps tailnet trust OFF.
+
+    Round-2 Codex blocker: even when Tailscale IS detected, an operator
+    who deliberately overrode the bind to a non-tailnet interface
+    (e.g. 0.0.0.0 for a reverse proxy front-end) must NOT have the
+    auth dependency hand out credential-free access to peers whose
+    source IP lives in 100.64.0.0/10. Some ISP CGNATs use RFC 6598
+    shared address space; trusting it on the public interface is the
+    exact attack the round-2 review flagged.
+    """
+    result, captured = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result="100.64.0.5",  # Tailscale IS up
+        extra_args=["--host", "0.0.0.0", "--allow-remote"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"]["host"] == "0.0.0.0"
+    create_app_kwargs = captured["create_app_kwargs"]
+    assert create_app_kwargs["tailnet_trust_enabled"] is False, (
+        "Explicit --host override must NOT inherit tailnet trust even "
+        "when detect_tailscale_ip succeeds; "
+        f"got create_app kwargs: {create_app_kwargs}"
+    )
+
+
+def test_pm_serve_enables_tailnet_trust_on_auto_tailscale_bind(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default ``pm serve`` + detected Tailscale → tailnet_trust_enabled=True.
+
+    Companion to the override test above: the auto-detect happy path
+    is the ONLY mode that opts into credential-free CGNAT access.
+    """
+    result, captured = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result="100.64.0.5",
+    )
+    assert result.exit_code == 0, result.output
+    create_app_kwargs = captured["create_app_kwargs"]
+    assert create_app_kwargs["tailnet_trust_enabled"] is True, (
+        f"auto-tailscale bind should enable tailnet trust; got {create_app_kwargs}"
+    )
+
+
+def test_pm_serve_disables_tailnet_trust_on_loopback_fallback(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Loopback fallback (no Tailscale detected) keeps tailnet trust OFF.
+
+    Defensive: a future change that flipped the default to True would
+    silently regress the round-2 invariant; pin it.
+    """
+    result, captured = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result=None,
+    )
+    assert result.exit_code == 0, result.output
+    create_app_kwargs = captured["create_app_kwargs"]
+    assert create_app_kwargs["tailnet_trust_enabled"] is False, (
+        f"loopback fallback should NOT enable tailnet trust; got {create_app_kwargs}"
+    )
 
 
 # -------- P1: mobile CSS -----------------------------------------------

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -26,6 +26,9 @@ flows through the same code path ``pm serve`` uses at runtime.
 from __future__ import annotations
 
 import asyncio
+import json
+import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -319,6 +322,136 @@ def test_detect_tailscale_ip_returns_none_when_binary_missing() -> None:
         return_value=None,
     ):
         assert detect_tailscale_ip() is None
+
+
+# -------- Round-5: detect_tailscale_ip output validation ----------------
+#
+# Codex round-5 blocker: the detector previously returned the first
+# non-empty stdout token from ``tailscale ip -4`` without validating
+# either parseability or membership in the Tailscale CGNAT range
+# (100.64.0.0/10). The serve path enables ``tailnet_trust=True``
+# whenever this function returns a non-``None`` value, so leaking a
+# malformed token (e.g. "not-an-ip") or a parseable-but-non-tailnet
+# address would silently grant credential-free CGNAT trust to a peer
+# we could not have verified came in on tailscale0. Lock the validator
+# contract to (parseable IPv4) AND (inside CGNAT range).
+
+
+def _patch_tailscale_stdout(stdout: str):
+    """Build the (which + subprocess.run) double-mock the tests need."""
+
+    class _FakeResult:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = stdout
+
+    def _fake_run(*_args, **_kwargs):
+        return _FakeResult()
+
+    return patch(
+        "pollypm.cli_features.web_api.shutil.which",
+        return_value="/usr/bin/tailscale",
+    ), patch(
+        "pollypm.cli_features.web_api.subprocess.run",
+        side_effect=_fake_run,
+    )
+
+
+def test_detect_tailscale_ip_rejects_malformed_output() -> None:
+    """Garbage on stdout → ``None`` (not the raw token)."""
+    which_p, run_p = _patch_tailscale_stdout("not-an-ip\n")
+    with which_p, run_p:
+        assert detect_tailscale_ip() is None
+
+
+def test_detect_tailscale_ip_rejects_non_cgnat_ipv4() -> None:
+    """Parseable IPv4 outside 100.64.0.0/10 → ``None``.
+
+    A LAN router that happens to be reachable as 192.168.1.1 must NOT
+    be treated as a verified Tailscale peer; the serve path keys
+    ``tailnet_trust=True`` off this function's truthiness.
+    """
+    which_p, run_p = _patch_tailscale_stdout("192.168.1.1\n")
+    with which_p, run_p:
+        assert detect_tailscale_ip() is None
+
+
+def test_detect_tailscale_ip_rejects_public_ipv4() -> None:
+    """A public IPv4 (e.g. 8.8.8.8) must also be refused."""
+    which_p, run_p = _patch_tailscale_stdout("8.8.8.8\n")
+    with which_p, run_p:
+        assert detect_tailscale_ip() is None
+
+
+def test_detect_tailscale_ip_rejects_ipv6_output() -> None:
+    """IPv6 token (CGNAT is IPv4-only) → ``None``."""
+    which_p, run_p = _patch_tailscale_stdout("fd7a:115c:a1e0::1\n")
+    with which_p, run_p:
+        assert detect_tailscale_ip() is None
+
+
+def test_detect_tailscale_ip_accepts_valid_cgnat_ipv4() -> None:
+    """A parseable IPv4 inside 100.64.0.0/10 → the address string."""
+    which_p, run_p = _patch_tailscale_stdout("100.64.0.5\n")
+    with which_p, run_p:
+        assert detect_tailscale_ip() == "100.64.0.5"
+
+
+def test_detect_tailscale_ip_accepts_upper_cgnat_boundary() -> None:
+    """Boundary check: 100.127.255.254 is still inside 100.64.0.0/10."""
+    which_p, run_p = _patch_tailscale_stdout("100.127.255.254\n")
+    with which_p, run_p:
+        assert detect_tailscale_ip() == "100.127.255.254"
+
+
+def test_detect_tailscale_ip_rejects_just_outside_cgnat() -> None:
+    """100.128.0.0 is one bit outside 100.64.0.0/10 → ``None``."""
+    which_p, run_p = _patch_tailscale_stdout("100.128.0.1\n")
+    with which_p, run_p:
+        assert detect_tailscale_ip() is None
+
+
+def test_detect_tailscale_ip_handles_empty_output() -> None:
+    """Empty stdout → ``None`` (no token to validate)."""
+    which_p, run_p = _patch_tailscale_stdout("")
+    with which_p, run_p:
+        assert detect_tailscale_ip() is None
+
+
+def test_detect_tailscale_ip_handles_whitespace_only_output() -> None:
+    """Whitespace-only stdout → ``None`` (no non-empty token)."""
+    which_p, run_p = _patch_tailscale_stdout("\n   \n\t\n")
+    with which_p, run_p:
+        assert detect_tailscale_ip() is None
+
+
+def test_pm_serve_does_not_trust_explicit_host_matching_garbage(
+    api_config, token_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit ``--host not-an-ip`` cannot inherit tailnet trust.
+
+    Companion to the detector tests: even if a future detector
+    regression returned an unvalidated token, the validated detector
+    contract guarantees ``detected is None`` whenever the candidate is
+    not a verified CGNAT IPv4, so the explicit-host equality branch
+    (``cli_features/web_api.py:245-248``) cannot flip
+    ``tailnet_trust_enabled`` for a non-CGNAT host.
+    """
+    # detect_result=None simulates the post-validation detector
+    # rejecting an invalid `tailscale ip -4` output.
+    result, captured = _run_serve_command(
+        api_config,
+        token_path,
+        monkeypatch,
+        detect_result=None,
+        extra_args=["--host", "192.168.1.1", "--allow-remote"],
+    )
+    assert result.exit_code == 0, result.output
+    create_app_kwargs = captured["create_app_kwargs"]
+    assert create_app_kwargs["tailnet_trust_enabled"] is False, (
+        "Non-CGNAT explicit host must never enable tailnet trust; "
+        f"got create_app kwargs: {create_app_kwargs}"
+    )
 
 
 def _run_serve_command(
@@ -655,3 +788,292 @@ def test_ui_app_js_renderdashboard_uses_buildcard_helper(
     # workspace-wide.
     assert "scoped_fields" in body
     assert "(filtered)" in body
+
+
+# -------- Round-5: executable renderDashboard coverage ------------------
+#
+# Codex round-5 blocker: the prior three tests (static greps over
+# ``/ui/app.js``) cannot catch a runtime mapping bug where the right
+# field names appear in source but flow into the wrong card, or where a
+# refactor silently breaks the rendered output. Feed a representative
+# ``DashboardResponse`` payload through the REAL ``renderDashboard``
+# under node, then assert visible labels + values land in the rendered
+# DOM. This is the executable coverage Codex asked for.
+
+
+def _node_render_dashboard(payload: dict) -> str:
+    """Load ``app.js`` under node with a minimal DOM shim and render.
+
+    Returns the ``innerHTML`` of the ``#dashboard-rollups`` container
+    after ``window.PollyPM.renderDashboard(payload)`` executes. The DOM
+    shim implements only what ``app.js`` touches at render time:
+    ``document.getElementById``, ``document.createElement`` returning
+    nodes with ``setAttribute`` / ``appendChild`` / ``className`` /
+    ``textContent`` / ``innerHTML`` / ``querySelector``. We deliberately
+    avoid pulling in ``jsdom`` to keep the dev-deps surface flat — this
+    SPA is tiny enough that ~60 LOC of shim covers it.
+    """
+    node_bin = shutil.which("node")
+    if node_bin is None:
+        pytest.skip("node binary not available; cannot run executable JS harness")
+    app_js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "pollypm"
+        / "web_api"
+        / "ui"
+        / "app.js"
+    )
+    assert app_js_path.is_file(), f"app.js missing at {app_js_path}"
+    # When invoked as ``node -e <code> ARG1 ARG2``, ``process.argv`` is
+    # ``[node, ARG1, ARG2]`` (no script slot for ``-e``), so the
+    # app.js path lands at argv[1] and the JSON payload at argv[2].
+    harness = r"""
+const fs = require("fs");
+const path = process.argv[1];
+const payload = JSON.parse(process.argv[2]);
+
+// ---- minimal DOM shim --------------------------------------------------
+function makeNode(tag) {
+  const node = {
+    tagName: (tag || "div").toUpperCase(),
+    children: [],
+    attrs: {},
+    className: "",
+    textContent: "",
+    style: {},
+  };
+  Object.defineProperty(node, "innerHTML", {
+    get() {
+      function render(n) {
+        if (n.__text != null) {
+          return String(n.__text)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+        }
+        const tag = n.tagName.toLowerCase();
+        const parts = [];
+        for (const k of Object.keys(n.attrs)) {
+          parts.push(k + '="' + n.attrs[k] + '"');
+        }
+        if (n.className) parts.push('class="' + n.className + '"');
+        const open = parts.length
+          ? "<" + tag + " " + parts.join(" ") + ">"
+          : "<" + tag + ">";
+        let inner = "";
+        if (n.textContent && n.children.length === 0) {
+          inner = String(n.textContent)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+        } else {
+          inner = n.children.map(render).join("");
+        }
+        return open + inner + "</" + tag + ">";
+      }
+      return node.children.map(render).join("");
+    },
+    set(v) {
+      if (v === "") node.children = [];
+    },
+  });
+  node.setAttribute = function (k, v) { node.attrs[k] = v; };
+  node.appendChild = function (child) { node.children.push(child); return child; };
+  node.removeChild = function (child) {
+    node.children = node.children.filter((c) => c !== child);
+    return child;
+  };
+  node.querySelector = function () { return null; };
+  node.addEventListener = function () {};
+  return node;
+}
+
+const elements = {
+  "dashboard-rollups": makeNode("div"),
+  "surface-list": makeNode("ul"),
+  "message-list": makeNode("div"),
+  "send-input": makeNode("input"),
+  "send-button": makeNode("button"),
+  "send-form": makeNode("form"),
+  "pane-title": makeNode("div"),
+  "pane-meta": makeNode("div"),
+  "conn-status": makeNode("div"),
+  "layout": makeNode("div"),
+};
+
+global.document = {
+  getElementById: (id) => elements[id] || null,
+  createElement: (tag) => makeNode(tag),
+  createTextNode: (text) => {
+    const n = makeNode("span");
+    n.__text = text;
+    return n;
+  },
+  addEventListener: function () {},
+  readyState: "complete",
+  body: makeNode("body"),
+};
+global.window = {};
+global.setInterval = function () { return 0; };
+global.clearInterval = function () {};
+global.setTimeout = function () { return 0; };
+global.fetch = function () { return Promise.reject(new Error("no network")); };
+
+// ---- load app.js IIFE --------------------------------------------------
+const source = fs.readFileSync(path, "utf8");
+// eslint-disable-next-line no-eval
+eval(source);
+
+if (!global.window.PollyPM || typeof global.window.PollyPM.renderDashboard !== "function") {
+  console.error("PollyPM.renderDashboard not exposed");
+  process.exit(2);
+}
+global.window.PollyPM.renderDashboard(payload);
+process.stdout.write(elements["dashboard-rollups"].innerHTML);
+"""
+    proc = subprocess.run(
+        [node_bin, "-e", harness, str(app_js_path), json.dumps(payload)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"node harness failed (rc={proc.returncode}):\n"
+            f"STDOUT: {proc.stdout}\nSTDERR: {proc.stderr}"
+        )
+    return proc.stdout
+
+
+def test_render_dashboard_real_payload_executes() -> None:
+    """Feed a representative DashboardResponse through ``renderDashboard``.
+
+    Asserts the rendered DOM contains:
+    - the inbox count + label
+    - the plan-reviews count + label
+    - the alert count + ``alerts`` label
+    - the daemon ``up`` status + label
+    - the activity sweeps/msgs label
+    - the active-sessions count
+    - the tracked-projects count
+
+    Static greps could not catch (a) a refactor that routes
+    ``rollups.open_inbox_count`` into the ``alerts`` card by mistake,
+    or (b) a typo that drops the value from the rendered DOM while
+    keeping the field name in source. This test fails on both.
+    """
+    payload = {
+        "rollups": {
+            "open_inbox_count": 7,
+            "pending_plan_reviews": 2,
+            "alert_count": 3,
+            "sweep_count_24h": 12,
+            "message_count_24h": 47,
+            "tracked_count": 5,
+        },
+        "daemon_status": "up",
+        "active_sessions": [
+            {"session_name": "a"},
+            {"session_name": "b"},
+            {"session_name": "c"},
+            {"session_name": "d"},
+        ],
+        "scoped_fields": [],
+        "projects": [],
+        "recent_messages": [],
+    }
+    rendered = _node_render_dashboard(payload)
+
+    # Sanity: the container actually got cards.
+    assert "rollup-card" in rendered, (
+        f"renderDashboard produced no cards; output was:\n{rendered}"
+    )
+
+    # Each counter's label appears.
+    for label in (
+        "inbox",
+        "plan reviews",
+        "alerts",
+        "activity (24h)",
+        "daemon",
+        "active sessions",
+        "projects tracked",
+    ):
+        assert label in rendered, (
+            f"expected card label {label!r} in rendered DOM; got:\n{rendered}"
+        )
+
+    # Values are present (these are the load-bearing assertions — a
+    # mapping bug that routes the wrong field into the wrong card
+    # would fail here even if the labels still grep-match).
+    assert "7 items" in rendered, "inbox count missing/wrong"
+    assert "2 waiting" in rendered, "plan-reviews count missing/wrong"
+    assert ">3<" in rendered, "alert_count value 3 missing"
+    assert "12 sweeps / 47 msgs" in rendered, "activity 24h composite missing"
+    assert ">up<" in rendered, "daemon status 'up' missing"
+    assert ">4<" in rendered, "active_sessions count (len=4) missing"
+    assert ">5<" in rendered, "tracked_count value 5 missing"
+
+    # Color-coding contract: daemon=up → rollup-working; alert_count>0
+    # → rollup-blocked. Pin these too so a future restyle that drops
+    # the class hooks fails loudly.
+    assert "rollup-working" in rendered
+    assert "rollup-blocked" in rendered
+
+
+def test_render_dashboard_daemon_down_uses_blocked_class() -> None:
+    """``daemon_status='down'`` flips the daemon card to the blocked class.
+
+    Executable variant of the per-status branch in ``renderDashboard``
+    (``app.js:358-367``). Pinning this catches a future swap of
+    ``up``/``down`` or ``rollup-working``/``rollup-blocked``.
+    """
+    payload = {
+        "rollups": {
+            "open_inbox_count": 0,
+            "pending_plan_reviews": 0,
+            "alert_count": 0,
+            "sweep_count_24h": 0,
+            "message_count_24h": 0,
+            "tracked_count": 0,
+        },
+        "daemon_status": "down",
+        "active_sessions": [],
+        "scoped_fields": [],
+        "projects": [],
+        "recent_messages": [],
+    }
+    rendered = _node_render_dashboard(payload)
+    assert ">down<" in rendered
+    # daemon card is the one with text "daemon" and class rollup-blocked
+    assert "rollup-blocked" in rendered
+
+
+def test_render_dashboard_scoped_fields_tag_filtered_cards() -> None:
+    """``scoped_fields`` flags a card with ``(filtered)`` in its label.
+
+    Executable variant of the ``scoped_fields`` path
+    (``app.js:280-291``). Confirms the runtime mapping actually appends
+    the tag rather than just containing the literal in source.
+    """
+    payload = {
+        "rollups": {
+            "open_inbox_count": 1,
+            "pending_plan_reviews": 0,
+            "alert_count": 0,
+            "sweep_count_24h": 0,
+            "message_count_24h": 0,
+            "tracked_count": 0,
+        },
+        "daemon_status": "up",
+        "active_sessions": [],
+        "scoped_fields": ["rollups.open_inbox_count"],
+        "projects": [],
+        "recent_messages": [],
+    }
+    rendered = _node_render_dashboard(payload)
+    assert "inbox (filtered)" in rendered, (
+        f"scoped inbox card should carry the (filtered) tag; got:\n{rendered}"
+    )


### PR DESCRIPTION
## Summary

- Ships a v0 web UI at `/ui/`: vanilla HTML/JS/CSS SPA served by FastAPI StaticFiles, no build step.
- `GET /ui/` reads `~/.pollypm/api-token` and seeds an `HttpOnly` `pollypm-session` cookie so the browser never has to paste / store the token. JS uses `fetch(..., {credentials: 'include'})`.
- Auth dependency now accepts (a) `Authorization: Bearer …`, (b) `pollypm-session` cookie, (c) client IP in `100.64.0.0/10` Tailscale CGNAT range (no cred).
- `pm serve --tailscale` shells out to `tailscale ip -4`, binds `0.0.0.0` alongside loopback when an address is returned, and warns + falls back to localhost-only when the binary is missing.

## UI layout (vanilla, no framework)

- Top bar: brand + connection status (`ok` / `warn` / `error` dot).
- Left rail: chat surfaces from `/api/v1/chat/sessions`.
- Center: selected surface's last 50 messages from `/api/v1/chat/{name}/messages` (desc, render reversed so newest sticks to the bottom).
- Bottom: text input → `POST /api/v1/chat/{name}/send`.
- Right rail: dashboard rollups from `/api/v1/dashboard` (polls every 15s).

Color palette mirrors `cockpit_theme.State` (waiting amber, working green, blocked red, info blue, etc).

## Auth model

```
Authorization: Bearer <token>  →  match against ~/.pollypm/api-token  →  200
pollypm-session cookie         →  match against ~/.pollypm/api-token  →  200
client IP ∈ 100.64.0.0/10      →  bypass cred check                   →  200
none of the above              →  401 unauthorized
```

Loopback is NOT auto-trusted; the cookie path already covers the local-browser convenience case and avoids a footgun on shared machines.

## Files

- `src/pollypm/web_api/auth.py` — `is_tailscale_ip()` + cookie/CGNAT acceptance in both bearer + SSE dependencies.
- `src/pollypm/web_api/app.py` — `_mount_web_ui()`: `/ui/` cookie-setting handler + `StaticFiles` mount.
- `src/pollypm/web_api/ui/index.html` (62 lines, 1.8 KB)
- `src/pollypm/web_api/ui/app.js` (356 lines, 10.6 KB)
- `src/pollypm/web_api/ui/styles.css` (339 lines, 7.1 KB)
- `src/pollypm/cli_features/web_api.py` — `--tailscale` flag + `detect_tailscale_ip()`.
- `pyproject.toml` — package-data globs for `web_api/ui/*`.
- `tests/web_api/test_web_ui.py` — 10 cases.

Access doc: `~/Desktop/pollypm-web-ui-access.md`.

## Test plan

- [x] `pytest tests/web_api/test_web_ui.py` — 10/10 pass
- [x] `pytest tests/web_api/test_auth.py` — 7/7 still pass
- [x] `pytest tests/web_api/test_sse.py tests/web_api/test_openapi_conformance.py` — 12/12 still pass
- [x] `ruff check` clean on all touched files
- [ ] Manual: `pm serve --tailscale` → open `http://<tailnet-ip>:8765/ui/` on phone, send a chat message
- [ ] Manual: `pm serve` (no flag) → open `http://127.0.0.1:8765/ui/`, verify cookie is set + surfaces load

🤖 Generated with [Claude Code](https://claude.com/claude-code)