### PR TITLE
fix(perf): move inbox detail hydration off Textual UI loop (closes #1969)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -6190,6 +6190,10 @@ class PollyInboxApp(App[None]):
         self._tasks: list = []
         self._selected_task_id: str | None = None
         self._selected_row_key: str | None = None
+        # #1969 — tracks the most-recent deferred-hydration dispatch so
+        # a worker callback whose target row was navigated away from
+        # can drop its result without re-painting stale data.
+        self._pending_detail_hydration_task_id: str | None = None
         self._unread_ids: set[str] = set()
         self._session_read_ids: set[str] = set()
         self._replies_by_task: dict[str, list] = {}
@@ -6681,42 +6685,252 @@ class PollyInboxApp(App[None]):
         self._update_status(total=total, shown=len(visible))
 
     def _schedule_deferred_detail_hydration(self, task_id: str) -> None:
-        """Defer ``_render_detail`` onto the next event-loop tick.
+        """Defer detail hydration onto a worker thread (#1969).
 
-        #1959 perf — the inbox initial-load completion callback runs on
-        the UI thread; calling ``_render_detail`` synchronously inside
-        that callback blocks first-paint on a work-service open + task
-        + replies + context fetch. Showing a "Loading…" placeholder and
-        scheduling the hydration via ``set_timer(0)`` lets the list
-        paint immediately; the timer fires in the next event-loop tick
-        and runs the same code path against the same task_id. If the
-        user has navigated away by then we skip hydration.
+        #1959 first deferred ``_render_detail`` by one event-loop tick
+        via ``set_timer(0)``, but the actual hydration callback still
+        ran synchronously on the UI thread — opening a work service,
+        calling ``svc.get`` / ``svc.list_replies`` / ``svc.get_context``,
+        then loading the inline review artifact off disk. On a project
+        with a cold sqlite cache that easily costs 100-400ms of blocked
+        keypresses while the j/k cursor input piles up behind the
+        Textual loop.
+
+        The fix (#1969) paints a "Loading…" placeholder synchronously
+        and runs the IO-heavy fetch on ``run_worker(thread=True)`` —
+        the same pattern ``_initial_load_sync`` already uses. The
+        worker hands its result back via ``call_from_thread`` to a
+        stale-guarded UI-thread applier; if the user navigated away
+        mid-fetch the result is discarded.
         """
         try:
             self.detail.update("[dim]Loading detail…[/dim]")
         except Exception:  # noqa: BLE001
             pass
 
-        def _hydrate() -> None:
-            # Cancellable / stale-result guard: only hydrate if the user
-            # is still on this row (no navigation away during the gap).
-            if self._selected_task_id != task_id:
-                return
+        # Remember which task the most-recent dispatch covers — the
+        # applier re-checks this in addition to ``_selected_task_id``
+        # so a queued-then-superseded worker callback can't paint stale
+        # data over a freshly-selected row.
+        self._pending_detail_hydration_task_id = task_id
+
+        try:
+            self.run_worker(
+                lambda: self._hydrate_detail_worker(task_id),
+                thread=True,
+                exclusive=True,
+                group="inbox_detail_hydrate",
+            )
+        except Exception:  # noqa: BLE001
+            # No event loop / worker dispatch failure (unit tests,
+            # teardown) — fall back to the synchronous path so the
+            # user isn't stranded on the placeholder.
             try:
-                self._render_detail(task_id)
+                if self._selected_task_id == task_id:
+                    self._render_detail(task_id)
             except Exception:  # noqa: BLE001
                 pass
 
+    def _hydrate_detail_worker(self, task_id: str) -> None:
+        """Off-thread fetch for the inbox detail pane (#1969).
+
+        Resolves task + replies + rollup items + inline review
+        artifact off the UI loop, then dispatches the apply step back
+        via ``call_from_thread``. All branches re-check the stale
+        guard before scheduling UI mutations: if the user navigated
+        away (``_selected_task_id`` no longer matches ``task_id``, or
+        a newer hydration dispatch superseded ours), the result is
+        discarded silently.
+        """
+        if self._selected_task_id != task_id:
+            return
+        if getattr(self, "_pending_detail_hydration_task_id", None) != task_id:
+            return
         try:
-            self.set_timer(0, _hydrate)
+            item = self._item_for_id(task_id)
         except Exception:  # noqa: BLE001
-            # Defensive: if the timer can't be scheduled (shutdown), fall
-            # back to the synchronous path so the user isn't stranded on
-            # the placeholder.
+            item = None
+        if item is None:
             try:
-                self._render_detail(task_id)
+                self.call_from_thread(
+                    self._apply_hydrated_detail_missing, task_id,
+                )
             except Exception:  # noqa: BLE001
                 pass
+            return
+        if not is_task_inbox_entry(item):
+            try:
+                self.call_from_thread(
+                    self._apply_hydrated_detail_message, task_id, item,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return
+
+        # Mirrors ``_detail_fetch_task_data`` but without any UI side
+        # effects — those run on the applier thread once we re-check
+        # the stale guard. We also pre-resolve the inline review
+        # artifact here because ``load_task_review_artifact`` is the
+        # other disk-hitting call ``_render_detail`` made on the UI
+        # loop pre-#1969.
+        project_key = task_id.split("/", 1)[0] if "/" in task_id else None
+        is_workspace = (
+            project_key is None
+            or project_key in {"inbox", "workspace", "[workspace]"}
+            or self._project_key_is_unknown(project_key)
+        )
+        try:
+            svc = self._resolve_inbox_svc(item, task_id)
+        except Exception:  # noqa: BLE001
+            svc = None
+        if svc is None:
+            try:
+                self.call_from_thread(
+                    self._apply_hydrated_detail_unresolved,
+                    task_id, item, is_workspace,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return
+
+        task = None
+        replies: list = []
+        rollup_items_raw: list = []
+        fetch_error: str | None = None
+        try:
+            task = svc.get(task_id)
+            replies = svc.list_replies(task_id)
+            rollup_items_raw = (
+                svc.get_context(task_id, entry_type="rollup_item")
+                if _task_is_rollup(task) else []
+            )
+        except Exception as exc:  # noqa: BLE001
+            fetch_error = str(exc)
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+        if fetch_error is not None or task is None:
+            try:
+                self.call_from_thread(
+                    self._apply_hydrated_detail_error,
+                    task_id, fetch_error or "task unavailable",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return
+
+        review_block: str | None = None
+        try:
+            review_block = self._render_inline_review_artifact(task)
+        except Exception:  # noqa: BLE001
+            review_block = None
+
+        try:
+            self.call_from_thread(
+                self._apply_hydrated_detail,
+                task_id, item, task, replies, rollup_items_raw, review_block,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _hydration_target_is_stale(self, task_id: str) -> bool:
+        """Return True if a queued hydration callback should be dropped."""
+        if self._selected_task_id != task_id:
+            return True
+        if getattr(self, "_pending_detail_hydration_task_id", None) != task_id:
+            return True
+        return False
+
+    def _apply_hydrated_detail(
+        self,
+        task_id: str,
+        item,
+        task,
+        replies: list,
+        rollup_items_raw: list,
+        review_block: str | None,
+    ) -> None:
+        """UI-thread applier for ``_hydrate_detail_worker``.
+
+        Mirrors the back half of ``_render_detail`` but consumes the
+        pre-fetched payload instead of doing IO inline. Stale-guard
+        first so we never paint data over a row the user moved off.
+        """
+        if self._hydration_target_is_stale(task_id):
+            return
+        self._set_reply_mode_for_task()
+        sections = self._detail_build_sections(task)
+        self._detail_append_thread(sections, replies)
+        self._detail_apply_label_hints(task, task_id, item, replies)
+        if review_block:
+            sections.append("")
+            sections.append("[dim]── review artifact ──[/dim]")
+            sections.append(review_block)
+        try:
+            self.detail.update("\n".join(sections))
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self._render_rollup_items(rollup_items_raw)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self.query_one("#inbox-detail-scroll", VerticalScroll).scroll_home(
+                animate=False,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _apply_hydrated_detail_missing(self, task_id: str) -> None:
+        if self._hydration_target_is_stale(task_id):
+            return
+        try:
+            self.detail.update("[red]Inbox item is no longer available.[/red]")
+        except Exception:  # noqa: BLE001
+            pass
+        self._clear_rollup_items()
+        self._set_reply_mode_for_task()
+
+    def _apply_hydrated_detail_message(self, task_id: str, item) -> None:
+        if self._hydration_target_is_stale(task_id):
+            return
+        try:
+            self._render_message_detail(item)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _apply_hydrated_detail_unresolved(
+        self, task_id: str, item, is_workspace: bool,
+    ) -> None:
+        if self._hydration_target_is_stale(task_id):
+            return
+        if is_workspace:
+            try:
+                self._render_message_detail(item)
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        try:
+            self.detail.update(
+                "[#f0c45a]This task lives in a project that is not "
+                "currently registered with PollyPM. Add the project from "
+                "the project picker to load its details here.[/#f0c45a]"
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        self._clear_rollup_items()
+
+    def _apply_hydrated_detail_error(self, task_id: str, error: str) -> None:
+        if self._hydration_target_is_stale(task_id):
+            return
+        try:
+            self.detail.update(f"[red]Error loading task: {error}[/red]")
+        except Exception:  # noqa: BLE001
+            pass
+        self._clear_rollup_items()
 
     def _update_status(self, *, total: int, shown: int) -> None:
         """Render the bottom counter strip — folds in active filters.

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -6797,6 +6797,16 @@ class PollyInboxApp(App[None]):
         replies: list = []
         rollup_items_raw: list = []
         fetch_error: str | None = None
+        # #1969 (Codex review on PR #2077): the plan-review detail path
+        # has TWO more disk/storage helpers that ran on the UI thread
+        # before this refactor — ``_plan_content_for_review`` (loads
+        # config + reads the canonical plan markdown off disk) and
+        # ``_plan_review_discussion_marker_exists`` (opens the work
+        # service and runs ``get_context``). Precompute both here on the
+        # worker thread so the applier consumes pure data and never
+        # touches the filesystem or the store.
+        plan_content_precomputed: str | None = None
+        discussion_marker_precomputed: bool | None = None
         try:
             task = svc.get(task_id)
             replies = svc.list_replies(task_id)
@@ -6804,6 +6814,45 @@ class PollyInboxApp(App[None]):
                 svc.get_context(task_id, entry_type="rollup_item")
                 if _task_is_rollup(task) else []
             )
+            task_labels_for_precompute = list(
+                getattr(task, "labels", []) or []
+            )
+            if "plan_review" in task_labels_for_precompute:
+                plan_review_meta_pre = _extract_plan_review_meta(
+                    task_labels_for_precompute,
+                )
+                try:
+                    plan_content_precomputed = _plan_content_for_review(
+                        plan_review_meta_pre,
+                        getattr(self, "config_path", None),
+                    )
+                except Exception:  # noqa: BLE001
+                    plan_content_precomputed = None
+                # Mirror the label-hint short-circuit: only resolve the
+                # discussion-marker store lookup when the reply thread
+                # doesn't already prove the round-trip.
+                requester_for_round_trip = (
+                    (task.roles or {}).get("requester", "user")
+                    if hasattr(task, "roles") else "user"
+                )
+                try:
+                    replies_round_trip = _plan_review_has_round_trip(
+                        replies, requester=requester_for_round_trip,
+                    )
+                except Exception:  # noqa: BLE001
+                    replies_round_trip = False
+                if replies_round_trip:
+                    discussion_marker_precomputed = True
+                else:
+                    try:
+                        marker_existing = svc.get_context(
+                            task_id,
+                            entry_type=_PLAN_REVIEW_DISCUSSION_ENTRY_TYPE,
+                            limit=1,
+                        )
+                        discussion_marker_precomputed = bool(marker_existing)
+                    except Exception:  # noqa: BLE001
+                        discussion_marker_precomputed = False
         except Exception as exc:  # noqa: BLE001
             fetch_error = str(exc)
         finally:
@@ -6832,6 +6881,7 @@ class PollyInboxApp(App[None]):
             self.call_from_thread(
                 self._apply_hydrated_detail,
                 task_id, item, task, replies, rollup_items_raw, review_block,
+                plan_content_precomputed, discussion_marker_precomputed,
             )
         except Exception:  # noqa: BLE001
             pass
@@ -6852,19 +6902,31 @@ class PollyInboxApp(App[None]):
         replies: list,
         rollup_items_raw: list,
         review_block: str | None,
+        plan_content_precomputed: str | None = None,
+        discussion_marker_precomputed: bool | None = None,
     ) -> None:
         """UI-thread applier for ``_hydrate_detail_worker``.
 
         Mirrors the back half of ``_render_detail`` but consumes the
         pre-fetched payload instead of doing IO inline. Stale-guard
         first so we never paint data over a row the user moved off.
+
+        ``plan_content_precomputed`` and ``discussion_marker_precomputed``
+        are populated by the worker for plan-review rows so the section
+        builder + label-hint applier never reach for the filesystem or
+        the work store on the UI loop (Codex review on PR #2077).
         """
         if self._hydration_target_is_stale(task_id):
             return
         self._set_reply_mode_for_task()
-        sections = self._detail_build_sections(task)
+        sections = self._detail_build_sections(
+            task, plan_content_precomputed=plan_content_precomputed,
+        )
         self._detail_append_thread(sections, replies)
-        self._detail_apply_label_hints(task, task_id, item, replies)
+        self._detail_apply_label_hints(
+            task, task_id, item, replies,
+            discussion_marker_precomputed=discussion_marker_precomputed,
+        )
         if review_block:
             sections.append("")
             sections.append("[dim]── review artifact ──[/dim]")
@@ -7822,8 +7884,21 @@ class PollyInboxApp(App[None]):
             except Exception:  # noqa: BLE001
                 pass
 
-    def _detail_build_sections(self, task) -> list[str]:
-        """Build the section list (header + meta + triage + body)."""
+    def _detail_build_sections(
+        self,
+        task,
+        *,
+        plan_content_precomputed: str | None = None,
+    ) -> list[str]:
+        """Build the section list (header + meta + triage + body).
+
+        When ``plan_content_precomputed`` is provided, the plan-review
+        body branch uses it directly instead of calling
+        ``_plan_content_for_review`` (which loads config + reads the
+        plan markdown off disk). The off-UI-loop hydration worker
+        (#1969 / PR #2077) passes this so plan-review formatting on the
+        Textual loop is pure.
+        """
         from pollypm.tz import format_relative
 
         updated_iso = (
@@ -7879,13 +7954,19 @@ class PollyInboxApp(App[None]):
         # Users on a remote TUI cannot click through to a local file.
         _task_labels_for_body = list(getattr(task, "labels", []) or [])
         if "plan_review" in _task_labels_for_body:
-            _plan_review_meta_for_body = _extract_plan_review_meta(
-                _task_labels_for_body,
-            )
-            _plan_text_for_body = _plan_content_for_review(
-                _plan_review_meta_for_body,
-                getattr(self, "config_path", None),
-            )
+            if plan_content_precomputed is not None:
+                # Hot path from the off-UI-loop hydration worker — the
+                # worker already loaded the plan content off disk so the
+                # applier never re-enters the file/config IO here.
+                _plan_text_for_body = plan_content_precomputed
+            else:
+                _plan_review_meta_for_body = _extract_plan_review_meta(
+                    _task_labels_for_body,
+                )
+                _plan_text_for_body = _plan_content_for_review(
+                    _plan_review_meta_for_body,
+                    getattr(self, "config_path", None),
+                )
             if _plan_text_for_body:
                 sections.append(
                     _md_to_rich(_escape_body(_plan_text_for_body))
@@ -7916,9 +7997,23 @@ class PollyInboxApp(App[None]):
             sections.append(_md_to_rich(_escape_body(entry.text)))
 
     def _detail_apply_label_hints(
-        self, task, task_id: str, item, replies: list,
+        self,
+        task,
+        task_id: str,
+        item,
+        replies: list,
+        *,
+        discussion_marker_precomputed: bool | None = None,
     ) -> None:
-        """Update the hint bar + state caches based on label-driven affordances."""
+        """Update the hint bar + state caches based on label-driven affordances.
+
+        When ``discussion_marker_precomputed`` is provided, the
+        plan-review round-trip resolution uses it directly instead of
+        opening a work service and running ``get_context`` on the UI
+        thread (Codex review on PR #2077). The off-UI-loop hydration
+        worker passes the precomputed boolean so this method stays
+        pure UI-state mutation on the Textual loop.
+        """
         # Improvement-proposal detection (#275). Proposal items carry a
         # ``proposal`` label; when present, swap the hint bar for the
         # accept/reject keybindings. The body itself already embeds the
@@ -7937,13 +8032,20 @@ class PollyInboxApp(App[None]):
         if _is_plan_review:
             meta = _extract_plan_review_meta(_labels)
             self._plan_review_meta[task_id] = meta
-            round_trip = _plan_review_has_round_trip(
-                replies, requester=(task.roles or {}).get("requester", "user"),
-            )
-            if not round_trip:
-                round_trip = self._plan_review_discussion_marker_exists(
-                    item, task_id,
+            if discussion_marker_precomputed is not None:
+                # Worker pre-resolved the round-trip (reply heuristic
+                # OR the store-backed discussion marker) so the applier
+                # never opens a work service on the UI loop.
+                round_trip = bool(discussion_marker_precomputed)
+            else:
+                round_trip = _plan_review_has_round_trip(
+                    replies,
+                    requester=(task.roles or {}).get("requester", "user"),
                 )
+                if not round_trip:
+                    round_trip = self._plan_review_discussion_marker_exists(
+                        item, task_id,
+                    )
             self._plan_review_round_trip[task_id] = round_trip
             self._update_hint_for_plan_review(
                 fast_track=meta.get("fast_track", False),

--- a/tests/test_inbox_detail_hydration_off_ui_loop.py
+++ b/tests/test_inbox_detail_hydration_off_ui_loop.py
@@ -1,0 +1,333 @@
+"""Regression tests for #1969 — inbox detail hydration must not block
+the Textual UI loop.
+
+#1959 deferred the synchronous ``_render_detail`` by one event-loop
+tick via ``set_timer(0)``, but the timer callback still ran the
+work-service open + task/replies/context fetch + inline-review-
+artifact disk read inline on the UI thread. On a project with a cold
+sqlite cache that costs 100-400ms of blocked keypresses while the
+j/k cursor input piles up behind the Textual loop.
+
+The fix moves the IO-heavy fetches onto
+``run_worker(thread=True, exclusive=True)`` and applies the result
+via ``call_from_thread`` with a stale-guard so a worker callback
+whose target was navigated away cannot paint stale data over the
+freshly-selected row.
+
+These tests exercise the unit-level invariants of that fix:
+
+* ``_schedule_deferred_detail_hydration`` records the dispatched
+  ``task_id``, paints the placeholder, and calls ``run_worker``
+  (instead of invoking ``_render_detail`` inline).
+* The off-thread worker resolves the work service + fetches data
+  + dispatches the apply via ``call_from_thread`` — the UI thread
+  is never blocked.
+* The applier honours the stale-guard: if ``_selected_task_id``
+  shifts mid-fetch, the result is discarded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_inbox_app(tmp_path: Path):
+    """Construct a ``PollyInboxApp`` via ``__new__`` with the
+    minimum attribute surface the hydration codepath touches.
+
+    Mirrors the pattern other ``test_cockpit.py`` cases use to drive
+    pure method-level invariants without booting the full Textual
+    harness.
+    """
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    app = PollyInboxApp.__new__(PollyInboxApp)
+    app.config_path = tmp_path / "pollypm.toml"
+    app._selected_task_id = None
+    app._selected_row_key = None
+    app._pending_detail_hydration_task_id = None
+    app._tasks = []
+    app._replies_by_task = {}
+    app._unread_ids = set()
+    app._plan_review_meta = {}
+    app._plan_review_round_trip = {}
+    app._blocking_question_meta = {}
+    app._proposal_specs = {}
+    app._rollup_items = []
+    app._rollup_expanded = set()
+    app._rollup_show_all = False
+    app._rollup_focused_index = None
+
+    # Capture the most-recent placeholder so the test can assert it
+    # was painted synchronously before the worker dispatch.
+    detail_writes: list[str] = []
+
+    class _DetailStub:
+        def update(self, value: str) -> None:
+            detail_writes.append(value)
+
+    app.detail = _DetailStub()
+    app._detail_writes = detail_writes  # type: ignore[attr-defined]
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Placeholder + dispatch invariants
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_deferred_hydration_dispatches_worker_not_inline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deferred-hydration entrypoint paints the placeholder and
+    hands off to ``run_worker`` — it must NOT call ``_render_detail``
+    inline on the UI thread (the #1959 regression that #1969 fixes).
+    """
+    app = _make_inbox_app(tmp_path)
+    app._selected_task_id = "proj/task-123"
+
+    worker_dispatches: list[dict] = []
+
+    def fake_run_worker(fn, **kwargs):
+        worker_dispatches.append({"fn": fn, "kwargs": kwargs})
+
+    app.run_worker = fake_run_worker  # type: ignore[method-assign]
+
+    render_detail_calls: list[str] = []
+
+    def fake_render_detail(task_id: str, **kwargs) -> None:
+        render_detail_calls.append(task_id)
+
+    app._render_detail = fake_render_detail  # type: ignore[method-assign]
+
+    app._schedule_deferred_detail_hydration("proj/task-123")
+
+    # Placeholder painted synchronously.
+    assert app._detail_writes == ["[dim]Loading detail…[/dim]"]
+
+    # Worker dispatched — exclusive thread-mode in the inbox group.
+    assert len(worker_dispatches) == 1
+    kwargs = worker_dispatches[0]["kwargs"]
+    assert kwargs.get("thread") is True
+    assert kwargs.get("exclusive") is True
+    assert kwargs.get("group") == "inbox_detail_hydrate"
+
+    # CRITICAL: ``_render_detail`` was NOT called inline.
+    assert render_detail_calls == []
+
+    # Pending task id recorded so a superseded callback can drop.
+    assert app._pending_detail_hydration_task_id == "proj/task-123"
+
+
+def test_schedule_deferred_hydration_falls_back_when_worker_dispatch_fails(
+    tmp_path: Path,
+) -> None:
+    """If ``run_worker`` raises (no event loop, teardown), we still
+    paint a useful detail rather than leaving the user stranded on
+    the loading placeholder — match the #1959 fallback shape.
+    """
+    app = _make_inbox_app(tmp_path)
+    app._selected_task_id = "proj/task-789"
+
+    def boom_run_worker(*args, **kwargs):
+        raise RuntimeError("no event loop")
+
+    app.run_worker = boom_run_worker  # type: ignore[method-assign]
+
+    fallback_calls: list[str] = []
+
+    def fake_render_detail(task_id: str, **kwargs) -> None:
+        fallback_calls.append(task_id)
+
+    app._render_detail = fake_render_detail  # type: ignore[method-assign]
+
+    app._schedule_deferred_detail_hydration("proj/task-789")
+
+    # Placeholder still painted, then synchronous fallback fires.
+    assert app._detail_writes == ["[dim]Loading detail…[/dim]"]
+    assert fallback_calls == ["proj/task-789"]
+
+
+# ---------------------------------------------------------------------------
+# Worker thread does not touch the UI directly
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_detail_worker_routes_through_call_from_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The worker body must dispatch every UI mutation via
+    ``call_from_thread``; direct widget calls from a thread would
+    race the Textual loop.
+    """
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    app = _make_inbox_app(tmp_path)
+    app._selected_task_id = "proj/task-456"
+    app._pending_detail_hydration_task_id = "proj/task-456"
+
+    item = SimpleNamespace(
+        task_id="proj/task-456",
+        project="proj",
+        description="x",
+        title="y",
+        labels=[],
+        roles={},
+    )
+    # Make ``_item_for_id`` return our item without scanning ``_tasks``.
+    app._item_for_id = lambda _id: item  # type: ignore[method-assign]
+    app._project_key_is_unknown = lambda _key: False  # type: ignore[method-assign]
+
+    # ``is_task_inbox_entry`` is module-level — patch it for this test.
+    monkeypatch.setattr(
+        "pollypm.cockpit_ui.is_task_inbox_entry",
+        lambda _item: True,
+    )
+
+    svc = MagicMock()
+    svc.get.return_value = SimpleNamespace(
+        task_id="proj/task-456",
+        title="hydrated",
+        description="body",
+        project="proj",
+        priority=SimpleNamespace(value="normal"),
+        labels=[],
+        roles={},
+        updated_at=None,
+        created_at=None,
+        triage_bucket="action",
+    )
+    svc.list_replies.return_value = []
+    svc.get_context.return_value = []
+    app._resolve_inbox_svc = lambda *_a, **_kw: svc  # type: ignore[method-assign]
+
+    # Avoid the disk-touching review artifact path in this unit test.
+    app._render_inline_review_artifact = lambda _task: None  # type: ignore[method-assign]
+
+    call_from_thread_dispatches: list[tuple] = []
+
+    def fake_call_from_thread(fn, *args, **kwargs):
+        call_from_thread_dispatches.append((fn, args, kwargs))
+
+    app.call_from_thread = fake_call_from_thread  # type: ignore[method-assign]
+
+    app._hydrate_detail_worker("proj/task-456")
+
+    # Exactly one dispatch — the success path applier.
+    assert len(call_from_thread_dispatches) == 1
+    fn, args, _ = call_from_thread_dispatches[0]
+    assert fn == app._apply_hydrated_detail
+    # task_id is the first positional arg passed through.
+    assert args[0] == "proj/task-456"
+    # The svc was opened + closed cleanly.
+    assert svc.close.called
+
+
+def test_hydrate_detail_worker_short_circuits_when_selection_changed(
+    tmp_path: Path,
+) -> None:
+    """Stale-guard at worker entry: if the user already moved away,
+    the worker bails before opening the work service.
+    """
+    app = _make_inbox_app(tmp_path)
+    app._selected_task_id = "proj/task-NEW"
+    app._pending_detail_hydration_task_id = "proj/task-OLD"
+
+    resolve_calls: list = []
+    app._resolve_inbox_svc = lambda *a, **kw: resolve_calls.append(a) or None  # type: ignore[method-assign]
+
+    call_from_thread_dispatches: list[tuple] = []
+    app.call_from_thread = lambda fn, *a, **kw: call_from_thread_dispatches.append((fn, a))  # type: ignore[method-assign]
+
+    app._hydrate_detail_worker("proj/task-OLD")
+
+    # No svc resolve attempted; no UI applier scheduled.
+    assert resolve_calls == []
+    assert call_from_thread_dispatches == []
+
+
+# ---------------------------------------------------------------------------
+# Applier honours the stale-guard
+# ---------------------------------------------------------------------------
+
+
+def test_apply_hydrated_detail_discards_when_selection_changed(
+    tmp_path: Path,
+) -> None:
+    """If the selection shifts between worker dispatch and applier
+    execution, the result is dropped — no stale paint over the
+    freshly-selected row.
+    """
+    app = _make_inbox_app(tmp_path)
+    # Simulate the user navigated to a different row mid-fetch.
+    app._selected_task_id = "proj/task-NEW"
+    app._pending_detail_hydration_task_id = "proj/task-OLD"
+
+    # If the applier guards correctly it never touches these helpers.
+    app._set_reply_mode_for_task = MagicMock()  # type: ignore[method-assign]
+    app._detail_build_sections = MagicMock()  # type: ignore[method-assign]
+    app._detail_append_thread = MagicMock()  # type: ignore[method-assign]
+    app._detail_apply_label_hints = MagicMock()  # type: ignore[method-assign]
+    app._render_rollup_items = MagicMock()  # type: ignore[method-assign]
+
+    app._apply_hydrated_detail(
+        "proj/task-OLD",
+        item=SimpleNamespace(),
+        task=SimpleNamespace(),
+        replies=[],
+        rollup_items_raw=[],
+        review_block=None,
+    )
+
+    app._set_reply_mode_for_task.assert_not_called()
+    app._detail_build_sections.assert_not_called()
+    app._detail_append_thread.assert_not_called()
+    app._detail_apply_label_hints.assert_not_called()
+    app._render_rollup_items.assert_not_called()
+    # detail.update never invoked either.
+    assert app._detail_writes == []
+
+
+def test_apply_hydrated_detail_renders_when_selection_still_matches(
+    tmp_path: Path,
+) -> None:
+    """Happy path: selection still on the dispatched task — the
+    applier builds sections and updates the detail pane.
+    """
+    app = _make_inbox_app(tmp_path)
+    app._selected_task_id = "proj/task-OK"
+    app._pending_detail_hydration_task_id = "proj/task-OK"
+
+    app._set_reply_mode_for_task = MagicMock()  # type: ignore[method-assign]
+    app._detail_build_sections = MagicMock(return_value=["header", "body"])  # type: ignore[method-assign]
+    app._detail_append_thread = MagicMock()  # type: ignore[method-assign]
+    app._detail_apply_label_hints = MagicMock()  # type: ignore[method-assign]
+    app._render_rollup_items = MagicMock()  # type: ignore[method-assign]
+    app.query_one = MagicMock(side_effect=Exception("no UI"))  # type: ignore[method-assign]
+
+    app._apply_hydrated_detail(
+        "proj/task-OK",
+        item=SimpleNamespace(),
+        task=SimpleNamespace(),
+        replies=[],
+        rollup_items_raw=[],
+        review_block="review-text",
+    )
+
+    app._set_reply_mode_for_task.assert_called_once()
+    app._detail_build_sections.assert_called_once()
+    app._detail_append_thread.assert_called_once()
+    app._detail_apply_label_hints.assert_called_once()
+    app._render_rollup_items.assert_called_once_with([])
+    # Detail update painted the joined sections, with review_block
+    # appended under its banner.
+    assert len(app._detail_writes) == 1
+    painted = app._detail_writes[0]
+    assert "header" in painted
+    assert "review artifact" in painted
+    assert "review-text" in painted

--- a/tests/test_inbox_detail_hydration_off_ui_loop.py
+++ b/tests/test_inbox_detail_hydration_off_ui_loop.py
@@ -331,3 +331,237 @@ def test_apply_hydrated_detail_renders_when_selection_still_matches(
     assert "header" in painted
     assert "review artifact" in painted
     assert "review-text" in painted
+
+
+# ---------------------------------------------------------------------------
+# Plan-review precomputed-payload invariants (Codex review on PR #2077)
+# ---------------------------------------------------------------------------
+
+
+def test_plan_review_hydration_precomputes_disk_and_store_lookups_off_ui_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plan-review hydration must NOT call ``_plan_content_for_review``
+    or ``_plan_review_discussion_marker_exists`` from the UI-thread
+    applier — both have to be precomputed inside the worker so
+    ``_apply_hydrated_detail`` stays pure formatting.
+
+    Regression for the Codex review comment on PR #2077: even after
+    #1969 deferred the work-service open + task fetch, the
+    plan-review detail still leaked filesystem (canonical plan
+    markdown load + config load) and store (work-service
+    ``get_context``) calls into the section-builder + label-hint
+    applier when the worker callback ran.
+    """
+    from pollypm import cockpit_ui as cockpit_ui_module
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    app = _make_inbox_app(tmp_path)
+    app._selected_task_id = "proj/plan-task-1"
+    app._pending_detail_hydration_task_id = "proj/plan-task-1"
+
+    item = SimpleNamespace(
+        task_id="proj/plan-task-1",
+        project="proj",
+        description="plan body",
+        title="Plan review",
+        labels=["plan_review", "project:proj"],
+        roles={"requester": "user"},
+    )
+    app._item_for_id = lambda _id: item  # type: ignore[method-assign]
+    app._project_key_is_unknown = lambda _key: False  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "pollypm.cockpit_ui.is_task_inbox_entry",
+        lambda _item: True,
+    )
+
+    plan_task = SimpleNamespace(
+        task_id="proj/plan-task-1",
+        title="Plan review",
+        description="plan body",
+        project="proj",
+        priority=SimpleNamespace(value="normal"),
+        labels=["plan_review", "project:proj"],
+        roles={"requester": "user"},
+        updated_at=None,
+        created_at=None,
+        triage_bucket="action",
+    )
+
+    # Work service: ``get_context`` is invoked from the worker for
+    # both the rollup-items branch (skipped — task is not a rollup)
+    # and the discussion-marker branch (the precompute we're verifying
+    # lives off the UI loop). Mock returns [] so the marker resolves
+    # to False without raising.
+    svc = MagicMock()
+    svc.get.return_value = plan_task
+    svc.list_replies.return_value = []
+    svc.get_context.return_value = []
+    app._resolve_inbox_svc = lambda *_a, **_kw: svc  # type: ignore[method-assign]
+    app._render_inline_review_artifact = lambda _task: None  # type: ignore[method-assign]
+
+    # Avoid the rollup branch entirely.
+    monkeypatch.setattr(
+        "pollypm.cockpit_ui._task_is_rollup", lambda _t: False,
+    )
+
+    # Counter-stubs for the two helpers Codex flagged. We assert these
+    # are touched ONLY during the worker run (not during the applier).
+    plan_content_calls: list[tuple] = []
+
+    def fake_plan_content_for_review(meta, config_path):
+        plan_content_calls.append((dict(meta or {}), config_path))
+        return "## plan body precomputed off UI loop"
+
+    # ``_plan_content_for_review`` is imported into ``cockpit_ui`` at
+    # module load time — patch the binding callers actually resolve.
+    monkeypatch.setattr(
+        cockpit_ui_module,
+        "_plan_content_for_review",
+        fake_plan_content_for_review,
+    )
+
+    discussion_marker_calls: list[tuple] = []
+
+    def fake_discussion_marker_exists(_self, _item, _task_id):
+        discussion_marker_calls.append((_item, _task_id))
+        return False
+
+    monkeypatch.setattr(
+        PollyInboxApp,
+        "_plan_review_discussion_marker_exists",
+        fake_discussion_marker_exists,
+    )
+
+    # Capture the payload the worker dispatches to the applier so we
+    # can replay it without going through ``call_from_thread``.
+    dispatches: list[tuple] = []
+    app.call_from_thread = lambda fn, *a, **kw: dispatches.append((fn, a, kw))  # type: ignore[method-assign]
+
+    # --- WORKER PHASE -----------------------------------------------------
+    app._hydrate_detail_worker("proj/plan-task-1")
+
+    # Worker must have precomputed the plan content off the UI loop.
+    assert len(plan_content_calls) == 1, (
+        "expected _plan_content_for_review to fire exactly once — "
+        "from the worker thread, precomputing the plan body for the "
+        "applier"
+    )
+    # Worker must have precomputed the discussion-marker via the work
+    # service — replies are empty so the round-trip heuristic fell
+    # through to the store lookup. The worker uses ``svc.get_context``
+    # directly (not the helper method on the app) to avoid re-opening
+    # a second work service, so we assert the svc surface here AND
+    # confirm the helper method itself was NEVER reached on either
+    # the worker OR the applier path.
+    marker_get_context_calls = [
+        call for call in svc.get_context.call_args_list
+        if call.kwargs.get("entry_type") == "plan_review_discussed"
+    ]
+    assert len(marker_get_context_calls) == 1, (
+        "expected exactly one svc.get_context call with the plan-"
+        "review discussion entry-type — the worker's precompute"
+    )
+    assert discussion_marker_calls == [], (
+        "the dedicated _plan_review_discussion_marker_exists helper "
+        "must NOT be invoked from either the worker or the applier "
+        "(the worker calls svc.get_context directly to avoid opening "
+        "a second work service)"
+    )
+
+    # Exactly one dispatch — the success-path applier — with the
+    # precomputed plan content + discussion-marker bool in the
+    # positional payload.
+    assert len(dispatches) == 1
+    fn, args, _ = dispatches[0]
+    assert fn == app._apply_hydrated_detail
+    # Positional layout: task_id, item, task, replies, rollup, review_block,
+    # plan_content_precomputed, discussion_marker_precomputed
+    assert args[0] == "proj/plan-task-1"
+    assert args[6] == "## plan body precomputed off UI loop"
+    assert args[7] is False
+
+    # --- APPLIER PHASE ----------------------------------------------------
+    # Reset counters so the next phase's assertions only see calls
+    # made by the applier itself.
+    plan_content_calls.clear()
+    discussion_marker_calls.clear()
+    svc.get_context.reset_mock()
+
+    # Stub helpers the applier reaches that aren't relevant to the
+    # disk/store invariant we're asserting. We replace the section
+    # builder + label-hint applier with capture-stubs so we can
+    # assert the precomputed payload reached them — and so the
+    # underlying ``_format_sender`` / ``_resolve_pm_target`` chain
+    # (which expects more attrs than this SimpleNamespace carries)
+    # does not run inside the unit test.
+    build_section_calls: list[dict] = []
+
+    def fake_build_sections(_task, **kwargs):
+        build_section_calls.append(kwargs)
+        return ["[plan-review-header]", kwargs.get("plan_content_precomputed", "")]
+
+    app._detail_build_sections = fake_build_sections  # type: ignore[method-assign]
+
+    label_hint_calls: list[dict] = []
+
+    def fake_label_hints(_task, _task_id, _item, _replies, **kwargs):
+        label_hint_calls.append(kwargs)
+        # Mirror the real applier's round-trip state write so we can
+        # assert the precomputed bool flowed through, not a re-lookup.
+        marker = kwargs.get("discussion_marker_precomputed")
+        if marker is not None:
+            app._plan_review_round_trip[_task_id] = bool(marker)
+
+    app._detail_apply_label_hints = fake_label_hints  # type: ignore[method-assign]
+
+    app._render_rollup_items = MagicMock()  # type: ignore[method-assign]
+    app.query_one = MagicMock(side_effect=Exception("no UI in unit test"))  # type: ignore[method-assign]
+    app._set_reply_mode_for_task = MagicMock()  # type: ignore[method-assign]
+
+    # Replay the worker's payload synchronously — this is what
+    # ``call_from_thread`` would do on the UI loop.
+    fn(*args)
+
+    # CRITICAL: neither disk nor store helper is touched during the
+    # applier. All the plan-review content + round-trip state came
+    # from the precomputed payload.
+    assert plan_content_calls == [], (
+        "_plan_content_for_review fired during _apply_hydrated_detail "
+        "— plan-review hydration is leaking filesystem IO back onto "
+        "the Textual UI loop"
+    )
+    assert discussion_marker_calls == [], (
+        "_plan_review_discussion_marker_exists fired during "
+        "_apply_hydrated_detail — plan-review hydration is leaking "
+        "work-service IO back onto the Textual UI loop"
+    )
+    marker_get_context_calls_during_apply = [
+        call for call in svc.get_context.call_args_list
+        if call.kwargs.get("entry_type") == "plan_review_discussed"
+    ]
+    assert marker_get_context_calls_during_apply == [], (
+        "svc.get_context for the plan-review discussion marker fired "
+        "during the applier — the worker's precompute is being "
+        "bypassed"
+    )
+
+    # The applier forwarded the precomputed payload into the section
+    # builder + label-hint applier.
+    assert len(build_section_calls) == 1
+    assert (
+        build_section_calls[0].get("plan_content_precomputed")
+        == "## plan body precomputed off UI loop"
+    )
+    assert len(label_hint_calls) == 1
+    assert label_hint_calls[0].get("discussion_marker_precomputed") is False
+
+    # Applier produced output and surfaced the precomputed plan body
+    # in the rendered detail pane.
+    assert len(app._detail_writes) == 1
+    painted = app._detail_writes[0]
+    assert "plan body precomputed off UI loop" in painted
+
+    # Round-trip state was set from the precomputed bool (False here:
+    # no replies, store-marker absent), not by re-running the lookup.
+    assert app._plan_review_round_trip.get("proj/plan-task-1") is False


### PR DESCRIPTION
## Summary

- #1959 deferred ``_render_detail`` by one event-loop tick via ``set_timer(0)``, but the hydration callback still ran the work-service open + ``svc.get`` / ``svc.list_replies`` / ``svc.get_context`` + inline review-artifact disk read inline on the UI thread — easily 100-400ms of blocked keypresses on a cold sqlite cache. After clicking an Inbox row the next loop tick could still freeze the pane for the same slow fetch.
- Placeholder (``[dim]Loading detail…[/dim]``) now paints synchronously; the IO-heavy fetch runs on ``run_worker(thread=True, exclusive=True, group=\"inbox_detail_hydrate\")`` (the same pattern ``_initial_load_sync`` already uses).
- The worker dispatches the apply step back to the UI thread via ``call_from_thread`` to a stale-guarded applier that re-checks both ``_selected_task_id`` and a new ``_pending_detail_hydration_task_id`` token. If the user navigated away mid-fetch (or a newer dispatch superseded the in-flight one), the result is discarded silently — no stale paint over the freshly-selected row.
- The inline review-artifact load (``load_task_review_artifact``) is also moved off the UI loop — it was the other disk-hitting call ``_render_detail`` made post-#1959.

## Test plan

- [x] New ``tests/test_inbox_detail_hydration_off_ui_loop.py`` — 6 regression tests, all passing:
  - placeholder painted synchronously + worker dispatched with the right ``thread`` / ``exclusive`` / ``group`` kwargs (and ``_render_detail`` NOT invoked inline)
  - ``run_worker`` dispatch-failure falls back to the synchronous path so the user isn't stranded on the placeholder
  - worker body routes every UI mutation through ``call_from_thread``; svc opened + closed cleanly
  - stale-guard at worker entry skips the svc resolve when ``_selected_task_id`` already moved
  - applier discards mid-fetch selection changes (no widget calls)
  - applier renders sections + review-artifact block on the happy path
- [x] Existing inbox + cockpit tests still pass (``test_cockpit_inbox_threads.py``, ``test_cockpit.py -k 'inbox or hydrate or render_detail'`` → 13 + 2 passed)
- [ ] Manual sanity check: open cockpit inbox, hit ``j``/``k`` rapidly after a row selection — keypresses should land instantly while the detail pane shows the placeholder then swaps to content