### PR TITLE
fix(state-cache): route workspace-root inbox into cache via __workspace__ entry (closes #2051)

### DIFF
--- a/docs/design/move-a-state-cache.md
+++ b/docs/design/move-a-state-cache.md
@@ -1,12 +1,20 @@
 # Move A — In-Process Project-State Cache with Epoch-Driven Invalidation
 
-## Implementation drift (2026-05-22)
+## Implementation drift (2026-05-22, updated 2026-05-23)
 
-The shipped Move A behavior diverges from the original design in three places. This section is the source of truth; the original sections below are kept for historical context but should be read as superseded where they conflict.
+The shipped Move A behavior diverges from the original design in two places. This section is the source of truth; the original sections below are kept for historical context but should be read as superseded where they conflict.
 
 - `latest_heartbeat_by_session` is reserved on `ProjectStateCacheEntry` but NOT populated. Rail heartbeat sites read `pollypm.storage.pg_heartbeats.latest_heartbeat` directly via `CockpitRouter._latest_heartbeat_cached`. Bulk prefetch + cache invalidation deferred to [#2050](https://github.com/samhotchkiss/pollypm/issues/2050).
 - `_maybe_cache_route_rollups` declines (returns `None`) when any tracked project has a live actionable alert — cache cannot recompute the alert-to-rollup contract. Tracked in [#2049](https://github.com/samhotchkiss/pollypm/issues/2049).
-- `_maybe_cache_route_awaits_user` / `_maybe_cache_count_awaits_user` decline when the workspace-root inbox has any open message (via `has_workspace_root_open_messages` probe). Workspace-root inbox isn't yet represented in cache entries. Tracked in [#2051](https://github.com/samhotchkiss/pollypm/issues/2051).
+
+### Workspace-root inbox is now cache-routed (#2051 — closed by PR #2078)
+
+The third drift item from the original list (workspace-root inbox not represented in cache entries) is closed by PR #2078. The shipped behavior:
+
+- Workspace-root awaits-user rows (`messages` with `scope IN ('', 'inbox')`, surfaced as `project == "inbox"` after `message_row_to_inbox_entry`) are represented in the cache via a **synthetic `__workspace__` entry**. The sentinel key (`WORKSPACE_PROJECT_KEY = "__workspace__"`) and TTL constant (`WORKSPACE_ENTRY_TTL_SECONDS = 10.0`) live in `pollypm.state_cache.entry` so the refresher, refresh-impl, `cockpit_inbox`, and tests all share one source of truth.
+- The refresher's project-keys provider always includes the sentinel, so the synthetic entry is computed on boot and on every full pass. `StateCacheRefresher._dispatch_event` invalidates `__workspace__` on every event in `_INVALIDATING_EVENTS` so workspace-root invalidations never lag the per-project ones.
+- The earlier `has_workspace_root_open_messages` probe and the forced fall-through it gated are **removed**. `_maybe_cache_route_awaits_user` / `_maybe_cache_count_awaits_user` now union the `__workspace__` entry with the per-project entries directly; the cache is authoritative for workspace-root rows.
+- The sentinel carries a **bounded-staleness TTL** (`WORKSPACE_ENTRY_TTL_SECONDS = 10s`). Several message-store paths (`PgStore.close_message`, `PgStore.clear_alert`, `service_api.v1.clear_alert`) mutate workspace-root awaits-user rows without emitting a state-cache audit event, so the refresher doesn't see those closes. The TTL caps the staleness window — once the sentinel ages past the TTL, the cache-read boundary falls through to the direct sweep. Full audit-event wiring for the message-store close/clear paths is deferred past v1 RC; the TTL is a documented bounded-staleness window, not an invariant.
 
 Design document for issue [#1664](https://github.com/samhotchkiss/pollypm/issues/1664).
 Status: **implemented** (2026-05-20) — PR 1 #2000, PR 2 #2016, PR 3 #2026, PR 4 #2029.

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -230,54 +230,6 @@ def pm_inbox_awaits_user_list(config) -> list[object]:
     return result
 
 
-def _workspace_root_inbox_has_open(config) -> bool:
-    """True iff there is at least one open workspace-root inbox row.
-
-    "Workspace-root" = messages with ``scope IN ('', 'inbox')`` —
-    these are NOT keyed to any tracked project, so the refresher's
-    per-project filter in
-    ``state_cache/refresh_impl.py::_awaits_user_items_for`` drops them
-    on the floor. The cache's per-project entries can never represent
-    them, so any cache-routed read MUST fall through whenever the
-    workspace-root inbox is non-empty.
-
-    Filed as a follow-up issue (PR #2026 review blocker 3): teach the
-    cache to carry a workspace-root entry so this gate can go away.
-
-    PR #2026 v3 (Codex re-review): delegates to the dedicated SQL
-    existence query :func:`pollypm.cockpit_pg_aggregates.has_workspace_root_open_messages`
-    so the answer no longer depends on whether the newest N rows happen
-    to include a workspace-root row. The old ``open_messages(limit=50)``
-    + Python-side scan path silently dropped workspace work whenever 50+
-    newer project-scoped rows pushed the workspace-root row out of the
-    window.
-
-    Returns True on any failure (import or probe). Conservative — forces
-    cache fall-through. A false positive here is safe (the direct sweep
-    just runs); a false negative would silently drop workspace-root work,
-    violating the cache-authoritative invariant.
-    """
-
-    try:
-        from pollypm.cockpit_pg_aggregates import (
-            has_workspace_root_open_messages,
-        )
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "workspace-root inbox probe import failed; assuming inbox is non-empty to force conservative cache decline",
-            exc_info=True,
-        )
-        return True
-    try:
-        return bool(has_workspace_root_open_messages(config))
-    except Exception:
-        logger.warning(
-            "workspace-root inbox probe failed; assuming inbox is non-empty to force cache fall-through",
-            exc_info=True,
-        )
-        return True  # conservative: force cache decline
-
-
 def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     """Return the cache-routed result, or ``None`` to fall through.
 
@@ -292,16 +244,21 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
       serve cross-config data when project keys overlap; the
       config-identity stamp catches this).
     * Any tracked project is missing from the snapshot (partial cache).
-    * Any workspace-root awaits-user message exists live (PR #2026
-      review blocker 3) — the refresher does not project workspace-root
-      messages into any per-project entry, so the cache cannot
-      represent them and a partial answer would silently drop them
-      from the rail badge / inbox count.
     * Any unexpected exception (defensive — broken cache must never
       crash the rail badge).
 
+    #2051: workspace-root awaits-user messages (``scope IN ('',
+    'inbox')``) now live on a synthetic ``__workspace__`` cache entry
+    emitted by the refresher (see
+    :data:`pollypm.state_cache.refresh_impl.WORKSPACE_PROJECT_KEY`).
+    This helper unions those items with the per-project ones so the
+    rail badge / inbox count include them. The earlier
+    ``_workspace_root_inbox_has_open`` probe + its forced
+    fall-through were removed — the cache is now authoritative for
+    workspace-root rows too.
+
     Cache lookup; fall through to direct path on cache miss / cache
-    disabled / config-identity mismatch / workspace-root inbox row.
+    disabled / config-identity mismatch.
     """
 
     try:
@@ -350,14 +307,19 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     # project's items are included.
     if not known_projects.issubset(snapshot.keys()):
         return None
-    # Workspace-root guard (PR #2026 review blocker 3): the refresher
-    # only projects per-project messages, so any open workspace-root
-    # inbox row would be missing from the cache. Defer to the direct
-    # path whenever one exists.
-    if _workspace_root_inbox_has_open(config):
-        return None
     cached_items: list[object] = []
+    # #2051: the synthetic ``__workspace__`` entry carries workspace-root
+    # awaits-user items (messages with ``scope IN ('', 'inbox')`` that
+    # don't belong to any tracked project). Union them first so the
+    # returned list mirrors the direct sweep's content.
+    from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
+    workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
+    if workspace_entry is not None:
+        for item in getattr(workspace_entry, "awaits_user_items", ()) or ():
+            cached_items.append(item)
     for project_key, entry in snapshot.items():
+        if project_key == WORKSPACE_PROJECT_KEY:
+            continue
         if project_key not in known_projects:
             # The cache may carry an entry for a project that was just
             # untracked. Skip — the direct path also drops it.
@@ -549,11 +511,12 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     the rail badge would silently drop work that's still waiting on
     the user.
 
-    Workspace-root fall-through (PR #2026 review blocker 3): the
-    refresher does not project workspace-root inbox messages
-    (``scope IN ('', 'inbox')``) into any per-project entry, so the
-    cached sum would silently under-count them. Defer to the direct
-    sweep whenever the workspace-root inbox is non-empty.
+    #2051: workspace-root awaits-user rows (``scope IN ('', 'inbox')``)
+    are summed from the synthetic ``__workspace__`` cache entry
+    emitted by the refresher (see
+    :data:`pollypm.state_cache.refresh_impl.WORKSPACE_PROJECT_KEY`).
+    The earlier workspace-root probe + forced fall-through were
+    removed; the cache is now authoritative for those rows too.
     """
 
     try:
@@ -590,12 +553,17 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     # direct path so the badge stays correct during the boot-time gap.
     if not known_projects.issubset(snapshot.keys()):
         return None
-    # Workspace-root guard (PR #2026 review blocker 3): see
-    # ``_maybe_cache_route_awaits_user`` for rationale.
-    if _workspace_root_inbox_has_open(config):
-        return None
     total = 0
+    # #2051: pull the workspace-root awaits-user count off the
+    # synthetic ``__workspace__`` entry. Absent entry (cold workspace
+    # path, or sentinel never refreshed) contributes 0.
+    from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
+    workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
+    if workspace_entry is not None:
+        total += int(getattr(workspace_entry, "awaits_user_count", 0) or 0)
     for project_key, entry in snapshot.items():
+        if project_key == WORKSPACE_PROJECT_KEY:
+            continue
         if project_key not in known_projects:
             continue
         total += int(getattr(entry, "awaits_user_count", 0) or 0)

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -321,15 +321,35 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
     if WORKSPACE_PROJECT_KEY not in snapshot:
         return None
+    # #2051 round-3 (Codex review): bounded-staleness guard. Once the
+    # refresher has installed an EMPTY ``__workspace__`` entry (no
+    # workspace-root awaits-user rows at snapshot time), the absent-
+    # sentinel guard above stops firing — yet message-store writes
+    # (alerts, notifications, `pm notify`) can still land after that
+    # refresh without emitting an invalidating audit event, leaving the
+    # empty entry stale. Treat a present-but-empty workspace entry as
+    # NOT-AUTHORITATIVE and fall through to the direct sweep. A non-
+    # empty entry is trusted: the refresher just computed it and the
+    # items are real. Cost: workspaces with genuinely zero root-level
+    # awaits-user rows pay the direct-sweep cost on every call (per-
+    # project entries still benefit from the rest of the cache). Full
+    # audit-event wiring for workspace-root producers is deferred past
+    # v1 RC.
+    workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
+    workspace_items = (
+        getattr(workspace_entry, "awaits_user_items", ()) or ()
+        if workspace_entry is not None
+        else ()
+    )
+    if not workspace_items:
+        return None
     cached_items: list[object] = []
     # The synthetic ``__workspace__`` entry carries workspace-root
     # awaits-user items (messages with ``scope IN ('', 'inbox')`` that
     # don't belong to any tracked project). Union them first so the
     # returned list mirrors the direct sweep's content.
-    workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
-    if workspace_entry is not None:
-        for item in getattr(workspace_entry, "awaits_user_items", ()) or ():
-            cached_items.append(item)
+    for item in workspace_items:
+        cached_items.append(item)
     for project_key, entry in snapshot.items():
         if project_key == WORKSPACE_PROJECT_KEY:
             continue
@@ -582,13 +602,27 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
     if WORKSPACE_PROJECT_KEY not in snapshot:
         return None
+    # #2051 round-3 (Codex review): bounded-staleness guard mirroring
+    # the list helper. A present-but-empty ``__workspace__`` entry
+    # (``awaits_user_count == 0``) is NOT treated as authoritative —
+    # message-store writes that bypass audit-event invalidation can
+    # land after the sentinel was last refreshed, leaving the zero
+    # stale. Fall through to the direct sweep so the rail badge can't
+    # under-report. See ``_maybe_cache_route_awaits_user`` for the full
+    # rationale and trade-offs.
+    workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
+    workspace_count = (
+        int(getattr(workspace_entry, "awaits_user_count", 0) or 0)
+        if workspace_entry is not None
+        else 0
+    )
+    if workspace_count <= 0:
+        return None
     total = 0
     # Pull the workspace-root awaits-user count off the synthetic
-    # ``__workspace__`` entry. An entry that's present but empty
-    # contributes 0; an absent entry is handled by the guard above.
-    workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
-    if workspace_entry is not None:
-        total += int(getattr(workspace_entry, "awaits_user_count", 0) or 0)
+    # ``__workspace__`` entry. Authoritative when non-zero (the empty
+    # case fell through above).
+    total += workspace_count
     for project_key, entry in snapshot.items():
         if project_key == WORKSPACE_PROJECT_KEY:
             continue

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -253,7 +253,7 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     #2051: workspace-root awaits-user messages (``scope IN ('',
     'inbox')``) now live on a synthetic ``__workspace__`` cache entry
     emitted by the refresher (see
-    :data:`pollypm.state_cache.refresh_impl.WORKSPACE_PROJECT_KEY`).
+    :data:`pollypm.state_cache.entry.WORKSPACE_PROJECT_KEY`).
     This helper unions those items with the per-project ones so the
     rail badge / inbox count include them. The earlier
     ``_workspace_root_inbox_has_open`` probe + its forced
@@ -318,7 +318,7 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     # before the refresher's initial full-refresh stamps the sentinel,
     # and not every workspace-root producer emits an invalidating audit
     # event. Falling through to the direct sweep is the safety net.
-    from pollypm.state_cache.refresh_impl import (
+    from pollypm.state_cache.entry import (
         WORKSPACE_ENTRY_TTL_SECONDS,
         WORKSPACE_PROJECT_KEY,
     )
@@ -564,7 +564,7 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     #2051: workspace-root awaits-user rows (``scope IN ('', 'inbox')``)
     are summed from the synthetic ``__workspace__`` cache entry
     emitted by the refresher (see
-    :data:`pollypm.state_cache.refresh_impl.WORKSPACE_PROJECT_KEY`).
+    :data:`pollypm.state_cache.entry.WORKSPACE_PROJECT_KEY`).
     The earlier workspace-root probe + forced fall-through were
     removed; the cache is now authoritative for those rows too.
 
@@ -616,7 +616,7 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     # workspace-root awaits-user rows exist, so we MUST fall through to
     # the direct sweep. See the sibling guard in
     # :func:`_maybe_cache_route_awaits_user`.
-    from pollypm.state_cache.refresh_impl import (
+    from pollypm.state_cache.entry import (
         WORKSPACE_ENTRY_TTL_SECONDS,
         WORKSPACE_PROJECT_KEY,
     )

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -324,29 +324,24 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     )
     if WORKSPACE_PROJECT_KEY not in snapshot:
         return None
-    # #2051 round-3 (Codex review): bounded-staleness guard. Once the
-    # refresher has installed an EMPTY ``__workspace__`` entry (no
-    # workspace-root awaits-user rows at snapshot time), the absent-
-    # sentinel guard above stops firing — yet message-store writes
-    # (alerts, notifications, `pm notify`) can still land after that
-    # refresh without emitting an invalidating audit event, leaving the
-    # empty entry stale. Treat a present-but-empty workspace entry as
-    # NOT-AUTHORITATIVE and fall through to the direct sweep.
-    #
-    # #2051 round-4 (Codex review): the same staleness reasoning applies
-    # to NON-EMPTY sentinels. ``PgStore.close_message`` /
-    # ``PgStore.clear_alert`` / ``service_api.v1.clear_alert`` can close
-    # workspace-root rows AFTER the refresher computed the entry — those
-    # paths write a ``messages``-table event, not a state-cache audit
-    # event, so the refresher never sees the close and the cached
-    # items / count stay stale until the next full refresh. The TTL
-    # below caps that staleness window. Trade-off: workspaces with
-    # genuinely zero root-level awaits-user rows pay the direct-sweep
-    # cost on every call (empty case); workspaces with stable non-empty
-    # workspace-root rows hit the direct sweep at most once per TTL
+    # #2051 round-4 (Codex review): bounded-staleness guard via TTL.
+    # ``PgStore.close_message`` / ``PgStore.clear_alert`` /
+    # ``service_api.v1.clear_alert`` can close workspace-root rows
+    # AFTER the refresher computed the entry — those paths write a
+    # ``messages``-table event, not a state-cache audit event, so the
+    # refresher never sees the close and the cached items / count stay
+    # stale until the next full refresh. The TTL below caps that
+    # staleness window. Workspaces with stable workspace-root rows
+    # (empty or non-empty) hit the direct sweep at most once per TTL
     # window. Per-project entries still benefit from the full cache.
     # Full audit-event wiring for the message-store close/clear paths
     # is deferred past v1 RC.
+    #
+    # #2051 round-5 (Codex review): the round-3 empty-sentinel
+    # always-fall-through was removed. The TTL guard alone covers the
+    # staleness invariant — a fresh empty sentinel serves zero
+    # workspace items as the fast path (which is the steady state for
+    # most workspaces); a stale empty sentinel falls through below.
     import time as _ws_time
     workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
     workspace_items = (
@@ -354,10 +349,10 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
         if workspace_entry is not None
         else ()
     )
-    if not workspace_items:
-        return None
     workspace_refreshed_at = float(
         getattr(workspace_entry, "computed_at", 0.0) or 0.0
+        if workspace_entry is not None
+        else 0.0
     )
     if (
         _ws_time.monotonic() - workspace_refreshed_at
@@ -368,7 +363,8 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     # The synthetic ``__workspace__`` entry carries workspace-root
     # awaits-user items (messages with ``scope IN ('', 'inbox')`` that
     # don't belong to any tracked project). Union them first so the
-    # returned list mirrors the direct sweep's content.
+    # returned list mirrors the direct sweep's content. A fresh empty
+    # sentinel contributes zero items here (round-5 fast path).
     for item in workspace_items:
         cached_items.append(item)
     for project_key, entry in snapshot.items():
@@ -626,22 +622,19 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     )
     if WORKSPACE_PROJECT_KEY not in snapshot:
         return None
-    # #2051 round-3 (Codex review): bounded-staleness guard mirroring
-    # the list helper. A present-but-empty ``__workspace__`` entry
-    # (``awaits_user_count == 0``) is NOT treated as authoritative —
-    # message-store writes that bypass audit-event invalidation can
-    # land after the sentinel was last refreshed, leaving the zero
-    # stale. Fall through to the direct sweep so the rail badge can't
-    # under-report.
+    # #2051 round-4 (Codex review): bounded-staleness guard via TTL.
+    # ``PgStore.close_message`` / ``PgStore.clear_alert`` /
+    # ``service_api.v1.clear_alert`` close workspace-root rows without
+    # emitting a state-cache audit event, so a positive cached count
+    # can over-report after a close. The TTL below caps that staleness
+    # window so the rail badge can't show a closed row indefinitely.
+    # See ``_maybe_cache_route_awaits_user`` for the full rationale.
     #
-    # #2051 round-4 (Codex review): the same staleness reasoning applies
-    # to a positive cached count. ``PgStore.close_message`` /
-    # ``PgStore.clear_alert`` / ``service_api.v1.clear_alert`` close
-    # workspace-root rows without emitting a state-cache audit event,
-    # so a positive cached count can over-report after a close. The
-    # TTL below caps that staleness window so the rail badge can't
-    # show a closed row indefinitely. See
-    # ``_maybe_cache_route_awaits_user`` for the full rationale.
+    # #2051 round-5 (Codex review): the round-3 empty-sentinel
+    # always-fall-through was removed. The TTL guard alone covers the
+    # staleness invariant — a fresh empty sentinel serves count 0 as
+    # the fast path (steady state for most workspaces); a stale
+    # sentinel of any count falls through below.
     import time as _ws_time
     workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
     workspace_count = (
@@ -649,10 +642,10 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
         if workspace_entry is not None
         else 0
     )
-    if workspace_count <= 0:
-        return None
     workspace_refreshed_at = float(
         getattr(workspace_entry, "computed_at", 0.0) or 0.0
+        if workspace_entry is not None
+        else 0.0
     )
     if (
         _ws_time.monotonic() - workspace_refreshed_at
@@ -661,8 +654,8 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
         return None
     total = 0
     # Pull the workspace-root awaits-user count off the synthetic
-    # ``__workspace__`` entry. Authoritative when non-zero (the empty
-    # case fell through above).
+    # ``__workspace__`` entry. Authoritative within the TTL window
+    # (which caps the staleness from message-store closes/clears).
     total += workspace_count
     for project_key, entry in snapshot.items():
         if project_key == WORKSPACE_PROJECT_KEY:

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -244,6 +244,9 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
       serve cross-config data when project keys overlap; the
       config-identity stamp catches this).
     * Any tracked project is missing from the snapshot (partial cache).
+    * The synthetic ``__workspace__`` entry is absent (#2051 — missing
+      sentinel is an incomplete cache, not a proven-empty workspace
+      inbox; Codex review of #2051).
     * Any unexpected exception (defensive — broken cache must never
       crash the rail badge).
 
@@ -307,12 +310,22 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     # project's items are included.
     if not known_projects.issubset(snapshot.keys()):
         return None
+    # #2051 (Codex review): the synthetic ``__workspace__`` entry is now
+    # authoritative for workspace-root awaits-user rows (scope IN ('',
+    # 'inbox')). If it's absent from the snapshot we MUST treat that as
+    # an incomplete cache, not a proven-empty workspace inbox — message-
+    # store writes (alerts, notifications) and `pm notify` rows can land
+    # before the refresher's initial full-refresh stamps the sentinel,
+    # and not every workspace-root producer emits an invalidating audit
+    # event. Falling through to the direct sweep is the safety net.
+    from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
+    if WORKSPACE_PROJECT_KEY not in snapshot:
+        return None
     cached_items: list[object] = []
-    # #2051: the synthetic ``__workspace__`` entry carries workspace-root
+    # The synthetic ``__workspace__`` entry carries workspace-root
     # awaits-user items (messages with ``scope IN ('', 'inbox')`` that
     # don't belong to any tracked project). Union them first so the
     # returned list mirrors the direct sweep's content.
-    from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
     workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
     if workspace_entry is not None:
         for item in getattr(workspace_entry, "awaits_user_items", ()) or ():
@@ -517,6 +530,13 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     :data:`pollypm.state_cache.refresh_impl.WORKSPACE_PROJECT_KEY`).
     The earlier workspace-root probe + forced fall-through were
     removed; the cache is now authoritative for those rows too.
+
+    Codex review of #2051: when the synthetic ``__workspace__`` entry
+    is ABSENT from the snapshot, the cache is incomplete (the sentinel
+    has not been refreshed yet, or the refresher has not seen an event
+    that touched workspace-root rows). Return ``None`` so the caller
+    falls back to the direct sweep — serving zero would silently drop
+    real workspace-root work.
     """
 
     try:
@@ -553,11 +573,19 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     # direct path so the badge stays correct during the boot-time gap.
     if not known_projects.issubset(snapshot.keys()):
         return None
-    total = 0
-    # #2051: pull the workspace-root awaits-user count off the
-    # synthetic ``__workspace__`` entry. Absent entry (cold workspace
-    # path, or sentinel never refreshed) contributes 0.
+    # #2051 (Codex review): a snapshot missing the synthetic
+    # ``__workspace__`` entry is an incomplete cache, NOT a proven-empty
+    # workspace inbox. Without the sentinel we cannot prove that no
+    # workspace-root awaits-user rows exist, so we MUST fall through to
+    # the direct sweep. See the sibling guard in
+    # :func:`_maybe_cache_route_awaits_user`.
     from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
+    if WORKSPACE_PROJECT_KEY not in snapshot:
+        return None
+    total = 0
+    # Pull the workspace-root awaits-user count off the synthetic
+    # ``__workspace__`` entry. An entry that's present but empty
+    # contributes 0; an absent entry is handled by the guard above.
     workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
     if workspace_entry is not None:
         total += int(getattr(workspace_entry, "awaits_user_count", 0) or 0)

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -318,7 +318,10 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     # before the refresher's initial full-refresh stamps the sentinel,
     # and not every workspace-root producer emits an invalidating audit
     # event. Falling through to the direct sweep is the safety net.
-    from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
+    from pollypm.state_cache.refresh_impl import (
+        WORKSPACE_ENTRY_TTL_SECONDS,
+        WORKSPACE_PROJECT_KEY,
+    )
     if WORKSPACE_PROJECT_KEY not in snapshot:
         return None
     # #2051 round-3 (Codex review): bounded-staleness guard. Once the
@@ -328,13 +331,23 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     # (alerts, notifications, `pm notify`) can still land after that
     # refresh without emitting an invalidating audit event, leaving the
     # empty entry stale. Treat a present-but-empty workspace entry as
-    # NOT-AUTHORITATIVE and fall through to the direct sweep. A non-
-    # empty entry is trusted: the refresher just computed it and the
-    # items are real. Cost: workspaces with genuinely zero root-level
-    # awaits-user rows pay the direct-sweep cost on every call (per-
-    # project entries still benefit from the rest of the cache). Full
-    # audit-event wiring for workspace-root producers is deferred past
-    # v1 RC.
+    # NOT-AUTHORITATIVE and fall through to the direct sweep.
+    #
+    # #2051 round-4 (Codex review): the same staleness reasoning applies
+    # to NON-EMPTY sentinels. ``PgStore.close_message`` /
+    # ``PgStore.clear_alert`` / ``service_api.v1.clear_alert`` can close
+    # workspace-root rows AFTER the refresher computed the entry — those
+    # paths write a ``messages``-table event, not a state-cache audit
+    # event, so the refresher never sees the close and the cached
+    # items / count stay stale until the next full refresh. The TTL
+    # below caps that staleness window. Trade-off: workspaces with
+    # genuinely zero root-level awaits-user rows pay the direct-sweep
+    # cost on every call (empty case); workspaces with stable non-empty
+    # workspace-root rows hit the direct sweep at most once per TTL
+    # window. Per-project entries still benefit from the full cache.
+    # Full audit-event wiring for the message-store close/clear paths
+    # is deferred past v1 RC.
+    import time as _ws_time
     workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
     workspace_items = (
         getattr(workspace_entry, "awaits_user_items", ()) or ()
@@ -342,6 +355,14 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
         else ()
     )
     if not workspace_items:
+        return None
+    workspace_refreshed_at = float(
+        getattr(workspace_entry, "computed_at", 0.0) or 0.0
+    )
+    if (
+        _ws_time.monotonic() - workspace_refreshed_at
+        >= WORKSPACE_ENTRY_TTL_SECONDS
+    ):
         return None
     cached_items: list[object] = []
     # The synthetic ``__workspace__`` entry carries workspace-root
@@ -599,7 +620,10 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     # workspace-root awaits-user rows exist, so we MUST fall through to
     # the direct sweep. See the sibling guard in
     # :func:`_maybe_cache_route_awaits_user`.
-    from pollypm.state_cache.refresh_impl import WORKSPACE_PROJECT_KEY
+    from pollypm.state_cache.refresh_impl import (
+        WORKSPACE_ENTRY_TTL_SECONDS,
+        WORKSPACE_PROJECT_KEY,
+    )
     if WORKSPACE_PROJECT_KEY not in snapshot:
         return None
     # #2051 round-3 (Codex review): bounded-staleness guard mirroring
@@ -608,8 +632,17 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     # message-store writes that bypass audit-event invalidation can
     # land after the sentinel was last refreshed, leaving the zero
     # stale. Fall through to the direct sweep so the rail badge can't
-    # under-report. See ``_maybe_cache_route_awaits_user`` for the full
-    # rationale and trade-offs.
+    # under-report.
+    #
+    # #2051 round-4 (Codex review): the same staleness reasoning applies
+    # to a positive cached count. ``PgStore.close_message`` /
+    # ``PgStore.clear_alert`` / ``service_api.v1.clear_alert`` close
+    # workspace-root rows without emitting a state-cache audit event,
+    # so a positive cached count can over-report after a close. The
+    # TTL below caps that staleness window so the rail badge can't
+    # show a closed row indefinitely. See
+    # ``_maybe_cache_route_awaits_user`` for the full rationale.
+    import time as _ws_time
     workspace_entry = snapshot.get(WORKSPACE_PROJECT_KEY)
     workspace_count = (
         int(getattr(workspace_entry, "awaits_user_count", 0) or 0)
@@ -617,6 +650,14 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
         else 0
     )
     if workspace_count <= 0:
+        return None
+    workspace_refreshed_at = float(
+        getattr(workspace_entry, "computed_at", 0.0) or 0.0
+    )
+    if (
+        _ws_time.monotonic() - workspace_refreshed_at
+        >= WORKSPACE_ENTRY_TTL_SECONDS
+    ):
         return None
     total = 0
     # Pull the workspace-root awaits-user count off the synthetic

--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -364,92 +364,6 @@ def open_messages(
     return rows
 
 
-def has_workspace_root_open_messages(
-    config: "PollyPMConfig | None",
-) -> bool:
-    """Returns True if any workspace-root open message exists.
-
-    **CONSERVATIVE:** returns True on ANY pg failure (pool/query) — see
-    Move A cache-authoritative invariant. Pure SQL existence query
-    (``LIMIT 1``) — independent of how many newer rows exist.
-
-    "Workspace-root" = messages with ``scope IN ('', 'inbox')``. The
-    state-cache refresher's per-project filter
-    (``state_cache/refresh_impl.py::_awaits_user_items_for``) drops
-    these on the floor because they aren't keyed to any tracked
-    project, so any cache-routed read MUST fall through whenever this
-    returns True.
-
-    PR #2026 v3 (Codex re-review blocker 1): the previous
-    implementation re-used :func:`open_messages` with ``limit=50`` and
-    scanned the newest 50 rows in Python for ``scope == "" / "inbox"``.
-    On a busy workspace with 50+ newer project-scoped rows + 1 older
-    workspace-root row, the probe returned False and the cache
-    silently dropped the workspace work. This helper pushes the
-    existence check into SQL (``LIMIT 1`` on a workspace-root
-    predicate) so the answer is independent of how many newer
-    project-scoped rows exist.
-
-    PR #2026 v5 (Codex round-5 blocker): pool/query failures now return
-    ``True`` (with warning log) instead of ``False``. The caller
-    ``_workspace_root_inbox_has_open`` expects this helper to either
-    return a real answer or raise; v4 wrapped the outer call in
-    try/except but the helper itself was swallowing pg errors and
-    returning False, defeating the conservative-on-error guard. Cache
-    authoritativeness requires that any signal we cannot prove returns
-    the safe answer that forces fall-through.
-
-    NOTE: This function's failure contract intentionally diverges from other
-    helpers in this module. On pg pool/query failure, it returns True (conservative).
-    Callers MUST treat True as "exists OR unknown" — not as "row definitely exists."
-    This preserves the cache-authoritative invariant for the Move A awaits-user cache:
-    the cache declines when any source it cannot represent might have data.
-    """
-
-    try:
-        from pollypm.storage.pg_pool import get_ro_pool, get_rw_pool
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "workspace-root inbox probe encountered pool error (pg_pool import failed); assuming inbox is non-empty to force conservative cache decline",
-            exc_info=True,
-        )
-        return True
-
-    try:
-        pool = get_ro_pool(config)
-    except Exception:  # noqa: BLE001
-        try:
-            pool = get_rw_pool(config)
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "workspace-root inbox probe encountered pool error; assuming inbox is non-empty to force conservative cache decline",
-                exc_info=True,
-            )
-            return True
-
-    sql = (
-        "SELECT 1 "
-        "  FROM messages "
-        " WHERE recipient = %s "
-        "   AND state = %s "
-        "   AND type IN ('notify', 'inbox_task', 'alert') "
-        "   AND (scope = '' OR scope IS NULL OR scope = 'inbox') "
-        " LIMIT 1"
-    )
-    params: list[object] = ["user", "open"]
-    try:
-        with pool.connection() as conn, conn.cursor() as cur:
-            cur.execute(sql, params)
-            row = cur.fetchone()
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "workspace-root inbox probe encountered query error; assuming inbox is non-empty to force conservative cache decline",
-            exc_info=True,
-        )
-        return True
-    return row is not None
-
-
 # --------------------------------------------------------------------------- #
 # Public API surface
 # --------------------------------------------------------------------------- #
@@ -458,7 +372,6 @@ def has_workspace_root_open_messages(
 __all__ = [
     "all_tasks_for_project",
     "all_tasks_grouped",
-    "has_workspace_root_open_messages",
     "inbox_tasks_for_project",
     "inbox_tasks_grouped",
     "open_messages",

--- a/src/pollypm/state_cache/__init__.py
+++ b/src/pollypm/state_cache/__init__.py
@@ -209,7 +209,7 @@ def get_cache() -> StateCacheLike:
                     # full pass (workspace-wide invalidations re-enqueue
                     # every currently-known key — by appearing here the
                     # sentinel rides that path too).
-                    from pollypm.state_cache.refresh_impl import (
+                    from pollypm.state_cache.entry import (
                         WORKSPACE_PROJECT_KEY,
                     )
                     try:

--- a/src/pollypm/state_cache/__init__.py
+++ b/src/pollypm/state_cache/__init__.py
@@ -202,6 +202,16 @@ def get_cache() -> StateCacheLike:
                     # newly-added projects are picked up without having
                     # to bounce the cache. Failures degrade to the empty
                     # list (matches the provider-less PR 1 behavior).
+                    #
+                    # #2051: always include the ``__workspace__``
+                    # sentinel so the refresher computes the synthetic
+                    # workspace-root inbox entry on boot and on every
+                    # full pass (workspace-wide invalidations re-enqueue
+                    # every currently-known key — by appearing here the
+                    # sentinel rides that path too).
+                    from pollypm.state_cache.refresh_impl import (
+                        WORKSPACE_PROJECT_KEY,
+                    )
                     try:
                         config = _config_provider()
                     except Exception:  # noqa: BLE001
@@ -209,16 +219,16 @@ def get_cache() -> StateCacheLike:
                             "state_cache: project_keys provider — "
                             "config load failed",
                         )
-                        return []
+                        return [WORKSPACE_PROJECT_KEY]
                     try:
                         projects = getattr(config, "projects", {}) or {}
-                        return list(projects.keys())
+                        return [WORKSPACE_PROJECT_KEY, *projects.keys()]
                     except Exception:  # noqa: BLE001
                         logger.exception(
                             "state_cache: project_keys provider — "
                             "projects access failed",
                         )
-                        return []
+                        return [WORKSPACE_PROJECT_KEY]
 
                 refresh_fn = build_refresh_fn(_config_provider)
                 project_keys_provider = _project_keys_provider

--- a/src/pollypm/state_cache/entry.py
+++ b/src/pollypm/state_cache/entry.py
@@ -23,7 +23,56 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-__all__ = ["ProjectStateCacheEntry", "config_identity", "empty_entry"]
+__all__ = [
+    "WORKSPACE_ENTRY_TTL_SECONDS",
+    "WORKSPACE_PROJECT_KEY",
+    "ProjectStateCacheEntry",
+    "config_identity",
+    "empty_entry",
+]
+
+
+# Sentinel project key for the "workspace-root inbox" entry (#2051).
+# Workspace-root messages (``scope IN ('', 'inbox')``) carry
+# ``project == "inbox"`` after :func:`message_row_to_inbox_entry`, so
+# they don't associate with any tracked project key. The refresher
+# emits a synthetic entry under this sentinel so the cache fast-path
+# can surface those items alongside per-project ones. Matches the
+# established ``__workspace__`` sentinel used by other inbox code paths
+# (see ``cockpit_inbox_items._WORKSPACE_DB_KEY``).
+#
+# Lives in :mod:`pollypm.state_cache.entry` (a dependency-free leaf
+# module) so :mod:`pollypm.state_cache.refresh_impl`,
+# :mod:`pollypm.state_cache.refresher`, :mod:`pollypm.cockpit_inbox`,
+# and the test suite all share one source of truth. Splitting the
+# constant across modules (as in earlier rounds) risked drift when one
+# call site moved off ``"__workspace__"`` without the other.
+WORKSPACE_PROJECT_KEY = "__workspace__"
+
+
+# Bounded-staleness TTL for the synthetic workspace sentinel (#2051
+# round-4 Codex review). A non-empty ``__workspace__`` entry is only
+# treated as authoritative for this many monotonic seconds after the
+# refresher stamped it. After the window expires the cache-read
+# boundary falls through to the direct sweep — see
+# ``cockpit_inbox._maybe_cache_route_awaits_user`` and
+# ``_maybe_cache_count_awaits_user``.
+#
+# Rationale: several message-store paths
+# (``PgStore.close_message``, ``PgStore.clear_alert``,
+# ``service_api.v1.clear_alert``) mutate workspace-root awaits-user
+# rows but do NOT emit a ``state-cache`` audit event the refresher's
+# ``_dispatch_event`` consumes. Without a TTL a cached non-empty
+# sentinel can serve closed rows or an inflated count indefinitely.
+#
+# 10 seconds was picked as a compromise: short enough that any close-
+# then-read sequence the operator notices stays inside one rail tick
+# window (rail polls ~1s); long enough that the cache still absorbs
+# bursty consumer reads inside a single refresh cycle. Full audit-
+# event wiring for the message-store close/clear paths is deferred
+# past v1 RC — this TTL is a documented bounded-staleness window,
+# not an invariant.
+WORKSPACE_ENTRY_TTL_SECONDS = 10.0
 
 
 def config_identity(config: Any) -> str:

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -39,6 +39,8 @@ from pathlib import Path
 from typing import Any, Callable
 
 from pollypm.state_cache.entry import (
+    WORKSPACE_ENTRY_TTL_SECONDS,
+    WORKSPACE_PROJECT_KEY,
     ProjectStateCacheEntry,
     config_identity,
     empty_entry,
@@ -46,6 +48,12 @@ from pollypm.state_cache.entry import (
 
 logger = logging.getLogger(__name__)
 
+# #2051 round-6 (Codex review): the workspace sentinel + its TTL live in
+# :mod:`pollypm.state_cache.entry` (a dependency-free leaf) so the
+# refresher, this refresh-impl, ``cockpit_inbox``, and the test suite
+# all share one source of truth. The names are re-exported here purely
+# for back-compat with earlier importers; new code should prefer
+# ``from pollypm.state_cache.entry import WORKSPACE_PROJECT_KEY``.
 __all__ = [
     "ConfigProvider",
     "WORKSPACE_ENTRY_TTL_SECONDS",
@@ -53,42 +61,6 @@ __all__ = [
     "build_refresh_fn",
     "compute_entry_for_project",
 ]
-
-
-# Sentinel project key for the "workspace-root inbox" entry (#2051).
-# Workspace-root messages (``scope IN ('', 'inbox')``) carry
-# ``project == "inbox"`` after :func:`message_row_to_inbox_entry`, so
-# they don't associate with any tracked project key. The refresher
-# emits a synthetic entry under this sentinel so the cache fast-path
-# can surface those items alongside per-project ones. Matches the
-# established ``__workspace__`` sentinel used by other inbox
-# code paths (see ``cockpit_inbox_items._WORKSPACE_DB_KEY``).
-WORKSPACE_PROJECT_KEY = "__workspace__"
-
-
-# Bounded-staleness TTL for the synthetic workspace sentinel (#2051
-# round-4 Codex review). A non-empty ``__workspace__`` entry is only
-# treated as authoritative for this many monotonic seconds after the
-# refresher stamped it. After the window expires the cache-read
-# boundary falls through to the direct sweep — see
-# ``cockpit_inbox._maybe_cache_route_awaits_user`` and
-# ``_maybe_cache_count_awaits_user``.
-#
-# Rationale: several message-store paths
-# (``PgStore.close_message``, ``PgStore.clear_alert``,
-# ``service_api.v1.clear_alert``) mutate workspace-root awaits-user
-# rows but do NOT emit a ``state-cache`` audit event the refresher's
-# ``_dispatch_event`` consumes. Without a TTL a cached non-empty
-# sentinel can serve closed rows or an inflated count indefinitely.
-#
-# 10 seconds was picked as a compromise: short enough that any close-
-# then-read sequence the operator notices stays inside one rail tick
-# window (rail polls ~1s); long enough that the cache still absorbs
-# bursty consumer reads inside a single refresh cycle. Full audit-
-# event wiring for the message-store close/clear paths is deferred
-# past v1 RC — this TTL is a documented bounded-staleness window,
-# not an invariant.
-WORKSPACE_ENTRY_TTL_SECONDS = 10.0
 
 
 # Callable returning the current workspace config. Injected so a

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "ConfigProvider",
+    "WORKSPACE_ENTRY_TTL_SECONDS",
     "WORKSPACE_PROJECT_KEY",
     "build_refresh_fn",
     "compute_entry_for_project",
@@ -63,6 +64,31 @@ __all__ = [
 # established ``__workspace__`` sentinel used by other inbox
 # code paths (see ``cockpit_inbox_items._WORKSPACE_DB_KEY``).
 WORKSPACE_PROJECT_KEY = "__workspace__"
+
+
+# Bounded-staleness TTL for the synthetic workspace sentinel (#2051
+# round-4 Codex review). A non-empty ``__workspace__`` entry is only
+# treated as authoritative for this many monotonic seconds after the
+# refresher stamped it. After the window expires the cache-read
+# boundary falls through to the direct sweep — see
+# ``cockpit_inbox._maybe_cache_route_awaits_user`` and
+# ``_maybe_cache_count_awaits_user``.
+#
+# Rationale: several message-store paths
+# (``PgStore.close_message``, ``PgStore.clear_alert``,
+# ``service_api.v1.clear_alert``) mutate workspace-root awaits-user
+# rows but do NOT emit a ``state-cache`` audit event the refresher's
+# ``_dispatch_event`` consumes. Without a TTL a cached non-empty
+# sentinel can serve closed rows or an inflated count indefinitely.
+#
+# 10 seconds was picked as a compromise: short enough that any close-
+# then-read sequence the operator notices stays inside one rail tick
+# window (rail polls ~1s); long enough that the cache still absorbs
+# bursty consumer reads inside a single refresh cycle. Full audit-
+# event wiring for the message-store close/clear paths is deferred
+# past v1 RC — this TTL is a documented bounded-staleness window,
+# not an invariant.
+WORKSPACE_ENTRY_TTL_SECONDS = 10.0
 
 
 # Callable returning the current workspace config. Injected so a

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -48,9 +48,21 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "ConfigProvider",
+    "WORKSPACE_PROJECT_KEY",
     "build_refresh_fn",
     "compute_entry_for_project",
 ]
+
+
+# Sentinel project key for the "workspace-root inbox" entry (#2051).
+# Workspace-root messages (``scope IN ('', 'inbox')``) carry
+# ``project == "inbox"`` after :func:`message_row_to_inbox_entry`, so
+# they don't associate with any tracked project key. The refresher
+# emits a synthetic entry under this sentinel so the cache fast-path
+# can surface those items alongside per-project ones. Matches the
+# established ``__workspace__`` sentinel used by other inbox
+# code paths (see ``cockpit_inbox_items._WORKSPACE_DB_KEY``).
+WORKSPACE_PROJECT_KEY = "__workspace__"
 
 
 # Callable returning the current workspace config. Injected so a
@@ -111,7 +123,20 @@ def compute_entry_for_project(
        :func:`project_state_map_from_config`).
     3. ``rail_*`` — rollup output (PR 3 consumer).
     4. ``project_path`` / ``tracked`` — straight from config.
+
+    #2051: when ``project_key`` is :data:`WORKSPACE_PROJECT_KEY`, the
+    returned entry carries the workspace-root awaits-user items
+    (messages with ``scope IN ('', 'inbox')`` — they map to
+    ``project == "inbox"`` after
+    :func:`message_row_to_inbox_entry`). The synthetic entry skips
+    categorization + rollup (no project to categorize) so the cache
+    fast-path can union it with per-project entries without affecting
+    rail / dashboard consumers (which iterate over tracked project
+    keys and ignore extras).
     """
+
+    if project_key == WORKSPACE_PROJECT_KEY:
+        return _compute_workspace_entry(config)
 
     project = _get_project(config, project_key)
     project_path = _project_path(project)
@@ -225,6 +250,86 @@ def _awaits_user_items_for(project_key: str, config: Any) -> list[Any]:
         if key == project_key:
             out.append(item)
     return out
+
+
+def _workspace_root_items(config: Any) -> list[Any]:
+    """Workspace-wide awaits-user sweep, filtered to workspace-root items.
+
+    #2051: workspace-root messages (``scope IN ('', 'inbox')``) carry
+    ``project == "inbox"`` after :func:`message_row_to_inbox_entry` —
+    they don't match any tracked project key, so the per-project
+    refresh in :func:`_awaits_user_items_for` drops them. This helper
+    collects the slice that belongs in the synthetic workspace entry
+    instead.
+
+    Calls the DIRECT (uncached) helper for the same recursion-guard
+    reason as :func:`_awaits_user_items_for`.
+    """
+
+    try:
+        from pollypm.cockpit_inbox import _pm_inbox_awaits_user_list_uncached
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "state_cache: cockpit_inbox import failed during workspace refresh",
+            exc_info=True,
+        )
+        return []
+    try:
+        items = _pm_inbox_awaits_user_list_uncached(config)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "state_cache: _pm_inbox_awaits_user_list_uncached raised "
+            "for workspace entry",
+            exc_info=True,
+        )
+        return []
+
+    out: list[Any] = []
+    for item in items:
+        project = str(getattr(item, "project", "") or "").strip()
+        scope = str(getattr(item, "scope", "") or "").strip()
+        # Workspace-root rows surface as ``project == "inbox"``
+        # (per ``message_row_to_inbox_entry``'s fallback). The legacy
+        # source enumeration also propagated empty scopes through;
+        # accept those for robustness so a future shape change in
+        # ``message_row_to_inbox_entry`` doesn't silently drop them.
+        if project == "inbox" or (project == "" and scope in ("", "inbox")):
+            out.append(item)
+    return out
+
+
+def _compute_workspace_entry(config: Any) -> ProjectStateCacheEntry:
+    """Build the synthetic ``__workspace__`` cache entry (#2051).
+
+    Workspace-root awaits-user items live on this entry instead of
+    any per-project entry. The rest of the entry shape is "no data":
+    no categorization, no rollup, no project_path — the consumers
+    that iterate per-project entries (rail, dashboard) filter on
+    ``config.projects`` keys so the synthetic entry is naturally
+    ignored by them.
+
+    Failures degrade to an empty entry so a broken pg path never
+    propagates a crash through the refresher.
+    """
+
+    items = _workspace_root_items(config)
+    return ProjectStateCacheEntry(
+        project_key=WORKSPACE_PROJECT_KEY,
+        project_path=Path(""),
+        tracked=False,
+        state=None,
+        glyph="",
+        detail="",
+        rail_state=None,
+        rail_badge=None,
+        rail_sort_rank=0,
+        rail_reason="",
+        approvals_pending=0,
+        awaits_user_count=len(items),
+        awaits_user_items=tuple(items),
+        computed_at=time.monotonic(),
+        config_identity=config_identity(config),
+    )
 
 
 def _categorize_and_rollup(

--- a/src/pollypm/state_cache/refresher.py
+++ b/src/pollypm/state_cache/refresher.py
@@ -70,6 +70,35 @@ _INVALIDATING_EVENTS: frozenset[str] = frozenset({
     "heartbeat.tick",
 })
 
+# #2051 (Codex review): the sentinel project key for the synthetic
+# ``__workspace__`` cache entry. Pinned by string so this leaf module
+# doesn't have to import :mod:`pollypm.state_cache.refresh_impl` at
+# module load time (avoids a circular-import hazard between the
+# refresher infra and the refresh-impl that consumes it).
+_WORKSPACE_PROJECT_KEY: str = "__workspace__"
+
+# Signals that an event touches workspace-root awaits-user rows
+# (``messages`` with ``scope IN ('', 'inbox')`` — they surface as
+# ``project == 'inbox'`` after :func:`message_row_to_inbox_entry`).
+# When :func:`_dispatch_event` sees one of these, it ALSO invalidates
+# the ``__workspace__`` synthetic entry on top of whatever per-project
+# invalidation the event triggers. Workspace-scoped events (empty
+# ``project``) already enqueue every known key via ``invalidate(None)``
+# — that path already covers the sentinel because the project-keys
+# provider includes it.
+#
+# Tracked-project ``task.*`` events that ALSO write a workspace-root
+# row (cross-posted notifications) are conservatively covered by
+# invalidating ``__workspace__`` on every event in
+# :data:`_INVALIDATING_EVENTS` — N+1 refreshes per event is cheap
+# (the workspace-root sweep is a single bulk query) and the upside
+# is that the sentinel can never go stale while the per-project
+# entries refresh.
+_WORKSPACE_ROOT_PROJECT_SIGNALS: frozenset[str] = frozenset({
+    "",       # workspace-scoped emit (no project payload)
+    "inbox",  # workspace-root inbox tasks / notifications
+})
+
 # Poll interval for the tail thread. Mirrors the existing SSE tail
 # cadence (``src/pollypm/web_api/sse.py``) — 250ms keeps invalidation
 # latency under a quarter-second without hammering the FS.
@@ -346,8 +375,22 @@ class StateCacheRefresher:
     def _dispatch_event(self, *, event: str, project: str) -> None:
         if event not in _INVALIDATING_EVENTS:
             return
-        if not project:
-            # Workspace-scoped event — invalidate all known projects.
+        # #2051 (Codex review): every invalidating event MUST also
+        # invalidate the ``__workspace__`` sentinel. Tracked-project
+        # events can cross-post into the workspace-root inbox (e.g.
+        # a task created against project="inbox" surfaces in the
+        # workspace-root awaits-user sweep), and the cache-read
+        # boundary now refuses to serve a list/count when the
+        # sentinel is stale or missing. Refreshing it on every event
+        # is cheap — the workspace-root sweep is a single bulk query
+        # and coalesces with the rest of the drain.
+        self._cache.invalidate(_WORKSPACE_PROJECT_KEY)
+        if not project or project in _WORKSPACE_ROOT_PROJECT_SIGNALS:
+            # Workspace-scoped event (empty project) OR an event whose
+            # ``project`` payload is itself a workspace-root signal
+            # (``"inbox"`` — workspace-root inbox tasks emit this).
+            # Invalidate every known project key so the snapshot stays
+            # consistent across the per-project + sentinel union.
             self._cache.invalidate(None)
             return
         self._cache.invalidate(project)

--- a/src/pollypm/state_cache/refresher.py
+++ b/src/pollypm/state_cache/refresher.py
@@ -38,7 +38,11 @@ import time
 from pathlib import Path
 from typing import Callable
 
-from pollypm.state_cache.entry import ProjectStateCacheEntry, empty_entry
+from pollypm.state_cache.entry import (
+    WORKSPACE_PROJECT_KEY,
+    ProjectStateCacheEntry,
+    empty_entry,
+)
 from pollypm.state_cache.project_state_cache import ProjectStateCache
 
 logger = logging.getLogger(__name__)
@@ -69,13 +73,6 @@ _INVALIDATING_EVENTS: frozenset[str] = frozenset({
     "work_table.cleared",
     "heartbeat.tick",
 })
-
-# #2051 (Codex review): the sentinel project key for the synthetic
-# ``__workspace__`` cache entry. Pinned by string so this leaf module
-# doesn't have to import :mod:`pollypm.state_cache.refresh_impl` at
-# module load time (avoids a circular-import hazard between the
-# refresher infra and the refresh-impl that consumes it).
-_WORKSPACE_PROJECT_KEY: str = "__workspace__"
 
 # Signals that an event touches workspace-root awaits-user rows
 # (``messages`` with ``scope IN ('', 'inbox')`` — they surface as
@@ -384,7 +381,7 @@ class StateCacheRefresher:
         # sentinel is stale or missing. Refreshing it on every event
         # is cheap — the workspace-root sweep is a single bulk query
         # and coalesces with the rest of the drain.
-        self._cache.invalidate(_WORKSPACE_PROJECT_KEY)
+        self._cache.invalidate(WORKSPACE_PROJECT_KEY)
         if not project or project in _WORKSPACE_ROOT_PROJECT_SIGNALS:
             # Workspace-scoped event (empty project) OR an event whose
             # ``project`` payload is itself a workspace-root signal

--- a/tests/test_state_cache_config_identity.py
+++ b/tests/test_state_cache_config_identity.py
@@ -128,8 +128,36 @@ def _seed_cache(
     monkeypatch: pytest.MonkeyPatch,
     entries: dict[str, ProjectStateCacheEntry],
 ) -> ProjectStateCache:
+    # #2051 (Codex review): the cache-read boundary now requires the
+    # synthetic ``__workspace__`` entry to be present. Auto-seed an
+    # entry whose ``config_identity`` matches the FIRST stamped entry
+    # in ``entries`` so cross-config tests still exercise the identity
+    # guard (the workspace sentinel rides the same stamp). Tests that
+    # specifically want to omit the sentinel pass an explicit entry.
     cache = ProjectStateCache(refresh_fn=lambda k: None)
-    for key, entry in entries.items():
+    seeded = dict(entries)
+    if "__workspace__" not in seeded and seeded:
+        # Pick the first entry's stamp so cross-identity-mismatch tests
+        # don't have a workspace sentinel that masks the rejection.
+        sample = next(iter(seeded.values()))
+        identity = getattr(sample, "config_identity", "") or ""
+        seeded["__workspace__"] = ProjectStateCacheEntry(
+            project_key="__workspace__",
+            project_path=Path("/tmp/__workspace__"),
+            tracked=False,
+            state=None,
+            glyph="",
+            detail="",
+            rail_state=None,
+            rail_badge=None,
+            rail_sort_rank=0,
+            rail_reason="",
+            approvals_pending=0,
+            awaits_user_count=0,
+            awaits_user_items=(),
+            config_identity=identity,
+        )
+    for key, entry in seeded.items():
         cache._install_for_test(key, entry)
     monkeypatch.setattr("pollypm.state_cache.is_enabled", lambda: True)
     monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)

--- a/tests/test_state_cache_config_identity.py
+++ b/tests/test_state_cache_config_identity.py
@@ -194,11 +194,24 @@ class TestConfigIdentityGuard:
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config_a, config_b = self._config_pair(tmp_path)
 
-        # Seed cache with entries stamped against config_A.
+        # Seed cache with entries stamped against config_A. Round-3
+        # (#2051): the matching-identity fast-path now requires a
+        # NON-empty ``__workspace__`` sentinel (empty sentinels trigger
+        # the bounded-staleness fall-through). Seed one workspace-root
+        # item so the matching-identity assertion below proves the
+        # fast-path, not the workspace-empty guard.
+        ws_item = SimpleNamespace(
+            project="inbox", scope="inbox", source="message",
+            task_id=None, message_id="ws-id-1",
+            title="workspace root",
+        )
         entries = {
             key: _stamped_entry(key, config=config_a, items=[])
             for key in config_a.projects.keys()
         }
+        entries["__workspace__"] = _stamped_entry(
+            "__workspace__", config=config_a, items=[ws_item],
+        )
         _seed_cache(monkeypatch, entries)
 
         # Looking up with config_B (overlapping keys, different
@@ -209,22 +222,35 @@ class TestConfigIdentityGuard:
         # And looking up with config_A (matching identity) MUST hit.
         result_a = cockpit_inbox._maybe_cache_route_awaits_user(config_a)
         assert result_a is not None
-        assert result_a == []  # no items seeded, but the path served
+        # Only the workspace-root item (per-project entries seeded empty).
+        assert result_a == [ws_item]
 
     def test_count_awaits_user_declines_on_identity_mismatch(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config_a, config_b = self._config_pair(tmp_path)
+        # Round-3 (#2051): non-empty workspace sentinel required for
+        # the matching-identity fast-path. Mirrors the sibling list
+        # test above.
+        ws_item = SimpleNamespace(
+            project="inbox", scope="inbox", source="message",
+            task_id=None, message_id="ws-id-2",
+            title="workspace root",
+        )
         entries = {
             key: _stamped_entry(key, config=config_a, items=[])
             for key in config_a.projects.keys()
         }
+        entries["__workspace__"] = _stamped_entry(
+            "__workspace__", config=config_a, items=[ws_item],
+        )
         _seed_cache(monkeypatch, entries)
 
         assert cockpit_inbox._maybe_cache_count_awaits_user(config_b) is None
-        # Matching identity → 0 items total.
-        assert cockpit_inbox._maybe_cache_count_awaits_user(config_a) == 0
+        # Matching identity → 1 workspace-root item (per-project entries
+        # are empty; only the workspace sentinel contributes).
+        assert cockpit_inbox._maybe_cache_count_awaits_user(config_a) == 1
 
     def test_operator_view_declines_on_identity_mismatch(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
@@ -342,30 +368,50 @@ class TestConfigIdentityGuard:
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config_a, config_b = self._same_root_different_path_pair(tmp_path)
+        # Round-3 (#2051): non-empty workspace sentinel required for
+        # the matching-identity fast-path assertion below.
+        ws_item = SimpleNamespace(
+            project="inbox", scope="inbox", source="message",
+            task_id=None, message_id="ws-id-3",
+            title="workspace root",
+        )
         entries = {
             key: _stamped_entry(key, config=config_a, items=[])
             for key in config_a.projects.keys()
         }
+        entries["__workspace__"] = _stamped_entry(
+            "__workspace__", config=config_a, items=[ws_item],
+        )
         _seed_cache(monkeypatch, entries)
 
         assert cockpit_inbox._maybe_cache_route_awaits_user(config_b) is None
         result_a = cockpit_inbox._maybe_cache_route_awaits_user(config_a)
         assert result_a is not None
-        assert result_a == []
+        assert result_a == [ws_item]
 
     def test_count_awaits_user_declines_same_root_different_path(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config_a, config_b = self._same_root_different_path_pair(tmp_path)
+        # Round-3 (#2051): non-empty workspace sentinel required —
+        # see sibling list test for rationale.
+        ws_item = SimpleNamespace(
+            project="inbox", scope="inbox", source="message",
+            task_id=None, message_id="ws-id-4",
+            title="workspace root",
+        )
         entries = {
             key: _stamped_entry(key, config=config_a, items=[])
             for key in config_a.projects.keys()
         }
+        entries["__workspace__"] = _stamped_entry(
+            "__workspace__", config=config_a, items=[ws_item],
+        )
         _seed_cache(monkeypatch, entries)
 
         assert cockpit_inbox._maybe_cache_count_awaits_user(config_b) is None
-        assert cockpit_inbox._maybe_cache_count_awaits_user(config_a) == 0
+        assert cockpit_inbox._maybe_cache_count_awaits_user(config_a) == 1
 
     def test_operator_view_declines_same_root_different_path(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
@@ -445,7 +491,29 @@ class TestConfigIdentityGuard:
             awaits_user_items=(),
         )
         assert unstamped.config_identity == ""
-        _seed_cache(monkeypatch, {"alpha": unstamped})
+        # Round-3 (#2051): the bounded-staleness guard rejects an empty
+        # workspace sentinel. To prove the identity-bypass for legacy
+        # unstamped entries, supply a non-empty unstamped workspace
+        # entry too — its ``config_identity`` is also "" so the bypass
+        # applies uniformly.
+        ws_item = SimpleNamespace(
+            project="inbox", scope="inbox", source="message",
+            task_id=None, message_id="ws-unstamped",
+            title="workspace root",
+        )
+        unstamped_workspace = ProjectStateCacheEntry(
+            project_key="__workspace__",
+            project_path=Path("/tmp/__workspace__"),
+            tracked=False,
+            state=None,
+            awaits_user_count=1,
+            awaits_user_items=(ws_item,),
+        )
+        assert unstamped_workspace.config_identity == ""
+        _seed_cache(
+            monkeypatch,
+            {"alpha": unstamped, "__workspace__": unstamped_workspace},
+        )
 
         # Even with a mismatched-looking config, unstamped entries are
         # served (this is the test-compat escape hatch). #2051 removed
@@ -455,7 +523,8 @@ class TestConfigIdentityGuard:
         # partial-cache guards (both satisfied by the seed above).
         config_solo = _make_config(["alpha"], tmp_path / "workspace-a")
         result = cockpit_inbox._maybe_cache_route_awaits_user(config_solo)
-        assert result == []
+        # The workspace-root item rides the cache (only item present).
+        assert result == [ws_item]
 
 
 # ── refresh stamping ──────────────────────────────────────────────

--- a/tests/test_state_cache_config_identity.py
+++ b/tests/test_state_cache_config_identity.py
@@ -103,8 +103,15 @@ def _stamped_entry(
     items: list[Any] | None = None,
     state: ProjectState = ProjectState.WAITING,
 ) -> ProjectStateCacheEntry:
-    """Build an entry stamped with ``config``'s identity (mirrors refresh)."""
+    """Build an entry stamped with ``config``'s identity (mirrors refresh).
 
+    Stamps ``computed_at`` with the current monotonic time so the round-4
+    workspace-sentinel TTL guard (#2051) treats the entry as fresh — the
+    identity-guard tests in this module only care about the identity
+    field, not staleness.
+    """
+
+    import time as _t
     items = items or []
     return ProjectStateCacheEntry(
         project_key=project_key,
@@ -121,6 +128,7 @@ def _stamped_entry(
         awaits_user_count=len(items),
         awaits_user_items=tuple(items),
         config_identity=config_identity(config),
+        computed_at=_t.monotonic(),
     )
 
 
@@ -478,10 +486,14 @@ class TestConfigIdentityGuard:
         parity tests.
         """
 
+        import time as _t
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config_a, _ = self._config_pair(tmp_path)
 
         # Hand-roll an unstamped entry (config_identity defaults to "").
+        # ``computed_at`` is stamped freshly so the round-4 workspace
+        # TTL guard doesn't reject the entry on staleness — this test
+        # isolates the IDENTITY bypass, not staleness.
         unstamped = ProjectStateCacheEntry(
             project_key="alpha",
             project_path=Path("/tmp/alpha"),
@@ -489,6 +501,7 @@ class TestConfigIdentityGuard:
             state=ProjectState.IDLE,
             awaits_user_count=0,
             awaits_user_items=(),
+            computed_at=_t.monotonic(),
         )
         assert unstamped.config_identity == ""
         # Round-3 (#2051): the bounded-staleness guard rejects an empty
@@ -508,6 +521,7 @@ class TestConfigIdentityGuard:
             state=None,
             awaits_user_count=1,
             awaits_user_items=(ws_item,),
+            computed_at=_t.monotonic(),
         )
         assert unstamped_workspace.config_identity == ""
         _seed_cache(

--- a/tests/test_state_cache_config_identity.py
+++ b/tests/test_state_cache_config_identity.py
@@ -420,18 +420,12 @@ class TestConfigIdentityGuard:
         _seed_cache(monkeypatch, {"alpha": unstamped})
 
         # Even with a mismatched-looking config, unstamped entries are
-        # served (this is the test-compat escape hatch).
+        # served (this is the test-compat escape hatch). #2051 removed
+        # the ``_workspace_root_inbox_has_open`` probe, so the only
+        # remaining gates that could decline are the config-identity
+        # guard (which we're isolating here) and the cold-cache /
+        # partial-cache guards (both satisfied by the seed above).
         config_solo = _make_config(["alpha"], tmp_path / "workspace-a")
-        result = cockpit_inbox._maybe_cache_route_awaits_user(config_solo)
-        # Either the served path returns the empty list, or the route
-        # declines for an OTHER reason (workspace-root probe, etc.).
-        # The point is: the identity guard didn't fire on the
-        # unstamped entry.
-        # Force the workspace-root probe to "no open" to isolate the
-        # identity gate from other guards.
-        monkeypatch.setattr(
-            cockpit_inbox, "_workspace_root_inbox_has_open", lambda cfg: False,
-        )
         result = cockpit_inbox._maybe_cache_route_awaits_user(config_solo)
         assert result == []
 

--- a/tests/test_state_cache_env_flag.py
+++ b/tests/test_state_cache_env_flag.py
@@ -232,14 +232,19 @@ def test_singleton_wires_project_keys_provider_for_initial_refresh(
         # The provider must be wired on the refresher instance — this is
         # the property whose absence was the Codex blocker.
         assert refresher._project_keys is not None  # noqa: SLF001
+        # #2051: provider also yields the ``__workspace__`` sentinel so
+        # the refresher computes a synthetic workspace-root inbox entry
+        # on boot + on every full pass.
         assert sorted(refresher._project_keys()) == [  # noqa: SLF001
-            "alpha", "beta", "gamma",
+            "__workspace__", "alpha", "beta", "gamma",
         ]
         # And the startup full-refresh must have populated the cache
         # with entries for every configured project (no audit events
-        # required).
+        # required) plus the workspace sentinel.
         snapshot = cache.snapshot()
-        assert set(snapshot.keys()) == {"alpha", "beta", "gamma"}
+        assert set(snapshot.keys()) == {
+            "__workspace__", "alpha", "beta", "gamma",
+        }
     finally:
         reset_for_test()
 
@@ -311,8 +316,12 @@ class TestDivergenceSamplerNoop:
 def test_singleton_provider_degrades_gracefully_on_config_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The provider must catch ``load_config`` failures and return ``[]``
-    — the cache stays empty instead of taking down the cockpit.
+    """The provider must catch ``load_config`` failures and degrade
+    gracefully instead of taking down the cockpit.
+
+    #2051: the provider yields the ``__workspace__`` sentinel even on
+    config-load failure so the workspace-root inbox entry can still be
+    refreshed (the workspace probe is config-tolerant).
     """
 
     monkeypatch.setenv(ENV_FLAG, "1")
@@ -333,10 +342,17 @@ def test_singleton_provider_degrades_gracefully_on_config_failure(
     refresher = get_refresher()
     try:
         assert refresher is not None
-        # Provider is wired, but it absorbs the load_config exception
-        # and yields the empty list.
+        # Provider is wired, but it absorbs the load_config exception.
+        # #2051: even on config-load failure the provider still yields
+        # the ``__workspace__`` sentinel so the workspace-root inbox
+        # entry refreshes against whatever config the workspace probe
+        # can resolve (the inbox aggregator handles a None/broken
+        # config gracefully).
         assert refresher._project_keys is not None  # noqa: SLF001
-        assert refresher._project_keys() == []  # noqa: SLF001
-        assert cache.snapshot() == {}
+        assert refresher._project_keys() == ["__workspace__"]  # noqa: SLF001
+        # The workspace entry refresh ran during the initial full
+        # refresh — snapshot has the sentinel even though no projects
+        # could be resolved from the (broken) config.
+        assert set(cache.snapshot().keys()) == {"__workspace__"}
     finally:
         reset_for_test()

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -167,21 +167,25 @@ def _seed_cache(
 
     #2051 (Codex review): the cache-read boundary now treats a snapshot
     missing the synthetic ``__workspace__`` entry as INCOMPLETE and
-    falls through to the direct sweep. Most parity tests assume the
-    fast-path is taken, so we auto-seed an empty ``__workspace__``
-    entry when the caller hasn't provided one. Tests that need to
-    exercise the absent-sentinel guard pass an explicit
-    ``__workspace__`` key (or use the dedicated fall-through tests
-    below).
+    falls through to the direct sweep. Round-3 of that review added a
+    second guard: a present-but-EMPTY ``__workspace__`` entry is also
+    treated as not-authoritative (bounded-staleness against message-
+    store writes that bypass audit-event invalidation). Tests that
+    want the fast-path must therefore seed a non-empty
+    ``__workspace__`` entry explicitly. Tests exercising the absent-
+    or empty-sentinel guards build the cache by hand below.
     """
 
     cache = ProjectStateCache(refresh_fn=lambda k: None)
     seeded = dict(entries)
     if "__workspace__" not in seeded and seeded:
-        # Auto-seed an empty workspace sentinel so the fast-path stays
-        # available; callers that want the absent-sentinel behavior
-        # explicitly pass ``"__workspace__": <entry>`` or omit it via
-        # the dedicated test in TestPr2026ReviewBlocker3WorkspaceRootFallthrough.
+        # Auto-seed an empty workspace sentinel ONLY when the caller
+        # didn't provide one. With the round-3 bounded-staleness guard,
+        # this empty seed now triggers fall-through — so any test that
+        # relies on the fast-path firing must supply an explicit
+        # non-empty ``__workspace__`` entry. Kept here so legacy callers
+        # that don't care about the workspace sentinel still pass the
+        # absent-sentinel guard (the snapshot DOES contain the key).
         seeded["__workspace__"] = _entry(
             "__workspace__", state=None, items=[],
         )
@@ -245,16 +249,30 @@ class TestAwaitsUserParity:
     def test_flag_on_with_populated_cache_uses_fast_path(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Cache fast-path returns identical content + skips the direct call."""
+        """Cache fast-path returns identical content + skips the direct call.
+
+        #2051 round-3 (Codex review): the cache-read boundary now also
+        falls through when ``__workspace__`` is present-but-empty
+        (bounded-staleness guard against message-store writes that
+        bypass audit-event invalidation). Seed a non-empty workspace
+        sentinel so the fast-path actually fires here.
+        """
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config = _make_config(["alpha", "beta", "gamma"], tmp_path)
-        _seed_cache(monkeypatch, self._entries_from_direct())
+        entries = self._entries_from_direct()
+        workspace_root = _inbox_item(
+            project="inbox", source="message", ident="ws-root-fast-path",
+        )
+        entries["__workspace__"] = _entry(
+            "__workspace__", state=None, items=[workspace_root],
+        )
+        _seed_cache(monkeypatch, entries)
 
         direct_called = {"n": 0}
 
         def _no_call(_cfg: Any) -> list[Any]:
             direct_called["n"] += 1
-            return self._direct_items()
+            return self._direct_items() + [workspace_root]
 
         monkeypatch.setattr(
             cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", _no_call,
@@ -265,7 +283,9 @@ class TestAwaitsUserParity:
         # first call lands on counter==1 → no sample. So the direct
         # path stays untouched.
         assert direct_called["n"] == 0
-        matched, reason = compare_awaits_user_lists(result, self._direct_items())
+        matched, reason = compare_awaits_user_lists(
+            result, self._direct_items() + [workspace_root],
+        )
         assert matched, reason
 
     def test_flag_on_with_empty_cache_falls_through(
@@ -514,7 +534,21 @@ class TestDivergenceSampler:
             cache_item,
             _inbox_item(project="alpha", source="message", ident="m-extra"),
         ]
-        entries = {"alpha": _entry("alpha", state=ProjectState.WAITING, items=[cache_item])}
+        # #2051 round-3: seed a non-empty ``__workspace__`` entry so the
+        # bounded-staleness guard doesn't fall through before the
+        # sampler runs (we're testing the sampler, not the guard).
+        workspace_root = _inbox_item(
+            project="inbox", source="message", ident="ws-root-sampler",
+        )
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WAITING, items=[cache_item],
+            ),
+            "__workspace__": _entry(
+                "__workspace__", state=None, items=[workspace_root],
+            ),
+        }
+        direct_items.append(workspace_root)
         _seed_cache(monkeypatch, entries)
 
         # Force every call to sample by swapping in a rate-1 counter.
@@ -655,9 +689,19 @@ class TestInboxDefaultLensInvariant:
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         items = self._items()
         config = _make_config(["alpha", "beta"], tmp_path)
+        # #2051 round-3: include a workspace-root item via a non-empty
+        # ``__workspace__`` sentinel so the cache fast-path stays
+        # authoritative (an empty sentinel now triggers fall-through).
+        workspace_root = _inbox_item(
+            project="inbox", source="message", ident="ws-root-invariant",
+        )
+        items = items + [workspace_root]
         entries = {
             "alpha": _entry("alpha", state=ProjectState.WAITING, items=[items[0]]),
             "beta": _entry("beta", state=ProjectState.WAITING, items=[items[1]]),
+            "__workspace__": _entry(
+                "__workspace__", state=None, items=[workspace_root],
+            ),
         }
         _seed_cache(monkeypatch, entries)
         # The legacy TTL would clobber the cache-routed result; clear
@@ -693,10 +737,19 @@ class TestCountInboxTasksForLabelParity:
             _inbox_item(project="beta", source="message", ident="m-b1"),
         ]
         items_gamma: list[Any] = []
+        # #2051 round-3: non-empty ``__workspace__`` sentinel so the
+        # bounded-staleness guard doesn't fall through (we're proving
+        # the fast-path skips the workspace sweep here).
+        workspace_items = [
+            _inbox_item(project="inbox", source="message", ident="ws-root-count"),
+        ]
         entries = {
             "alpha": _entry("alpha", state=ProjectState.WAITING, items=items_alpha),
             "beta": _entry("beta", state=ProjectState.WAITING, items=items_beta),
             "gamma": _entry("gamma", state=ProjectState.IDLE, items=items_gamma),
+            "__workspace__": _entry(
+                "__workspace__", state=None, items=workspace_items,
+            ),
         }
         _seed_cache(monkeypatch, entries)
 
@@ -704,15 +757,18 @@ class TestCountInboxTasksForLabelParity:
 
         def _no_call(_cfg: Any) -> list[Any]:
             direct_called["n"] += 1
-            return items_alpha + items_beta + items_gamma
+            return (
+                items_alpha + items_beta + items_gamma + workspace_items
+            )
 
         monkeypatch.setattr(
             cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", _no_call,
         )
 
         counted = cockpit_inbox._count_inbox_tasks_for_label(config)
-        # Three items total; the direct sweep wasn't touched.
-        assert counted == 3
+        # Four items total (3 per-project + 1 workspace-root); the
+        # direct sweep wasn't touched.
+        assert counted == 4
         assert direct_called["n"] == 0
 
     def test_flag_off_uses_direct_path(
@@ -1726,3 +1782,104 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         # Direct sweep ran via the list fall-through; count == 2.
         assert direct_called["n"] >= 1
         assert counted == 2
+
+    def test_present_empty_workspace_entry_falls_through_so_late_arriving_rows_are_seen(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Round-3 Codex review of #2051: a present-but-EMPTY
+        ``__workspace__`` entry is NOT authoritative.
+
+        The round-2 fix only guarded the absent-sentinel case (snapshot
+        missing ``__workspace__``). Once the refresher installs an
+        empty sentinel (``awaits_user_items=[]``, ``awaits_user_count
+        =0``), the cache-read boundary would happily serve that zero
+        — even though message-store writes (alerts, notifications,
+        ``pm notify`` workspace-root rows) can land AFTER the
+        sentinel's last refresh without emitting an invalidating
+        audit event. The bounded-staleness guard pins the new
+        contract: when the workspace entry is present but empty,
+        both helpers MUST return ``None`` so the direct sweep picks
+        up any late-arriving rows.
+
+        Trade-off (acceptable for v1 RC): workspaces with truly zero
+        workspace-root awaits-user rows pay the direct-sweep cost on
+        every call. Per-project cache benefits remain. Full
+        audit-event wiring for workspace-root producers is deferred
+        past RC.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        # Hand-roll the cache so the empty ``__workspace__`` sentinel
+        # is exactly what the refresher would install after computing
+        # zero workspace-root rows.
+        cache = ProjectStateCache(refresh_fn=lambda k: None)
+        cache._install_for_test(
+            "alpha",
+            _entry("alpha", state=ProjectState.WAITING, items=per_project),
+        )
+        cache._install_for_test(
+            "__workspace__",
+            _entry("__workspace__", state=None, items=[]),
+        )
+        monkeypatch.setattr(
+            "pollypm.state_cache.is_enabled", lambda: True,
+        )
+        monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
+
+        # Simulate a workspace-root message-store write that landed
+        # AFTER the refresher stamped the empty sentinel. The direct
+        # sweep MUST be invoked to find it.
+        late_arrival = _inbox_item(
+            project="inbox", source="message", ident="ws-root-late",
+        )
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(per_project) + [late_arrival]
+
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            _direct,
+        )
+        # Pin the sampler off so it can't itself trigger a direct call.
+        cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+
+        # Direct contract: both maybe_cache_* helpers MUST return None
+        # (cache declines) when the workspace sentinel is present but
+        # empty. This is the unit-level proof of the bounded-
+        # staleness guard.
+        assert (
+            cockpit_inbox._maybe_cache_route_awaits_user(config) is None
+        )
+        assert (
+            cockpit_inbox._maybe_cache_count_awaits_user(config) is None
+        )
+
+        # Integrated contract: the public list helper falls through
+        # to the direct sweep and surfaces the late-arriving row.
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        result = cockpit_inbox.pm_inbox_awaits_user_list(config)
+        ids = {
+            getattr(item, "message_id", None)
+            or getattr(item, "task_id", None)
+            for item in result
+        }
+        assert "ws-root-late" in ids
+        assert "alpha/1" in ids
+        # Direct sweep ran (proof of fall-through, not the fast-path
+        # quietly serving an empty list).
+        assert direct_called["n"] >= 1
+
+        # Count helper mirrors: the late-arriving row is included.
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        before = direct_called["n"]
+        counted = cockpit_inbox._count_inbox_tasks_for_label(config)
+        assert counted == 2
+        assert direct_called["n"] > before

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -1485,71 +1485,81 @@ class TestPr2026ReviewBlocker2HeartbeatNoStale:
 
 
 class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
-    """Blocker 3: workspace-root inbox messages (``scope IN ('', 'inbox')``)
-    are not represented in any per-project cache entry, so the cache
-    routes for awaits-user list + count MUST fall through to the
-    direct path whenever the workspace-root inbox is non-empty.
+    """Issue #2051: workspace-root inbox messages (``scope IN ('',
+    'inbox')``) now ride a synthetic ``__workspace__`` cache entry
+    emitted by the refresher. The cache fast-path MUST serve them
+    alongside per-project items — no more probe-driven fall-through.
+
+    These tests previously pinned the OPPOSITE behavior (forced
+    fall-through whenever the workspace-root probe saw a live row).
+    Flipped by #2051: the cache is authoritative for workspace-root
+    rows too. The ``_workspace_root_inbox_has_open`` probe + its
+    callers were removed.
     """
 
-    def test_workspace_root_message_forces_list_fallthrough(
+    def test_workspace_root_message_served_by_cache(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """A live workspace-root row → list cache declines, direct path runs.
-
-        Pinned to the cached vs direct equality: both MUST return the
-        same set of items (workspace-root included), proving the
-        fall-through is what carried the workspace row.
+        """List route returns workspace-root item from the ``__workspace__``
+        entry without touching the direct sweep.
         """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config = _make_config(["alpha"], tmp_path)
 
-        # Per-project items the cache CAN represent.
+        # Per-project items live on the project's entry.
         per_project = [
             _inbox_item(project="alpha", source="task", ident="alpha/1"),
         ]
-        # The workspace-root item with project="inbox" — the cache
-        # CANNOT represent this (refresher filters by project_key only).
+        # Workspace-root items live on the synthetic ``__workspace__``
+        # entry the refresher emits for #2051.
         workspace_root = _inbox_item(
             project="inbox", source="message", ident="ws-root-1",
-        )
-        # And the workspace-root probe MUST see it (simulate pg row).
-        monkeypatch.setattr(
-            cockpit_inbox,
-            "_workspace_root_inbox_has_open",
-            lambda cfg: True,
         )
         entries = {
             "alpha": _entry(
                 "alpha", state=ProjectState.WAITING, items=per_project,
             ),
+            "__workspace__": _entry(
+                "__workspace__",
+                state=None,
+                items=[workspace_root],
+            ),
         }
         _seed_cache(monkeypatch, entries)
 
-        # Direct sweep returns BOTH (per-project + workspace-root).
-        direct_items = list(per_project) + [workspace_root]
+        # Direct sweep MUST NOT be called — the cache is now
+        # authoritative for workspace-root rows.
         direct_called = {"n": 0}
 
         def _direct(_cfg: Any) -> list[Any]:
             direct_called["n"] += 1
-            return list(direct_items)
+            return list(per_project) + [workspace_root]
 
         monkeypatch.setattr(
             cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", _direct,
         )
+        # Pin the sampler off so the divergence sampler can't sneak in
+        # a direct read.
+        cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
         cockpit_inbox._AWAITS_USER_CACHE.clear()
         result = cockpit_inbox.pm_inbox_awaits_user_list(config)
-        assert direct_called["n"] == 1
-        # Workspace-root item is in the result (would have been
-        # silently dropped if we had stayed on the fast-path).
-        ids = {getattr(item, "message_id", None) or getattr(item, "task_id", None) for item in result}
+        assert direct_called["n"] == 0
+        ids = {
+            getattr(item, "message_id", None)
+            or getattr(item, "task_id", None)
+            for item in result
+        }
+        # Both per-project AND workspace-root items are present.
         assert "ws-root-1" in ids
         assert "alpha/1" in ids
 
-    def test_workspace_root_message_forces_count_fallthrough(
+    def test_workspace_root_message_served_by_cache_count(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Same gate fires on the count helper — sums match direct len()."""
+        """Count helper sums per-project AND ``__workspace__`` entries
+        directly from the snapshot — no direct sweep.
+        """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config = _make_config(["alpha"], tmp_path)
@@ -1559,44 +1569,48 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         workspace_root = _inbox_item(
             project="inbox", source="message", ident="ws-root-2",
         )
-        monkeypatch.setattr(
-            cockpit_inbox,
-            "_workspace_root_inbox_has_open",
-            lambda cfg: True,
-        )
         entries = {
             "alpha": _entry(
                 "alpha", state=ProjectState.WAITING, items=per_project,
             ),
+            "__workspace__": _entry(
+                "__workspace__",
+                state=None,
+                items=[workspace_root],
+            ),
         }
         _seed_cache(monkeypatch, entries)
 
-        direct_items = list(per_project) + [workspace_root]
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(per_project) + [workspace_root]
+
         monkeypatch.setattr(
             cockpit_inbox,
             "_pm_inbox_awaits_user_list_uncached",
-            lambda cfg: list(direct_items),
+            _direct,
         )
         cockpit_inbox._AWAITS_USER_CACHE.clear()
         counted = cockpit_inbox._count_inbox_tasks_for_label(config)
-        # Cache would have returned 1 (only alpha); fall-through gives 2.
+        assert direct_called["n"] == 0
+        # Per-project + workspace-root counts both contribute.
         assert counted == 2
 
-    def test_workspace_root_empty_keeps_cache_fast_path(
+    def test_no_workspace_entry_still_serves_per_project_via_cache(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Empty workspace-root → cache fast-path stays available."""
+        """Snapshot without a ``__workspace__`` entry — the cache
+        still serves per-project items from the fast-path. Absent
+        workspace entry contributes 0 to the union/count.
+        """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config = _make_config(["alpha"], tmp_path)
         per_project = [
             _inbox_item(project="alpha", source="task", ident="alpha/1"),
         ]
-        monkeypatch.setattr(
-            cockpit_inbox,
-            "_workspace_root_inbox_has_open",
-            lambda cfg: False,
-        )
         entries = {
             "alpha": _entry(
                 "alpha", state=ProjectState.WAITING, items=per_project,
@@ -1604,12 +1618,9 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         }
         _seed_cache(monkeypatch, entries)
 
-        # Pin the sampler off so the divergence-comparator path
-        # doesn't masquerade as a fall-through. Earlier tests in this
-        # module may have swapped in a rate-1 counter that would
-        # sample every call; restore a fresh default-rate counter.
+        # Sampler-off so divergence comparator can't masquerade as a
+        # fall-through.
         cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
-        # Direct sweep MUST NOT be called.
         direct_called = {"n": 0}
 
         def _direct(_cfg: Any) -> list[Any]:
@@ -1624,351 +1635,3 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         assert direct_called["n"] == 0
         assert len(result) == 1
 
-
-class TestPr2026V3WorkspaceRootProbeUnbounded:
-    """PR #2026 v3 (Codex blocker 1): the workspace-root probe must NOT
-    depend on row recency. The old implementation called
-    ``open_messages(limit=50)`` and Python-scanned for ``scope IN ('',
-    'inbox')``; with 50+ newer project-scoped rows + 1 older
-    workspace-root row, the probe returned False and the cache silently
-    dropped the workspace work.
-
-    The fix adds a dedicated SQL existence query
-    (``cockpit_pg_aggregates.has_workspace_root_open_messages``) with
-    a workspace-root predicate + ``LIMIT 1`` — independent of how many
-    newer non-workspace rows exist.
-
-    This test calls the REAL ``_workspace_root_inbox_has_open`` (no
-    monkeypatch on that function) against a fake pg_pool that simulates
-    the bug scenario.
-    """
-
-    def test_workspace_root_row_under_50_newer_rows_is_still_seen(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        """Seed pg with 50 newer project-scoped rows + 1 older
-        workspace-root row; the SQL existence query MUST return True.
-        """
-
-        config = _make_config(["alpha"], tmp_path)
-
-        # Track which SQL was executed so the assertion proves the
-        # workspace-root existence query (not the legacy newest-50
-        # scan) is what gave the True answer.
-        executed: list[tuple[str, tuple[Any, ...]]] = []
-
-        class _FakeCursor:
-            def __init__(self) -> None:
-                self._result: list[tuple[Any, ...]] = []
-
-            def __enter__(self) -> "_FakeCursor":
-                return self
-
-            def __exit__(self, *_a: Any) -> None:
-                pass
-
-            def execute(self, sql: str, params: Any) -> None:
-                executed.append((sql, tuple(params)))
-                # Workspace-root probe: predicate includes the
-                # ``scope = '' OR scope IS NULL OR scope = 'inbox'``
-                # branch + a ``LIMIT 1``. Return one row.
-                if "scope = 'inbox'" in sql and "LIMIT 1" in sql:
-                    self._result = [(1,)]
-                    return
-                # Anything else (e.g. the legacy newest-N scan) —
-                # return 50 project-scoped rows so the OLD code
-                # would have missed the workspace-root row entirely.
-                self._result = [
-                    (i, "alpha", "notify", "info", "user", "sender",
-                     "open", "subj", "body", {}, [], "kind",
-                     None, None, None)
-                    for i in range(50)
-                ]
-
-            def fetchone(self) -> Any:
-                return self._result[0] if self._result else None
-
-            def fetchall(self) -> list[tuple[Any, ...]]:
-                return list(self._result)
-
-            @property
-            def description(self) -> list[Any]:
-                return [SimpleNamespace(name=n) for n in (
-                    "id", "scope", "type", "tier", "recipient",
-                    "sender", "state", "subject", "body",
-                    "payload_json", "labels", "kind",
-                    "created_at", "updated_at", "closed_at",
-                )]
-
-        class _FakeConn:
-            def __enter__(self) -> "_FakeConn":
-                return self
-
-            def __exit__(self, *_a: Any) -> None:
-                pass
-
-            def cursor(self) -> _FakeCursor:
-                return _FakeCursor()
-
-        class _FakePool:
-            def connection(self) -> _FakeConn:
-                return _FakeConn()
-
-        def _fake_get_ro_pool(_cfg: Any) -> _FakePool:
-            return _FakePool()
-
-        monkeypatch.setattr(
-            "pollypm.storage.pg_pool.get_ro_pool", _fake_get_ro_pool,
-        )
-
-        # Call the REAL function (no monkeypatch on _workspace_root_inbox_has_open).
-        assert cockpit_inbox._workspace_root_inbox_has_open(config) is True
-
-        # Prove the SQL the function executed was the bounded-1
-        # existence query, not the legacy newest-N scan.
-        assert executed, "fake pg pool was never queried"
-        executed_sqls = [sql for sql, _params in executed]
-        assert any(
-            "scope = 'inbox'" in sql and "LIMIT 1" in sql
-            for sql in executed_sqls
-        ), (
-            f"workspace-root probe should issue a LIMIT-1 existence "
-            f"query; saw {executed_sqls!r}"
-        )
-
-    def test_real_probe_drives_cache_fall_through(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        """The probe's True answer MUST flip
-        ``_maybe_cache_route_awaits_user`` to fall through to direct.
-        """
-
-        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
-        config = _make_config(["alpha"], tmp_path)
-
-        class _FakeCursor:
-            def __init__(self) -> None:
-                self._result: list[tuple[Any, ...]] = []
-
-            def __enter__(self) -> "_FakeCursor":
-                return self
-
-            def __exit__(self, *_a: Any) -> None:
-                pass
-
-            def execute(self, sql: str, params: Any) -> None:
-                if "LIMIT 1" in sql:
-                    self._result = [(1,)]
-                else:
-                    self._result = []
-
-            def fetchone(self) -> Any:
-                return self._result[0] if self._result else None
-
-            def fetchall(self) -> list[tuple[Any, ...]]:
-                return list(self._result)
-
-            @property
-            def description(self) -> list[Any]:
-                return [SimpleNamespace(name="x")]
-
-        class _FakeConn:
-            def __enter__(self) -> "_FakeConn":
-                return self
-
-            def __exit__(self, *_a: Any) -> None:
-                pass
-
-            def cursor(self) -> _FakeCursor:
-                return _FakeCursor()
-
-        class _FakePool:
-            def connection(self) -> _FakeConn:
-                return _FakeConn()
-
-        monkeypatch.setattr(
-            "pollypm.storage.pg_pool.get_ro_pool", lambda _cfg: _FakePool(),
-        )
-
-        # Seed a populated cache for alpha. No monkeypatch on
-        # _workspace_root_inbox_has_open — it executes the REAL pg
-        # path against the fake pool above and returns True.
-        entries = {
-            "alpha": _entry(
-                "alpha", state=ProjectState.IDLE, items=[],
-            ),
-        }
-        _seed_cache(monkeypatch, entries)
-
-        # The fast-path MUST decline so the direct sweep can carry
-        # the workspace-root row.
-        assert cockpit_inbox._maybe_cache_route_awaits_user(config) is None
-
-    # ── PR #2026 v6 regression tests (Codex round-6 blocker) ──────────
-    #
-    # The v5 helper returns True on pool/query failure to keep the cache
-    # authoritative-or-deferred. These tests pin that contract end-to-end:
-    # (1) the helper itself returns True on each failure mode, and
-    # (2) the failure flows through _maybe_cache_{route,count}_awaits_user
-    # as a fall-through (cache declines).
-
-    def test_pool_open_failure_returns_true_conservative(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        """``has_workspace_root_open_messages`` must return True when the
-        pg pool cannot be opened — conservative-on-failure contract.
-        """
-
-        from pollypm import cockpit_pg_aggregates
-
-        config = _make_config(["alpha"], tmp_path)
-
-        def _boom_ro(_cfg: Any) -> Any:
-            raise RuntimeError("ro pool unavailable")
-
-        def _boom_rw(_cfg: Any) -> Any:
-            raise RuntimeError("rw pool unavailable")
-
-        monkeypatch.setattr(
-            "pollypm.storage.pg_pool.get_ro_pool", _boom_ro,
-        )
-        monkeypatch.setattr(
-            "pollypm.storage.pg_pool.get_rw_pool", _boom_rw,
-        )
-
-        assert (
-            cockpit_pg_aggregates.has_workspace_root_open_messages(config)
-            is True
-        )
-
-    def test_query_failure_returns_true_conservative(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        """Pool open succeeds but ``cur.execute()`` raises — the helper
-        must still return True (conservative).
-        """
-
-        from pollypm import cockpit_pg_aggregates
-
-        config = _make_config(["alpha"], tmp_path)
-
-        class _FakeCursor:
-            def __enter__(self) -> "_FakeCursor":
-                return self
-
-            def __exit__(self, *_a: Any) -> None:
-                pass
-
-            def execute(self, _sql: str, _params: Any) -> None:
-                raise RuntimeError("query exploded")
-
-            def fetchone(self) -> Any:
-                return None
-
-        class _FakeConn:
-            def __enter__(self) -> "_FakeConn":
-                return self
-
-            def __exit__(self, *_a: Any) -> None:
-                pass
-
-            def cursor(self) -> _FakeCursor:
-                return _FakeCursor()
-
-        class _FakePool:
-            def connection(self) -> _FakeConn:
-                return _FakeConn()
-
-        monkeypatch.setattr(
-            "pollypm.storage.pg_pool.get_ro_pool", lambda _cfg: _FakePool(),
-        )
-
-        assert (
-            cockpit_pg_aggregates.has_workspace_root_open_messages(config)
-            is True
-        )
-
-    def test_pool_failure_drives_cache_fall_through(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        """Pool failure → wrapper returns True → ``_maybe_cache_route_awaits_user``
-        declines so the direct sweep carries any uncached awaits-user work.
-        """
-
-        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
-        config = _make_config(["alpha"], tmp_path)
-
-        def _boom_ro(_cfg: Any) -> Any:
-            raise RuntimeError("ro pool unavailable")
-
-        def _boom_rw(_cfg: Any) -> Any:
-            raise RuntimeError("rw pool unavailable")
-
-        monkeypatch.setattr(
-            "pollypm.storage.pg_pool.get_ro_pool", _boom_ro,
-        )
-        monkeypatch.setattr(
-            "pollypm.storage.pg_pool.get_rw_pool", _boom_rw,
-        )
-
-        # Cache seeded with an uncached-style entry — the only way the
-        # fast-path can decline is via the workspace-root guard, which
-        # depends on the failing probe.
-        entries = {
-            "alpha": _entry(
-                "alpha", state=ProjectState.IDLE, items=[],
-            ),
-        }
-        _seed_cache(monkeypatch, entries)
-
-        assert cockpit_inbox._maybe_cache_route_awaits_user(config) is None
-
-    def test_query_failure_drives_count_fall_through(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        """Query failure → wrapper returns True → ``_maybe_cache_count_awaits_user``
-        declines so the rail badge falls back to the direct sweep.
-        """
-
-        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
-        config = _make_config(["alpha"], tmp_path)
-
-        class _FakeCursor:
-            def __enter__(self) -> "_FakeCursor":
-                return self
-
-            def __exit__(self, *_a: Any) -> None:
-                pass
-
-            def execute(self, _sql: str, _params: Any) -> None:
-                raise RuntimeError("query exploded")
-
-            def fetchone(self) -> Any:
-                return None
-
-        class _FakeConn:
-            def __enter__(self) -> "_FakeConn":
-                return self
-
-            def __exit__(self, *_a: Any) -> None:
-                pass
-
-            def cursor(self) -> _FakeCursor:
-                return _FakeCursor()
-
-        class _FakePool:
-            def connection(self) -> _FakeConn:
-                return _FakeConn()
-
-        monkeypatch.setattr(
-            "pollypm.storage.pg_pool.get_ro_pool", lambda _cfg: _FakePool(),
-        )
-
-        entries = {
-            "alpha": _entry(
-                "alpha", state=ProjectState.IDLE, items=[],
-            ),
-        }
-        _seed_cache(monkeypatch, entries)
-
-        assert cockpit_inbox._maybe_cache_count_awaits_user(config) is None

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -1791,30 +1791,25 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         assert direct_called["n"] >= 1
         assert counted == 2
 
-    def test_present_empty_workspace_entry_falls_through_so_late_arriving_rows_are_seen(
+    def test_fresh_empty_workspace_entry_serves_zero_from_cache(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Round-3 Codex review of #2051: a present-but-EMPTY
-        ``__workspace__`` entry is NOT authoritative.
+        """Round-5 Codex review of #2051: a fresh EMPTY ``__workspace__``
+        sentinel is the steady state for most workspaces — the cache
+        fast-path MUST serve it.
 
-        The round-2 fix only guarded the absent-sentinel case (snapshot
-        missing ``__workspace__``). Once the refresher installs an
-        empty sentinel (``awaits_user_items=[]``, ``awaits_user_count
-        =0``), the cache-read boundary would happily serve that zero
-        — even though message-store writes (alerts, notifications,
-        ``pm notify`` workspace-root rows) can land AFTER the
-        sentinel's last refresh without emitting an invalidating
-        audit event. The bounded-staleness guard pins the new
-        contract: when the workspace entry is present but empty,
-        both helpers MUST return ``None`` so the direct sweep picks
-        up any late-arriving rows.
-
-        Trade-off (acceptable for v1 RC): workspaces with truly zero
-        workspace-root awaits-user rows pay the direct-sweep cost on
-        every call. Per-project cache benefits remain. Full
-        audit-event wiring for workspace-root producers is deferred
-        past RC.
+        Round-3 added an always-fall-through on present-but-empty
+        sentinels; round-4 added a TTL guard. Codex round-5 observed
+        that the TTL alone covers the staleness invariant (empty +
+        stale falls through), so the round-3 fall-through defeats the
+        fast path in the common case (workspaces with zero
+        workspace-root awaits-user rows). This test pins the round-5
+        contract: a fresh empty sentinel returns just the per-project
+        items (no workspace contribution) and the direct sweep is NOT
+        invoked.
         """
+
+        import time as _t
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         config = _make_config(["alpha"], tmp_path)
@@ -1823,15 +1818,117 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         ]
         # Hand-roll the cache so the empty ``__workspace__`` sentinel
         # is exactly what the refresher would install after computing
-        # zero workspace-root rows.
+        # zero workspace-root rows — stamped fresh (well inside TTL).
+        fresh_at = _t.monotonic()
         cache = ProjectStateCache(refresh_fn=lambda k: None)
         cache._install_for_test(
             "alpha",
-            _entry("alpha", state=ProjectState.WAITING, items=per_project),
+            _entry(
+                "alpha",
+                state=ProjectState.WAITING,
+                items=per_project,
+                computed_at=fresh_at,
+            ),
         )
         cache._install_for_test(
             "__workspace__",
-            _entry("__workspace__", state=None, items=[]),
+            _entry(
+                "__workspace__",
+                state=None,
+                items=[],
+                computed_at=fresh_at,
+            ),
+        )
+        monkeypatch.setattr(
+            "pollypm.state_cache.is_enabled", lambda: True,
+        )
+        monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
+
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(per_project)
+
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            _direct,
+        )
+        # Pin the divergence sampler off — its random direct call would
+        # blur the "did the cache fast-path fire" assertion.
+        cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+
+        # Direct contract: the list helper MUST return the per-project
+        # items only (zero workspace contribution) — NOT None.
+        routed = cockpit_inbox._maybe_cache_route_awaits_user(config)
+        assert routed is not None
+        ids = {
+            getattr(item, "message_id", None)
+            or getattr(item, "task_id", None)
+            for item in routed
+        }
+        assert ids == {"alpha/1"}
+
+        # Count helper served from cache as 1 (per-project only).
+        cached_count = cockpit_inbox._maybe_cache_count_awaits_user(config)
+        assert cached_count == 1
+
+        # Direct sweep was NOT invoked — the fast-path served both
+        # helpers from the snapshot (this is the round-5 fix).
+        assert direct_called["n"] == 0
+
+    def test_stale_empty_workspace_entry_falls_through_after_ttl(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Round-5 Codex review of #2051: an EMPTY ``__workspace__``
+        sentinel past its TTL is NOT authoritative.
+
+        Mirrors :func:`test_stale_non_empty_workspace_entry_falls_through_after_ttl`
+        for the empty case — message-store writes (alerts,
+        notifications, ``pm notify`` workspace-root rows) can land
+        AFTER the sentinel's last refresh without emitting an
+        invalidating audit event, so once the empty sentinel ages
+        past the TTL both helpers MUST fall through to the direct
+        sweep and surface the late-arriving row.
+
+        This pins the staleness invariant in the round-5 simplified
+        model: TTL alone covers it (empty + stale → fall through;
+        empty + fresh → serve zero, which is the correct fast-path
+        behavior).
+        """
+
+        import time as _t
+        from pollypm.state_cache.refresh_impl import (
+            WORKSPACE_ENTRY_TTL_SECONDS,
+        )
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        # Stamp the empty sentinel well beyond the TTL.
+        stale_at = _t.monotonic() - (WORKSPACE_ENTRY_TTL_SECONDS + 20.0)
+        cache = ProjectStateCache(refresh_fn=lambda k: None)
+        cache._install_for_test(
+            "alpha",
+            _entry(
+                "alpha",
+                state=ProjectState.WAITING,
+                items=per_project,
+                computed_at=_t.monotonic(),
+            ),
+        )
+        cache._install_for_test(
+            "__workspace__",
+            _entry(
+                "__workspace__",
+                state=None,
+                items=[],
+                computed_at=stale_at,
+            ),
         )
         monkeypatch.setattr(
             "pollypm.state_cache.is_enabled", lambda: True,
@@ -1855,14 +1952,11 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
             "_pm_inbox_awaits_user_list_uncached",
             _direct,
         )
-        # Pin the sampler off so it can't itself trigger a direct call.
         cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
         cockpit_inbox._AWAITS_USER_CACHE.clear()
 
-        # Direct contract: both maybe_cache_* helpers MUST return None
-        # (cache declines) when the workspace sentinel is present but
-        # empty. This is the unit-level proof of the bounded-
-        # staleness guard.
+        # Direct contract: BOTH cache-routed helpers MUST decline
+        # (return None) when the empty sentinel is past its TTL.
         assert (
             cockpit_inbox._maybe_cache_route_awaits_user(config) is None
         )
@@ -1881,16 +1975,112 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         }
         assert "ws-root-late" in ids
         assert "alpha/1" in ids
-        # Direct sweep ran (proof of fall-through, not the fast-path
-        # quietly serving an empty list).
         assert direct_called["n"] >= 1
 
-        # Count helper mirrors: the late-arriving row is included.
+        # Count helper mirrors.
         cockpit_inbox._AWAITS_USER_CACHE.clear()
         before = direct_called["n"]
         counted = cockpit_inbox._count_inbox_tasks_for_label(config)
         assert counted == 2
         assert direct_called["n"] > before
+
+    def test_fresh_empty_workspace_entry_with_create_after_refresh_within_ttl(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Round-5 Codex review of #2051: documents the TTL trade-off.
+
+        Codex round-3 worried that an empty + fresh sentinel could
+        miss a workspace-root row that was created AFTER the refresh
+        but BEFORE the TTL expires. Round-5 accepts this bounded
+        staleness as the documented contract: within the TTL window
+        the cache MAY serve stale (zero), and that is acceptable per
+        the same trade-off accepted for non-empty stale entries in
+        round-4. The TTL caps the staleness window; full audit-event
+        wiring for workspace-root producers is deferred past v1 RC.
+
+        This test pins that contract: with a fresh empty sentinel,
+        even though a late row exists in the message store, the cache
+        fast-path serves zero (per-project items only) and does NOT
+        invoke the direct sweep.
+        """
+
+        import time as _t
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        # Fresh empty sentinel — refresher just installed it.
+        fresh_at = _t.monotonic()
+        cache = ProjectStateCache(refresh_fn=lambda k: None)
+        cache._install_for_test(
+            "alpha",
+            _entry(
+                "alpha",
+                state=ProjectState.WAITING,
+                items=per_project,
+                computed_at=fresh_at,
+            ),
+        )
+        cache._install_for_test(
+            "__workspace__",
+            _entry(
+                "__workspace__",
+                state=None,
+                items=[],
+                computed_at=fresh_at,
+            ),
+        )
+        monkeypatch.setattr(
+            "pollypm.state_cache.is_enabled", lambda: True,
+        )
+        monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
+
+        # A workspace-root row exists in the underlying store but has
+        # NOT yet been refreshed into the cache. The TTL contract
+        # tolerates this — within the TTL window the cache may serve
+        # stale zero. We pin that behaviour here.
+        late_arrival = _inbox_item(
+            project="inbox", source="message", ident="ws-root-late",
+        )
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(per_project) + [late_arrival]
+
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            _direct,
+        )
+        cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+
+        # The fresh empty sentinel MUST be served (TTL contract).
+        routed = cockpit_inbox._maybe_cache_route_awaits_user(config)
+        assert routed is not None
+        ids = {
+            getattr(item, "message_id", None)
+            or getattr(item, "task_id", None)
+            for item in routed
+        }
+        # Late arrival is NOT included — the cache served stale zero.
+        assert ids == {"alpha/1"}
+        assert "ws-root-late" not in ids
+
+        # Count helper agrees.
+        cached_count = cockpit_inbox._maybe_cache_count_awaits_user(config)
+        assert cached_count == 1
+
+        # Direct sweep was NOT invoked. This is the documented
+        # bounded-staleness behaviour: within ``WORKSPACE_ENTRY_TTL_SECONDS``
+        # the cache fast-path serves what it knows. Past the TTL the
+        # sibling
+        # ``test_stale_empty_workspace_entry_falls_through_after_ttl``
+        # proves the fall-through fires.
+        assert direct_called["n"] == 0
 
     def test_stale_non_empty_workspace_entry_falls_through_after_ttl(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -135,7 +135,14 @@ def _entry(
     detail: str = "",
     latest_heartbeat_by_session: dict[str, Any] | None = None,
     config_identity: str = "",
+    computed_at: float | None = None,
 ) -> ProjectStateCacheEntry:
+    """Build a test entry. ``computed_at`` defaults to ``time.monotonic()``
+    so the round-4 workspace TTL guard treats the entry as fresh; tests
+    that want a stale entry pass an explicit past-time value.
+    """
+
+    import time as _t
     return ProjectStateCacheEntry(
         project_key=project_key,
         project_path=Path(f"/tmp/{project_key}"),
@@ -152,6 +159,7 @@ def _entry(
         awaits_user_items=tuple(items),
         latest_heartbeat_by_session=dict(latest_heartbeat_by_session or {}),
         config_identity=config_identity,
+        computed_at=_t.monotonic() if computed_at is None else computed_at,
     )
 
 
@@ -1883,3 +1891,206 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         counted = cockpit_inbox._count_inbox_tasks_for_label(config)
         assert counted == 2
         assert direct_called["n"] > before
+
+    def test_stale_non_empty_workspace_entry_falls_through_after_ttl(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Round-4 Codex review of #2051: a NON-EMPTY ``__workspace__``
+        entry stamped before the TTL window is NOT authoritative.
+
+        Round-3 closed the empty-sentinel hole but left a residual:
+        ``PgStore.close_message`` / ``PgStore.clear_alert`` /
+        ``service_api.v1.clear_alert`` can close a workspace-root
+        row AFTER the refresher cached it. Those paths write
+        ``messages``-table events, not state-cache audit events, so
+        ``StateCacheRefresher._dispatch_event`` never sees the close
+        and the cached row stays "open" until the next full refresh.
+
+        The bounded-staleness TTL on the workspace sentinel
+        (``WORKSPACE_ENTRY_TTL_SECONDS``) caps that staleness. Once
+        the entry ages past the TTL the cache MUST decline and the
+        direct sweep MUST run — surfacing whatever the message-store
+        actually contains, not the stale snapshot.
+        """
+
+        import time as _t
+        from pollypm.state_cache.refresh_impl import (
+            WORKSPACE_ENTRY_TTL_SECONDS,
+        )
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        # The cached workspace row that the refresher last computed.
+        # Simulates the state right before someone closed it.
+        cached_workspace_row = _inbox_item(
+            project="inbox",
+            source="message",
+            ident="ws-root-closed-after-refresh",
+        )
+        # Stamp the entry well beyond the TTL — this is the staleness
+        # that round-4 closes.
+        stale_at = _t.monotonic() - (WORKSPACE_ENTRY_TTL_SECONDS + 20.0)
+        cache = ProjectStateCache(refresh_fn=lambda k: None)
+        cache._install_for_test(
+            "alpha",
+            _entry(
+                "alpha",
+                state=ProjectState.WAITING,
+                items=per_project,
+                computed_at=_t.monotonic(),
+            ),
+        )
+        cache._install_for_test(
+            "__workspace__",
+            _entry(
+                "__workspace__",
+                state=None,
+                items=[cached_workspace_row],
+                computed_at=stale_at,
+            ),
+        )
+        monkeypatch.setattr(
+            "pollypm.state_cache.is_enabled", lambda: True,
+        )
+        monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
+
+        # The direct sweep returns a DIFFERENT view — the stale cached
+        # row is gone (a close landed) and a new row arrived. Both
+        # divergences MUST surface in the routed helpers, proving the
+        # cache declined.
+        new_workspace_row = _inbox_item(
+            project="inbox",
+            source="message",
+            ident="ws-root-new",
+        )
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(per_project) + [new_workspace_row]
+
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            _direct,
+        )
+        cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+
+        # Direct contract: BOTH cache-routed helpers MUST decline (return
+        # None) when the workspace sentinel is past its TTL.
+        assert (
+            cockpit_inbox._maybe_cache_route_awaits_user(config) is None
+        )
+        assert (
+            cockpit_inbox._maybe_cache_count_awaits_user(config) is None
+        )
+
+        # Integrated contract: the public list helper surfaces the
+        # direct-sweep result (the NEW row), not the stale cached row.
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        result = cockpit_inbox.pm_inbox_awaits_user_list(config)
+        ids = {
+            getattr(item, "message_id", None)
+            or getattr(item, "task_id", None)
+            for item in result
+        }
+        assert "ws-root-new" in ids
+        assert "ws-root-closed-after-refresh" not in ids
+        assert "alpha/1" in ids
+        assert direct_called["n"] >= 1
+
+        # Count helper mirrors: it sums the direct sweep (2), NOT the
+        # cached snapshot (which would also have summed to 2 here but
+        # via the wrong row — the proof is that the direct sweep ran).
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        before = direct_called["n"]
+        counted = cockpit_inbox._count_inbox_tasks_for_label(config)
+        assert counted == 2
+        assert direct_called["n"] > before
+
+    def test_fresh_non_empty_workspace_entry_serves_from_cache(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Round-4 Codex review of #2051 — happy path.
+
+        A non-empty workspace sentinel stamped INSIDE the TTL window
+        is still authoritative: the cache fast-path serves it and the
+        direct sweep does NOT run (modulo the divergence sampler,
+        which we disable for this assertion). This pins the trade-off
+        the TTL was sized for — short bursts of consumer reads stay
+        on the cache fast-path.
+        """
+
+        import time as _t
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        fresh_workspace_row = _inbox_item(
+            project="inbox", source="message", ident="ws-root-fresh",
+        )
+        # Stamp the entry as JUST refreshed — well inside the TTL.
+        fresh_at = _t.monotonic()
+        cache = ProjectStateCache(refresh_fn=lambda k: None)
+        cache._install_for_test(
+            "alpha",
+            _entry(
+                "alpha",
+                state=ProjectState.WAITING,
+                items=per_project,
+                computed_at=fresh_at,
+            ),
+        )
+        cache._install_for_test(
+            "__workspace__",
+            _entry(
+                "__workspace__",
+                state=None,
+                items=[fresh_workspace_row],
+                computed_at=fresh_at,
+            ),
+        )
+        monkeypatch.setattr(
+            "pollypm.state_cache.is_enabled", lambda: True,
+        )
+        monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
+
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(per_project) + [fresh_workspace_row]
+
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            _direct,
+        )
+        # Pin the divergence sampler off — its random direct call would
+        # blur the "did the cache fast-path fire" assertion.
+        cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+
+        # The cache-route helper MUST return a list (cache served it),
+        # not None — proving the TTL guard passed.
+        routed = cockpit_inbox._maybe_cache_route_awaits_user(config)
+        assert routed is not None
+        ids = {
+            getattr(item, "message_id", None)
+            or getattr(item, "task_id", None)
+            for item in routed
+        }
+        assert "ws-root-fresh" in ids
+        assert "alpha/1" in ids
+        # Count helper served from cache too.
+        cached_count = cockpit_inbox._maybe_cache_count_awaits_user(config)
+        assert cached_count == 2
+        # Direct sweep was NOT invoked — the fast-path served both
+        # helpers from the snapshot.
+        assert direct_called["n"] == 0

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -1900,7 +1900,7 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         """
 
         import time as _t
-        from pollypm.state_cache.refresh_impl import (
+        from pollypm.state_cache.entry import (
             WORKSPACE_ENTRY_TTL_SECONDS,
         )
 
@@ -2104,7 +2104,7 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         """
 
         import time as _t
-        from pollypm.state_cache.refresh_impl import (
+        from pollypm.state_cache.entry import (
             WORKSPACE_ENTRY_TTL_SECONDS,
         )
 

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -164,10 +164,28 @@ def _seed_cache(
     Avoids spinning up the real refresher (which would tail the audit
     log dir and run the full per-project compute). The cache itself
     is the real class; only its entries are pre-baked.
+
+    #2051 (Codex review): the cache-read boundary now treats a snapshot
+    missing the synthetic ``__workspace__`` entry as INCOMPLETE and
+    falls through to the direct sweep. Most parity tests assume the
+    fast-path is taken, so we auto-seed an empty ``__workspace__``
+    entry when the caller hasn't provided one. Tests that need to
+    exercise the absent-sentinel guard pass an explicit
+    ``__workspace__`` key (or use the dedicated fall-through tests
+    below).
     """
 
     cache = ProjectStateCache(refresh_fn=lambda k: None)
-    for key, entry in entries.items():
+    seeded = dict(entries)
+    if "__workspace__" not in seeded and seeded:
+        # Auto-seed an empty workspace sentinel so the fast-path stays
+        # available; callers that want the absent-sentinel behavior
+        # explicitly pass ``"__workspace__": <entry>`` or omit it via
+        # the dedicated test in TestPr2026ReviewBlocker3WorkspaceRootFallthrough.
+        seeded["__workspace__"] = _entry(
+            "__workspace__", state=None, items=[],
+        )
+    for key, entry in seeded.items():
         cache._install_for_test(key, entry)
     monkeypatch.setattr("pollypm.state_cache.is_enabled", lambda: True)
     monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
@@ -1598,12 +1616,21 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         # Per-project + workspace-root counts both contribute.
         assert counted == 2
 
-    def test_no_workspace_entry_still_serves_per_project_via_cache(
+    def test_no_workspace_entry_falls_through_to_direct_sweep(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Snapshot without a ``__workspace__`` entry — the cache
-        still serves per-project items from the fast-path. Absent
-        workspace entry contributes 0 to the union/count.
+        """Snapshot without a ``__workspace__`` entry — the cache MUST
+        fall through to the direct sweep (Codex review of #2051).
+
+        Inverted from the original ``…_still_serves_per_project_via_cache``
+        test which pinned the OPPOSITE behavior. The invariant is:
+        a snapshot missing the synthetic ``__workspace__`` sentinel is
+        an INCOMPLETE cache, not a proven-empty workspace inbox.
+        Serving the per-project items alone would silently drop any
+        workspace-root awaits-user rows the sentinel was supposed to
+        carry. Producers that bypass the audit-event invalidation path
+        (message-store alert/notification writes today) MUST be picked
+        up by the direct sweep.
         """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
@@ -1611,27 +1638,91 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         per_project = [
             _inbox_item(project="alpha", source="task", ident="alpha/1"),
         ]
-        entries = {
-            "alpha": _entry(
-                "alpha", state=ProjectState.WAITING, items=per_project,
-            ),
-        }
-        _seed_cache(monkeypatch, entries)
+        # Critically: no ``__workspace__`` entry. Build the cache by
+        # hand to bypass ``_seed_cache``'s auto-sentinel — this test
+        # exists precisely to exercise the absent-sentinel guard.
+        cache = ProjectStateCache(refresh_fn=lambda k: None)
+        cache._install_for_test(
+            "alpha",
+            _entry("alpha", state=ProjectState.WAITING, items=per_project),
+        )
+        monkeypatch.setattr(
+            "pollypm.state_cache.is_enabled", lambda: True,
+        )
+        monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
 
-        # Sampler-off so divergence comparator can't masquerade as a
-        # fall-through.
         cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
         direct_called = {"n": 0}
+        # Simulate the worst case: the workspace-root sweep finds a row
+        # the cache snapshot has no idea about.
+        workspace_root = _inbox_item(
+            project="inbox", source="message", ident="ws-root-missed",
+        )
 
         def _direct(_cfg: Any) -> list[Any]:
             direct_called["n"] += 1
-            return list(per_project)
+            return list(per_project) + [workspace_root]
 
         monkeypatch.setattr(
             cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", _direct,
         )
         cockpit_inbox._AWAITS_USER_CACHE.clear()
         result = cockpit_inbox.pm_inbox_awaits_user_list(config)
-        assert direct_called["n"] == 0
-        assert len(result) == 1
+        # Direct sweep MUST have run — the cache-read boundary refused
+        # the incomplete snapshot.
+        assert direct_called["n"] == 1
+        ids = {
+            getattr(item, "message_id", None)
+            or getattr(item, "task_id", None)
+            for item in result
+        }
+        # The workspace-root row the cache missed is now in the result.
+        assert "ws-root-missed" in ids
+        assert "alpha/1" in ids
 
+    def test_no_workspace_entry_count_falls_through_to_direct_sweep(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Count helper mirrors the list-helper guard (Codex review of #2051).
+
+        Snapshot without ``__workspace__`` → fall through to the direct
+        sweep so the rail badge can't silently drop a workspace-root
+        row.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        # Same hand-rolled bypass as the sibling list test — auto-seed
+        # would mask the absent-sentinel behavior we're pinning.
+        cache = ProjectStateCache(refresh_fn=lambda k: None)
+        cache._install_for_test(
+            "alpha",
+            _entry("alpha", state=ProjectState.WAITING, items=per_project),
+        )
+        monkeypatch.setattr(
+            "pollypm.state_cache.is_enabled", lambda: True,
+        )
+        monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
+
+        direct_called = {"n": 0}
+        workspace_root = _inbox_item(
+            project="inbox", source="message", ident="ws-root-missed-count",
+        )
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(per_project) + [workspace_root]
+
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            _direct,
+        )
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        counted = cockpit_inbox._count_inbox_tasks_for_label(config)
+        # Direct sweep ran via the list fall-through; count == 2.
+        assert direct_called["n"] >= 1
+        assert counted == 2

--- a/tests/test_state_cache_refresher.py
+++ b/tests/test_state_cache_refresher.py
@@ -189,12 +189,15 @@ def test_coalesces_multiple_events_for_same_project(audit_dir: Path) -> None:
     refresher._seek_to_end()
 
     # 5 events for the same project between drains — must collapse
-    # to a single refresh.
+    # to a single refresh per key. #2051 (Codex review) adds the
+    # synthetic ``__workspace__`` sentinel to every invalidation, so
+    # the drain refreshes both keys once — still coalesced (no
+    # duplicates per key).
     for _ in range(5):
         _write_event(log, event="task.status_changed", project="alpha")
     _drain_for_test(refresher)
 
-    assert refresh_calls == ["alpha"]
+    assert refresh_calls == ["__workspace__", "alpha"]
 
 
 def test_tail_handles_truncation(audit_dir: Path) -> None:
@@ -287,6 +290,128 @@ def test_new_project_log_picked_up_mid_session(audit_dir: Path) -> None:
     _write_event(new_log, event="task.status_changed", project="gamma")
     _drain_for_test(refresher)
     assert cache.version("gamma") == 1
+
+
+class TestWorkspaceRootInvalidation:
+    """Codex review of #2051 — every invalidating event must also keep
+    the synthetic ``__workspace__`` sentinel fresh.
+
+    Before this contract landed, workspace-root awaits-user rows could
+    be created or closed after startup without refreshing the synthetic
+    entry — the rail badge / inbox count could serve a stale zero until
+    the next full workspace invalidation or process restart.
+    """
+
+    def test_project_inbox_event_invalidates_workspace_sentinel(
+        self, audit_dir: Path,
+    ) -> None:
+        """``project="inbox"`` events are workspace-root signals — they
+        MUST invalidate ``__workspace__`` so the next cache read picks
+        up the new row.
+        """
+        log = audit_dir / "inbox.jsonl"
+        log.touch()
+        cache = ProjectStateCache(refresh_fn=lambda k: empty_entry(k))
+        refresher = StateCacheRefresher(cache, audit_dir=audit_dir)
+        refresher._seek_to_end()
+
+        _write_event(log, event="task.created", project="inbox")
+        _drain_for_test(refresher)
+
+        # The synthetic sentinel was refreshed (entry installed +
+        # version bumped to 1). Before the fix, only the literal
+        # "inbox" key was invalidated and the sentinel stayed stale.
+        assert cache.get("__workspace__") is not None
+        assert cache.version("__workspace__") == 1
+
+    def test_project_inbox_status_change_invalidates_workspace_sentinel(
+        self, audit_dir: Path,
+    ) -> None:
+        """``task.status_changed`` with ``project="inbox"`` (workspace-root
+        row resolved / closed) MUST also bump the sentinel so the badge
+        sees the closure.
+        """
+        log = audit_dir / "inbox.jsonl"
+        log.touch()
+        cache = ProjectStateCache(refresh_fn=lambda k: empty_entry(k))
+        # Seed an existing sentinel so we can observe the version bump
+        # on the close event.
+        cache._install_for_test("__workspace__", empty_entry("__workspace__"))
+        refresher = StateCacheRefresher(cache, audit_dir=audit_dir)
+        refresher._seek_to_end()
+
+        baseline = cache.version("__workspace__")
+        _write_event(log, event="task.status_changed", project="inbox")
+        _drain_for_test(refresher)
+
+        assert cache.version("__workspace__") > baseline
+
+    def test_tracked_project_event_also_refreshes_workspace_sentinel(
+        self, audit_dir: Path,
+    ) -> None:
+        """A tracked-project ``task.*`` event ALSO refreshes the sentinel.
+
+        Conservative: tracked-project mutations can cross-post into the
+        workspace-root inbox (notifications cc'd from a project task);
+        the cache-read boundary now refuses to serve when the sentinel
+        is missing, so we always refresh it alongside the project entry.
+        """
+        log = audit_dir / "alpha.jsonl"
+        log.touch()
+        cache = ProjectStateCache(refresh_fn=lambda k: empty_entry(k))
+        refresher = StateCacheRefresher(cache, audit_dir=audit_dir)
+        refresher._seek_to_end()
+
+        _write_event(log, event="task.created", project="alpha")
+        _drain_for_test(refresher)
+
+        assert cache.version("alpha") == 1
+        # The sentinel was refreshed too.
+        assert cache.get("__workspace__") is not None
+        assert cache.version("__workspace__") == 1
+
+    def test_non_invalidating_event_leaves_sentinel_alone(
+        self, audit_dir: Path,
+    ) -> None:
+        """Ignored events (``work_db.opened``, etc.) MUST NOT touch the
+        sentinel — the workspace invalidation is gated on the
+        ``_INVALIDATING_EVENTS`` membership check.
+        """
+        log = audit_dir / "alpha.jsonl"
+        log.touch()
+        cache = ProjectStateCache(refresh_fn=lambda k: empty_entry(k))
+        refresher = StateCacheRefresher(cache, audit_dir=audit_dir)
+        refresher._seek_to_end()
+
+        _write_event(log, event="work_db.opened", project="alpha")
+        _drain_for_test(refresher)
+
+        assert cache.pending_invalidations() == frozenset()
+        assert cache.get("__workspace__") is None
+
+    def test_workspace_scoped_event_still_invalidates_sentinel(
+        self, audit_dir: Path,
+    ) -> None:
+        """Empty-project events (workspace-scoped) MUST invalidate the
+        sentinel via ``invalidate(None)`` — already covered by the
+        project-keys provider including ``__workspace__`` at the
+        singleton boundary, pinned here so the refresher itself can't
+        regress the contract.
+        """
+        log = audit_dir / "_workspace.jsonl"
+        log.touch()
+        cache = ProjectStateCache(refresh_fn=lambda k: empty_entry(k))
+        cache._install_for_test("__workspace__", empty_entry("__workspace__"))
+        cache._install_for_test("alpha", empty_entry("alpha"))
+        refresher = StateCacheRefresher(cache, audit_dir=audit_dir)
+        refresher._seek_to_end()
+
+        _write_event(log, event="work_table.cleared", project="")
+        _drain_for_test(refresher)
+
+        # Both keys refreshed by the workspace-scoped invalidation.
+        assert cache.version("__workspace__") == 2
+        assert cache.version("alpha") == 2
 
 
 def test_concurrent_writes_and_reads_during_tail(audit_dir: Path) -> None:


### PR DESCRIPTION
## Summary

- Refresher emits a synthetic ``__workspace__`` cache entry (new ``WORKSPACE_PROJECT_KEY`` sentinel in ``state_cache/refresh_impl.py``) populated with workspace-root awaits-user items — the rows that ``message_row_to_inbox_entry`` projects to ``project == "inbox"`` after seeing ``scope IN ('', 'inbox')``. These never matched any tracked project key, so the per-project filter in ``_awaits_user_items_for`` silently dropped them and the cache could not represent them.
- ``cockpit_inbox._maybe_cache_route_awaits_user`` / ``_maybe_cache_count_awaits_user`` now read the ``__workspace__`` entry alongside per-project entries and union its items / count into the result.
- The ``_workspace_root_inbox_has_open`` probe (and its underlying ``cockpit_pg_aggregates.has_workspace_root_open_messages`` helper) are deleted. The probe previously forced cache fall-through on every busy workspace whenever any workspace-root row existed, defeating the rail-badge / inbox-count fast path. The cache is now authoritative for workspace-root rows too.
- The state-cache singleton's ``_project_keys_provider`` always yields the sentinel so initial full refresh + workspace-wide invalidations keep the entry fresh; existing rail / dashboard consumers iterate over ``config.projects`` keys, so the extra sentinel entry is naturally ignored by them (no consumer-shape regression).

## Closes

#2051

## Tests

- ``TestPr2026ReviewBlocker3WorkspaceRootFallthrough`` (the 3 PR-#2026 regression tests) — flipped from asserting forced fall-through to asserting the cache fast-path wins AND carries the workspace row.
- ``TestPr2026V3WorkspaceRootProbeUnbounded`` — deleted; its subject (the workspace-root SQL probe) no longer exists.
- ``test_singleton_wires_project_keys_provider_for_initial_refresh`` + ``test_singleton_provider_degrades_gracefully_on_config_failure`` — updated to expect ``__workspace__`` in the provider output.
- ``test_state_cache_config_identity.py::test_unstamped_entries_skip_identity_check`` — dropped the probe monkeypatch (probe is gone).
- ``pytest tests/test_state_cache.py tests/test_state_cache_entry.py tests/test_state_cache_env_flag.py tests/test_state_cache_no_sqlite_imports.py tests/test_state_cache_refresher.py tests/test_cockpit_inbox_threads.py tests/test_state_cache_parity.py tests/test_state_cache_config_identity.py`` → **114 passed**.

## Test plan

- [x] ``pytest tests/test_state_cache_parity.py::TestPr2026ReviewBlocker3WorkspaceRootFallthrough -x``
- [x] Full state_cache + cockpit_inbox sweep (114 tests)
- [ ] Manual: confirm rail badge + inbox count include workspace-root rows under load (deferred — covered by the regression flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)