### PR TITLE
perf(web-ui): mtime cache for parse_events_jsonl (closes #2069)

### DIFF
--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -290,6 +290,31 @@ def is_archive_stale(
     return (current - mtime) > threshold_seconds
 
 
+# mtime-keyed cache for ``parse_events_jsonl`` (issue #2069).
+#
+# The history endpoint polls every ~5s and the parse body forward-
+# readline's the full archive each call (operator transcripts hit
+# ~2,800 lines quickly). When the file hasn't been touched since the
+# last parse we can return the cached envelopes instead of re-parsing.
+#
+# Cache key is the ``Path`` instance the caller passed (resolution
+# left to the caller — the chat surfaces always pass the same Path).
+# Cache value is ``(mtime, envelopes, actor_fallback)`` so a caller
+# changing ``actor_fallback`` (different surface persona on the same
+# archive) doesn't get a stale fallback baked into the envelopes.
+#
+# Insertion-ordered dict + ``next(iter(...))`` gives us LRU-by-
+# insertion eviction without an extra dependency. The cap (100) is
+# generous given each entry is one events.jsonl per chat surface.
+_PARSE_CACHE: dict[Path, tuple[float, list[MessageEnvelope], str]] = {}
+_PARSE_CACHE_MAX = 100
+
+
+def _parse_cache_clear() -> None:
+    """Drop every cached parse result. Test-only helper."""
+    _PARSE_CACHE.clear()
+
+
 def parse_events_jsonl(
     events_path: Path,
     *,
@@ -317,7 +342,16 @@ def parse_events_jsonl(
     callers can map an unreadable archive to a typed 503
     ``archive_unreadable`` instead of silently returning ``200`` with
     an empty list (round-5 blocker 2). The chat-messages route catches
-    the propagated ``OSError`` and translates it.
+    the propagated ``OSError`` and translates it. ``strict=True``
+    callers also skip the mtime cache so validation paths always see a
+    fresh parse.
+
+    Caching (issue #2069): for ``strict=False`` callers we memoize on
+    ``(events_path, mtime, actor_fallback)``. The history endpoint
+    polls every few seconds and the underlying read forward-readlines
+    the full archive each call; with operator transcripts running into
+    the thousands of lines this dominates poll latency. When the file
+    mtime is unchanged the cached envelopes are returned directly.
 
     NOTE: provider ``thinking`` blocks are not surfaced — the
     transcript ingestor does not currently preserve them. Tracking the
@@ -326,6 +360,31 @@ def parse_events_jsonl(
     envelopes: list[MessageEnvelope] = []
     if not events_path.exists():
         return envelopes
+    # Cache lookup happens BEFORE the heavy parse. We stat once up
+    # front; ``strict=True`` callers skip the cache so validation paths
+    # always see a fresh parse + propagated OSError.
+    cache_eligible = not strict
+    cached_mtime: float | None = None
+    if cache_eligible:
+        try:
+            cached_mtime = events_path.stat().st_mtime
+        except OSError:
+            # Stat failure mirrors the existing fail-soft posture —
+            # fall through to the normal parse path so any OSError is
+            # logged with the same context as before.
+            cached_mtime = None
+        if cached_mtime is not None:
+            cached = _PARSE_CACHE.get(events_path)
+            if (
+                cached is not None
+                and cached[0] == cached_mtime
+                and cached[2] == actor_fallback
+            ):
+                # Defensive copy: callers downstream sort/filter the
+                # list in-place (see _apply_filters_and_paginate's
+                # ``indexed.sort``), so handing them the cached list
+                # directly would corrupt the cache on the next hit.
+                return list(cached[1])
     source_key = hashlib.blake2b(
         str(events_path).encode("utf-8"), digest_size=4,
     ).hexdigest()
@@ -366,6 +425,17 @@ def parse_events_jsonl(
             events_path, exc,
         )
         return envelopes
+    if cache_eligible and cached_mtime is not None:
+        # Evict oldest insertion before storing the new entry. Python
+        # dicts preserve insertion order so ``next(iter(...))`` gives
+        # us the oldest key without an auxiliary structure. Pop the
+        # current key first (if present) so re-stores refresh ordering.
+        _PARSE_CACHE.pop(events_path, None)
+        if len(_PARSE_CACHE) >= _PARSE_CACHE_MAX:
+            _PARSE_CACHE.pop(next(iter(_PARSE_CACHE)))
+        # Store a fresh list so test/in-place mutations on the
+        # returned copy don't bleed back into the cache.
+        _PARSE_CACHE[events_path] = (cached_mtime, list(envelopes), actor_fallback)
     return envelopes
 
 

--- a/tests/test_chat_transcripts.py
+++ b/tests/test_chat_transcripts.py
@@ -36,10 +36,12 @@ from pollypm.web_api.chat import (
     parse_events_jsonl,
     resolve_transcript_path,
 )
+from pollypm.web_api.chat import transcripts as transcripts_module
 from pollypm.web_api.chat.transcripts import (
     _extract_text_from_blocks,
     _format_tool_use_summary,
     _looks_like_subagent_result,
+    _parse_cache_clear,
     build_session_index,
     lookup_transcript_path,
 )
@@ -649,6 +651,135 @@ def test_parse_empty_file_returns_empty_list(tmp_path: Path) -> None:
     events_path.write_text("")
     envelopes = parse_events_jsonl(events_path)
     assert envelopes == []
+
+
+# ---------------------------------------------------------------------------
+# mtime cache (issue #2069)
+#
+# The history endpoint polls every ~5s and the parse body forward-
+# readlines the full archive each call. For unchanged files the
+# memoized envelopes must be returned without re-running the heavy
+# event-to-envelope translation. ``strict=True`` callers (validation
+# paths) MUST bypass the cache so they still see fresh parse errors.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_unchanged_file_hits_cache(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [
+        _claude_event("user_turn", text="hi"),
+        _claude_event("assistant_turn", text="hello"),
+    ])
+
+    parse_calls = {"count": 0}
+    real_event_to_envelopes = transcripts_module._event_to_envelopes
+
+    def counting(*args, **kwargs):  # type: ignore[no-untyped-def]
+        parse_calls["count"] += 1
+        return real_event_to_envelopes(*args, **kwargs)
+
+    monkeypatch.setattr(transcripts_module, "_event_to_envelopes", counting)
+
+    first = parse_events_jsonl(events_path)
+    second = parse_events_jsonl(events_path)
+    third = parse_events_jsonl(events_path)
+
+    # Two events in the archive -> 2 _event_to_envelopes calls on the
+    # initial parse, zero on subsequent calls when mtime is unchanged.
+    assert parse_calls["count"] == 2
+    assert [env.text for env in first] == ["hi", "hello"]
+    assert [env.text for env in second] == ["hi", "hello"]
+    assert [env.text for env in third] == ["hi", "hello"]
+    # Each call returns a fresh list — callers sort in place
+    # (_apply_filters_and_paginate), so handing them the cached list
+    # directly would corrupt the cache.
+    assert first is not second
+    assert second is not third
+
+
+def test_parse_cache_invalidates_on_mtime_change(
+    tmp_path: Path,
+) -> None:
+    _parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event("user_turn", text="one")])
+    first = parse_events_jsonl(events_path)
+    assert [env.text for env in first] == ["one"]
+
+    # Append a new event AND bump mtime so the cache invalidates.
+    with events_path.open("a") as handle:
+        handle.write(json.dumps(_claude_event("user_turn", text="two")) + "\n")
+    new_mtime = events_path.stat().st_mtime + 5.0
+    import os
+    os.utime(events_path, (new_mtime, new_mtime))
+
+    second = parse_events_jsonl(events_path)
+    assert [env.text for env in second] == ["one", "two"]
+
+
+def test_parse_cache_skips_strict_mode(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """``strict=True`` callers want fresh parses (validation surface)."""
+    _parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event("user_turn", text="a")])
+
+    parse_calls = {"count": 0}
+    real_event_to_envelopes = transcripts_module._event_to_envelopes
+
+    def counting(*args, **kwargs):  # type: ignore[no-untyped-def]
+        parse_calls["count"] += 1
+        return real_event_to_envelopes(*args, **kwargs)
+
+    monkeypatch.setattr(transcripts_module, "_event_to_envelopes", counting)
+
+    parse_events_jsonl(events_path, strict=True)
+    parse_events_jsonl(events_path, strict=True)
+    parse_events_jsonl(events_path, strict=True)
+    # One event * 3 strict calls = 3 conversions (no caching).
+    assert parse_calls["count"] == 3
+
+
+def test_parse_cache_distinguishes_actor_fallback(
+    tmp_path: Path,
+) -> None:
+    """Different actor_fallback must re-parse so the persona is baked in."""
+    _parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_claude_event("assistant_turn", text="hi")])
+
+    polly_run = parse_events_jsonl(events_path, actor_fallback="Polly")
+    worker_run = parse_events_jsonl(events_path, actor_fallback="worker")
+
+    assert polly_run[0].actor == "Polly"
+    assert worker_run[0].actor == "worker"
+
+
+def test_parse_cache_lru_evicts_oldest_when_full(tmp_path: Path) -> None:
+    """Cap at _PARSE_CACHE_MAX entries; oldest insertion evicts first."""
+    _parse_cache_clear()
+    # Fill the cache to cap by parsing one file per entry.
+    for idx in range(transcripts_module._PARSE_CACHE_MAX):
+        path = tmp_path / f"events-{idx}.jsonl"
+        _write_events(path, [_claude_event("user_turn", text=f"e{idx}")])
+        parse_events_jsonl(path)
+    assert len(transcripts_module._PARSE_CACHE) == transcripts_module._PARSE_CACHE_MAX
+    oldest_path = tmp_path / "events-0.jsonl"
+    assert oldest_path in transcripts_module._PARSE_CACHE
+
+    # One more parse pushes us past the cap -> oldest evicts.
+    overflow = tmp_path / "events-overflow.jsonl"
+    _write_events(overflow, [_claude_event("user_turn", text="overflow")])
+    parse_events_jsonl(overflow)
+    assert len(transcripts_module._PARSE_CACHE) == transcripts_module._PARSE_CACHE_MAX
+    assert oldest_path not in transcripts_module._PARSE_CACHE
+    assert overflow in transcripts_module._PARSE_CACHE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add mtime-keyed cache to `parse_events_jsonl` so unchanged event files skip the forward-readline parse on subsequent calls.
- 100-entry LRU cap (insertion-ordered eviction) to bound memory.
- `strict=True` callers bypass the cache so validation paths still see fresh `OSError`s.

## Test plan
- [x] Regression test: N back-to-back calls against unchanged file invoke heavy parse once.
- [x] Cache invalidates when mtime changes.
- [x] `strict=True` calls bypass the cache.
- [x] Different `actor_fallback` re-parses (persona is baked into envelopes).
- [x] LRU eviction once 100-entry cap is hit.
- [x] Existing chat-transcripts + chat-messages endpoint tests still pass (103 tests green).

Closes #2069