### PR TITLE
feat(web-ui): Playwright test scaffold for v0 web UI

### DIFF
--- a/tests/playwright/.gitignore
+++ b/tests/playwright/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+playwright/.cache/

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -3,11 +3,36 @@
 End-to-end tests for the v0 web UI shipped in PR #2065
 (`src/pollypm/web_api/ui/`). Covers:
 
-- cookie auth (`pollypm-session` set by `GET /ui/`)
+- cookie auth (`pollypm-session` minted by `GET /ui/` for trusted
+  callers only — loopback, verified tailnet peers, or a valid bearer
+  header — verified positively AND with negative cookie-isolation case)
 - surface rail rendering + selection
 - send-message flow against `POST /api/v1/chat/{session}/send`
 - edge cases (409 unsafe_mid_tool, 503 service_unavailable, empty list)
 - keyboard handling (Enter to send, plus TODO probes for the V1 UI)
+- mobile viewport smoke checks (360x800) — phone-over-Tailscale is an
+  advertised access mode for the v0 UI
+
+## Auth model under test
+
+Per `src/pollypm/web_api/auth.py` (merged in #2065), the API accepts
+three credential modes:
+
+1. `Authorization: Bearer <token>` header — any client.
+2. `pollypm-session` cookie — minted by `GET /ui/` for browsers.
+3. Tailscale CGNAT peer (`100.64.0.0/10`) — only when the daemon was
+   built with `tailnet_trust_enabled=True` (i.e. `pm serve` bound to a
+   verified Tailscale interface).
+
+`GET /ui/` is itself gated: the `Set-Cookie` header is only emitted
+for loopback callers, verified tailnet peers, or callers that present
+a valid bearer token. Untrusted callers still receive the HTML but no
+cookie — the SPA then surfaces a 401 on its first `/api/` call.
+
+`tests/auth.spec.ts` exercises the loopback-bootstrap path positively
+(Set-Cookie present, cookie HttpOnly, SameSite=Lax) and the negative
+cookie-isolation invariant (a fresh `APIRequestContext` with no cookie
+gets a hard 401, never 200/403).
 
 ## Prereqs
 
@@ -64,14 +89,28 @@ POLLYPM_BASE_URL=http://100.x.y.z:8765 npx playwright test
 This means the suite is safe to run while you're using PollyPM yourself:
 the only requests that touch live state are read-only `GET` calls.
 
+## Projects
+
+- `chromium` — Desktop Chrome, default development viewport.
+- `mobile-chrome` — Pixel 5 user-agent forced to a 360x800 viewport
+  (typical narrow Android portrait). Run with
+  `npx playwright test --project=mobile-chrome` to target it
+  specifically; the default `npx playwright test` runs both.
+
 ## Known limitations / TODOs
 
 - `Shift+Enter` newline and `j/k` surface navigation are marked
   `test.fixme` — V0 input is `<input type=text>` and the rail has no
   keyboard nav. Specs stay in place so the V1 UI work picks them up.
-- No mobile viewport project yet; V0 layout is desktop-only.
 - No Firefox/WebKit projects yet; per the V0 PR scope we ship Chromium
   only.
+- Non-loopback negative auth case (e.g. a LAN device hitting `/ui/`
+  and getting NO Set-Cookie) is verified at the FastAPI layer in
+  `tests/web_api/test_web_ui.py` (search for `_no_cookie_from_lan`,
+  `_no_cookie_minted_from_cgnat_when_trust_disabled`,
+  `_no_cookie_with_invalid_bearer`); reproducing it from Playwright
+  would require spoofing TCP source IP, which isn't worth the harness
+  complexity for the same invariant.
 
 ## Debugging tips
 

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -81,13 +81,19 @@ POLLYPM_BASE_URL=http://100.x.y.z:8765 npx playwright test
 | Spec | Hits real daemon | Notes |
 |------|------------------|-------|
 | `auth.spec.ts` | yes | Verifies the real cookie handshake. |
-| `surfaces.spec.ts` | partial | Real `/sessions` for live data, route stubs for the empty-state case. |
-| `send_message.spec.ts` | no (route-stubbed) | We never actually send keystrokes to a real tmux pane. |
-| `edge_cases.spec.ts` | no (route-stubbed) | 409/503 responses are simulated. |
-| `keyboard.spec.ts` | no (route-stubbed) | |
+| `surfaces.spec.ts` | partial | Real `/sessions` + `/dashboard` for live data; route stubs for the empty-state, 500, and stubbed-messages cases. |
+| `send_message.spec.ts` | no (route-stubbed) | Stubs `/api/v1/dashboard`, `/api/v1/chat/sessions`, `/messages*`, and `/send`. We never deliver keystrokes to a real tmux pane. |
+| `edge_cases.spec.ts` | no (route-stubbed) | Stubs `/api/v1/dashboard` + `/api/v1/chat/*`. 409/503 responses are simulated. |
+| `keyboard.spec.ts` | no (route-stubbed) | Stubs `/api/v1/dashboard` + `/api/v1/chat/*`. |
 
-This means the suite is safe to run while you're using PollyPM yourself:
-the only requests that touch live state are read-only `GET` calls.
+Concretely, the "no (route-stubbed)" specs install a `beforeEach`
+that mocks `/api/v1/dashboard` (the UI fires this on init for the
+right-rail rollups) plus all `/api/v1/chat/*` traffic. They still
+load the real `/ui/` HTML + static assets and go through the cookie
+bootstrap, but no mutating endpoint and no live `/chat/sessions` /
+`/dashboard` read leaks into the daemon. That makes the suite safe
+to run while you're using PollyPM yourself, and removes the
+fullyParallel timing coupling to live dashboard/session work.
 
 ## Projects
 

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -1,0 +1,83 @@
+# PollyPM v0 Web UI — Playwright Tests
+
+End-to-end tests for the v0 web UI shipped in PR #2065
+(`src/pollypm/web_api/ui/`). Covers:
+
+- cookie auth (`pollypm-session` set by `GET /ui/`)
+- surface rail rendering + selection
+- send-message flow against `POST /api/v1/chat/{session}/send`
+- edge cases (409 unsafe_mid_tool, 503 service_unavailable, empty list)
+- keyboard handling (Enter to send, plus TODO probes for the V1 UI)
+
+## Prereqs
+
+1. Node 18+ and npm.
+2. `pm serve` (or `pm up`) running on `http://127.0.0.1:8765` with a
+   valid `~/.pollypm/api-token` so the `GET /ui/` cookie endpoint can
+   issue `pollypm-session`.
+
+## Install
+
+```bash
+cd tests/playwright
+npm install
+npx playwright install chromium
+```
+
+## Run
+
+In one terminal (the daemon):
+
+```bash
+pm serve --tailscale
+# or just `pm up` if you already have that running
+```
+
+In another terminal (the tests):
+
+```bash
+cd tests/playwright
+npx playwright test                # headless, all specs
+npx playwright test auth.spec.ts   # one spec
+npm run test:headed                # show the browser
+npm run test:ui                    # Playwright UI mode (recommended)
+npm run test:debug                 # step-through debugger
+npm run report                     # open the last HTML report
+```
+
+To point the suite at a different host (e.g. a Tailscale URL):
+
+```bash
+POLLYPM_BASE_URL=http://100.x.y.z:8765 npx playwright test
+```
+
+## What gets stubbed vs. real
+
+| Spec | Hits real daemon | Notes |
+|------|------------------|-------|
+| `auth.spec.ts` | yes | Verifies the real cookie handshake. |
+| `surfaces.spec.ts` | partial | Real `/sessions` for live data, route stubs for the empty-state case. |
+| `send_message.spec.ts` | no (route-stubbed) | We never actually send keystrokes to a real tmux pane. |
+| `edge_cases.spec.ts` | no (route-stubbed) | 409/503 responses are simulated. |
+| `keyboard.spec.ts` | no (route-stubbed) | |
+
+This means the suite is safe to run while you're using PollyPM yourself:
+the only requests that touch live state are read-only `GET` calls.
+
+## Known limitations / TODOs
+
+- `Shift+Enter` newline and `j/k` surface navigation are marked
+  `test.fixme` — V0 input is `<input type=text>` and the rail has no
+  keyboard nav. Specs stay in place so the V1 UI work picks them up.
+- No mobile viewport project yet; V0 layout is desktop-only.
+- No Firefox/WebKit projects yet; per the V0 PR scope we ship Chromium
+  only.
+
+## Debugging tips
+
+- Run `npx playwright test --ui` for the recommended workflow.
+- Failures dump screenshots/videos under `playwright-report/`.
+- Set `DEBUG=pw:api` to see Playwright client traffic.
+- If `conn-status` won't go green, the token cookie isn't reaching the
+  browser — check that `pm serve` is on 8765 and that
+  `~/.pollypm/api-token` exists.

--- a/tests/playwright/package-lock.json
+++ b/tests/playwright/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "pollypm-playwright",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pollypm-playwright",
+      "devDependencies": {
+        "@playwright/test": "^1.40.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pollypm-playwright",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "test:debug": "playwright test --debug",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.40.0"
+  }
+}

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the PollyPM v0 web UI.
+ *
+ * Prereq: `pm serve` (or `pm up`) must be running on 127.0.0.1:8765,
+ * with the session cookie endpoint at /ui/ available. The webServer
+ * block below is commented out by default — uncomment if you want
+ * Playwright to start `pm serve` for you. We keep it off by default
+ * because Sam's normal dev loop already has the daemon running.
+ */
+
+const BASE_URL = process.env.POLLYPM_BASE_URL || "http://127.0.0.1:8765";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [["html", { open: "never" }], ["list"]],
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: BASE_URL,
+    headless: true,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  // Uncomment to have Playwright start `pm serve` itself.
+  // webServer: {
+  //   command: "pm serve",
+  //   url: BASE_URL + "/api/v1/health",
+  //   reuseExistingServer: !process.env.CI,
+  //   timeout: 30_000,
+  // },
+});

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -37,6 +37,20 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      // Mobile coverage — #2065 advertises phone-over-Tailscale access,
+      // and the v0 fixed-rail layout has known reflow issues at narrow
+      // widths. This project pins a 360x800 viewport (typical Android
+      // phone in portrait) so layout regressions are caught here
+      // instead of in production on Sam's phone.
+      name: "mobile-chrome",
+      use: {
+        ...devices["Pixel 5"],
+        // Pixel 5's default is 393x851; force a tighter 360x800 so we
+        // also catch overflow on smaller Android viewports.
+        viewport: { width: 360, height: 800 },
+      },
+    },
   ],
   // Uncomment to have Playwright start `pm serve` itself.
   // webServer: {

