### PR TITLE
fix(state-cache): invalidate latest_heartbeat_by_session on heartbeat writes (closes #2050)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1535,18 +1535,26 @@ class CockpitRouter:
     ) -> object | None:
         """Return the latest heartbeat for ``session_name``.
 
-        PR #2026 review blocker 2 (fall-through workaround): the cache
-        fast-path is DISABLED until the refresher learns to invalidate
-        on heartbeat writes. ``state_cache/refresher.py`` only listens
-        for ``task.*`` / ``marker.*`` audit events, so a fresh
-        heartbeat row never invalidates ``latest_heartbeat_by_session``
-        — the cache would serve a stale snapshot indefinitely and
-        drive the UI's "offline" / "stale" treatments off it.
+        #2050 fast-path: when the state cache is enabled, scan the
+        snapshot's per-project ``latest_heartbeat_by_session`` for
+        ``session_name``. The refresher subscribes to ``heartbeat.tick``
+        audit events (see ``state_cache/refresher.py``), so a fresh
+        heartbeat row invalidates the affected entries on the next
+        refresh — the snapshot can never go indefinitely stale the way
+        it did before PR #2026's workaround.
 
-        Until ``heartbeat.*`` invalidation lands (filed as a follow-up
-        issue), every call hits the direct pg facade. Method name kept
-        for call-site stability (no API change).
+        Direct pg facade remains the fallback for three cases:
+        1. Cache flag off (``POLLYPM_STATE_CACHE=0``).
+        2. Cache miss — session not represented in any entry (cold
+           start before the first refresh, or a session_name that
+           doesn't match a project's canonical / live-worker rows).
+        3. ``pg_heartbeats`` raises — degrades to ``supervisor.store``.
         """
+
+        # ── #2050 cache fast-path ────────────────────────────────────
+        cached = self._latest_heartbeat_from_cache(session_name)
+        if cached is not None:
+            return cached
 
         try:
             from pollypm.storage import pg_heartbeats
@@ -1570,6 +1578,42 @@ class CockpitRouter:
             return store.latest_heartbeat(session_name)
         except Exception:  # noqa: BLE001
             return None
