### PR TITLE
fix(api): Phase 6 P0 — drop stale yaml entries, add GET /tasks flat-list

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -831,11 +831,29 @@ paths:
           description: Opaque cursor from a previous response's `next_cursor`.
       responses:
         "200":
-          description: Page of task summaries.
+          description: |
+            Page of task summaries. The optional `warnings` array
+            lists any projects whose backing store failed during this
+            request — clients should surface that to the operator
+            rather than treat a 200 with warnings as a complete read.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/TaskListResponse"
+        "400":
+          description: |
+            `invalid_request` — a query parameter was rejected.
+            Includes:
+              - `since` malformed or missing a timezone offset
+                (task `updated_at` values are tz-aware; a naive
+                `since` would compare-error to a 500).
+              - `cursor` is stale (the item it referenced has been
+                updated or deleted). Restart paging without the
+                `cursor` parameter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
 
@@ -2521,6 +2539,29 @@ components:
         next_cursor:
           type: string
           description: Absent when no more pages.
+        warnings:
+          type: array
+          description: |
+            Per-project partial-failure notices. Absent/empty when
+            every project read succeeded. One entry per project whose
+            backing store raised during this request (clients should
+            render the partial-failure state explicitly rather than
+            assume the body is complete).
+          items:
+            $ref: "#/components/schemas/TaskListWarning"
+
+    TaskListWarning:
+      type: object
+      required: [project, error]
+      properties:
+        project:
+          type: string
+          description: Project key whose backing store failed.
+        error:
+          type: string
+          description: |
+            Short error code (e.g. `service_unavailable`). Stable across
+            releases so clients can switch on it.
 
     ApproveRequest:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,4 +1,10 @@
 openapi: 3.1.0
+# Phase 6 cleanup: removed stale entries for `/doctor`, `POST /projects`,
+# `POST /projects/{key}/chat`, `POST /projects/{key}/plan`, and the
+# `/tasks/{project}/{n}/approve` + `/reject` pair. None were wired in
+# `pollypm.web_api.app`. The plan approve/reject flow is tracked
+# separately as Phase 3 work; doctor reads live at `/doctor/checks`
+# and `/doctor/report`.
 info:
   title: PollyPM Web API
   version: 0.1.0
@@ -102,25 +108,6 @@ paths:
                     schema_version: 1
                     started_at: "2026-05-07T12:00:00Z"
 
