### PR TITLE
fix(perf): stamp _static_list_panes_cache after list_panes completes (closes #1967)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3444,7 +3444,18 @@ class CockpitRouter:
                 panes = self.tmux.list_panes(window_target)
             except Exception:  # noqa: BLE001
                 panes = None
-            self._static_list_panes_cache[window_target] = (t_start, panes)
+            # #1967 — stamp the cache with the *completion* timestamp,
+            # not ``t_start``. When ``list_panes`` takes longer than
+            # ``_STATIC_LIST_PANES_TTL_SECONDS`` (e.g. a slow/contended
+            # tmux server), using the pre-call ``t_start`` produces an
+            # entry that is already expired the moment it's written —
+            # so the very next click pays the same slow subprocess
+            # cost, defeating the burst-collapsing cache. The route
+            # timing log below still uses ``t_start`` because it
+            # measures user-perceived step duration, not freshness.
+            self._static_list_panes_cache[window_target] = (
+                time.monotonic(), panes,
+            )
         self._maybe_log_route_step("list_panes", key, t_start)
         if has_mount_state:
             if panes is None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4049,6 +4049,77 @@ def test_cockpit_router_ensure_layout_swap_preserves_pane_count(tmp_path: Path) 
     assert state["right_pane_id"] == "%1"
 
 
+def test_static_list_panes_cache_stamps_after_call_not_before(monkeypatch, tmp_path: Path) -> None:
+    """#1967 — when ``list_panes`` takes longer than the cache TTL, two
+    back-to-back static-route clicks must still collapse onto a single
+    ``list_panes`` subprocess.
+
+    Pre-fix, ``_route_supervisor_free_static`` captured ``t_start``
+    BEFORE the slow ``list_panes`` call and stored that pre-call
+    timestamp in ``_static_list_panes_cache``. With a 0.5s TTL, a
+    ``list_panes`` that took longer than 0.5s produced a cache entry
+    that was already expired the moment it was written — so the very
+    next click paid the same slow cost again, defeating the
+    burst-collapsing cache. The fix stamps the cache with the
+    completion timestamp so the TTL clock starts when the entry
+    becomes available, not before.
+    """
+    import time
+
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    list_pane_calls: list[str] = []
+
+    class SlowTmux:
+        # Sleep slightly longer than ``_STATIC_LIST_PANES_TTL_SECONDS``
+        # (0.5s) so a pre-call timestamp would expire before being read.
+        # Kept tight (0.6s) to keep total wall-clock under 1s.
+        _SLEEP = 0.6
+
+        def list_panes(self, target: str):
+            list_pane_calls.append(target)
+            time.sleep(self._SLEEP)
+            return []
+
+    class StubWindowManager:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def try_show_static_fast(self, *_args, **_kwargs):
+            return None
+
+        def show_static(self, *_args, **_kwargs):
+            return SimpleNamespace(
+                ok=True,
+                state=SimpleNamespace(
+                    right_pane_id=None, mounted_session=None,
+                ),
+                actions=(),
+                postcondition=SimpleNamespace(errors=(), right_pane_id=None),
+            )
+
+    router = CockpitRouter(config_path)
+    router.tmux = SlowTmux()  # type: ignore[assignment]
+    monkeypatch.setattr("pollypm.cockpit_rail.CockpitWindowManager", StubWindowManager)
+    # Avoid timing-warn log spam in the captured output; the threshold
+    # check isn't what we're testing.
+    monkeypatch.setattr(router, "_maybe_log_route_step", lambda *a, **k: None)
+
+    router._route_supervisor_free_static("inbox")
+    router._route_supervisor_free_static("inbox")
+
+    cockpit_calls = [t for t in list_pane_calls if t.endswith(":PollyPM")]
+    assert len(cockpit_calls) == 1, (
+        "expected the cache to collapse two back-to-back static-route "
+        "clicks onto one list_panes subprocess even when list_panes "
+        f"takes longer than the TTL, got {len(cockpit_calls)} calls: "
+        f"{cockpit_calls}"
+    )
+
+
 def test_cockpit_router_routes_idle_project_to_detail_pane(monkeypatch, tmp_path: Path) -> None:
     calls: dict[str, object] = {}
     (tmp_path / "pollypm.toml").write_text(f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n")


### PR DESCRIPTION
## Summary
- `_route_supervisor_free_static()` captured `t_start = time.monotonic()` BEFORE `self.tmux.list_panes(...)` and stored that pre-call timestamp in `_static_list_panes_cache`. With a 0.5s TTL, any `list_panes` slower than 0.5s produced a born-expired cache entry, so the very next static-route click re-paid the same slow subprocess cost — defeating the burst-collapsing cache (#1961) precisely when it matters (slow / contended tmux server).
- Stamp the cache with the completion timestamp (`time.monotonic()` after the call). The existing `_maybe_log_route_step("list_panes", ...)` keeps using `t_start` because it measures user-perceived step duration, not cache freshness.

## Test plan
- [x] Added `test_static_list_panes_cache_stamps_after_call_not_before` — wires a `SlowTmux.list_panes` (sleeps 0.6s, > 0.5s TTL) and asserts two back-to-back `_route_supervisor_free_static("inbox")` calls hit `list_panes` exactly once.
- [x] Verified the new test FAILS without the production fix (`got 2 calls`) and PASSES with it.
- [x] `pytest tests/test_cockpit.py -k "list_panes or static_route or cache or route_supervisor"` — 7 passed.
- [x] `pytest tests/test_cockpit_rail_routes.py` — 5 passed.

Closes #1967

Generated with [Claude Code](https://claude.com/claude-code)