### PR TITLE
feat(chat-api): re-implement include_subagents with raw-JSONL subagent parser (closes #2052)

### DIFF
--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -218,7 +218,7 @@ Pull a window of messages from a single session's transcript.
 | `since_id` | none | Message id (string). Return messages strictly after this id. Both `since` and `since_id` are applied if passed together (the `since` lower-bound is applied first, then the cursor walk). |
 | `limit` | `100` | Max messages, must be `1..500`. Values outside that range return `422 validation_error` (FastAPI Pydantic-level rejection). |
 | `direction` | `desc` | `desc` (newest first) or `asc`. Pagination cursors assume the same direction. |
-| `include_subagents` | `false` | DEFERRED — server returns 422 if true. Re-enabled when #2052 lands ingestor-side subagent normalization. |
+| `include_subagents` | `false` | When `true`, each `subagent_result` envelope's `metadata.subagent_transcript` is populated by parsing the raw Claude JSONL the parent `task-notification.output-file` points at. Paths outside the project/workspace transcript allowlist are silently skipped. Capped per envelope. (#2052) |
 | `source` | `auto` | `auto` (JSONL with capture fallback when archive is missing or >60s stale), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). Any other value returns `422 validation_error`. |
 
 > Note: A `type="thinking"` envelope is planned but not yet implemented — tracked in [#2048](https://github.com/samhotchkiss/pollypm/issues/2048).
@@ -414,7 +414,7 @@ structured original lives in `metadata`.
 | `ask_user` | assistant | `AskUserQuestion` tool | `metadata`: `questions[]`, `answered`, `answers`. See §5.5. |
 | `file` | assistant | `SendUserFile` tool | `metadata`: `files[]` (local paths), `caption`, `status`. |
 | `subagent_spawn` | assistant | `Task` tool call | `metadata`: `subagent_id`, `subagent_type`, `description`, `prompt`, `isolation`. |
-| `subagent_result` | tool | `Task` tool return | `metadata`: `subagent_id`, `summary`, `duration_ms`, `total_tokens`, `worktree_path`. Note: subagent_transcript inlining is deferred — see #2052. |
+| `subagent_result` | tool | `Task` tool return | `metadata`: `subagent_id`, `summary`, `duration_ms`, `total_tokens`, `worktree_path`, `output_file`. With `?include_subagents=true`: `metadata.subagent_transcript` carries envelopes parsed from the raw subagent JSONL at `output_file` (#2052). |
 | `system_event` | system | Compaction, session-start, error | `metadata.subtype` ∈ `compaction`, `session_start`, `session_resume`, `error`. |
 
 ### Example payloads
@@ -520,7 +520,11 @@ Once answered, the envelope reappears with `answered=true` and
 }
 ```
 
-Note: subagent_transcript inlining is deferred — see #2052.
+With `?include_subagents=true` the same envelope also carries
+`metadata.subagent_transcript` — a list of envelopes parsed from the
+raw Claude JSONL referenced by `output_file`. Paths outside the
+project/workspace transcript allowlist are silently skipped; inlining
+is capped per envelope to keep responses bounded (#2052).
 
 `system_event`:
 
@@ -568,7 +572,15 @@ block.
 `subagent_result` envelopes; the subagent's full transcript is NOT
 inlined.
 
-Note: subagent_transcript inlining is deferred — see #2052.
+**Opt-in inlining:** pass `?include_subagents=true` and each
+`subagent_result` carries `metadata.subagent_transcript`, parsed
+from the raw Claude JSONL referenced by `output_file`. The path
+resolver constrains candidates to project + workspace transcript
+roots (`.pollypm/transcripts/`); paths outside the allowlist are
+silently skipped so a malformed transcript cannot stat arbitrary
+files. Inlining is capped per envelope (default 500 child envelopes);
+callers who need the entire subagent transcript should query its own
+session through `/api/v1/chat/sessions`. (#2052)
 
 ### 5.3 Mid-stream sends (`409 unsafe_mid_stream`)
 
@@ -813,9 +825,10 @@ pm chat send <session_name> <text> [--no-enter]
   every flag as the matching query param. `--since-id` is cursor
   pagination (pass the previous response's `next_cursor`). `--pane` is
   not exposed because GET never differentiates panes (§5.4).
-  `--include-subagents` is currently a no-op surface: the help text
-  flags it as deferred and the server returns `422 validation_error`
-  if you pass it until #2052 lands.
+  `--include-subagents` forwards as `?include_subagents=true`, which
+  enriches each `subagent_result` envelope with
+  `metadata.subagent_transcript` parsed from the raw subagent JSONL
+  at `output_file` (allowlist-constrained, capped per envelope).
 - `pm chat send` → `POST /api/v1/chat/<session>/send`. `--no-enter`
   maps to `press_enter=false`. `--selection` is repeatable for
   multi-select `AskUserQuestion` replies. `--pane` forwards the
@@ -902,9 +915,24 @@ selection.
    `AskUserQuestion` stdin protocol may have changed (see §5.5 open
    question). File a bug.
 
-### (f) `include_subagents=true` returns 422
+### (f) `include_subagents=true` returns an empty `subagent_transcript`
 
-`include_subagents=true` returns 422 until #2052 lands.
+Most likely causes:
+
+1. **The `output_file` path is outside the allowlist.** Only paths
+   under a project or the workspace `.pollypm/transcripts/` root are
+   eligible — anything else (an `/etc/...` path, a worktree outside
+   the configured project, an absolute path the agent fabricated) is
+   silently skipped. Confirm via `metadata.output_file` on the
+   `subagent_result` envelope.
+2. **The subagent JSONL hasn't been written yet.** Brand-new
+   subagents may have a `task-notification.output-file` set but the
+   raw JSONL is empty / still being appended.
+3. **The subagent JSONL is not raw Claude shape.** The resolver
+   expects the per-session Claude format (`type=user|assistant`,
+   `message.content`). A normalized `events.jsonl` archive at that
+   path will parse empty — request the child surface directly via
+   `/api/v1/chat/sessions` instead.
 
 ### (g) Transcript appears truncated or out of order
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -714,14 +714,17 @@ paths:
             type: boolean
             default: false
           description: |
-            DEFERRED (#2052). The runtime accepts this parameter for
-            forward-compat with the v3 inliner, but currently returns
-            `422 validation_error` when set to `true`. The v3
-            implementation called `parse_events_jsonl` on the raw
-            Claude task-notification `metadata.output_file`, which is
-            a different JSONL shape than the normalized archive the
-            parser consumes; re-implementation is tracked in #2052.
-            Pass `false` (or omit) until the resolver lands.
+            When `true`, each `subagent_result` envelope on the page
+            is enriched with `metadata.subagent_transcript` — a list
+            of envelopes parsed from the raw Claude JSONL the parent
+            `task-notification.output-file` points at. Paths are
+            constrained to project + workspace transcript roots; any
+            `output_file` outside the allowlist is silently skipped
+            (no inlining, no error) so a malformed transcript cannot
+            stat arbitrary files. Inlining is capped per envelope to
+            keep response sizes bounded; callers needing the full
+            subagent transcript should query its own session via
+            `/api/v1/chat/sessions`. See issue #2052.
         - in: query
           name: source
           schema:
@@ -3160,8 +3163,11 @@ components:
           additionalProperties: true
           description: |
             Type-dependent payload. `subagent_result` envelopes carry
-            `output_file` and `summary`. `subagent_transcript` inlining
-            is deferred — see #2052.
+            `output_file` and `summary`; when the request passes
+            `include_subagents=true`, they also carry
+            `subagent_transcript` — a list of envelopes parsed from
+            the raw Claude subagent JSONL referenced by `output_file`
+            (allowlist-constrained, capped per envelope). See #2052.
 
     ChatMessagesResponse:
       type: object

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -472,7 +472,7 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | POST   | `/api/v1/inbox/{id}/archive` | Archive (close) the item |
 | GET    | `/api/v1/events` | SSE stream of audit-log events (`?since=&project=&event=`) |
 | GET    | `/api/v1/chat/sessions` | Discover every chat surface (operator/architect/advisor/worker) |
-| GET    | `/api/v1/chat/{session_name}/messages` | Paginated message history for one chat surface (`?since=&since_id=&limit=&direction=&source=`) — `include_subagents` deferred (#2052) |
+| GET    | `/api/v1/chat/{session_name}/messages` | Paginated message history for one chat surface (`?since=&since_id=&limit=&direction=&source=&include_subagents=`) — `include_subagents=true` inlines the raw subagent JSONL at each `subagent_result.metadata.output_file` (allowlist-constrained, capped per envelope, #2052) |
 
 The OpenAPI document is the authoritative list; if anything here
 drifts, the YAML wins.

--- a/src/pollypm/cli_features/chat.py
+++ b/src/pollypm/cli_features/chat.py
@@ -339,8 +339,9 @@ def chat_history(
         False,
         "--include-subagents",
         help=(
-            "DEFERRED — see issue #2052. Currently the server returns "
-            "422 if this is true."
+            "Enrich subagent_result envelopes with the parsed raw "
+            "subagent JSONL at metadata.output_file (allowlist-"
+            "constrained, capped per envelope). See issue #2052."
         ),
     ),
     source: str | None = typer.Option(

--- a/src/pollypm/web_api/chat/__init__.py
+++ b/src/pollypm/web_api/chat/__init__.py
@@ -44,6 +44,7 @@ from pollypm.web_api.chat.transcripts import (
     is_archive_stale,
     parse_events_jsonl,
     parse_events_jsonl_tail,
+    parse_raw_subagent_jsonl,
     resolve_transcript_path,
 )
 
@@ -61,6 +62,7 @@ __all__ = [
     "is_archive_stale",
     "parse_events_jsonl",
     "parse_events_jsonl_tail",
+    "parse_raw_subagent_jsonl",
     "resolve_transcript_path",
     "synthesize_capture_id",
 ]

--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -1169,6 +1169,185 @@ def _extract_task_notification(content: Any) -> dict[str, Any] | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Raw Claude subagent JSONL parser (issue #2052).
+#
+# Subagents spawned via the Claude ``Task`` tool write their own JSONL
+# stream to the path carried in the parent's ``task-notification``
+# block as ``output-file``. That file is the RAW provider JSONL — the
+# same shape :func:`pollypm.transcript_ingest._normalize_claude_line`
+# consumes — NOT the normalized ``events.jsonl`` archive that
+# :func:`parse_events_jsonl` consumes.
+#
+# We deliberately keep this resolver-side (in the chat API) rather
+# than forcing the ingestor to normalize per-subagent: subagent
+# transcripts are read-only artifacts referenced only when a caller
+# explicitly opts into ``include_subagents=true`` on the messages
+# endpoint, so paying the parse cost lazily at request time is
+# strictly better than pre-normalizing every subagent JSONL on every
+# ingest tick.
+# ---------------------------------------------------------------------------
+
+
+_RAW_USER_TYPES = frozenset({"user"})
+_RAW_ASSISTANT_TYPES = frozenset({"assistant"})
+
+
+def parse_raw_subagent_jsonl(
+    path: Path,
+    *,
+    actor_fallback: str = "subagent",
+    limit: int | None = None,
+) -> list[MessageEnvelope]:
+    """Parse a raw Claude subagent JSONL into :class:`MessageEnvelope` rows.
+
+    The subagent JSONL shape (one JSON object per line) is what the
+    Claude CLI writes verbatim — distinct from the normalized
+    ``events.jsonl`` :func:`parse_events_jsonl` consumes:
+
+    .. code-block:: json
+
+        {
+          "type": "user" | "assistant" | "error",
+          "sessionId": "<uuid>",
+          "cwd": "/path/to/project",
+          "timestamp": "2026-05-21T20:48:11Z",
+          "message": {
+            "model": "claude-opus-4-7",
+            "content": "..." | [{"type": "text", "text": "..."}, ...],
+            "usage": {...}
+          }
+        }
+
+    Each ``user`` / ``assistant`` line becomes one envelope; ``error``
+    lines become ``system_event`` envelopes with ``subtype=error``.
+    Anything else (``summary``, telemetry-only lines, malformed JSON)
+    is skipped.
+
+    ``limit`` (optional): cap on emitted envelopes. ``None`` returns
+    every envelope. The caller (the chat-messages route) sets a small
+    cap so the inlined transcript doesn't balloon the parent response.
+
+    Fail-soft: every I/O or JSON failure is logged at debug and the
+    caller receives whatever envelopes were accumulated so far. This
+    mirrors the posture of :func:`parse_events_jsonl` with
+    ``strict=False`` — the subagent transcript is a best-effort
+    enrichment, never the primary signal.
+    """
+    envelopes: list[MessageEnvelope] = []
+    if not path.exists():
+        return envelopes
+    source_key = hashlib.blake2b(
+        str(path).encode("utf-8"), digest_size=4,
+    ).hexdigest()
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for index, line in enumerate(handle):
+                if limit is not None and len(envelopes) >= limit:
+                    break
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    obj = json.loads(stripped)
+                except json.JSONDecodeError:
+                    logger.debug(
+                        "chat.transcripts: skipping malformed raw "
+                        "subagent line in %s @ %d", path, index,
+                    )
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                envelope = _raw_subagent_line_to_envelope(
+                    obj,
+                    index=index,
+                    source_key=source_key,
+                    actor_fallback=actor_fallback,
+                )
+                if envelope is not None:
+                    envelopes.append(envelope)
+    except OSError as exc:
+        logger.warning(
+            "chat.transcripts: read failed for raw subagent %s: %s",
+            path, exc,
+        )
+    return envelopes
+
+
+def _raw_subagent_line_to_envelope(
+    obj: dict[str, Any],
+    *,
+    index: int,
+    source_key: str,
+    actor_fallback: str,
+) -> MessageEnvelope | None:
+    """Map one raw Claude JSONL line to a :class:`MessageEnvelope`.
+
+    Returns ``None`` for line types we don't surface (``summary``,
+    ``session_state``, malformed shapes). The id is deterministic per
+    ``(file, line index)`` so a repeated parse yields stable ids.
+    """
+    line_type = obj.get("type")
+    timestamp = str(obj.get("timestamp") or "")
+    msg_id = f"sub_{source_key}_{index:06d}"
+    message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
+    content = message.get("content") if isinstance(message, dict) else None
+
+    if line_type in _RAW_USER_TYPES:
+        text = _extract_text_from_blocks(content) or _extract_text_from_blocks(message)
+        return MessageEnvelope(
+            id=msg_id,
+            ts=timestamp,
+            role=MessageRole.USER,
+            actor="user",
+            type=MessageType.TEXT,
+            text=text,
+            metadata={
+                "provider": "claude",
+                "source": "subagent_jsonl",
+                "session_id": str(obj.get("sessionId") or ""),
+            },
+        )
+    if line_type in _RAW_ASSISTANT_TYPES:
+        text = _extract_text_from_blocks(content) or _extract_text_from_blocks(message)
+        model_name = ""
+        if isinstance(message, dict):
+            raw_model = message.get("model")
+            if isinstance(raw_model, str):
+                model_name = raw_model
+        return MessageEnvelope(
+            id=msg_id,
+            ts=timestamp,
+            role=MessageRole.ASSISTANT,
+            actor=actor_fallback,
+            type=MessageType.TEXT,
+            text=text,
+            metadata={
+                "provider": "claude",
+                "source": "subagent_jsonl",
+                "session_id": str(obj.get("sessionId") or ""),
+                "model": model_name,
+            },
+        )
+    if line_type == "error":
+        # Surface subagent errors as system_event so the caller's UI
+        # doesn't lose them in the inlined stream.
+        return MessageEnvelope(
+            id=msg_id,
+            ts=timestamp,
+            role=MessageRole.SYSTEM,
+            actor="system",
+            type=MessageType.SYSTEM_EVENT,
+            text=_extract_text_from_blocks(obj.get("error")) or "(subagent error)",
+            metadata={
+                "subtype": "error",
+                "provider": "claude",
+                "source": "subagent_jsonl",
+            },
+        )
+    return None
+
+
 __all__ = [
     "STALE_THRESHOLD_SECONDS",
     "build_session_index",
@@ -1176,5 +1355,6 @@ __all__ = [
     "lookup_transcript_path",
     "parse_events_jsonl",
     "parse_events_jsonl_tail",
+    "parse_raw_subagent_jsonl",
     "resolve_transcript_path",
 ]

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -26,6 +26,7 @@ opening a read-only work-service handle (matches the pattern used by
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -943,10 +944,20 @@ def _inline_subagent_transcript(
             sub_path, exc_info=True,
         )
         return envelope
-    envelope.metadata["subagent_transcript"] = [
+    # Cache-poisoning guard: the transcript parser cache stores the
+    # same ``MessageEnvelope`` instances we receive here (the cache
+    # only copies the outer list, not the dataclass or its mutable
+    # ``metadata`` dict — see ``transcripts._PARSE_CACHE``). Mutating
+    # ``envelope.metadata`` in place would persist ``subagent_transcript``
+    # on the cached entry, so a later default ``include_subagents=false``
+    # request against the same archive/mtime would still return the
+    # inlined payload. Build a fresh envelope with a shallow-cloned
+    # metadata dict so the enrichment never leaks back into the cache.
+    new_metadata = dict(envelope.metadata or {})
+    new_metadata["subagent_transcript"] = [
         env.to_dict() for env in sub_envelopes
     ]
-    return envelope
+    return dataclasses.replace(envelope, metadata=new_metadata)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -45,6 +45,7 @@ from pollypm.web_api.chat import (
     is_archive_stale,
     parse_events_jsonl,
     parse_events_jsonl_tail,
+    parse_raw_subagent_jsonl,
 )
 from pollypm.web_api.errors import APIError, service_unavailable
 from pollypm.web_api.routes._deps import ConfigDep
@@ -699,6 +700,7 @@ def _apply_filters_and_paginate(
     since_id: str | None,
     direction: Direction,
     limit: int,
+    post_process: Any = None,
 ) -> tuple[list[ChatMessageEnvelope], bool, str | None]:
     """Apply spec §2.2 query semantics and return ``(rows, has_more, cursor)``.
 
@@ -724,12 +726,10 @@ def _apply_filters_and_paginate(
        endpoint).
     6. Slice to ``limit`` and compute ``has_more`` / ``next_cursor``.
 
-    NOTE: ``include_subagents`` is deferred to #2052 — the v3
-    implementation called ``parse_events_jsonl`` on
-    ``metadata.output_file``, but that field is the raw Claude
-    task-notification subagent JSONL (different shape than the
-    normalized archive). The path-traversal allowlist and inliner
-    were removed alongside the query param.
+    NOTE: subagent inlining lives in
+    :func:`_inline_subagent_transcript` and runs in the endpoint after
+    pagination — see the doc-block above that function for the
+    allowlist + raw-parser contract (issue #2052).
     """
     # Normalize the lower bound to tz-aware UTC so the comparison with
     # parsed timestamps (always tz-aware after _parse_envelope_ts) never
@@ -788,15 +788,165 @@ def _apply_filters_and_paginate(
     if has_more and page:
         next_cursor = page[-1].id
 
+    if post_process is not None:
+        page = [post_process(env) for env in page]
+
     return [_envelope_to_wire(env) for env in page], has_more, next_cursor
 
 
-# NOTE: ``_inline_subagent`` / ``_allowed_transcript_roots`` /
-# ``_is_within`` were removed in PR #2045 round-4. The v3 implementation
-# called ``parse_events_jsonl`` on ``metadata.output_file``, but that
-# field is the raw Claude task-notification subagent JSONL — a totally
-# different shape than the normalized archive ``parse_events_jsonl``
-# consumes. Re-implementation tracked in #2052.
+# ---------------------------------------------------------------------------
+# Subagent inlining (#2052)
+#
+# When ``include_subagents=true`` is passed, each ``subagent_result``
+# envelope in the page is enriched with ``metadata.subagent_transcript``
+# — a list of envelopes parsed from the raw Claude JSONL the parent
+# ``task-notification`` block points at (``metadata.output_file``).
+#
+# Security boundary: ``metadata.output_file`` is supplied by transcript
+# content and an authenticated caller who can influence what an agent
+# writes could otherwise make the API stat/read arbitrary local paths
+# (``/etc/passwd``, ``../../../escape.jsonl``). The inliner constrains
+# candidates to :func:`_allowed_transcript_roots` (project + workspace
+# transcript dirs) via ``Path.resolve`` + ``is_relative_to``. Paths
+# outside every allowed root are skipped silently (debug log, no
+# raise) so a malformed transcript can't 500 the endpoint.
+#
+# Parser asymmetry: subagent JSONLs are the RAW Claude per-session
+# stream, not the normalized ``events.jsonl`` archive — we route the
+# read through :func:`parse_raw_subagent_jsonl`. See the docstring on
+# that function for the shape contract.
+# ---------------------------------------------------------------------------
+
+
+# Cap per-subagent inlined envelopes so a runaway subagent transcript
+# can't balloon a single parent response. The cap is generous (matches
+# the messages endpoint's hard max) but bounded; callers who need the
+# full subagent transcript should query it through its own session.
+_SUBAGENT_INLINE_LIMIT = 500
+
+
+def _allowed_transcript_roots(config: Any) -> list[Path]:
+    """Compute directories that may contain subagent transcripts.
+
+    Security boundary for :func:`_inline_subagent`. ``metadata.output_file``
+    is supplied by transcript content and must never be trusted as a
+    filesystem authority — the inliner only reads paths that resolve
+    under one of these roots.
+
+    Roots covered:
+
+    - ``<workspace>/.pollypm/transcripts/`` for the operator workspace.
+    - ``<project>/.pollypm/transcripts/`` for every known project in
+      ``config.projects`` (same set the chat registry enumerates).
+
+    Each returned root is ``resolve()``d so the membership check lines
+    up with a likewise-resolved candidate path.
+    """
+    from pollypm.projects import project_transcripts_dir
+
+    roots: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(path: Path | None) -> None:
+        if path is None:
+            return
+        try:
+            resolved = path.resolve()
+        except (OSError, RuntimeError):
+            return
+        key = str(resolved)
+        if key in seen:
+            return
+        seen.add(key)
+        roots.append(resolved)
+
+    project_settings = getattr(config, "project", None)
+    if project_settings is not None:
+        for attr in ("workspace_root", "root_dir"):
+            base = getattr(project_settings, attr, None)
+            if isinstance(base, Path):
+                _add(project_transcripts_dir(base))
+
+    projects = getattr(config, "projects", None) or {}
+    for known in projects.values():
+        project_path = getattr(known, "path", None)
+        if isinstance(project_path, Path):
+            _add(project_transcripts_dir(project_path))
+
+    return roots
+
+
+def _is_within(candidate: Path, root: Path) -> bool:
+    """``Path.is_relative_to`` shim that returns ``False`` instead of raising.
+
+    Both ``candidate`` and ``root`` are expected to already be
+    ``resolve()``d so symlinks don't sneak a candidate past the
+    boundary.
+    """
+    try:
+        candidate.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _inline_subagent_transcript(
+    envelope: MessageEnvelope,
+    *,
+    allowed_roots: list[Path],
+    actor_fallback: str,
+) -> MessageEnvelope:
+    """Enrich a ``subagent_result`` envelope with its subagent transcript.
+
+    Reads the raw Claude JSONL at ``metadata.output_file`` (set by the
+    parser when the parent ``task-notification`` block carries one),
+    rejects any candidate outside ``allowed_roots``, and dumps the
+    parsed envelopes into ``metadata.subagent_transcript``.
+
+    Failures are silent — a missing, unreadable, or out-of-bounds
+    subagent transcript just leaves the envelope unchanged. The chat
+    history endpoint never 500s on enrichment.
+    """
+    if str(envelope.type) != "subagent_result":
+        return envelope
+    output_file = envelope.metadata.get("output_file")
+    if not isinstance(output_file, str) or not output_file:
+        return envelope
+    try:
+        sub_path = Path(output_file).resolve()
+    except (OSError, RuntimeError):
+        logger.debug(
+            "chat_messages: subagent path resolve failed for %s",
+            output_file, exc_info=True,
+        )
+        return envelope
+    if not allowed_roots or not any(
+        _is_within(sub_path, root) for root in allowed_roots
+    ):
+        logger.debug(
+            "chat_messages: subagent path %s outside allowed transcript "
+            "roots (%d roots); skipping inline",
+            output_file, len(allowed_roots),
+        )
+        return envelope
+    if not sub_path.exists():
+        return envelope
+    try:
+        sub_envelopes = parse_raw_subagent_jsonl(
+            sub_path,
+            actor_fallback=actor_fallback,
+            limit=_SUBAGENT_INLINE_LIMIT,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "chat_messages: subagent parse failed for %s",
+            sub_path, exc_info=True,
+        )
+        return envelope
+    envelope.metadata["subagent_transcript"] = [
+        env.to_dict() for env in sub_envelopes
+    ]
+    return envelope
 
 
 # ---------------------------------------------------------------------------
@@ -865,29 +1015,15 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
     )] = "auto",
     include_subagents: Annotated[bool, Query(
         description=(
-            "DEFERRED (#2052): the v3 inliner called the normalized "
-            "events.jsonl parser on metadata.output_file, but that "
-            "field is the raw Claude subagent JSONL (different shape). "
-            "Passing include_subagents=true returns 422 until the "
-            "task-notification.output-file → normalized child archive "
-            "resolver lands."
+            "Inline each subagent_result envelope's child transcript at "
+            "metadata.subagent_transcript. The child JSONL is read from "
+            "the parent task-notification.output-file via the raw "
+            "Claude-shape parser; paths are constrained to project + "
+            "workspace transcript roots (issue #2052)."
         ),
     )] = False,
 ) -> ChatMessagesResponse:
     """GET /api/v1/chat/{session_name}/messages per spec §2.2."""
-    if include_subagents:
-        # Reject the deferred param explicitly so callers learn it's
-        # gone rather than silently getting un-inlined results.
-        raise APIError(
-            status_code=422,
-            code="validation_error",
-            message=(
-                "include_subagents is not currently supported; the "
-                "task-notification.output-file -> normalized archive "
-                "resolver is deferred."
-            ),
-            hint="Track re-implementation in #2052.",
-        )
     surface = _find_surface(config, session_name)
     since_dt = _parse_since(since)
 
@@ -912,12 +1048,25 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
         surface, source=source, tail_hint=tail_hint,
     )
 
+    post_process: Any = None
+    if include_subagents:
+        allowed_roots = _allowed_transcript_roots(config)
+        actor_fallback = surface.persona or "subagent"
+
+        def post_process(env: MessageEnvelope) -> MessageEnvelope:
+            return _inline_subagent_transcript(
+                env,
+                allowed_roots=allowed_roots,
+                actor_fallback=actor_fallback,
+            )
+
     rows, has_more, next_cursor = _apply_filters_and_paginate(
         envelopes,
         since=since_dt,
         since_id=since_id,
         direction=direction,
         limit=limit,
+        post_process=post_process,
     )
 
     return ChatMessagesResponse(

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -640,9 +640,11 @@ def test_messages_endpoint_rejects_include_thinking_query_param(
 def test_messages_endpoint_no_subagent_inlining_by_default(
     client, auth_headers, patch_registry, patch_parser, tmp_path,
 ):
-    """``include_subagents`` is deferred (#2052) — default behavior
-    returns the parent envelope without any ``subagent_transcript``
-    field, even when the parent carries an ``output_file`` reference.
+    """Without ``include_subagents=true`` no ``subagent_transcript`` is added.
+
+    The parent envelope still carries ``output_file`` (the
+    task-notification reference) but inlining stays opt-in to keep the
+    default response shape stable (#2052).
     """
     archive = tmp_path / "events.jsonl"
     archive.write_text("x")
@@ -886,50 +888,14 @@ def test_messages_endpoint_desc_cursor_pagination_no_overlap(
 
 
 # ---------------------------------------------------------------------------
-# Security: subagent path-traversal allowlist (PR #2045 blocker 3)
+# Security: subagent path-traversal allowlist (#2052)
 # ---------------------------------------------------------------------------
-
-
-def test_messages_endpoint_rejects_include_subagents_true_with_422(
-    client, auth_headers, patch_registry, tmp_path,
-):
-    """``include_subagents=true`` is deferred (#2052) and must return 422.
-
-    The v3 implementation called ``parse_events_jsonl`` on
-    ``metadata.output_file``, but that field is the raw Claude
-    subagent JSONL — a different shape than the normalized archive
-    the parser consumes. Until a proper resolver lands, the param is
-    rejected so callers don't get silently-empty inlining (and the
-    path-traversal attack surface goes with it).
-
-    Replaces the v3 path-traversal tests: those exercised the
-    allowlist that no longer exists. The 422 here forecloses on
-    ``/etc/passwd`` / ``../../../escape.jsonl`` exploits at the same
-    boundary.
-    """
-    archive = tmp_path / "events.jsonl"
-    archive.write_text("x")
-    patch_registry([_surface(
-        "operator", SurfaceType.OPERATOR, persona="Polly",
-        transcript_path=archive,
-    )])
-    response = client.get(
-        "/api/v1/chat/operator/messages?include_subagents=true",
-        headers=auth_headers,
-    )
-    assert response.status_code == 422
-    body = response.json()
-    assert body["error"]["code"] == "validation_error"
-    assert "include_subagents" in body["error"]["message"]
 
 
 def test_messages_endpoint_include_subagents_false_explicit_is_ok(
     client, auth_headers, patch_registry, patch_parser, tmp_path,
 ):
-    """Explicit ``include_subagents=false`` must still return 200.
-
-    Only ``=true`` trips the deferral guard.
-    """
+    """Explicit ``include_subagents=false`` must return 200."""
     archive = tmp_path / "events.jsonl"
     archive.write_text("x")
     patch_registry([_surface(
@@ -942,6 +908,216 @@ def test_messages_endpoint_include_subagents_false_explicit_is_ok(
         headers=auth_headers,
     )
     assert response.status_code == 200
+
+
+def test_messages_endpoint_include_subagents_rejects_path_traversal(
+    client, auth_headers, patch_registry, patch_parser, tmp_path,
+):
+    """``output_file`` pointing outside the project transcripts root is skipped.
+
+    The allowlist forecloses on ``/etc/passwd`` / ``../../../escape.jsonl``
+    exploits: an envelope referencing a path outside the project +
+    workspace transcripts roots silently skips inlining (no raise, no
+    metadata.subagent_transcript) so a malformed transcript can't 500
+    the endpoint or stat arbitrary files.
+    """
+    archive = tmp_path / "events.jsonl"
+    archive.write_text("x")
+    escape = tmp_path / "escape.jsonl"
+    escape.write_text('{"type":"assistant","message":{"content":"leaked"}}\n')
+    parent = _env(
+        "result_1",
+        type_=MessageType.SUBAGENT_RESULT,
+        text="Subagent done.",
+        metadata={
+            "subagent_id": "abc",
+            "output_file": str(escape),  # outside transcripts roots
+        },
+    )
+    patch_registry([_surface(
+        "operator", SurfaceType.OPERATOR, persona="Polly",
+        transcript_path=archive,
+    )])
+    patch_parser({archive: [parent]})
+    response = client.get(
+        "/api/v1/chat/operator/messages?include_subagents=true",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "subagent_transcript" not in body["messages"][0]["metadata"]
+
+
+def test_messages_endpoint_include_subagents_inlines_with_real_parser(
+    client, auth_headers, patch_registry, project_root,
+    monkeypatch, tmp_path,
+):
+    """Real-parser regression for ``include_subagents=true`` (issue #2052).
+
+    Does NOT monkeypatch ``parse_events_jsonl`` or ``parse_raw_subagent_jsonl``;
+    instead writes both a real normalized ``events.jsonl`` archive
+    (parent) and a real raw Claude subagent JSONL (child) under the
+    project's ``.pollypm/transcripts/`` root so the allowlist accepts
+    the path. Asserts the inlined ``metadata.subagent_transcript``
+    actually contains envelopes derived from the raw shape — proves
+    the round-4 contract gap (events.jsonl parser called on raw JSONL)
+    is closed.
+    """
+    import json
+
+    from pollypm.projects import project_transcripts_dir
+
+    transcripts_root = project_transcripts_dir(project_root)
+    # Parent surface archive (normalized shape).
+    parent_dir = transcripts_root / "parent-session"
+    parent_dir.mkdir(parents=True)
+    parent_archive = parent_dir / "events.jsonl"
+    # Child subagent JSONL (raw Claude shape) — must live under the
+    # project transcripts root so the allowlist admits it.
+    child_dir = transcripts_root / "child-subagent"
+    child_dir.mkdir(parents=True)
+    child_jsonl = child_dir / "raw.jsonl"
+    child_jsonl.write_text(
+        "\n".join([
+            json.dumps({
+                "type": "user",
+                "sessionId": "child-1",
+                "cwd": str(project_root),
+                "timestamp": "2026-05-21T10:00:00Z",
+                "message": {"content": "kick off subagent"},
+            }),
+            json.dumps({
+                "type": "assistant",
+                "sessionId": "child-1",
+                "cwd": str(project_root),
+                "timestamp": "2026-05-21T10:00:05Z",
+                "message": {
+                    "model": "claude-opus-4-7",
+                    "content": [{"type": "text", "text": "subagent reply"}],
+                },
+            }),
+        ]) + "\n"
+    )
+
+    # Parent normalized events.jsonl: spawn + result with the
+    # task-notification pointing at the child raw JSONL.
+    parent_events = [
+        {
+            "timestamp": "2026-05-21T09:59:00Z",
+            "event_type": "tool_call",
+            "session_id": "parent-1",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": str(parent_archive),
+            "source_offset": 0,
+            "cwd": str(project_root),
+            "model_name": "claude-opus-4-7",
+            "payload": {
+                "type": "tool_use",
+                "id": "toolu_sub_real",
+                "name": "Task",
+                "input": {"description": "Run the subagent"},
+            },
+        },
+        {
+            "timestamp": "2026-05-21T10:00:10Z",
+            "event_type": "tool_result",
+            "session_id": "parent-1",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": str(parent_archive),
+            "source_offset": 1,
+            "cwd": str(project_root),
+            "model_name": "claude-opus-4-7",
+            "payload": {
+                "type": "tool_result",
+                "tool_use_id": "toolu_sub_real",
+                "content": [
+                    {"type": "text", "text": "Subagent done."},
+                    {
+                        "type": "task-notification",
+                        "task-id": "child-1",
+                        "output-file": str(child_jsonl),
+                        "duration-ms": 1234,
+                        "total-tokens": 567,
+                        "worktree-path": str(project_root),
+                    },
+                ],
+            },
+        },
+    ]
+    parent_archive.write_text(
+        "\n".join(json.dumps(e) for e in parent_events) + "\n"
+    )
+
+    # Drop the in-process parse cache so a previous test's cached
+    # entry can't shadow our fixture.
+    from pollypm.web_api.chat.transcripts import _parse_cache_clear
+
+    _parse_cache_clear()
+
+    patch_registry([_surface(
+        "operator", SurfaceType.OPERATOR, persona="Polly",
+        transcript_path=parent_archive,
+    )])
+
+    response = client.get(
+        "/api/v1/chat/operator/messages?include_subagents=true&direction=asc",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Locate the subagent_result envelope.
+    result_envs = [
+        m for m in body["messages"] if m["type"] == "subagent_result"
+    ]
+    assert len(result_envs) == 1, body
+    metadata = result_envs[0]["metadata"]
+    assert metadata["output_file"] == str(child_jsonl)
+    transcript = metadata.get("subagent_transcript")
+    assert isinstance(transcript, list)
+    assert len(transcript) == 2
+    # First child envelope: user turn with "kick off" text; second:
+    # assistant turn with the reply.
+    assert transcript[0]["role"] == "user"
+    assert transcript[0]["type"] == "text"
+    assert "kick off" in transcript[0]["text"]
+    assert transcript[1]["role"] == "assistant"
+    assert transcript[1]["type"] == "text"
+    assert transcript[1]["text"] == "subagent reply"
+    # Provenance marker so downstream consumers can distinguish
+    # inlined-from-raw envelopes from the normalized stream.
+    assert transcript[0]["metadata"]["source"] == "subagent_jsonl"
+    assert transcript[1]["metadata"]["model"] == "claude-opus-4-7"
+
+
+def test_messages_endpoint_include_subagents_default_no_inline(
+    client, auth_headers, patch_registry, patch_parser, tmp_path,
+):
+    """Omitting ``include_subagents`` leaves ``subagent_transcript`` absent."""
+    archive = tmp_path / "events.jsonl"
+    archive.write_text("x")
+    parent = _env(
+        "result_1",
+        type_=MessageType.SUBAGENT_RESULT,
+        text="Subagent done.",
+        metadata={
+            "subagent_id": "abc",
+            "output_file": str(tmp_path / "subagent.jsonl"),
+        },
+    )
+    patch_registry([_surface(
+        "operator", SurfaceType.OPERATOR, persona="Polly",
+        transcript_path=archive,
+    )])
+    patch_parser({archive: [parent]})
+    body = client.get(
+        "/api/v1/chat/operator/messages",
+        headers=auth_headers,
+    ).json()
+    assert "subagent_transcript" not in body["messages"][0]["metadata"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -1093,6 +1093,183 @@ def test_messages_endpoint_include_subagents_inlines_with_real_parser(
     assert transcript[1]["metadata"]["model"] == "claude-opus-4-7"
 
 
+def test_include_subagents_does_not_poison_cache_for_subsequent_default_request(
+    client, auth_headers, patch_registry, project_root,
+    monkeypatch, tmp_path,
+):
+    """Cache-poisoning regression for ``include_subagents`` (Codex review #2083).
+
+    The transcript parser cache stores ``MessageEnvelope`` instances by
+    reference (the cache only copies the outer list, not the dataclass
+    or its mutable ``metadata`` dict). A prior implementation mutated
+    ``envelope.metadata['subagent_transcript']`` in place, so a single
+    ``?include_subagents=true`` request would leave the inlined payload
+    on the cached envelope and a subsequent default
+    ``include_subagents=false`` (or omitted) request against the same
+    archive/mtime would still return the inlined data — even though the
+    client never opted in.
+
+    This test uses the REAL parser / cache (no monkeypatched parser):
+
+    1. First request with ``?include_subagents=true`` — envelope must
+       carry ``metadata.subagent_transcript``.
+    2. Second request with default opt-out (no query) against the SAME
+       archive (mtime unchanged → cache HIT) — envelope must NOT carry
+       ``metadata.subagent_transcript``.
+    """
+    import json
+
+    from pollypm.projects import project_transcripts_dir
+
+    transcripts_root = project_transcripts_dir(project_root)
+    parent_dir = transcripts_root / "parent-session-cache"
+    parent_dir.mkdir(parents=True)
+    parent_archive = parent_dir / "events.jsonl"
+    child_dir = transcripts_root / "child-subagent-cache"
+    child_dir.mkdir(parents=True)
+    child_jsonl = child_dir / "raw.jsonl"
+    child_jsonl.write_text(
+        "\n".join([
+            json.dumps({
+                "type": "user",
+                "sessionId": "child-cache",
+                "cwd": str(project_root),
+                "timestamp": "2026-05-22T10:00:00Z",
+                "message": {"content": "kick off subagent"},
+            }),
+            json.dumps({
+                "type": "assistant",
+                "sessionId": "child-cache",
+                "cwd": str(project_root),
+                "timestamp": "2026-05-22T10:00:05Z",
+                "message": {
+                    "model": "claude-opus-4-7",
+                    "content": [{"type": "text", "text": "subagent reply"}],
+                },
+            }),
+        ]) + "\n"
+    )
+
+    parent_events = [
+        {
+            "timestamp": "2026-05-22T09:59:00Z",
+            "event_type": "tool_call",
+            "session_id": "parent-cache",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": str(parent_archive),
+            "source_offset": 0,
+            "cwd": str(project_root),
+            "model_name": "claude-opus-4-7",
+            "payload": {
+                "type": "tool_use",
+                "id": "toolu_sub_cache",
+                "name": "Task",
+                "input": {"description": "Run the subagent"},
+            },
+        },
+        {
+            "timestamp": "2026-05-22T10:00:10Z",
+            "event_type": "tool_result",
+            "session_id": "parent-cache",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": str(parent_archive),
+            "source_offset": 1,
+            "cwd": str(project_root),
+            "model_name": "claude-opus-4-7",
+            "payload": {
+                "type": "tool_result",
+                "tool_use_id": "toolu_sub_cache",
+                "content": [
+                    {"type": "text", "text": "Subagent done."},
+                    {
+                        "type": "task-notification",
+                        "task-id": "child-cache",
+                        "output-file": str(child_jsonl),
+                        "duration-ms": 1234,
+                        "total-tokens": 567,
+                        "worktree-path": str(project_root),
+                    },
+                ],
+            },
+        },
+    ]
+    parent_archive.write_text(
+        "\n".join(json.dumps(e) for e in parent_events) + "\n"
+    )
+
+    # Capture the archive mtime so we can assert the second request
+    # actually hits the parser cache (same mtime → cache HIT, which is
+    # precisely the path that previously exposed the mutation bug).
+    initial_mtime = parent_archive.stat().st_mtime
+
+    # Drop any cached parse from prior tests so this run is clean.
+    from pollypm.web_api.chat.transcripts import (
+        _PARSE_CACHE,
+        _parse_cache_clear,
+    )
+
+    _parse_cache_clear()
+
+    patch_registry([_surface(
+        "operator", SurfaceType.OPERATOR, persona="Polly",
+        transcript_path=parent_archive,
+    )])
+
+    # --- First request: opt IN to inlined subagent transcript. ---
+    response_in = client.get(
+        "/api/v1/chat/operator/messages?include_subagents=true&direction=asc",
+        headers=auth_headers,
+    )
+    assert response_in.status_code == 200, response_in.text
+    body_in = response_in.json()
+    result_envs_in = [
+        m for m in body_in["messages"] if m["type"] == "subagent_result"
+    ]
+    assert len(result_envs_in) == 1, body_in
+    transcript_in = result_envs_in[0]["metadata"].get("subagent_transcript")
+    assert isinstance(transcript_in, list)
+    assert len(transcript_in) == 2
+
+    # The parser cache should now hold a single entry for the parent
+    # archive. The cached envelopes are the same objects we just
+    # enriched; if the enrichment was in-place they would still carry
+    # ``subagent_transcript`` and leak it into the next request.
+    assert parent_archive.resolve() in _PARSE_CACHE
+    cached_mtime, cached_envelopes, _ = _PARSE_CACHE[parent_archive.resolve()]
+    assert cached_mtime == initial_mtime
+    for env in cached_envelopes:
+        assert "subagent_transcript" not in (env.metadata or {}), (
+            "Cached envelope metadata was mutated by include_subagents=true; "
+            "later default requests will leak the inlined transcript."
+        )
+
+    # --- Second request: default (no ``include_subagents``). ---
+    # Archive mtime is unchanged so the parser cache is hit; if the
+    # enrichment had mutated the cached envelopes, this response would
+    # still expose ``subagent_transcript`` even though the client did
+    # not opt in.
+    assert parent_archive.stat().st_mtime == initial_mtime
+    response_default = client.get(
+        "/api/v1/chat/operator/messages?direction=asc",
+        headers=auth_headers,
+    )
+    assert response_default.status_code == 200, response_default.text
+    body_default = response_default.json()
+    result_envs_default = [
+        m for m in body_default["messages"] if m["type"] == "subagent_result"
+    ]
+    assert len(result_envs_default) == 1, body_default
+    metadata_default = result_envs_default[0]["metadata"]
+    assert "subagent_transcript" not in metadata_default, (
+        "Cache poisoning: a prior include_subagents=true request leaked "
+        "metadata.subagent_transcript into a later default response."
+    )
+
+
 def test_messages_endpoint_include_subagents_default_no_inline(
     client, auth_headers, patch_registry, patch_parser, tmp_path,
 ):


### PR DESCRIPTION
## Summary

Closes #2052 — restores `include_subagents=true` on `GET /api/v1/chat/{session}/messages` with a real path resolver. The PR #2045 round-4 revert had to back the param out because the inliner was calling `parse_events_jsonl` (which consumes the normalized `events.jsonl` archive) on `metadata.output_file` — but that field points at the **raw Claude subagent JSONL**, an entirely different per-session shape. This PR closes the contract gap by adding a raw-shape parser instead of forcing per-subagent normalization in the ingestor.

## What lands

- **`parse_raw_subagent_jsonl`** (`src/pollypm/web_api/chat/transcripts.py`) — a new parser that reads the raw Claude per-session JSONL (`type=user|assistant|error`, `message.content` blocks) and emits `MessageEnvelope` rows. Fail-soft on bad lines / unreadable files; accepts an optional `limit` so a runaway subagent transcript can't balloon a parent response.

- **`include_subagents=true` restored** in `src/pollypm/web_api/routes/chat_messages.py`. The endpoint computes the project + workspace transcript allowlist once per request, threads a post-processor through `_apply_filters_and_paginate`, and enriches each `subagent_result` envelope with `metadata.subagent_transcript`. Out-of-allowlist `output_file` values are silently skipped — the same path-traversal posture PR #2045 round-3 introduced, restored against the raw parser. The 422 deferral guard is gone.

- **Real-parser regression test** (`tests/test_chat_messages_endpoint.py::test_messages_endpoint_include_subagents_inlines_with_real_parser`) writes BOTH a real normalized parent archive AND a real raw subagent JSONL under the project transcripts root, then asserts the inlined `subagent_transcript` carries the right envelopes — no monkeypatching of either parser. The round-4 contract gap would fail this test loudly. Path-traversal test `test_messages_endpoint_include_subagents_rejects_path_traversal` pins the allowlist behavior.

- **Docs:** `docs/api/openapi.yaml`, `docs/api-chat-endpoints.md`, `docs/web-api-spec.md` re-document the param. CLI help text on `pm chat history --include-subagents` no longer flags it as deferred.

## Independence from `include_thinking` (PR #2079)

This change is intentionally orthogonal to #2079 / #2048: the raw subagent parser does NOT surface thinking blocks and the `include_thinking` query param remains parked. A rebase may be needed if #2079 merges first — the touched files overlap (`transcripts.py`, possibly `envelope.py`), but the conflicts are mechanical and the human will resolve them at integration time.

## Test plan

- [x] `pytest --noconftest tests/test_chat_messages_endpoint.py tests/test_chat_transcripts.py -x` → 105 passed
- [x] All 5 subagent-related tests in `test_chat_messages_endpoint.py` pass (real-parser inline, path-traversal reject, default-no-inline, explicit-false, default behavior).
- [ ] OpenAPI conformance test (`tests/web_api/test_openapi_conformance.py`) — couldn't run locally (`openapi_spec_validator` not in this env); CI will catch any drift.
- [ ] Manual smoke: `pm chat history <session> --include-subagents` against a live operator surface with a recent `Task` tool result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)