-  /doctor:
-    get:
-      tags: [Health]
-      operationId: getDoctor
-      summary: Structured pm doctor output
-      description: |
-        Mirrors the structured JSON output of `pm doctor` (PR #1347).
-        Returns each check with status (ok / warn / fail), an actor
-        message, and an optional remediation hint.
-      responses:
-        "200":
-          description: Doctor results (200 even when checks fail; consult `overall`).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DoctorResponse"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-
   /projects:
     get:
       tags: [Projects]
@@ -146,41 +133,6 @@ paths:
                       $ref: "#/components/schemas/Project"
         "401":
           $ref: "#/components/responses/Unauthorized"
-
-    post:
-      tags: [Projects]
-      operationId: registerProject
-      summary: Register a new project
-      description: Mirrors `pm add-project`. Idempotent on `path`.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RegisterProjectRequest"
-            examples:
-              minimal:
-                value:
-                  path: /Users/me/dev/myrepo
-              full:
-                value:
-                  path: /Users/me/dev/myrepo
-                  name: My Project
-                  slug: myproj
-                  tracked: true
-      responses:
-        "201":
-          description: Project registered (or returned if already present at path).
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Project"
-        "400":
-          $ref: "#/components/responses/InvalidRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "422":
-          $ref: "#/components/responses/ValidationError"
 
   /projects/{key}:
     parameters:
@@ -516,6 +468,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+
   /chat/sessions:
     get:
       tags: [Chat]
@@ -833,6 +786,59 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /tasks:
+    get:
+      tags: [Tasks]
+      operationId: listTasks
+      summary: Flat list of tasks across all projects
+      description: |
+        Cross-project flat task list (spec §5.1). The per-project list
+        at `/projects/{key}/tasks` keeps its narrow contract; this
+        endpoint exists so a single round trip can populate cross-
+        project surfaces (cockpit dashboards, web UI task board).
+        Pagination matches the per-project list (opaque `cursor` +
+        `next_cursor`); filters are stackable.
+      parameters:
+        - in: query
+          name: project
+          schema: { type: string }
+          description: Limit results to this project key.
+        - in: query
+          name: status
+          schema:
+            $ref: "#/components/schemas/TaskStatus"
+          description: |
+            Filter by `work_status`. Repeatable — pass `status=draft&status=queued`
+            to OR multiple statuses.
+        - in: query
+          name: assignee
+          schema: { type: string }
+          description: Filter by assignee (exact match).
+        - in: query
+          name: since
+          schema:
+            type: string
+            format: date-time
+          description: |
+            ISO-8601 lower bound on `updated_at`. Only tasks whose
+            `updated_at` is strictly after this value are returned.
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+        - in: query
+          name: cursor
+          schema: { type: string }
+          description: Opaque cursor from a previous response's `next_cursor`.
+      responses:
+        "200":
+          description: Page of task summaries.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /tasks/{project}/{n}:
     parameters:
       - $ref: "#/components/parameters/ProjectKey2"
@@ -855,80 +861,6 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
-
-  /tasks/{project}/{n}/approve:
-    parameters:
-      - $ref: "#/components/parameters/ProjectKey2"
-      - $ref: "#/components/parameters/TaskNumber"
-    post:
-      tags: [Tasks]
-      operationId: approveTask
-      summary: Approve plan or code review
-      description: |
-        Approves the current review-node execution. The `kind` field
-        on the request body discriminates plan-review vs
-        code-review approvals; absent it, the API approves whichever
-        review is active.
-      parameters:
-        - $ref: "#/components/parameters/IdempotencyKey"
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ApproveRequest"
-      responses:
-        "200":
-          description: Approval recorded.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ActionResult"
-        "400":
-          $ref: "#/components/responses/InvalidRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "409":
-          $ref: "#/components/responses/Conflict"
-
-  /tasks/{project}/{n}/reject:
-    parameters:
-      - $ref: "#/components/parameters/ProjectKey2"
-      - $ref: "#/components/parameters/TaskNumber"
-    post:
-      tags: [Tasks]
-      operationId: rejectTask
-      summary: Reject plan or code review with a reason
-      parameters:
-        - $ref: "#/components/parameters/IdempotencyKey"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RejectRequest"
-            examples:
-              plan:
-                value:
-                  kind: plan
-                  reason: "Scope is too broad — split into 3 tasks first."
-      responses:
-        "200":
-          description: Rejection recorded; task transitions to `rework`.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ActionResult"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "409":
-          $ref: "#/components/responses/Conflict"
-        "422":
-          $ref: "#/components/responses/ValidationError"
 
   /tasks/{project}/{n}/queue:
     parameters:

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -266,9 +266,28 @@ class TaskDetail(TaskSummary):
     plan: Plan | None = None
 
 
+class TaskListWarning(BaseModel):
+    """Per-project partial-failure notice on the cross-project task list.
+
+    Round 1 of Codex review on PR #2067 flagged that silently skipping
+    a project on backing-store failure makes the flat list look
+    complete when it is not (operator can't tell that pg outage on one
+    project is hiding live work behind 200). The aggregator now
+    surfaces every skipped project here so clients can render the
+    partial-failure surface explicitly.
+    """
+
+    project: str
+    error: str  # short code, e.g. "service_unavailable"
+
+
 class TaskListResponse(BaseModel):
     items: list[TaskSummary]
     next_cursor: str | None = None
+    # Empty/absent means every project read succeeded. One entry per
+    # project whose backing store raised during this request — see
+    # ``TaskListWarning`` for the rationale.
+    warnings: list[TaskListWarning] | None = None
 
 
 class ProjectDrilldown(Project):
@@ -478,6 +497,7 @@ __all__ = [
     "StorageReport",
     "TaskDetail",
     "TaskListResponse",
+    "TaskListWarning",
     "TaskRelationships",
     "TaskSummary",
     "Transition",

--- a/src/pollypm/web_api/routes/tasks.py
+++ b/src/pollypm/web_api/routes/tasks.py
@@ -19,9 +19,19 @@ from typing import Annotated
 from fastapi import APIRouter, Header, Query
 
 from pollypm.web_api.errors import APIError, not_found
-from pollypm.web_api.models import ActionResult, TaskDetail, TaskListResponse
+from pollypm.web_api.models import (
+    ActionResult,
+    TaskDetail,
+    TaskListResponse,
+    TaskListWarning,
+)
 from pollypm.web_api.routes._deps import ConfigDep
-from pollypm.web_api.service import get_task_detail, list_all_tasks, queue_task
+from pollypm.web_api.service import (
+    StaleCursorError,
+    get_task_detail,
+    list_all_tasks,
+    queue_task,
+)
 
 router = APIRouter(tags=["Tasks"])
 
@@ -63,17 +73,51 @@ def list_tasks_endpoint(
                 message=f"Invalid `since` value: {since!r}",
                 hint="Use ISO-8601 (e.g. 2026-05-22T00:00:00Z).",
             ) from exc
+        # P0 #2 (PR #2067 Codex round 1): task ``updated_at`` is
+        # offset-aware in pg, so a naive ``since`` would trigger
+        # ``TypeError: can't compare offset-naive and offset-aware``
+        # inside ``list_all_tasks`` and surface as a 500 on
+        # syntactically-valid input. Reject naive timestamps with a
+        # typed 400 — explicit is better than implicit timezone
+        # assumptions.
+        if since_dt.tzinfo is None or since_dt.tzinfo.utcoffset(since_dt) is None:
+            raise APIError(
+                status_code=400,
+                code="invalid_request",
+                message=f"`since` must include a timezone offset: {since!r}",
+                hint="Use an offset suffix (e.g. 2026-05-22T00:00:00Z or +00:00).",
+            )
 
-    items, next_cursor = list_all_tasks(
-        config,
-        project=project,
-        statuses=status,
-        assignee=assignee,
-        since=since_dt,
-        limit=limit,
-        cursor=cursor,
+    try:
+        items, next_cursor, warnings = list_all_tasks(
+            config,
+            project=project,
+            statuses=status,
+            assignee=assignee,
+            since=since_dt,
+            limit=limit,
+            cursor=cursor,
+        )
+    except StaleCursorError as exc:
+        # P0 #3 (PR #2067 Codex round 1): a cursor that no longer
+        # matches any current item used to silently restart at page
+        # one, creating duplicate rows / infinite-pagination loops
+        # under concurrent updates. Surface it as a typed 400 so the
+        # client restarts without a cursor explicitly.
+        raise APIError(
+            status_code=400,
+            code="invalid_request",
+            message="Cursor is stale (item no longer exists or has been updated).",
+            hint="Retry the request without the `cursor` parameter to restart paging.",
+        ) from exc
+
+    return TaskListResponse(
+        items=items,
+        next_cursor=next_cursor,
+        warnings=(
+            [TaskListWarning(**w) for w in warnings] if warnings else None
+        ),
     )
-    return TaskListResponse(items=items, next_cursor=next_cursor)
 
 
 @router.get(

--- a/src/pollypm/web_api/routes/tasks.py
+++ b/src/pollypm/web_api/routes/tasks.py
@@ -13,16 +13,67 @@ the wedge is in.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Query
 
-from pollypm.web_api.errors import not_found
-from pollypm.web_api.models import ActionResult, TaskDetail
+from pollypm.web_api.errors import APIError, not_found
+from pollypm.web_api.models import ActionResult, TaskDetail, TaskListResponse
 from pollypm.web_api.routes._deps import ConfigDep
-from pollypm.web_api.service import get_task_detail, queue_task
+from pollypm.web_api.service import get_task_detail, list_all_tasks, queue_task
 
 router = APIRouter(tags=["Tasks"])
+
+
+@router.get(
+    "/tasks",
+    response_model=TaskListResponse,
+    summary="Flat list of tasks across all projects",
+    operation_id="listTasks",
+)
+def list_tasks_endpoint(
+    config: ConfigDep,
+    project: Annotated[str | None, Query(description="Filter to a single project key.")] = None,
+    # Repeatable ``status=`` per spec §5.1 — FastAPI maps a list-typed
+    # Query into ``?status=draft&status=queued`` (OR semantics on the
+    # service side).
+    status: Annotated[list[str] | None, Query(description="Filter by work_status (repeatable).")] = None,
+    assignee: Annotated[str | None, Query(description="Filter by exact assignee.")] = None,
+    since: Annotated[
+        str | None,
+        Query(description="ISO-8601 lower bound on updated_at (strictly after)."),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=200, description="Page size (capped at 200).")] = 50,
+    cursor: Annotated[str | None, Query(description="Opaque cursor from next_cursor.")] = None,
+) -> TaskListResponse:
+    since_dt: datetime | None = None
+    if since is not None:
+        try:
+            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        except ValueError as exc:
+            # Spec §6: malformed query → 400 invalid_request with a
+            # hint about the expected format, not 422. The body shape
+            # is fine; the *value* is unparseable, but the
+            # invalid_request distinction matches how the other
+            # endpoints surface bad timestamps (e.g. /events).
+            raise APIError(
+                status_code=400,
+                code="invalid_request",
+                message=f"Invalid `since` value: {since!r}",
+                hint="Use ISO-8601 (e.g. 2026-05-22T00:00:00Z).",
+            ) from exc
+
+    items, next_cursor = list_all_tasks(
+        config,
+        project=project,
+        statuses=status,
+        assignee=assignee,
+        since=since_dt,
+        limit=limit,
+        cursor=cursor,
+    )
+    return TaskListResponse(items=items, next_cursor=next_cursor)
 
 
 @router.get(

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -1005,6 +1005,18 @@ def list_project_tasks(
         ) from exc
 
 
+class StaleCursorError(Exception):
+    """Raised when ``list_all_tasks`` is given a cursor that no longer
+    matches any item in the current snapshot.
+
+    Round 1 of Codex review on PR #2067 noted that the previous
+    behaviour (silently restart at page one) creates duplicate rows
+    and infinite-pagination loops under concurrent updates. We now
+    raise this typed error so the route layer can map it to a 400
+    ``invalid_request`` rather than mask the failure.
+    """
+
+
 def list_all_tasks(
     config: PollyPMConfig,
     *,
@@ -1014,7 +1026,7 @@ def list_all_tasks(
     since: datetime | None = None,
     limit: int = 50,
     cursor: str | None = None,
-) -> tuple[list[APITaskSummary], str | None]:
+) -> tuple[list[APITaskSummary], str | None, list[dict[str, str]]]:
     """Cross-project flat task list (spec §5.1 / Phase 6 P0).
 
     No cross-project helper exists on the work-service yet, so we
@@ -1033,15 +1045,23 @@ def list_all_tasks(
       ``None`` means no status filter.
     * ``assignee`` — exact-match assignee filter.
     * ``since`` — only tasks with ``updated_at > since`` are returned.
-      Tasks missing ``updated_at`` are kept (treated as "always
-      newer") so the filter never silently drops untracked tasks.
+      Must be timezone-aware; the route layer rejects naive ISO
+      values before they reach this helper.
     * Pagination uses an opaque cursor; the cursor encodes the
       ``(updated_at_iso, task_id)`` of the last item on the previous
-      page so paging is stable when tasks are updated between calls.
+      page. A cursor that no longer matches any item raises
+      :class:`StaleCursorError` (route maps to 400) so clients restart
+      from page one explicitly — silently restarting would create
+      duplicate rows / infinite loops under concurrent updates
+      (PR #2067 Codex round 1, P0 #3).
 
-    Backing-store failures on individual projects degrade to "skip
-    that project" so a single bad DB doesn't 503 the whole flat list
-    (matches the inbox aggregator's posture).
+    Returns ``(page, next_cursor, warnings)``. ``warnings`` is a list
+    of ``{"project": <key>, "error": <code>}`` dicts — one entry per
+    project whose backing store raised during this request. An empty
+    list means every project read succeeded; the partial-failure
+    surface is explicit so a pg outage on one project can't hide
+    behind a 200 with a silently-truncated body (PR #2067 Codex round
+    1, P0 #1).
     """
     keys: Iterable[str]
     if project is not None:
@@ -1051,6 +1071,7 @@ def list_all_tasks(
 
     status_filter = set(statuses or [])
     summaries: list[APITaskSummary] = []
+    warnings: list[dict[str, str]] = []
     for key in keys:
         proj = config.projects[key]
         try:
@@ -1065,11 +1086,12 @@ def list_all_tasks(
                 tasks = svc.list_tasks(project=key)
         except _BACKING_STORE_ERRORS as exc:
             logger.warning(
-                "list_all_tasks: backing store error for %s; skipping: %s",
+                "list_all_tasks: backing store error for %s; surfacing as warning: %s",
                 key,
                 exc,
                 exc_info=True,
             )
+            warnings.append({"project": key, "error": "service_unavailable"})
             continue
 
         for task in tasks:
@@ -1089,8 +1111,10 @@ def list_all_tasks(
     # Newest-first ordering is the most useful default for cross-
     # project list views (cockpit "what changed recently?"). Tasks
     # without ``updated_at`` sort to the end via the epoch fallback so
-    # the cursor encoding stays well-defined.
-    epoch = datetime.min
+    # the cursor encoding stays well-defined. Use a tz-aware epoch so
+    # the sort key is comparable with the offset-aware ``updated_at``
+    # values pg returns.
+    epoch = datetime.min.replace(tzinfo=timezone.utc)
     summaries.sort(
         key=lambda t: (t.updated_at or epoch, t.task_id),
         reverse=True,
@@ -1098,18 +1122,26 @@ def list_all_tasks(
 
     cursor_idx = 0
     if cursor is not None:
+        matched = False
         for idx, item in enumerate(summaries):
             cursor_key = f"{(item.updated_at or epoch).isoformat()}|{item.task_id}"
             if cursor_key == cursor:
                 cursor_idx = idx + 1
+                matched = True
                 break
+        if not matched:
+            # Empty-result + cursor is the only ambiguous case (the
+            # caller could legitimately be paging past the end of a
+            # now-empty list). Treat any other miss as a stale cursor
+            # and force the client to restart explicitly.
+            raise StaleCursorError(cursor)
 
     page = summaries[cursor_idx : cursor_idx + limit]
     next_cursor: str | None = None
     if cursor_idx + limit < len(summaries) and page:
         tail = page[-1]
         next_cursor = f"{(tail.updated_at or epoch).isoformat()}|{tail.task_id}"
-    return page, next_cursor
+    return page, next_cursor, warnings
 
 
 def get_task_detail(
@@ -2507,4 +2539,5 @@ __all__ = [
     "reply_inbox_item",
     "set_project_tracked",
     "snooze_inbox_item",
+    "StaleCursorError",
 ]

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -1005,6 +1005,113 @@ def list_project_tasks(
         ) from exc
 
 
+def list_all_tasks(
+    config: PollyPMConfig,
+    *,
+    project: str | None = None,
+    statuses: list[str] | None = None,
+    assignee: str | None = None,
+    since: datetime | None = None,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> tuple[list[APITaskSummary], str | None]:
+    """Cross-project flat task list (spec §5.1 / Phase 6 P0).
+
+    No cross-project helper exists on the work-service yet, so we
+    iterate the registered projects, call :meth:`list_tasks` per
+    project, and concatenate. This is acceptable for v1 — workspaces
+    are small (<20 projects, low hundreds of tasks each) and the
+    per-project DB open is the same cost ``list_project_tasks`` pays.
+    A native cross-project query can replace this body without
+    changing the route signature.
+
+    * ``project`` — when set, restricts to a single project. The
+      result is equivalent to ``list_project_tasks`` minus the 404 on
+      unknown project (an unknown project here yields an empty page,
+      matching the cross-project "no matches" semantics).
+    * ``statuses`` — repeatable status filter; OR semantics. Empty /
+      ``None`` means no status filter.
+    * ``assignee`` — exact-match assignee filter.
+    * ``since`` — only tasks with ``updated_at > since`` are returned.
+      Tasks missing ``updated_at`` are kept (treated as "always
+      newer") so the filter never silently drops untracked tasks.
+    * Pagination uses an opaque cursor; the cursor encodes the
+      ``(updated_at_iso, task_id)`` of the last item on the previous
+      page so paging is stable when tasks are updated between calls.
+
+    Backing-store failures on individual projects degrade to "skip
+    that project" so a single bad DB doesn't 503 the whole flat list
+    (matches the inbox aggregator's posture).
+    """
+    keys: Iterable[str]
+    if project is not None:
+        keys = (project,) if project in config.projects else ()
+    else:
+        keys = config.projects.keys()
+
+    status_filter = set(statuses or [])
+    summaries: list[APITaskSummary] = []
+    for key in keys:
+        proj = config.projects[key]
+        try:
+            with _open_work_service_readonly(
+                config=config, project_key=key, project_path=proj.path
+            ) as svc:
+                # The work-service ``list_tasks`` only supports a
+                # single ``work_status`` filter, so we apply the
+                # OR-set client-side; assignee + since likewise apply
+                # client-side to keep the wrapper portable across
+                # backends.
+                tasks = svc.list_tasks(project=key)
+        except _BACKING_STORE_ERRORS as exc:
+            logger.warning(
+                "list_all_tasks: backing store error for %s; skipping: %s",
+                key,
+                exc,
+                exc_info=True,
+            )
+            continue
+
+        for task in tasks:
+            if status_filter:
+                value = _enum_value(getattr(task, "work_status", ""))
+                if value not in status_filter:
+                    continue
+            if assignee is not None:
+                if (getattr(task, "assignee", None) or "") != assignee:
+                    continue
+            if since is not None:
+                updated = getattr(task, "updated_at", None)
+                if updated is not None and updated <= since:
+                    continue
+            summaries.append(_task_to_summary(task))
+
+    # Newest-first ordering is the most useful default for cross-
+    # project list views (cockpit "what changed recently?"). Tasks
+    # without ``updated_at`` sort to the end via the epoch fallback so
+    # the cursor encoding stays well-defined.
+    epoch = datetime.min
+    summaries.sort(
+        key=lambda t: (t.updated_at or epoch, t.task_id),
+        reverse=True,
+    )
+
+    cursor_idx = 0
+    if cursor is not None:
+        for idx, item in enumerate(summaries):
+            cursor_key = f"{(item.updated_at or epoch).isoformat()}|{item.task_id}"
+            if cursor_key == cursor:
+                cursor_idx = idx + 1
+                break
+
+    page = summaries[cursor_idx : cursor_idx + limit]
+    next_cursor: str | None = None
+    if cursor_idx + limit < len(summaries) and page:
+        tail = page[-1]
+        next_cursor = f"{(tail.updated_at or epoch).isoformat()}|{tail.task_id}"
+    return page, next_cursor
+
+
 def get_task_detail(
     config: PollyPMConfig, project_key: str, task_number: int
 ) -> APITaskDetail | None:
@@ -2388,6 +2495,7 @@ __all__ = [
     "get_project",
     "get_task_detail",
     "init_project_guide_for_role",
+    "list_all_tasks",
     "list_inbox",
     "list_project_tasks",
     "list_projects",

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -43,6 +43,8 @@ PHASE_1_PATHS: set[tuple[str, str]] = {
     ("GET", "/chat/{session_name}/messages"),
     # Chat-endpoints P3 (#2043) — POST send path.
     ("POST", "/chat/{session_name}/send"),
+    # Phase 6 P0 — cross-project flat task list (spec §5.1).
+    ("GET", "/tasks"),
 }
 
 

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -1,0 +1,230 @@
+"""Tests for the ``GET /api/v1/tasks`` cross-project flat list (Phase 6 P0).
+
+The per-project list at ``/projects/{key}/tasks`` already covers
+narrow-scope reads; this endpoint adds the cross-project surface
+spec §5.1 calls for. The test suite verifies the four filter axes
+(project / status / assignee / since), the pagination contract
+(opaque cursor + ``next_cursor`` only when more remains), and the
+graceful-empty-list response on unknown filters.
+
+Each test takes ``pg_schema_pool`` so the per-test pg schema is set
+up and torn down — that fixture lives in ``tests/conftest_pg.py``
+and patches ``POLLYPM_PG_DSN`` + the pool factory so every
+work-service open lands in an isolated namespace. Without it tests
+run against the dev machine's real ``pollypm`` pg DB and accumulate
+state across runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.work.factory import create_work_service
+
+from .conftest import make_task
+
+
+# Mark every test in this module as needing pg isolation. The
+# ``pg_schema_pool`` fixture (from ``tests/conftest_pg.py``) creates
+# ``CREATE SCHEMA test_<uuid>``, patches the pool factory to set
+# ``search_path`` to that schema, then drops the schema on teardown —
+# so each test starts with empty work_tasks / work_node_executions /
+# work_transitions tables. The fixture handles its own skip when
+# Docker / a local pg+pgvector isn't reachable.
+pytestmark = pytest.mark.usefixtures("pg_schema_pool")
+
+
+def _seed_two_projects(api_config, workspace_root):
+    """Register a second tracked project on the same shared DB.
+
+    The conftest registers a single ``myproj``; we add ``second`` so
+    cross-project assertions have something to merge. Both projects
+    share the per-test pg schema so they read distinct rows by the
+    work-service's per-row ``project_key`` column.
+    """
+    from pollypm.models import KnownProject, ProjectKind
+
+    second_root = workspace_root / "second"
+    second_root.mkdir()
+    (second_root / ".pollypm").mkdir()
+    api_config.projects["second"] = KnownProject(
+        key="second",
+        path=second_root,
+        name="Second",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+    return second_root
+
+
+def test_list_tasks_returns_all_projects(
+    api_config, client, auth_headers, project_root, workspace_root
+) -> None:
+    """No filter ⇒ every task from every registered project surfaces."""
+    _seed_two_projects(api_config, workspace_root)
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        make_task(svc, project="myproj", title="My A")
+        make_task(svc, project="myproj", title="My B")
+        make_task(svc, project="second", title="Second A")
+
+    response = client.get("/api/v1/tasks", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    titles = sorted(item["title"] for item in body["items"])
+    assert titles == ["My A", "My B", "Second A"]
+    # ``next_cursor`` is absent when no more pages remain.
+    assert body.get("next_cursor") is None
+    # Every item carries the cross-project ``project`` field so the
+    # client can disambiguate without re-querying.
+    projects = {item["project"] for item in body["items"]}
+    assert projects == {"myproj", "second"}
+
+
+def test_list_tasks_project_filter(
+    api_config, client, auth_headers, project_root, workspace_root
+) -> None:
+    """``?project=`` restricts the result to that project only."""
+    _seed_two_projects(api_config, workspace_root)
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        make_task(svc, project="myproj", title="Mine")
+        make_task(svc, project="second", title="Theirs")
+
+    response = client.get(
+        "/api/v1/tasks?project=second", headers=auth_headers
+    )
+    assert response.status_code == 200
+    titles = [item["title"] for item in response.json()["items"]]
+    assert titles == ["Theirs"]
+
+
+def test_list_tasks_status_filter_or_semantics(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """Repeatable ``?status=`` is OR — multiple statuses union."""
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        # All freshly-created tasks land in ``draft``. Queue one so
+        # we have a non-draft status to filter against, and cancel
+        # another so we have a status nobody asks for.
+        make_task(svc, project="myproj", title="Drafty")
+        cancelled = make_task(svc, project="myproj", title="Cancelled one")
+        queued = make_task(svc, project="myproj", title="Queued one")
+        svc.queue(queued.task_id, actor="tester")
+        svc.cancel(cancelled.task_id, actor="tester", reason="cleanup")
+
+    response = client.get(
+        "/api/v1/tasks?status=draft&status=queued", headers=auth_headers
+    )
+    assert response.status_code == 200
+    titles = sorted(item["title"] for item in response.json()["items"])
+    # The draft+queued union excludes the cancelled task.
+    assert titles == ["Drafty", "Queued one"]
+
+
+def test_list_tasks_since_filter_rejects_bad_iso(
+    api_config, client, auth_headers
+) -> None:
+    """Malformed ``since`` → 400 invalid_request (spec §6)."""
+    response = client.get(
+        "/api/v1/tasks?since=not-a-timestamp", headers=auth_headers
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "since" in body["error"]["message"].lower()
+
+
+def test_list_tasks_since_filter_strict_after(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """``since`` is strictly-after, so a timestamp matching ``updated_at``
+    does NOT include that row. This pins the half-open contract the
+    docstring promises so a future ``>=`` regression trips the test."""
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        make_task(svc, project="myproj", title="Old one")
+
+    # First read: the API surfaces ``updated_at``. We then pass that
+    # exact value back as ``since`` — the strict-after contract means
+    # the row should NOT appear again.
+    initial = client.get("/api/v1/tasks", headers=auth_headers).json()
+    assert initial["items"], "fixture must seed at least one task"
+    pivot_ts = initial["items"][0]["updated_at"]
+
+    response = client.get(
+        f"/api/v1/tasks?since={pivot_ts}", headers=auth_headers
+    )
+    assert response.status_code == 200
+    # Strict-after: a row with updated_at == pivot must be excluded.
+    later_titles = [item["title"] for item in response.json()["items"]]
+    assert "Old one" not in later_titles
+
+
+def test_list_tasks_pagination_cursor(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """Pagination walks every row with no overlap between pages."""
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        for i in range(5):
+            make_task(svc, project="myproj", title=f"Task {i}")
+
+    first = client.get(
+        "/api/v1/tasks?limit=2", headers=auth_headers
+    ).json()
+    assert len(first["items"]) == 2
+    assert first.get("next_cursor") is not None
+
+    second = client.get(
+        f"/api/v1/tasks?limit=2&cursor={first['next_cursor']}",
+        headers=auth_headers,
+    ).json()
+    assert len(second["items"]) == 2
+    # The pages must not overlap.
+    first_ids = {item["task_id"] for item in first["items"]}
+    second_ids = {item["task_id"] for item in second["items"]}
+    assert first_ids.isdisjoint(second_ids)
+
+
+def test_list_tasks_limit_capped(
+    api_config, client, auth_headers
+) -> None:
+    """``limit`` over 200 is rejected with 422 (spec §5.1, Query bounds)."""
+    response = client.get(
+        "/api/v1/tasks?limit=9999", headers=auth_headers
+    )
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+
+
+def test_list_tasks_unknown_project_returns_empty(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """Unknown ``project=`` is a no-match, not a 404 — the flat-list
+    endpoint never raises ``not_found`` for filter values (only for
+    auth)."""
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        make_task(svc, project="myproj", title="Exists")
+
+    response = client.get(
+        "/api/v1/tasks?project=does-not-exist", headers=auth_headers
+    )
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+
+
+def test_list_tasks_requires_auth(client) -> None:
+    """No bearer token ⇒ 401, matching every other authed endpoint."""
+    response = client.get("/api/v1/tasks")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "unauthorized"

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -228,3 +228,114 @@ def test_list_tasks_requires_auth(client) -> None:
     response = client.get("/api/v1/tasks")
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "unauthorized"
+
+
+# ---------------------------------------------------------------------------
+# PR #2067 Codex round 1 — P0 regressions
+# ---------------------------------------------------------------------------
+
+
+def test_cross_project_list_partial_failure_envelope(
+    api_config, client, auth_headers, project_root, workspace_root, monkeypatch
+) -> None:
+    """P0 #1: one project failing must surface as a `warnings` entry
+    and NOT silently drop. Other projects' data still comes back."""
+    import psycopg
+
+    from pollypm.web_api import service as svc_mod
+
+    second_root = _seed_two_projects(api_config, workspace_root)  # noqa: F841
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        make_task(svc, project="myproj", title="Healthy A")
+        make_task(svc, project="second", title="Healthy B")
+
+    # Stub the readonly work-service open so the *second* project
+    # raises a psycopg error (mirroring a pg outage on one DB),
+    # while ``myproj`` opens normally.
+    real_open = svc_mod._open_work_service_readonly
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def flaky_open(*, config, project_key, project_path):
+        if project_key == "second":
+            raise psycopg.OperationalError("simulated pg outage")
+        with real_open(
+            config=config, project_key=project_key, project_path=project_path
+        ) as svc:
+            yield svc
+
+    monkeypatch.setattr(svc_mod, "_open_work_service_readonly", flaky_open)
+
+    response = client.get("/api/v1/tasks", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Surviving project's row is still present — partial > none.
+    titles = sorted(item["title"] for item in body["items"])
+    assert "Healthy A" in titles
+    # Failed project does NOT appear in items (the read failed).
+    assert "Healthy B" not in titles
+    # ...but the operator sees an explicit warning so they can act.
+    assert body.get("warnings"), "partial failure must surface in warnings"
+    failed = [w for w in body["warnings"] if w["project"] == "second"]
+    assert failed, f"expected `second` in warnings, got {body['warnings']!r}"
+    assert failed[0]["error"] == "service_unavailable"
+
+
+def test_cross_project_list_rejects_naive_since(
+    api_config, client, auth_headers
+) -> None:
+    """P0 #2: a syntactically-valid naive ISO `since` used to crash
+    with TypeError (offset-naive vs offset-aware) → 500. Reject it as
+    a typed 400 instead."""
+    # No `Z` suffix, no `+00:00` — pure naive ISO.
+    response = client.get(
+        "/api/v1/tasks?since=2026-05-22T10:00:00", headers=auth_headers
+    )
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "timezone" in body["error"]["message"].lower()
+
+
+def test_cross_project_list_stale_cursor_returns_400(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """P0 #3: when the cursor's anchor item is updated/deleted between
+    page requests, the helper used to silently restart at page one
+    (duplicate rows / infinite pagination). It must now 400 so the
+    client restarts explicitly."""
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    task_ids: list[str] = []
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        for i in range(3):
+            task = make_task(svc, project="myproj", title=f"Task {i}")
+            task_ids.append(task.task_id)
+
+    # Take page one (limit=1) so we get a cursor.
+    first = client.get(
+        "/api/v1/tasks?limit=1", headers=auth_headers
+    ).json()
+    cursor = first.get("next_cursor")
+    assert cursor, "fixture must produce a next_cursor"
+
+    # Mutate the task the cursor refers to. The cursor anchor is the
+    # *last item of the previous page* (per the helper's contract).
+    # Cancelling bumps ``updated_at``, which changes the cursor key —
+    # so the next page request can no longer locate the anchor and
+    # must surface stale-cursor explicitly.
+    tail_id = first["items"][-1]["task_id"]
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        svc.cancel(tail_id, actor="tester", reason="stale-cursor test")
+
+    # The next request must fail explicitly, not silently page-one.
+    response = client.get(
+        f"/api/v1/tasks?limit=1&cursor={cursor}", headers=auth_headers
+    )
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "cursor" in body["error"]["message"].lower()


### PR DESCRIPTION
## Summary

Phase 5 integration testing surfaced three P0 doc-vs-code mismatches. This PR closes all three.

- **P0-1 + P0-3 — OpenAPI doc-drift cleanup.** Removed six path entries that `pollypm.web_api.app` never wires: `GET /doctor`, `POST /projects`, `POST /projects/{key}/chat`, `POST /projects/{key}/plan`, `POST /tasks/{project}/{n}/approve`, `POST /tasks/{project}/{n}/reject`. Codegen clients branched on these and 404'd on every call. The plan approve/reject flow is Phase 3 work; the rest are Phase 1 carry-over. Orphan schemas left in `components/schemas` for Phase 3 reuse (no impact on codegen — only path entries trip clients).
- **P0-2 — Add `GET /api/v1/tasks` cross-project flat list.** Spec §5.1 calls for this; previously only the per-project `/projects/{key}/tasks` and single-task `/tasks/{project}/{n}` shipped. New endpoint supports the four documented filters (`project`, repeatable `status`, `assignee`, strict-after `since`) and opaque-cursor pagination via a new `list_all_tasks` helper that iterates per-project `list_tasks` and concatenates (acceptable for v1 workspace scale, swappable for a native cross-project query without changing the route signature).

YAML net: 56 additions / 188 deletions (`-132` lines).

## Spec gaps still deferred (per Phase 5 report, ~14 endpoints)

Untouched by this PR — tracked for Phase 2.5 / Phase 3:

- `POST /inbox/bulk`
- `POST /doctor/fix`, `GET /doctor/checks/{name}`
- Task `PATCH /labels` + `/relationships`; `POST .../append-context`, `/approve-plan`, `/reject-plan`
- `GET /heartbeats/{name}/history`, SSE `/heartbeats/stream`
- `GET /briefings/{type}/last` and `/render` as distinct GETs
- `GET /sessions/{name}/config`
- `GET /projects/{key}/activity`
- Dashboard SSE `/dashboard/stream`

## Test plan

- [x] `pytest tests/web_api/test_tasks_list_endpoint.py -v` — 9 new tests pass (filter axes, pagination, auth, bad-iso 400)
- [x] `pytest tests/web_api/test_openapi_conformance.py -v` — 5/5 pass; `PHASE_1_PATHS` extended to include `GET /tasks` so future drift trips CI
- [x] `openapi_spec_validator.validate()` on the updated YAML — passes as OpenAPI 3.1
- [x] Generated `openapi.json` from `create_app()` lists `/api/v1/tasks` alongside the existing routes
- [x] Pre-existing failures in `test_endpoints.py` (4 tests, dev-pg-state pollution) reproduce on `origin/main` and are not caused by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)