+
+    def _latest_heartbeat_from_cache(self, session_name: str) -> object | None:
+        """Look up ``session_name`` in the state-cache snapshot.
+
+        Returns the cached :class:`HeartbeatRecord` (or whatever the
+        refresher stamped under ``latest_heartbeat_by_session``) if
+        any project entry holds an entry for this session, else
+        ``None``. A ``None`` return means the caller falls through to
+        the direct pg facade.
+
+        Safe to call when the cache is disabled / unimported — every
+        failure mode (flag off, import error, empty snapshot) returns
+        ``None`` and the direct facade takes over.
+        """
+
+        try:
+            from pollypm.state_cache import get_cache, is_enabled
+        except Exception:  # noqa: BLE001
+            return None
+        if not is_enabled():
+            return None
+        try:
+            cache = get_cache()
+            snapshot = cache.snapshot()
+        except Exception:  # noqa: BLE001
+            return None
+        if not snapshot:
+            return None
+        for entry in snapshot.values():
+            by_session = getattr(entry, "latest_heartbeat_by_session", None)
+            if not by_session:
+                continue
+            hb = by_session.get(session_name)
+            if hb is not None:
+                return hb
+        return None
 
     # ── #989 — alert metadata attachment ────────────────────────────────
     #

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1552,7 +1552,8 @@ class CockpitRouter:
         """
 
         # ── #2050 cache fast-path ────────────────────────────────────
-        cached = self._latest_heartbeat_from_cache(session_name)
+        config = getattr(supervisor, "config", None)
+        cached = self._latest_heartbeat_from_cache(session_name, config)
         if cached is not None:
             return cached
 
@@ -1560,7 +1561,6 @@ class CockpitRouter:
             from pollypm.storage import pg_heartbeats
         except Exception:  # noqa: BLE001
             pg_heartbeats = None  # type: ignore[assignment]
-        config = getattr(supervisor, "config", None)
         if pg_heartbeats is not None:
             try:
                 return pg_heartbeats.latest_heartbeat(
@@ -1579,7 +1579,11 @@ class CockpitRouter:
         except Exception:  # noqa: BLE001
             return None
 
-    def _latest_heartbeat_from_cache(self, session_name: str) -> object | None:
+    def _latest_heartbeat_from_cache(
+        self,
+        session_name: str,
+        config: object | None,
+    ) -> object | None:
         """Look up ``session_name`` in the state-cache snapshot.
 
         Returns the cached :class:`HeartbeatRecord` (or whatever the
@@ -1591,6 +1595,18 @@ class CockpitRouter:
         Safe to call when the cache is disabled / unimported — every
         failure mode (flag off, import error, empty snapshot) returns
         ``None`` and the direct facade takes over.
+
+        Config-identity guard (PR #2026 v7 — Codex r7 contract): the
+        cache singleton is process-wide and may carry entries computed
+        against a different ``config`` (different config_path /
+        workspace_root) than the live caller. Skip any entry whose
+        stamped identity disagrees with the live config's identity —
+        without this guard a session_name collision across workspaces
+        would serve cross-config heartbeat data. Unstamped entries
+        (``""``) are treated as matching so legacy / test fixtures
+        that construct entries by hand still hit the fast path.
+        Mirrors the guard pattern in ``cockpit_inbox`` and the rail
+        rollup map's ``_project_rollups_from_cache``.
         """
 
         try:
@@ -1606,7 +1622,18 @@ class CockpitRouter:
             return None
         if not snapshot:
             return None
+        try:
+            from pollypm.state_cache.entry import config_identity
+            live_identity = config_identity(config)
+        except Exception:  # noqa: BLE001
+            return None
         for entry in snapshot.values():
+            entry_identity = getattr(entry, "config_identity", "") or ""
+            if entry_identity and entry_identity != live_identity:
+                # Cross-config entry — refuse to serve and keep
+                # scanning in case another entry (or the direct
+                # facade) holds the live value.
+                continue
             by_session = getattr(entry, "latest_heartbeat_by_session", None)
             if not by_session:
                 continue

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -70,13 +70,13 @@ def build_refresh_fn(
     a config reload during a long-running cockpit picks up the new
     paths automatically.
 
-    PR #2026 v3 (Codex re-review): heartbeat prefetch removed entirely.
-    The two rail consumers (``cockpit_rail._latest_heartbeat_cached``)
-    were converted to direct pg-facade reads because the refresher had
-    no ``heartbeat.*`` audit-event subscription and so could only ever
-    serve a stale snapshot. Until that invalidation lands (filed as
-    #2050 follow-up) there's nothing for the refresher to prefetch —
-    the closure is a thin config-provider wrapper.
+    #2050: heartbeat prefetch is back. ``refresher._INVALIDATING_EVENTS``
+    now contains ``heartbeat.tick`` so every workspace heartbeat sweep
+    invalidates the per-project entries and the refresher repopulates
+    ``latest_heartbeat_by_session`` from one bulk pg query per project.
+    The PR #2026 v3 fast-path-disable workaround on
+    ``cockpit_rail._latest_heartbeat_cached`` is reverted in tandem so
+    rail reads serve from the snapshot again.
     """
 
     def _refresh(project_key: str) -> ProjectStateCacheEntry | None:
@@ -118,22 +118,25 @@ def compute_entry_for_project(
     tracked = bool(getattr(project, "tracked", True)) if project else False
 
     awaits_user_items = _awaits_user_items_for(project_key, config)
-    state, glyph, detail, rail_rollup = _categorize_and_rollup(
+    state, glyph, detail, rail_rollup, session_names = _categorize_and_rollup(
         project_key=project_key,
         config=config,
         tracked=tracked,
         awaits_user_items=list(awaits_user_items),
     )
 
-    # PR #2026 v3 (Codex re-review blocker 2): the heartbeat prefetch
-    # path was dead code. ``cockpit_rail._latest_heartbeat_cached``
-    # bypasses ``entry.latest_heartbeat_by_session`` and reads
-    # ``pollypm.storage.pg_heartbeats`` directly because the refresher
-    # has no ``heartbeat.*`` audit-event subscription and can only
-    # serve stale snapshots. Populating the field meant N pg reads
-    # per project per refresh with zero consumers. The entry field is
-    # retained (defaults to ``{}``) so callers don't crash on
-    # attribute access; the bulk-prefetch wiring lands with #2050.
+    # #2050: bulk-prefetch heartbeats for every session known to this
+    # project. ``refresher._INVALIDATING_EVENTS`` listens for
+    # ``heartbeat.tick`` so this dict reflects the freshest pg state on
+    # every refresh; the rail's ``_latest_heartbeat_cached`` reads from
+    # ``latest_heartbeat_by_session`` again and only falls through to
+    # the direct facade on a cache miss (cold start / unknown session
+    # name). One ``latest_heartbeats_bulk`` query per project replaces
+    # the per-call ``latest_heartbeat`` round-trips PR #2026 introduced.
+    latest_heartbeat_by_session = _fetch_latest_heartbeats(
+        session_names, config,
+    )
+
     entry = ProjectStateCacheEntry(
         project_key=project_key,
         project_path=project_path,
@@ -148,6 +151,7 @@ def compute_entry_for_project(
         approvals_pending=rail_rollup[4] if rail_rollup else 0,
         awaits_user_count=len(awaits_user_items),
         awaits_user_items=tuple(awaits_user_items),
+        latest_heartbeat_by_session=latest_heartbeat_by_session,
         computed_at=time.monotonic(),
         # PR #2026 v7 (Codex r7 blocker): stamp the config identity so
         # every cache lookup can verify the snapshot was computed
@@ -232,23 +236,24 @@ def _categorize_and_rollup(
 ) -> tuple[
     Any, str, str,
     tuple[Any, Any, int, str, int] | None,
+    list[str],
 ]:
     """Run ``categorize_project`` + ``rollup_project_state`` for one project.
 
-    Returns ``(state, glyph, detail, rollup_tuple_or_None)``. The
-    rollup tuple is ``(rail_state, rail_badge, sort_rank, reason,
+    Returns ``(state, glyph, detail, rollup_tuple_or_None, session_names)``.
+    The rollup tuple is ``(rail_state, rail_badge, sort_rank, reason,
     approvals_pending)`` — kept positional so the caller can ``zip``
     it into the entry fields without a second import of the rollup
-    types here.
-
-    PR #2026 v3 (Codex re-review blocker 2): no longer returns
-    ``live_workers``. The heartbeat prefetch that consumed that list
-    was dead code (cockpit_rail bypasses the cache for heartbeats);
-    keeping the slice-svc roster query alive cost N pg reads per
-    refresh with zero readers.
+    types here. ``session_names`` is every tmux session this project
+    is known to drive (canonical ``architect_<key>`` /
+    ``plan_gate-<key>`` / ``worker_<key>`` plus the per-task
+    ``worker_<key>/<n>`` rows the live worker_sessions table reports)
+    — passed to :func:`_fetch_latest_heartbeats` for the heartbeat
+    prefetch (#2050).
 
     Failures degrade silently — a broken work-service drops the
-    project to IDLE (or PAUSED when not tracked) with no rollup.
+    project to IDLE (or PAUSED when not tracked) with no rollup and an
+    empty session-name list (heartbeat prefetch becomes a no-op).
     """
 
     try:
@@ -273,7 +278,7 @@ def _categorize_and_rollup(
             project_key,
             exc_info=True,
         )
-        return None, "", "", None
+        return None, "", "", None, []
 
     shared_svc = _open_shared_work_service(config)
     try:
@@ -289,14 +294,22 @@ def _categorize_and_rollup(
                 detail = "Paused"
             else:
                 detail = "Quiet"
-            return state, glyph, detail, None
+            # Without a work-service we still know the canonical session
+            # names for this project — return them so heartbeats keep
+            # flowing through the snapshot even when the work db is
+            # unreachable.
+            return (
+                state, glyph, detail, None,
+                _canonical_session_names(project_key, []),
+            )
 
         tasks_by_alias, workers_by_alias = _prefetch_project_state(
             config, shared_svc,
         )
+        aliases = _aliases_for(config, project_key)
         slice_svc = _ProjectSliceService(
             project_key=project_key,
-            aliases=_aliases_for(config, project_key),
+            aliases=aliases,
             tasks_by_alias=tasks_by_alias,
             workers_by_alias=workers_by_alias,
             shared_svc=shared_svc,
@@ -347,10 +360,110 @@ def _categorize_and_rollup(
             )
             rollup_tuple = None
 
-        return state, glyph, detail, rollup_tuple
+        # #2050: collect every session_name this project is known to
+        # drive, so the bulk heartbeat fetch downstream produces a
+        # snapshot the rail can serve. We union the canonical workspace
+        # sessions (``architect_<key>`` etc.) with the per-task
+        # ``worker_<key>/<n>`` rows the live worker_sessions table
+        # reports — the latter come from the already-prefetched
+        # ``workers_by_alias`` so this costs no extra db round-trip.
+        live_worker_sessions: list[Any] = []
+        for alias in [project_key, *aliases]:
+            live_worker_sessions.extend(
+                workers_by_alias.get(alias, []),
+            )
+        session_names = _canonical_session_names(
+            project_key, aliases,
+            live_worker_sessions=live_worker_sessions,
+        )
+
+        return state, glyph, detail, rollup_tuple, session_names
     finally:
         if shared_svc is not None:
             _safe_close(shared_svc)
+
+
+def _canonical_session_names(
+    project_key: str,
+    aliases: list[str],
+    *,
+    live_worker_sessions: list[Any] | None = None,
+) -> list[str]:
+    """Enumerate every tmux session name this project might heartbeat under.
+
+    The rail's ``_latest_heartbeat_cached`` looks up entries by exact
+    ``session_name``; we union three sources so the snapshot covers
+    every name it might be asked for:
+
+    1. Canonical workspace sessions — ``architect_<key>``,
+       ``plan_gate-<key>``, ``worker_<key>`` (and the same for every
+       storage alias) — these are the rows
+       ``_session_name_for_item`` resolves for project-row PMs.
+    2. Per-task worker sessions reported by ``list_worker_sessions``
+       (``worker_<key>/<task_num>``) — pulled from the already-
+       prefetched ``workers_by_alias`` so no extra db round-trip.
+    3. (de-duplicated, empty names dropped)
+
+    The list is intentionally bounded — only sessions this project is
+    known to drive contribute, never the workspace-wide heartbeat
+    table.
+    """
+
+    seen: set[str] = set()
+    out: list[str] = []
+    keys = [project_key, *aliases]
+    for key in keys:
+        if not key:
+            continue
+        for prefix in ("architect_", "plan_gate-", "worker_"):
+            name = f"{prefix}{key}"
+            if name not in seen:
+                seen.add(name)
+                out.append(name)
+    for session in live_worker_sessions or []:
+        name = str(getattr(session, "session_name", "") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return out
+
+
+def _fetch_latest_heartbeats(
+    session_names: list[str], config: Any,
+) -> dict[str, Any]:
+    """Bulk-fetch the most-recent heartbeat row for each session.
+
+    Wraps :func:`pollypm.storage.pg_heartbeats.latest_heartbeats_bulk`
+    behind a soft import so the leaf ``state_cache`` package stays
+    importable in environments where the storage layer is missing
+    (test harnesses that mock the cache out, etc.). On any failure
+    the refresher degrades silently — the cache fast-path will miss
+    on every session name and the rail will fall through to the
+    direct pg facade (same shape as today).
+    """
+
+    if not session_names:
+        return {}
+    try:
+        from pollypm.storage import pg_heartbeats
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "state_cache: pg_heartbeats unavailable; "
+            "skipping heartbeat prefetch", exc_info=True,
+        )
+        return {}
+    try:
+        return pg_heartbeats.latest_heartbeats_bulk(
+            session_names, config=config,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "state_cache: latest_heartbeats_bulk failed; "
+            "rail will fall through to direct facade",
+            exc_info=True,
+        )
+        return {}
 
 
 # ── refresher integration ─────────────────────────────────────────

--- a/src/pollypm/state_cache/refresher.py
+++ b/src/pollypm/state_cache/refresher.py
@@ -49,6 +49,15 @@ __all__ = ["StateCacheRefresher", "default_audit_dir", "stub_refresh_fn"]
 # Event names that should invalidate a project's cache entry. Pinned
 # to the constants exported from ``pollypm.audit.log`` so the cache
 # stays in sync if those names ever change (a test pins this list).
+#
+# ``heartbeat.tick`` is workspace-scoped (audit_watchdog.emit_heartbeat_tick
+# fires with ``project=""``) so a single tick invalidates every known
+# project's entry. That's the contract that lets
+# ``cockpit_rail._latest_heartbeat_cached`` serve the snapshot's
+# ``latest_heartbeat_by_session`` fast-path without going stale —
+# without this entry the cache would serve an indefinitely-old
+# heartbeat and drive the UI's "offline" / "stale" treatments off it
+# (#2050).
 _INVALIDATING_EVENTS: frozenset[str] = frozenset({
     "task.created",
     "task.status_changed",
@@ -58,6 +67,7 @@ _INVALIDATING_EVENTS: frozenset[str] = frozenset({
     "marker.create_failed",
     "marker.leaked",
     "work_table.cleared",
+    "heartbeat.tick",
 })
 
 # Poll interval for the tail thread. Mirrors the existing SSE tail

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -970,10 +970,16 @@ class TestProjectStateRollupsParity:
 
 
 class TestLatestHeartbeatParity:
-    """PR #2026 review blocker 2: ``_latest_heartbeat_cached`` is now a
-    direct-facade pass-through until cache invalidation on heartbeat
-    writes lands (filed as follow-up). The "cached" name is preserved
-    for call-site stability; the body bypasses the cache snapshot.
+    """#2050: ``_latest_heartbeat_cached`` reads the state-cache snapshot
+    first and only falls through to the direct pg facade on a miss.
+
+    PR #2026 disabled the fast-path because the refresher had no
+    ``heartbeat.*`` audit-event subscription and would serve a stale
+    snapshot indefinitely. #2050 added ``heartbeat.tick`` to
+    ``refresher._INVALIDATING_EVENTS`` so every workspace sweep
+    invalidates the affected entries — the snapshot is bounded-stale
+    by the tick cadence again, the rail's fast-path is restored, and
+    the direct facade remains the cold-start / pg-failure fallback.
     """
 
     def _router(self, tmp_path: Path):
@@ -989,42 +995,39 @@ class TestLatestHeartbeatParity:
         )
         return CockpitRouter(config_path)
 
-    def test_always_reads_direct_facade_even_with_populated_cache(
+    def test_populated_cache_skips_direct_facade(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Even with a populated cache, the direct pg facade is the
-        source of truth — guards against the stale-snapshot pathology
-        the cache had with no heartbeat-write invalidation.
+        """Populated cache entry → fast-path hit; pg facade NOT called.
+
+        Pins the #2050 contract: when the refresher has already stamped
+        a heartbeat into ``latest_heartbeat_by_session``, the rail
+        serves it from the snapshot and skips the per-call pg query.
         """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         router = self._router(tmp_path)
 
-        stale_hb = SimpleNamespace(
+        cached_hb = SimpleNamespace(
             session_name="worker_alpha/1",
-            created_at="2026-05-20T01:00:00Z",
-            tag="STALE_CACHE",
+            created_at="2026-05-21T01:00:00Z",
+            tag="FROM_CACHE",
         )
         entries = {
             "alpha": _entry(
                 "alpha",
                 state=ProjectState.WORKING,
                 items=[],
-                latest_heartbeat_by_session={"worker_alpha/1": stale_hb},
+                latest_heartbeat_by_session={"worker_alpha/1": cached_hb},
             ),
         }
         _seed_cache(monkeypatch, entries)
 
-        fresh_hb = SimpleNamespace(
-            session_name="worker_alpha/1",
-            created_at="2026-05-21T01:00:00Z",
-            tag="FRESH_DIRECT",
-        )
         pg_calls: list[str] = []
 
         def _direct(name, *, config=None):  # noqa: ANN001, ANN201
             pg_calls.append(name)
-            return fresh_hb
+            return SimpleNamespace(tag="UNEXPECTED_DIRECT_HIT")
 
         monkeypatch.setattr(
             "pollypm.storage.pg_heartbeats.latest_heartbeat", _direct,
@@ -1032,10 +1035,54 @@ class TestLatestHeartbeatParity:
 
         supervisor = SimpleNamespace(store=None, config=None)
         result = router._latest_heartbeat_cached(supervisor, "worker_alpha/1")
-        # Direct facade hit; cached stale snapshot ignored.
+        # Cache hit; direct facade was NOT consulted.
+        assert pg_calls == []
+        assert result is cached_hb
+        assert getattr(result, "tag", None) == "FROM_CACHE"
+
+    def test_cache_miss_falls_through_to_direct_facade(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Session not in any cache entry → direct facade serves the read.
+
+        Cold-start safety net: the rail must render heartbeat data even
+        before the refresher has populated the entry for this session.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+
+        # Cache entry exists but holds no heartbeat for the queried
+        # session_name — that's the cache-miss shape.
+        entries = {
+            "alpha": _entry(
+                "alpha",
+                state=ProjectState.WORKING,
+                items=[],
+                latest_heartbeat_by_session={},
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        direct_hb = SimpleNamespace(
+            session_name="worker_alpha/1",
+            created_at="2026-05-21T02:00:00Z",
+            tag="FROM_DIRECT",
+        )
+        pg_calls: list[str] = []
+
+        def _direct(name, *, config=None):  # noqa: ANN001, ANN201
+            pg_calls.append(name)
+            return direct_hb
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_heartbeats.latest_heartbeat", _direct,
+        )
+
+        supervisor = SimpleNamespace(store=None, config=None)
+        result = router._latest_heartbeat_cached(supervisor, "worker_alpha/1")
         assert pg_calls == ["worker_alpha/1"]
-        assert result is fresh_hb
-        assert getattr(result, "tag", None) == "FRESH_DIRECT"
+        assert result is direct_hb
 
     def test_pg_failure_falls_back_to_supervisor_store(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
@@ -1067,7 +1114,12 @@ class TestLatestHeartbeatParity:
     def test_flag_off_still_uses_direct_facade(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Flag state is irrelevant — the cache is fully bypassed."""
+        """Flag off → cache fast-path skipped; direct facade serves the read.
+
+        Kill-switch behavior — operators can disable the cache route
+        with ``POLLYPM_STATE_CACHE=0`` and the rail still renders
+        heartbeats via the direct pg path.
+        """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "0")
         router = self._router(tmp_path)
@@ -1236,10 +1288,19 @@ class TestPr2026ReviewBlocker1ActionableAlertFallthrough:
 
 
 class TestPr2026ReviewBlocker2HeartbeatNoStale:
-    """Blocker 2: heartbeat reads MUST reflect the latest pg write
-    immediately. The cache had no invalidation on heartbeat ticks and
-    would serve a stale snapshot indefinitely — until the follow-up
-    issue lands, every call hits the direct facade.
+    """Blocker 2 (#2050 follow-up): heartbeat reads MUST NOT serve an
+    indefinitely-stale snapshot. The refresher subscribes to
+    ``heartbeat.tick`` audit events so every workspace sweep
+    invalidates the affected project entries; the next refresh
+    repopulates ``latest_heartbeat_by_session`` from the bulk pg query
+    and the rail's fast-path serves the fresh row.
+
+    These tests pin two invariants:
+    1. ``heartbeat.tick`` is in ``refresher._INVALIDATING_EVENTS`` —
+       the invalidation contract itself.
+    2. After ``cache.invalidate(project)`` the rail no longer sees the
+       previously-cached heartbeat (snapshot miss → direct facade
+       picks up the fresh row).
     """
 
     def _router(self, tmp_path: Path):
@@ -1255,16 +1316,30 @@ class TestPr2026ReviewBlocker2HeartbeatNoStale:
         )
         return CockpitRouter(config_path)
 
-    def test_newer_store_heartbeat_reflected_immediately(
+    def test_heartbeat_tick_is_an_invalidating_event(self) -> None:
+        """The invalidation contract that unblocks the cache fast-path."""
+
+        from pollypm.state_cache.refresher import _INVALIDATING_EVENTS
+
+        assert "heartbeat.tick" in _INVALIDATING_EVENTS
+
+    def test_refresh_after_invalidate_replaces_stale_snapshot(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """A second pg write is visible on the next call — no stale cache."""
+        """Heartbeat tick → invalidate → refresh → fresh row served.
+
+        Simulates the full production cascade end-to-end: the audit
+        tail saw a ``heartbeat.tick`` event, the refresher called
+        ``cache.invalidate(project)``, then drained the pending queue
+        through ``cache.refresh`` (which now repopulates
+        ``latest_heartbeat_by_session`` via ``latest_heartbeats_bulk``).
+        The rail's next read sees the fresh row out of the snapshot —
+        no indefinite stale window the way PR #2026 reverted around.
+        """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         router = self._router(tmp_path)
 
-        # Seed the cache with an OLD heartbeat to prove we're not
-        # reading from it.
         stale = SimpleNamespace(created_at="2026-05-20T01:00:00Z", n="stale")
         entries = {
             "alpha": _entry(
@@ -1272,31 +1347,71 @@ class TestPr2026ReviewBlocker2HeartbeatNoStale:
                 latest_heartbeat_by_session={"worker_alpha/1": stale},
             ),
         }
-        _seed_cache(monkeypatch, entries)
+        cache = _seed_cache(monkeypatch, entries)
 
-        # First direct read.
-        first = SimpleNamespace(created_at="2026-05-20T02:00:00Z", n="first")
-        second = SimpleNamespace(created_at="2026-05-20T03:00:00Z", n="second")
-        state = {"next": first}
+        # Refresher would call this on a ``heartbeat.tick`` event.
+        cache.invalidate("alpha")
 
+        fresh = SimpleNamespace(created_at="2026-05-20T03:00:00Z", n="fresh")
+        # Re-point the refresh fn so the next refresh repopulates with
+        # the fresh row (mirrors ``compute_entry_for_project`` calling
+        # ``latest_heartbeats_bulk`` after the tick).
+        cache._refresh_fn = lambda key: _entry(  # noqa: SLF001
+            key, state=ProjectState.WORKING, items=[],
+            latest_heartbeat_by_session={"worker_alpha/1": fresh},
+        )
+        # Drain the pending queue (the refresher worker would do this).
+        for pending_key in cache.drain_pending():
+            cache.refresh(pending_key)
+
+        # Guard against any accidental direct-facade fall-through —
+        # the snapshot MUST hold the fresh row now.
         def _direct(name, *, config=None):  # noqa: ANN001, ANN201
-            return state["next"]
+            raise AssertionError(
+                "direct facade hit despite a populated snapshot",
+            )
 
         monkeypatch.setattr(
             "pollypm.storage.pg_heartbeats.latest_heartbeat", _direct,
         )
 
         supervisor = SimpleNamespace(store=None, config=None)
-        assert router._latest_heartbeat_cached(
+        result = router._latest_heartbeat_cached(
             supervisor, "worker_alpha/1",
-        ) is first
-        # Simulate a fresh pg row landing. Without cache invalidation,
-        # the stale snapshot would have won; the direct-facade contract
-        # means the next call sees the newer row.
-        state["next"] = second
+        )
+        assert result is fresh
+
+    def test_pg_failure_still_falls_back_to_supervisor_store(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Direct-facade safety net survives the fast-path restoration.
+
+        PR #2026's blocker-2 fallback contract (pg unreachable →
+        ``supervisor.store.latest_heartbeat``) MUST keep working when
+        the cache is empty / missing the session.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+        _seed_cache(monkeypatch, {})
+
+        def _boom(name, *, config=None):  # noqa: ANN001, ANN201
+            raise RuntimeError("pg pool unreachable")
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_heartbeats.latest_heartbeat", _boom,
+        )
+
+        fallback = SimpleNamespace(created_at="2026-05-20T02:00:00Z")
+
+        class _Store:
+            def latest_heartbeat(self, name):  # noqa: ANN001, ANN201
+                return fallback
+
+        supervisor = SimpleNamespace(store=_Store(), config=None)
         assert router._latest_heartbeat_cached(
-            supervisor, "worker_alpha/1",
-        ) is second
+            supervisor, "worker_beta/3",
+        ) is fallback
 
 
 class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -134,6 +134,7 @@ def _entry(
     glyph: str = "",
     detail: str = "",
     latest_heartbeat_by_session: dict[str, Any] | None = None,
+    config_identity: str = "",
 ) -> ProjectStateCacheEntry:
     return ProjectStateCacheEntry(
         project_key=project_key,
@@ -150,6 +151,7 @@ def _entry(
         awaits_user_count=len(items),
         awaits_user_items=tuple(items),
         latest_heartbeat_by_session=dict(latest_heartbeat_by_session or {}),
+        config_identity=config_identity,
     )
 
 
@@ -1139,6 +1141,74 @@ class TestLatestHeartbeatParity:
         result = router._latest_heartbeat_cached(supervisor, "worker_alpha/1")
         assert called == ["worker_alpha/1"]
         assert result is hb
+
+    def test_cross_config_cache_entry_is_skipped(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Stamped cross-config entry → fast-path declines, direct serves.
+
+        PR #2080 Codex r1 blocker: the cache singleton is process-wide
+        and the heartbeat fast-path was returning the first
+        ``by_session[session_name]`` hit without comparing
+        ``entry.config_identity`` to the live config's identity. With
+        overlapping session names across workspaces, that leaks
+        cross-config data. Pin the guard: when the stamped identity
+        disagrees, skip the entry and fall through to the direct pg
+        facade (matches the guard in ``cockpit_inbox`` and the rail
+        rollup map).
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+
+        cross_hb = SimpleNamespace(
+            session_name="worker_alpha/1",
+            created_at="2026-05-21T01:00:00Z",
+            tag="STALE_CROSS_CONFIG",
+        )
+        # Entry stamped with config_identity="alpha" — a different
+        # workspace from the live config below (identity "beta").
+        entries = {
+            "alpha": _entry(
+                "alpha",
+                state=ProjectState.WORKING,
+                items=[],
+                latest_heartbeat_by_session={"worker_alpha/1": cross_hb},
+                config_identity="alpha",
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # Direct facade returns the authoritative live-config value.
+        direct_hb = SimpleNamespace(
+            session_name="worker_alpha/1",
+            created_at="2026-05-21T02:00:00Z",
+            tag="FROM_DIRECT_LIVE_CONFIG",
+        )
+        pg_calls: list[str] = []
+
+        def _direct(name, *, config=None):  # noqa: ANN001, ANN201
+            pg_calls.append(name)
+            return direct_hb
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_heartbeats.latest_heartbeat", _direct,
+        )
+
+        # Live config has identity "beta" — different from the
+        # stamped entry — via ``config_path`` (the preferred identity
+        # source in ``state_cache.entry.config_identity``).
+        live_config = SimpleNamespace(config_path="beta")
+        supervisor = SimpleNamespace(store=None, config=live_config)
+
+        result = router._latest_heartbeat_cached(supervisor, "worker_alpha/1")
+
+        # The cross-config entry must NOT be served. The direct
+        # facade was called and its result was returned.
+        assert result is not cross_hb
+        assert getattr(result, "tag", None) != "STALE_CROSS_CONFIG"
+        assert pg_calls == ["worker_alpha/1"]
+        assert result is direct_hb
 
 
 # ── Move A PR 3 — TTL removal regression test ───────────────────────

--- a/tests/test_state_cache_refresher.py
+++ b/tests/test_state_cache_refresher.py
@@ -106,6 +106,52 @@ def test_non_invalidating_event_is_ignored(audit_dir: Path) -> None:
     assert cache.get("alpha") is None
 
 
+def test_heartbeat_tick_event_invalidates_project(audit_dir: Path) -> None:
+    """#2050 — ``heartbeat.tick`` is now in ``_INVALIDATING_EVENTS``.
+
+    The audit watchdog emits one ``heartbeat.tick`` per sweep; the
+    refresher must invalidate the affected project entry so the next
+    refresh repopulates ``latest_heartbeat_by_session`` from a fresh
+    pg query and the rail's snapshot can never go indefinitely stale.
+    """
+
+    log = audit_dir / "alpha.jsonl"
+    log.touch()
+    cache = ProjectStateCache(refresh_fn=lambda k: empty_entry(k))
+    refresher = StateCacheRefresher(cache, audit_dir=audit_dir)
+    refresher._seek_to_end()
+
+    _write_event(log, event="heartbeat.tick", project="alpha")
+    _drain_for_test(refresher)
+
+    assert cache.get("alpha") is not None
+    assert cache.version("alpha") == 1
+
+
+def test_workspace_scoped_heartbeat_tick_invalidates_all_known(
+    audit_dir: Path,
+) -> None:
+    """``heartbeat.tick`` fires with ``project=""`` from
+    ``audit_watchdog.emit_heartbeat_tick`` — must enqueue every known
+    project (matches the ``work_table.cleared`` workspace-scope path).
+    """
+
+    log = audit_dir / "_workspace.jsonl"
+    log.touch()
+    cache = ProjectStateCache(refresh_fn=lambda k: empty_entry(k))
+    cache._install_for_test("alpha", empty_entry("alpha"))
+    cache._install_for_test("beta", empty_entry("beta"))
+
+    refresher = StateCacheRefresher(cache, audit_dir=audit_dir)
+    refresher._seek_to_end()
+
+    _write_event(log, event="heartbeat.tick", project="")
+    _drain_for_test(refresher)
+
+    assert cache.version("alpha") == 2
+    assert cache.version("beta") == 2
+
+
 def test_workspace_scoped_event_invalidates_known_projects(
     audit_dir: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Adds `heartbeat.tick` to `state_cache/refresher._INVALIDATING_EVENTS` so every workspace heartbeat sweep invalidates the affected project entries (closes #2050).
- `refresh_impl.compute_entry_for_project` now repopulates `latest_heartbeat_by_session` from one `pg_heartbeats.latest_heartbeats_bulk` call per project. Session-name set is the canonical `architect_<key>` / `plan_gate-<key>` / `worker_<key>` (and aliases) union the live `worker_<key>/<n>` rows the prefetched worker_sessions table reports — no extra db round-trip beyond the bulk heartbeat query itself.
- Restores the rail's cache fast-path in `CockpitRouter._latest_heartbeat_cached`: scans the snapshot first, falls through to the direct pg facade only on a cache miss (cold start / unknown session) or pg failure (degrades to `supervisor.store.latest_heartbeat`). Reverts the PR #2026 review-blocker-2 workaround.

## Test plan

- [x] `pytest tests/test_state_cache_parity.py tests/test_state_cache_refresher.py tests/test_state_cache.py -x` — 73 passed
- [x] `pytest tests/test_state_cache_config_identity.py tests/test_state_cache_env_flag.py tests/test_state_cache_entry.py tests/test_state_cache_no_sqlite_imports.py -x` — 50 passed
- [x] New regression test `TestPr2026ReviewBlocker2HeartbeatNoStale::test_heartbeat_tick_is_an_invalidating_event` pins `heartbeat.tick` in `_INVALIDATING_EVENTS`.
- [x] New test `test_refresh_after_invalidate_replaces_stale_snapshot` exercises the full cascade (invalidate → refresh → fresh row served from snapshot, direct facade NOT called).
- [x] New tests in `test_state_cache_refresher.py` pin `heartbeat.tick` for both project-scoped and workspace-scoped (`project=""`) emit shapes.
- [x] PR #2026 fallback contracts preserved: cache miss → direct facade; pg unreachable → `supervisor.store.latest_heartbeat`; `POLLYPM_STATE_CACHE=0` → direct facade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)