--- a/tests/playwright/tests/auth.spec.ts
+++ b/tests/playwright/tests/auth.spec.ts
@@ -3,10 +3,24 @@ import { test, expect } from "@playwright/test";
 /**
  * Auth scenarios.
  *
- * Auth model (per /ui/app.js header comment):
- *   GET /ui/ reads the on-disk token and sets the `pollypm-session`
- *   cookie. Every subsequent fetch uses credentials: "include" to ride
- *   that cookie. We never expose the token to the browser.
+ * Auth model (per src/pollypm/web_api/auth.py and #2065 security spec):
+ *   GET /ui/ mints the `pollypm-session` cookie ONLY for:
+ *     1. Authorization: Bearer <token> matching the on-disk token, OR
+ *     2. Loopback client (127.0.0.1, ::1), OR
+ *     3. Tailscale CGNAT peer when `tailnet_trust_enabled=True`.
+ *   Untrusted callers still get the HTML, but NO Set-Cookie header.
+ *
+ *   Subsequent /api/v1/... calls accept three credential modes:
+ *     - Authorization: Bearer header
+ *     - pollypm-session cookie
+ *     - Tailscale CGNAT IP (when trust is enabled)
+ *
+ *   These tests run against a loopback dev daemon (POLLYPM_BASE_URL
+ *   defaults to http://127.0.0.1:8765), so the local cookie-mint path
+ *   is exercised positively. The non-local negative case is asserted
+ *   via a forged X-Forwarded-For — see notes on `direct API call`
+ *   below; with no real way to spoof TCP source IP from userspace we
+ *   verify what we CAN: missing cookie + missing bearer → 401.
  */
 
 test.describe("auth", () => {
@@ -18,12 +32,35 @@ test.describe("auth", () => {
     await expect(page.locator("#topbar .brand-name")).toHaveText("PollyPM");
   });
 
-  test("session cookie is set after visiting /ui/", async ({ page, context }) => {
+  test("loopback bootstrap: /ui/ mints session cookie for local caller", async ({ page, context }) => {
+    // Playwright drives the browser against 127.0.0.1, so this is the
+    // sanctioned local-operator path. Cookie MUST be set.
     await page.goto("/ui/");
     const cookies = await context.cookies();
     const session = cookies.find((c) => c.name === "pollypm-session");
     expect(session, "pollypm-session cookie").toBeDefined();
     expect(session!.value.length, "cookie value is non-empty").toBeGreaterThan(0);
+    // Defense-in-depth: cookie must be HttpOnly so XSS can't exfiltrate
+    // the bearer token.
+    expect(session!.httpOnly, "cookie is HttpOnly").toBe(true);
+    // SameSite=Lax keeps it off cross-site POSTs while still allowing
+    // top-level navigation.
+    expect(
+      ["Lax", "lax"].includes(session!.sameSite ?? ""),
+      "cookie SameSite=Lax",
+    ).toBe(true);
+  });
+
+  test("loopback bootstrap: GET /ui/ Set-Cookie header is present", async ({ request }) => {
+    // The `request` fixture in Playwright runs from the same host as
+    // the browser (loopback), so we still expect a Set-Cookie. This
+    // asserts the header contract directly, not just the cookie jar.
+    const resp = await request.get("/ui/");
+    expect(resp.status()).toBe(200);
+    const setCookie = resp.headers()["set-cookie"];
+    expect(setCookie, "Set-Cookie header on loopback /ui/").toBeTruthy();
+    expect(setCookie).toContain("pollypm-session=");
+    expect(setCookie!.toLowerCase()).toContain("httponly");
   });
 
   test("protected API call from JS rides the cookie", async ({ page }) => {
@@ -35,27 +72,60 @@ test.describe("auth", () => {
     await expect(status.locator(".conn-label")).toHaveText("online");
   });
 
-  test("direct API call without cookie returns 401", async ({ request }) => {
-    // request fixture starts with no cookies — hitting a protected
-    // endpoint directly should be rejected.
-    const resp = await request.get("/api/v1/chat/sessions");
-    // Accept 401 or 403 depending on auth middleware shape.
-    expect([401, 403]).toContain(resp.status());
+  test("direct API call without cookie returns 401", async ({ playwright }) => {
+    // Spin up an isolated APIRequestContext with NO cookies, NO bearer.
+    // This is the canonical "untrusted client" probe — the request
+    // fixture inherits state from the project, so we want a clean one.
+    const ctx = await playwright.request.newContext({
+      baseURL: process.env.POLLYPM_BASE_URL || "http://127.0.0.1:8765",
+    });
+    try {
+      const resp = await ctx.get("/api/v1/chat/sessions");
+      // Auth middleware returns 401 specifically (not 403). The PR
+      // previously accepted either; the merged auth.py always raises
+      // `unauthorized()` for missing credentials, so pin to 401.
+      expect(resp.status(), "status with no credentials").toBe(401);
+      const body = await resp.json();
+      expect(body, "error envelope shape").toHaveProperty("error");
+    } finally {
+      await ctx.dispose();
+    }
   });
 
-  test("direct API call shape after /ui/ loads cookie", async ({ page, request }) => {
+  test("cookie isolation: fresh context after /ui/ load gets NO cookie", async ({ page, playwright }) => {
+    // Load /ui/ in the browser to mint the page's cookie.
     await page.goto("/ui/");
-    // After visiting /ui/, the request fixture should NOT share that
-    // cookie (it's a separate context); this asserts the cookie is
-    // scoped to the browser context, not the test runner.
-    const resp = await request.get("/api/v1/chat/sessions");
-    expect([200, 401, 403]).toContain(resp.status());
-    // If the deployment uses the same browser context's cookies, accept
-    // 200 with the expected envelope shape.
-    if (resp.status() === 200) {
-      const body = await resp.json();
-      expect(body).toHaveProperty("sessions");
-      expect(Array.isArray(body.sessions)).toBe(true);
+    const pageCookies = await page.context().cookies();
+    expect(
+      pageCookies.find((c) => c.name === "pollypm-session"),
+      "browser context has the cookie",
+    ).toBeDefined();
+
+    // Now open a SEPARATE APIRequestContext (no shared state with the
+    // browser). The cookie must NOT leak across contexts; this is the
+    // invariant the previous "accept 200/401/403" test was trying to
+    // express but couldn't enforce.
+    const isolated = await playwright.request.newContext({
+      baseURL: process.env.POLLYPM_BASE_URL || "http://127.0.0.1:8765",
+    });
+    try {
+      const resp = await isolated.get("/api/v1/chat/sessions");
+      expect(resp.status(), "isolated context has no cookie → 401").toBe(401);
+    } finally {
+      await isolated.dispose();
     }
+  });
+
+  test("API call from page's browser context rides the cookie → 200", async ({ page }) => {
+    // Positive cookie-rider invariant: after /ui/ mints the cookie,
+    // requests made FROM THE SAME BROWSER CONTEXT (i.e. via the page's
+    // own APIRequestContext, which shares the cookie jar) succeed.
+    // This proves the JS app's `credentials: "include"` model works.
+    await page.goto("/ui/");
+    const resp = await page.request.get("/api/v1/chat/sessions");
+    expect(resp.status(), "status with cookie").toBe(200);
+    const body = await resp.json();
+    expect(body).toHaveProperty("sessions");
+    expect(Array.isArray(body.sessions)).toBe(true);
   });
 });

--- a/tests/playwright/tests/auth.spec.ts
+++ b/tests/playwright/tests/auth.spec.ts
@@ -15,13 +15,18 @@ import { test, expect } from "@playwright/test";
  *     - pollypm-session cookie
  *     - Tailscale CGNAT IP (when trust is enabled)
  *
- *   These tests run against a loopback dev daemon (POLLYPM_BASE_URL
- *   defaults to http://127.0.0.1:8765), so the local cookie-mint path
- *   is exercised positively. The non-local negative case is asserted
- *   via a forged X-Forwarded-For — see notes on `direct API call`
- *   below; with no real way to spoof TCP source IP from userspace we
- *   verify what we CAN: missing cookie + missing bearer → 401.
+ *   These tests are written for a loopback dev daemon (POLLYPM_BASE_URL
+ *   defaults to http://127.0.0.1:8765), where the local cookie-mint
+ *   path is exercised positively and the "no cookie + no bearer → 401"
+ *   negative path is enforceable. When POLLYPM_BASE_URL points at a
+ *   tailnet CGNAT address (100.x.y.z), the peer IP itself is a valid
+ *   credential, so the negative tests below skip — the product is
+ *   behaving correctly in that environment, just not in a way the
+ *   "missing cookie" probe can falsify.
  */
+
+const BASE_URL = process.env.POLLYPM_BASE_URL || "http://127.0.0.1:8765";
+const IS_TAILNET = /\/\/100\.\d+\.\d+\.\d+/.test(BASE_URL);
 
 test.describe("auth", () => {
   test("GET /ui/ loads and serves index.html", async ({ page }) => {
@@ -73,11 +78,15 @@ test.describe("auth", () => {
   });
 
   test("direct API call without cookie returns 401", async ({ playwright }) => {
+    test.skip(
+      IS_TAILNET,
+      "Tailscale-trusted base URL accepts unauthenticated requests via peer IP; auth negative tests are loopback-only",
+    );
     // Spin up an isolated APIRequestContext with NO cookies, NO bearer.
     // This is the canonical "untrusted client" probe — the request
     // fixture inherits state from the project, so we want a clean one.
     const ctx = await playwright.request.newContext({
-      baseURL: process.env.POLLYPM_BASE_URL || "http://127.0.0.1:8765",
+      baseURL: BASE_URL,
     });
     try {
       const resp = await ctx.get("/api/v1/chat/sessions");
@@ -93,6 +102,10 @@ test.describe("auth", () => {
   });
 
   test("cookie isolation: fresh context after /ui/ load gets NO cookie", async ({ page, playwright }) => {
+    test.skip(
+      IS_TAILNET,
+      "Tailscale-trusted base URL accepts unauthenticated requests via peer IP; auth negative tests are loopback-only",
+    );
     // Load /ui/ in the browser to mint the page's cookie.
     await page.goto("/ui/");
     const pageCookies = await page.context().cookies();
@@ -106,7 +119,7 @@ test.describe("auth", () => {
     // invariant the previous "accept 200/401/403" test was trying to
     // express but couldn't enforce.
     const isolated = await playwright.request.newContext({
-      baseURL: process.env.POLLYPM_BASE_URL || "http://127.0.0.1:8765",
+      baseURL: BASE_URL,
     });
     try {
       const resp = await isolated.get("/api/v1/chat/sessions");

--- a/tests/playwright/tests/auth.spec.ts
+++ b/tests/playwright/tests/auth.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Auth scenarios.
+ *
+ * Auth model (per /ui/app.js header comment):
+ *   GET /ui/ reads the on-disk token and sets the `pollypm-session`
+ *   cookie. Every subsequent fetch uses credentials: "include" to ride
+ *   that cookie. We never expose the token to the browser.
+ */
+
+test.describe("auth", () => {
+  test("GET /ui/ loads and serves index.html", async ({ page }) => {
+    const response = await page.goto("/ui/");
+    expect(response, "navigation response").not.toBeNull();
+    expect(response!.status(), "status").toBe(200);
+    await expect(page).toHaveTitle(/PollyPM/);
+    await expect(page.locator("#topbar .brand-name")).toHaveText("PollyPM");
+  });
+
+  test("session cookie is set after visiting /ui/", async ({ page, context }) => {
+    await page.goto("/ui/");
+    const cookies = await context.cookies();
+    const session = cookies.find((c) => c.name === "pollypm-session");
+    expect(session, "pollypm-session cookie").toBeDefined();
+    expect(session!.value.length, "cookie value is non-empty").toBeGreaterThan(0);
+  });
+
+  test("protected API call from JS rides the cookie", async ({ page }) => {
+    await page.goto("/ui/");
+    // After the page loads, app.js calls /api/v1/chat/sessions. If the
+    // cookie auth works the conn-status badge becomes "online".
+    const status = page.locator("#conn-status");
+    await expect(status).toHaveClass(/conn-ok/, { timeout: 10_000 });
+    await expect(status.locator(".conn-label")).toHaveText("online");
+  });
+
+  test("direct API call without cookie returns 401", async ({ request }) => {
+    // request fixture starts with no cookies — hitting a protected
+    // endpoint directly should be rejected.
+    const resp = await request.get("/api/v1/chat/sessions");
+    // Accept 401 or 403 depending on auth middleware shape.
+    expect([401, 403]).toContain(resp.status());
+  });
+
+  test("direct API call shape after /ui/ loads cookie", async ({ page, request }) => {
+    await page.goto("/ui/");
+    // After visiting /ui/, the request fixture should NOT share that
+    // cookie (it's a separate context); this asserts the cookie is
+    // scoped to the browser context, not the test runner.
+    const resp = await request.get("/api/v1/chat/sessions");
+    expect([200, 401, 403]).toContain(resp.status());
+    // If the deployment uses the same browser context's cookies, accept
+    // 200 with the expected envelope shape.
+    if (resp.status() === 200) {
+      const body = await resp.json();
+      expect(body).toHaveProperty("sessions");
+      expect(Array.isArray(body.sessions)).toBe(true);
+    }
+  });
+});

--- a/tests/playwright/tests/edge_cases.spec.ts
+++ b/tests/playwright/tests/edge_cases.spec.ts
@@ -26,7 +26,32 @@ async function stubSurfaces(page: import("@playwright/test").Page) {
   );
 }
 
+// Stub the dashboard read endpoint the UI fires on init so this spec
+// doesn't race live daemon state. Each test below additionally stubs
+// /chat/sessions to whatever shape it needs.
+async function stubDashboard(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/dashboard", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rollups: {},
+        daemon_status: "up",
+        active_sessions: [],
+        recent_messages: [],
+        projects: [],
+        generated_at: "2026-05-23T00:00:00Z",
+        scoped_fields: [],
+      }),
+    }),
+  );
+}
+
 test.describe("edge cases", () => {
+  test.beforeEach(async ({ page }) => {
+    await stubDashboard(page);
+  });
+
   test("409 unsafe_mid_tool surfaces in UI", async ({ page }) => {
     await stubSurfaces(page);
     await page.route("**/api/v1/chat/operator/messages*", (route) =>

--- a/tests/playwright/tests/edge_cases.spec.ts
+++ b/tests/playwright/tests/edge_cases.spec.ts
@@ -137,6 +137,13 @@ test.describe("edge cases", () => {
   });
 
   test("connection badge reflects HTTP failures", async ({ page }) => {
+    // The conn-status badge reflects the union of read-endpoint health.
+    // beforeEach() above stubs /api/v1/dashboard as a successful 200, and
+    // app.js fires loadSurfaces() + pollDashboard() in parallel on init.
+    // If only /chat/sessions fails, the successful dashboard response can
+    // win the race and flip the badge back to conn-ok. To assert the
+    // failure-surfacing contract deterministically, override BOTH read
+    // endpoints to fail in this specific test.
     await page.route("**/api/v1/chat/sessions", (route) =>
       route.fulfill({
         status: 500,
@@ -144,7 +151,17 @@ test.describe("edge cases", () => {
         body: JSON.stringify({ error: { code: "internal", message: "x" } }),
       }),
     );
+    await page.route("**/api/v1/dashboard", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "internal", message: "x" } }),
+      }),
+    );
     await page.goto("/ui/");
-    await expect(page.locator("#conn-status")).toHaveClass(/conn-warn|conn-error/);
+    await expect(page.locator("#conn-status")).toHaveClass(
+      /conn-warn|conn-error/,
+      { timeout: 5000 },
+    );
   });
 });

--- a/tests/playwright/tests/edge_cases.spec.ts
+++ b/tests/playwright/tests/edge_cases.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Edge cases per spec §4 (mid-tool, service unavailable, empty states).
+ *
+ * The UI surfaces errors via two channels:
+ *   - history errors land in #message-list as `.error-banner`
+ *   - the connection badge (#conn-status) flips to conn-warn / conn-error
+ */
+
+const FAKE_SURFACE = {
+  session_name: "operator",
+  surface_type: "operator",
+  persona: "polly",
+  project: "pollypm",
+  window: { present: true, pane_dead: false },
+};
+
+async function stubSurfaces(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/chat/sessions", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [FAKE_SURFACE] }),
+    }),
+  );
+}
+
+test.describe("edge cases", () => {
+  test("409 unsafe_mid_tool surfaces in UI", async ({ page }) => {
+    await stubSurfaces(page);
+    await page.route("**/api/v1/chat/operator/messages*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session_name: "operator",
+          surface_type: "operator",
+          transcript_source: "jsonl",
+          messages: [],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/chat/operator/send", (route) =>
+      route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: { code: "unsafe_mid_tool", message: "agent is mid-tool-use" },
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    await page.locator("#send-input").fill("oops");
+    await page.locator("#send-button").click();
+
+    const banner = page.locator("#message-list .error-banner");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(/mid-tool|unsafe_mid_tool/i);
+  });
+
+  test("503 service_unavailable surfaces in UI", async ({ page }) => {
+    await stubSurfaces(page);
+    await page.route("**/api/v1/chat/operator/messages*", (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: { code: "service_unavailable", message: "daemon restarting" },
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+
+    const banner = page.locator("#message-list .error-banner");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(/restart|service_unavailable|503/i);
+  });
+
+  test("empty session list shows empty-state in left rail", async ({ page }) => {
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      }),
+    );
+    await page.goto("/ui/");
+    await expect(page.locator("#surface-list .surface-empty")).toHaveText(
+      "no surfaces registered",
+    );
+  });
+
+  test("sessions endpoint 500 shows error in left rail", async ({ page }) => {
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: { code: "internal", message: "boom" },
+        }),
+      }),
+    );
+    await page.goto("/ui/");
+    const empty = page.locator("#surface-list .surface-empty");
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText(/error/i);
+  });
+
+  test("connection badge reflects HTTP failures", async ({ page }) => {
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "internal", message: "x" } }),
+      }),
+    );
+    await page.goto("/ui/");
+    await expect(page.locator("#conn-status")).toHaveClass(/conn-warn|conn-error/);
+  });
+});

--- a/tests/playwright/tests/keyboard.spec.ts
+++ b/tests/playwright/tests/keyboard.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Keyboard scenarios.
+ *
+ * V0 wires only the <form> submit handler — so Enter inside the input
+ * triggers send via native form submission. We verify that and probe
+ * for optional shortcuts (Shift+Enter newline, j/k surface nav).
+ * Probes that the UI doesn't yet implement are marked test.fixme so the
+ * spec stays as a TODO trail without failing the suite.
+ */
+
+const FAKE_SURFACE = {
+  session_name: "operator",
+  surface_type: "operator",
+  persona: "polly",
+  project: "pollypm",
+  window: { present: true, pane_dead: false },
+};
+
+async function stubBasics(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/chat/sessions", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [FAKE_SURFACE] }),
+    }),
+  );
+  await page.route("**/api/v1/chat/operator/messages*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        session_name: "operator",
+        surface_type: "operator",
+        transcript_source: "jsonl",
+        messages: [],
+      }),
+    }),
+  );
+}
+
+test.describe("keyboard", () => {
+  test("Enter in input submits the send form", async ({ page }) => {
+    await stubBasics(page);
+    let captured: string | null = null;
+    await page.route("**/api/v1/chat/operator/send", (route, req) => {
+      captured = req.postData();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    const input = page.locator("#send-input");
+    await input.fill("via enter");
+    await input.press("Enter");
+    await expect.poll(() => captured).not.toBeNull();
+    expect(JSON.parse(captured!)).toEqual({ text: "via enter" });
+  });
+
+  test.fixme("Shift+Enter inserts newline without sending (V0 not implemented)", async ({ page }) => {
+    // V0 input is <input type="text">, which can't hold newlines. This
+    // would only pass once it becomes <textarea> with a keydown handler
+    // that distinguishes Shift+Enter from Enter. Documented as a TODO
+    // for the V1 web UI.
+    await stubBasics(page);
+    let hit = false;
+    await page.route("**/api/v1/chat/operator/send", (route) => {
+      hit = true;
+      return route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    const input = page.locator("#send-input");
+    await input.focus();
+    await input.type("line one");
+    await page.keyboard.press("Shift+Enter");
+    await input.type("line two");
+    await page.waitForTimeout(250);
+    expect(hit).toBe(false);
+    expect(await input.inputValue()).toContain("\n");
+  });
+
+  test.fixme("j/k or arrow keys navigate surfaces (V0 not implemented)", async ({ page }) => {
+    // V0 has no keyboard navigation on the surface rail. Logged as a
+    // V1 web UI follow-up; this test is a placeholder so we don't lose
+    // the requirement.
+    await stubBasics(page);
+    await page.goto("/ui/");
+    const list = page.locator("#surface-list");
+    await list.focus();
+    await page.keyboard.press("j");
+    await expect(page.locator("#surface-list li.active")).toBeVisible();
+  });
+
+  test("Tab moves focus from input to send button", async ({ page }) => {
+    await stubBasics(page);
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    await page.locator("#send-input").focus();
+    await page.keyboard.press("Tab");
+    const focused = await page.evaluate(() => document.activeElement?.id);
+    expect(focused).toBe("send-button");
+  });
+});

--- a/tests/playwright/tests/keyboard.spec.ts
+++ b/tests/playwright/tests/keyboard.spec.ts
@@ -40,7 +40,31 @@ async function stubBasics(page: import("@playwright/test").Page) {
   );
 }
 
+// Stub the dashboard read endpoint the UI fires on init so this spec
+// doesn't race live daemon state under fullyParallel runs.
+async function stubDashboard(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/dashboard", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rollups: {},
+        daemon_status: "up",
+        active_sessions: [],
+        recent_messages: [],
+        projects: [],
+        generated_at: "2026-05-23T00:00:00Z",
+        scoped_fields: [],
+      }),
+    }),
+  );
+}
+
 test.describe("keyboard", () => {
+  test.beforeEach(async ({ page }) => {
+    await stubDashboard(page);
+  });
+
   test("Enter in input submits the send form", async ({ page }) => {
     await stubBasics(page);
     let captured: string | null = null;

--- a/tests/playwright/tests/mobile_viewport.spec.ts
+++ b/tests/playwright/tests/mobile_viewport.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Mobile viewport smoke checks.
+ *
+ * #2065 ships the web UI explicitly intending phone-over-Tailscale
+ * access. The v0 layout is desktop-first with a fixed left rail, so
+ * we want at least one project that catches the obvious narrow-screen
+ * regressions:
+ *   - core chrome (topbar, rail, send pane) is rendered, not hidden
+ *     or scrolled off-screen
+ *   - no horizontal overflow on the document
+ *   - tappable send button stays inside the viewport
+ *
+ * These tests run under all projects but are most meaningful under
+ * the `mobile-chrome` project (360x800) declared in playwright.config.
+ * Running under `chromium` (Desktop Chrome) is fine — assertions hold
+ * there too.
+ */
+
+test.describe("mobile viewport", () => {
+  test("core chrome renders at 360px wide", async ({ page }) => {
+    await page.goto("/ui/");
+    await expect(page.locator("#topbar")).toBeVisible();
+    await expect(page.locator("#topbar .brand-name")).toHaveText("PollyPM");
+    // Surface rail still exists (may be visually collapsed on narrow
+    // viewports; the assertion is that the DOM survives, not that the
+    // layout is pretty — V1 will fix the rail).
+    await expect(page.locator("#surface-list")).toBeAttached();
+    await expect(page.locator("#pane-title")).toBeAttached();
+  });
+
+  test("no horizontal overflow on /ui/", async ({ page }) => {
+    await page.goto("/ui/");
+    // Allow a tiny rounding fudge factor — sub-pixel widths from font
+    // rendering sometimes nudge scrollWidth one pixel over clientWidth.
+    const overflow = await page.evaluate(() => {
+      const doc = document.documentElement;
+      return doc.scrollWidth - doc.clientWidth;
+    });
+    expect(overflow, "horizontal overflow in CSS pixels").toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/playwright/tests/send_message.spec.ts
+++ b/tests/playwright/tests/send_message.spec.ts
@@ -40,7 +40,32 @@ async function stubMessages(page: import("@playwright/test").Page) {
   );
 }
 
+// Stub the read endpoints the UI fires on init (dashboard rollups)
+// so this spec stays a pure unit of the send-message flow and doesn't
+// race live daemon state under fullyParallel runs.
+async function stubDashboard(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/dashboard", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rollups: {},
+        daemon_status: "up",
+        active_sessions: [],
+        recent_messages: [],
+        projects: [],
+        generated_at: "2026-05-23T00:00:00Z",
+        scoped_fields: [],
+      }),
+    }),
+  );
+}
+
 test.describe("send message", () => {
+  test.beforeEach(async ({ page }) => {
+    await stubDashboard(page);
+  });
+
   test("typing + clicking Send POSTs to /chat/{name}/send", async ({ page }) => {
     await stubSurfaces(page);
     await stubMessages(page);

--- a/tests/playwright/tests/send_message.spec.ts
+++ b/tests/playwright/tests/send_message.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Send-message flow.
+ *
+ * We mock both /sessions and /send so we never actually deliver
+ * keystrokes to a real tmux pane.
+ */
+
+const FAKE_SURFACE = {
+  session_name: "operator",
+  surface_type: "operator",
+  persona: "polly",
+  project: "pollypm",
+  window: { present: true, pane_dead: false },
+};
+
+async function stubSurfaces(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/chat/sessions", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [FAKE_SURFACE] }),
+    }),
+  );
+}
+
+async function stubMessages(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/chat/operator/messages*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        session_name: "operator",
+        surface_type: "operator",
+        transcript_source: "jsonl",
+        messages: [],
+      }),
+    }),
+  );
+}
+
+test.describe("send message", () => {
+  test("typing + clicking Send POSTs to /chat/{name}/send", async ({ page }) => {
+    await stubSurfaces(page);
+    await stubMessages(page);
+
+    let captured: { method: string; postData: string | null } | null = null;
+    await page.route("**/api/v1/chat/operator/send", (route, req) => {
+      captured = { method: req.method(), postData: req.postData() };
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "queued" }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    await page.locator("#send-input").fill("test message from playwright");
+    await page.locator("#send-button").click();
+
+    await expect.poll(() => captured?.method).toBe("POST");
+    const body = JSON.parse(captured!.postData!);
+    expect(body).toEqual({ text: "test message from playwright" });
+  });
+
+  test("input clears after send", async ({ page }) => {
+    await stubSurfaces(page);
+    await stubMessages(page);
+    await page.route("**/api/v1/chat/operator/send", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" }),
+    );
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    const input = page.locator("#send-input");
+    await input.fill("hello");
+    await page.locator("#send-button").click();
+    await expect(input).toHaveValue("");
+  });
+
+  test("send is disabled until a surface is selected", async ({ page }) => {
+    await stubSurfaces(page);
+    await stubMessages(page);
+    await page.goto("/ui/");
+    await expect(page.locator("#send-input")).toBeDisabled();
+    await expect(page.locator("#send-button")).toBeDisabled();
+    await page.locator("li[data-session='operator']").click();
+    await expect(page.locator("#send-input")).toBeEnabled();
+    await expect(page.locator("#send-button")).toBeEnabled();
+  });
+
+  test("empty / whitespace-only text does not POST", async ({ page }) => {
+    await stubSurfaces(page);
+    await stubMessages(page);
+    let hit = false;
+    await page.route("**/api/v1/chat/operator/send", (route) => {
+      hit = true;
+      return route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    await page.locator("#send-input").fill("   ");
+    await page.locator("#send-button").click();
+    // Give the click a moment to (not) fire.
+    await page.waitForTimeout(250);
+    expect(hit).toBe(false);
+  });
+});

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Surface list (left rail) scenarios.
+ *
+ * Anchors: #surface-list, .surface-empty, [data-session], #pane-title,
+ * #pane-meta, #message-list, .message-empty.
+ */
+
+test.describe("surfaces", () => {
+  test("left rail renders surface list after load", async ({ page }) => {
+    await page.goto("/ui/");
+    const list = page.locator("#surface-list");
+    await expect(list).toBeVisible();
+    // Either real surfaces render as <li data-session=...> or the
+    // empty-state literal appears.
+    await expect
+      .poll(async () => {
+        const items = await list.locator("li[data-session]").count();
+        const emptyText = await list.locator(".surface-empty").innerText().catch(() => "");
+        return items > 0 || emptyText.includes("no surfaces registered") || emptyText.startsWith("error:");
+      }, { timeout: 10_000 })
+      .toBe(true);
+  });
+
+  test("clicking a surface populates the center pane", async ({ page }) => {
+    await page.goto("/ui/");
+    const list = page.locator("#surface-list");
+    await expect(list).toBeVisible();
+    const items = list.locator("li[data-session]");
+    const count = await items.count();
+    test.skip(count === 0, "no surfaces registered on this daemon");
+    const first = items.first();
+    const sessionName = await first.getAttribute("data-session");
+    await first.click();
+    await expect(page.locator("#pane-title")).toHaveText(sessionName!);
+    await expect(page.locator("#send-input")).toBeEnabled();
+    await expect(page.locator("#send-button")).toBeEnabled();
+  });
+
+  test("each surface type can be selected if present", async ({ page }) => {
+    await page.goto("/ui/");
+    const list = page.locator("#surface-list");
+    await expect(list).toBeVisible();
+    const items = await list.locator("li[data-session]").all();
+    test.skip(items.length === 0, "no surfaces registered on this daemon");
+    // Click up to 4 surfaces and assert pane swaps each time.
+    for (const item of items.slice(0, 4)) {
+      const name = await item.getAttribute("data-session");
+      await item.click();
+      await expect(page.locator("#pane-title")).toHaveText(name!);
+      // Message list either shows messages or "no messages yet".
+      const ml = page.locator("#message-list");
+      await expect(ml).toBeVisible();
+    }
+  });
+
+  test("empty session shows 'no messages yet' placeholder", async ({ page }) => {
+    // Stub the messages endpoint to return an empty list.
+    await page.route("**/api/v1/chat/*/messages*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session_name: "fake-empty",
+          surface_type: "worker",
+          transcript_source: "jsonl",
+          messages: [],
+        }),
+      }),
+    );
+    // Stub the sessions endpoint to ensure at least one selectable surface.
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessions: [
+            {
+              session_name: "fake-empty",
+              surface_type: "worker",
+              persona: "worker",
+              project: "demo",
+              window: { present: true, pane_dead: false },
+            },
+          ],
+        }),
+      }),
+    );
+    await page.goto("/ui/");
+    await page.locator("li[data-session='fake-empty']").click();
+    await expect(page.locator("#message-list .message-empty")).toHaveText(
+      "no messages yet",
+    );
+  });
+
+  test("initial center-pane state shows 'Select a surface'", async ({ page }) => {
+    await page.goto("/ui/");
+    await expect(page.locator("#pane-title")).toHaveText("Select a surface");
+    await expect(page.locator("#send-input")).toBeDisabled();
+    await expect(page.locator("#send-button")).toBeDisabled();
+  });
+});

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -8,25 +8,52 @@ import { test, expect } from "@playwright/test";
  */
 
 test.describe("surfaces", () => {
+  // Wait for the surface rail to reach a terminal load state: at least
+  // one <li data-session> rendered, OR a `.surface-empty` element whose
+  // text matches "no surfaces registered" or starts with "error:". This
+  // avoids racing the async /api/v1/chat/sessions fetch (which would
+  // otherwise let tests skip while data is still loading) and avoids
+  // awaiting `.surface-empty.innerText()` when the element is absent
+  // (which previously stalled the populated-daemon case for the full
+  // actionTimeout).
+  async function waitForSurfaceRailTerminal(page: import("@playwright/test").Page) {
+    await page.waitForFunction(
+      () => {
+        const items = document.querySelectorAll(
+          "#surface-list li[data-session]",
+        ).length;
+        if (items > 0) return true;
+        const empty = document.querySelector(
+          "#surface-list .surface-empty",
+        ) as HTMLElement | null;
+        if (!empty) return false;
+        const text = (empty.textContent ?? "").trim();
+        return (
+          text.includes("no surfaces registered") || text.startsWith("error:")
+        );
+      },
+      undefined,
+      { timeout: 10_000 },
+    );
+  }
+
   test("left rail renders surface list after load", async ({ page }) => {
     await page.goto("/ui/");
     const list = page.locator("#surface-list");
     await expect(list).toBeVisible();
     // Either real surfaces render as <li data-session=...> or the
     // empty-state literal appears.
-    await expect
-      .poll(async () => {
-        const items = await list.locator("li[data-session]").count();
-        const emptyText = await list.locator(".surface-empty").innerText().catch(() => "");
-        return items > 0 || emptyText.includes("no surfaces registered") || emptyText.startsWith("error:");
-      }, { timeout: 10_000 })
-      .toBe(true);
+    await waitForSurfaceRailTerminal(page);
   });
 
   test("clicking a surface populates the center pane", async ({ page }) => {
     await page.goto("/ui/");
     const list = page.locator("#surface-list");
     await expect(list).toBeVisible();
+    // Wait for terminal state before deciding to skip; otherwise we'd
+    // race the async /chat/sessions fetch and silently no-op on live
+    // daemons that do have surfaces.
+    await waitForSurfaceRailTerminal(page);
     const items = list.locator("li[data-session]");
     const count = await items.count();
     test.skip(count === 0, "no surfaces registered on this daemon");
@@ -42,6 +69,7 @@ test.describe("surfaces", () => {
     await page.goto("/ui/");
     const list = page.locator("#surface-list");
     await expect(list).toBeVisible();
+    await waitForSurfaceRailTerminal(page);
     const items = await list.locator("li[data-session]").all();
     test.skip(items.length === 0, "no surfaces registered on this daemon");
     // Click up to 4 surfaces and assert pane swaps each time.


### PR DESCRIPTION
## Summary

Phase 8 of the 8-step web-UI pipeline: Playwright end-to-end test scaffold for the v0 web UI shipped in PR #2065.

- New `tests/playwright/` directory with config, README, and 5 test files (23 specs total) covering cookie auth, surface rail rendering/selection, send-message flow, edge cases (409 unsafe_mid_tool, 503 service_unavailable, empty states), and keyboard handling.
- Chromium-only, headless by default; screenshots on failure and video on retry.
- Send/edge-case specs route-mock the API so the suite never delivers real keystrokes to a tmux pane — safe to run while PollyPM is in use.
- README documents prereqs (`pm serve` on `127.0.0.1:8765`), how to run (`npm install && npx playwright install chromium && npx playwright test`), and which specs hit the live daemon vs. stub.

## Files

- `tests/playwright/package.json` + `package-lock.json` (npm scripts: `test`, `test:headed`, `test:ui`, `test:debug`, `report`)
- `tests/playwright/playwright.config.ts` (baseURL via `POLLYPM_BASE_URL`, 30s timeout, retries on CI, commented webServer block)
- `tests/playwright/README.md`
- `tests/playwright/.gitignore` (node_modules, reports, results)
- `tests/playwright/tests/auth.spec.ts` (5 tests)
- `tests/playwright/tests/surfaces.spec.ts` (5 tests)
- `tests/playwright/tests/send_message.spec.ts` (4 tests)
- `tests/playwright/tests/edge_cases.spec.ts` (5 tests)
- `tests/playwright/tests/keyboard.spec.ts` (4 tests, 2 marked `test.fixme` as V1-UI TODOs)

## Verification

- Ran `npm install` (3 packages, 0 vulnerabilities) and `npx playwright test --list` — all 23 tests discovered and parsed cleanly.
- Did NOT run the suite end-to-end; Sam runs it in the morning against a live daemon.

## Test plan

- [ ] `cd tests/playwright && npm install && npx playwright install chromium`
- [ ] Start `pm serve --tailscale` in another terminal
- [ ] `npx playwright test` — expect green for auth/surfaces (live data), all stubbed specs green
- [ ] `npm run test:ui` for the recommended interactive workflow
- [ ] Confirm `Shift+Enter` and `j/k` `test.fixme` markers stay skipped (V0 limitations)

Generated with Claude Code.