### PR TITLE
fix(perf): stamp pm_inbox_awaits_user_list cache after uncached fetch (closes #1968)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -212,6 +212,10 @@ def pm_inbox_awaits_user_list(config) -> list[object]:
         return list(cached[1])
 
     result = _pm_inbox_awaits_user_list_uncached(config)
+    # #1957 #1968 perf — stamp the cache AFTER the uncached sweep returns
+    # so a cold awaits-user fetch that exceeds the TTL doesn't write a
+    # born-expired entry that forces the next caller to recompute.
+    completed_at = _time.monotonic()
     # Best-effort eviction so the cache doesn't grow across long-lived
     # processes with config reloads (each reload yields a fresh
     # ``id(config)``). Cheap because the dict is typically tiny — one
@@ -219,10 +223,10 @@ def pm_inbox_awaits_user_list(config) -> list[object]:
     if len(_AWAITS_USER_CACHE) > 8:
         for stale_key in [
             k for k, (ts, _v) in _AWAITS_USER_CACHE.items()
-            if now - ts >= _AWAITS_USER_TTL_SECONDS
+            if completed_at - ts >= _AWAITS_USER_TTL_SECONDS
         ]:
             _AWAITS_USER_CACHE.pop(stale_key, None)
-    _AWAITS_USER_CACHE[cache_key] = (now, tuple(result))
+    _AWAITS_USER_CACHE[cache_key] = (completed_at, tuple(result))
     return result
 
 

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -269,6 +269,70 @@ class TestAwaitsUserParity:
         assert called["n"] == 1
         assert len(result) == len(direct)
 
+    def test_slow_uncached_fetch_does_not_write_born_expired_entry(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """#1968 regression — when the uncached awaits-user fetch takes
+        longer than ``_AWAITS_USER_TTL_SECONDS``, the cache MUST stamp
+        the completion time (post-fetch) so the entry stays fresh for
+        a full TTL window. Stamping the pre-fetch time would make the
+        entry born-expired and force every subsequent caller within the
+        TTL window to re-run the multi-second sweep.
+
+        Asserts that back-to-back calls share a single uncached invocation
+        even when the first call exceeds the TTL — matching the #1957
+        contract already pinned for ``all_tasks_grouped`` /
+        ``_gather_worker_roster`` / ``_prefetch_project_state``.
+        """
+        # Force the cache fast-path off so we exercise the legacy TTL
+        # cache wrapper (the path that #1968 regresses).
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "0")
+        config = _make_config(["alpha"], tmp_path)
+        direct = self._direct_items()
+
+        call_count = {"n": 0}
+        ttl = cockpit_inbox._AWAITS_USER_TTL_SECONDS
+        # Drive the post-fetch monotonic stamp forward by more than the
+        # TTL during the first call. Using a fake clock keeps the test
+        # fast + deterministic (no real sleep). The first call advances
+        # the clock by ``ttl + 0.2`` between the pre-fetch read inside
+        # the wrapper and the post-fetch read; the second call should
+        # then hit the cache because the post-fetch stamp was used.
+        clock = {"t": 1000.0}
+
+        def _slow_uncached(_cfg: Any) -> list[Any]:
+            call_count["n"] += 1
+            # Simulate a fetch that takes longer than the TTL.
+            clock["t"] += ttl + 0.2
+            return list(direct)
+
+        def _fake_monotonic() -> float:
+            return clock["t"]
+
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            _slow_uncached,
+        )
+        # Patch the ``time`` module imported lazily inside the wrapper.
+        import time as _time
+
+        monkeypatch.setattr(_time, "monotonic", _fake_monotonic)
+
+        first = cockpit_inbox.pm_inbox_awaits_user_list(config)
+        # Second call is immediately back-to-back; clock has not
+        # advanced further (no sleep between calls). With the #1968 fix
+        # the cache stamp is the post-fetch time, so the entry's age is
+        # ~0s and the second call MUST be served from cache.
+        second = cockpit_inbox.pm_inbox_awaits_user_list(config)
+
+        assert call_count["n"] == 1, (
+            "uncached fetch was invoked twice — cache entry was born-expired "
+            "(stale pre-fetch stamp). #1968 regression."
+        )
+        assert len(first) == len(direct)
+        assert len(second) == len(direct)
+
 
 # ── project_state_map_from_config parity ───────────────────────────
 


### PR DESCRIPTION
## Summary

- `pm_inbox_awaits_user_list()` in `src/pollypm/cockpit_inbox.py` still captured `_time.monotonic()` **before** calling `_pm_inbox_awaits_user_list_uncached(config)` and wrote that pre-fetch timestamp into the cache. When the uncached sweep exceeded the 1s TTL, the cache entry was born-expired and the next caller within the same tick re-ran the multi-query sweep.
- The #1957 completion-stamp pattern was applied to `all_tasks_grouped`, `_prefetch_project_state`, `activity_feed_transition_rows`, and `_gather_worker_roster` — but missed this wrapper. This PR adds it: capture `completed_at = _time.monotonic()` **after** the uncached call returns and use it for both eviction comparison and cache storage.
- Adds a regression test (`tests/test_state_cache_parity.py::TestAwaitsUserParity::test_slow_uncached_fetch_does_not_write_born_expired_entry`) that monkeypatches the uncached fetch to advance a fake monotonic clock past the TTL and asserts back-to-back wrapper calls share a single uncached invocation. Verified the test fails on `main` and passes with the fix.

Closes #1968.

## Test plan

- [x] `uv run --extra test pytest tests/test_state_cache_parity.py -x` — 41/41 pass with the fix.
- [x] Same test FAILS when the fix is reverted (uncached called twice).