### PR TITLE
perf(web-ui): tail-read parse_events_jsonl when ?limit is small (closes #2070)

### DIFF
--- a/src/pollypm/web_api/chat/__init__.py
+++ b/src/pollypm/web_api/chat/__init__.py
@@ -43,6 +43,7 @@ from pollypm.web_api.chat.transcripts import (
     STALE_THRESHOLD_SECONDS,
     is_archive_stale,
     parse_events_jsonl,
+    parse_events_jsonl_tail,
     resolve_transcript_path,
 )
 
@@ -59,6 +60,7 @@ __all__ = [
     "enumerate_worker_surfaces",
     "is_archive_stale",
     "parse_events_jsonl",
+    "parse_events_jsonl_tail",
     "resolve_transcript_path",
     "synthesize_capture_id",
 ]

--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -439,6 +439,212 @@ def parse_events_jsonl(
     return envelopes
 
 
+# Tail-read chunk progression for ``parse_events_jsonl_tail`` (issue
+# #2070). 64KB is enough to cover ~200 average lines, which satisfies
+# the common ``?limit=50`` cockpit poll without re-reading. If the
+# requested envelope count isn't met we widen to 256KB, then 1MB,
+# then give up and fall through to the full forward parse. The
+# progression is deliberately short — three attempts is enough to
+# absorb the long-tail of multi-kilobyte tool_result payloads without
+# silently re-reading the whole file in a loop.
+_TAIL_CHUNK_PROGRESSION = (64 * 1024, 256 * 1024, 1024 * 1024)
+
+
+def parse_events_jsonl_tail(
+    events_path: Path,
+    *,
+    limit: int,
+    actor_fallback: str = "agent",
+) -> list[MessageEnvelope]:
+    """Return roughly the last ``limit`` envelopes by tail-reading the file.
+
+    Optimization for the cold-path miss of the mtime cache (issue #2069
+    composes with this — that cache covers steady-state polls; tail-
+    read covers the first switch + every post-write call where the
+    file has changed). The default ``parse_events_jsonl`` forward-
+    readlines the entire archive even when the caller only wants the
+    last ``?limit=50`` envelopes; for operator transcripts running to
+    thousands of lines this dominates first-load latency (issue #2070).
+
+    Strategy:
+
+    1. Seek ``chunk`` bytes from EOF (start 64KB) and read forward.
+    2. Drop the first partial line (we almost certainly seeked into
+       the middle of one) UNLESS we landed at byte 0 (whole file fits
+       in one chunk).
+    3. Parse the remaining lines forward, mirroring
+       :func:`parse_events_jsonl` line-by-line.
+    4. If we got fewer than ``limit`` valid envelopes AND we haven't
+       hit byte 0, widen to the next chunk size (64KB → 256KB → 1MB)
+       and retry. After the last chunk size still falls short, fall
+       through to the full forward parse and slice — the file is
+       legitimately small or sparsely populated.
+    5. ``UnicodeDecodeError`` or any other parse exception bails to
+       the full forward parser (multi-line / pretty-printed events
+       can confuse a chunk-boundary read; the forward parser handles
+       those at line granularity).
+
+    Cache composition: a hit against ``_PARSE_CACHE`` short-circuits
+    even cheaper than the tail read, so we check it first. We do NOT
+    populate the cache from this path — the tail returns a partial
+    list, and seeding the cache with a partial list would corrupt
+    subsequent full-history reads.
+
+    Returns ``[]`` for missing files (matches ``parse_events_jsonl``).
+    """
+    if limit <= 0:
+        return []
+    if not events_path.exists():
+        return []
+
+    # Cache lookup first — the mtime cache holds the FULL parse, which
+    # is strictly more accurate than what tail-read can synthesize.
+    cached_mtime: float | None = None
+    try:
+        cached_mtime = events_path.stat().st_mtime
+    except OSError:
+        cached_mtime = None
+    if cached_mtime is not None:
+        cached = _PARSE_CACHE.get(events_path)
+        if (
+            cached is not None
+            and cached[0] == cached_mtime
+            and cached[2] == actor_fallback
+        ):
+            # Tail of the cached list. Defensive copy: downstream
+            # callers sort/filter in place.
+            return list(cached[1][-limit:])
+
+    source_key = hashlib.blake2b(
+        str(events_path).encode("utf-8"), digest_size=4,
+    ).hexdigest()
+
+    try:
+        file_size = events_path.stat().st_size
+    except OSError as exc:
+        logger.warning(
+            "chat.transcripts: tail stat failed for %s: %s",
+            events_path, exc,
+        )
+        return parse_events_jsonl(
+            events_path, actor_fallback=actor_fallback,
+        )[-limit:]
+
+    if file_size == 0:
+        return []
+
+    for chunk_size in _TAIL_CHUNK_PROGRESSION:
+        try:
+            envelopes = _parse_tail_chunk(
+                events_path,
+                file_size=file_size,
+                chunk_size=chunk_size,
+                source_key=source_key,
+                actor_fallback=actor_fallback,
+            )
+        except (UnicodeDecodeError, OSError) as exc:
+            # Chunk-boundary read landed inside a multi-byte sequence
+            # or the file went away mid-read — fall back to the full
+            # forward parser which reads with ``errors="ignore"`` and
+            # tolerates partial reads.
+            logger.debug(
+                "chat.transcripts: tail-read fell back for %s (%s)",
+                events_path, exc,
+            )
+            return parse_events_jsonl(
+                events_path, actor_fallback=actor_fallback,
+            )[-limit:]
+        if envelopes is None:
+            # Sentinel: chunk parse hit a defensive bailout (e.g. a
+            # malformed-but-not-skipped line). Treat the same as a
+            # decode error and use the forward parser.
+            return parse_events_jsonl(
+                events_path, actor_fallback=actor_fallback,
+            )[-limit:]
+        if len(envelopes) >= limit:
+            return envelopes[-limit:]
+        if chunk_size >= file_size:
+            # We read the whole file already — no point widening.
+            return envelopes[-limit:]
+
+    # Exhausted the chunk progression without satisfying ``limit``.
+    # Fall through to the forward parser — the file is large but
+    # sparsely populated with valid envelopes (lots of dropped
+    # token_usage / malformed lines).
+    return parse_events_jsonl(
+        events_path, actor_fallback=actor_fallback,
+    )[-limit:]
+
+
+def _parse_tail_chunk(
+    events_path: Path,
+    *,
+    file_size: int,
+    chunk_size: int,
+    source_key: str,
+    actor_fallback: str,
+) -> list[MessageEnvelope] | None:
+    """Read ``chunk_size`` bytes from EOF, parse the lines, return envelopes.
+
+    Returns ``None`` to signal "give up, use the forward parser"
+    (e.g. multi-line JSON event broken across the seek boundary).
+    Raises ``UnicodeDecodeError`` / ``OSError`` on read failure — the
+    caller catches and falls back.
+    """
+    seek_offset = max(0, file_size - chunk_size)
+    with events_path.open("rb") as handle:
+        handle.seek(seek_offset)
+        raw = handle.read()
+    # Decode strictly so a mid-codepoint seek raises and the caller
+    # falls back. The forward parser uses ``errors="ignore"`` for
+    # fault tolerance, but here we'd rather bail than emit garbled
+    # text from a half-codepoint at the chunk head.
+    text = raw.decode("utf-8")
+
+    # Drop the first partial line unless we landed at byte 0 — the
+    # seek almost certainly bisected a line.
+    if seek_offset > 0:
+        newline_idx = text.find("\n")
+        if newline_idx < 0:
+            # No newline in the chunk at all — single huge line we
+            # can't tail-parse safely. Bail to the forward parser.
+            return None
+        # The byte AFTER the newline is the first complete line.
+        first_line_byte = seek_offset + len(
+            text[: newline_idx + 1].encode("utf-8"),
+        )
+        text = text[newline_idx + 1 :]
+    else:
+        first_line_byte = 0
+
+    envelopes: list[MessageEnvelope] = []
+    cursor = first_line_byte
+    for line in text.splitlines(keepends=True):
+        line_offset = cursor
+        cursor += len(line.encode("utf-8"))
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            logger.debug(
+                "chat.transcripts: skipping malformed tail line in %s @ %d",
+                events_path, line_offset,
+            )
+            continue
+        if not isinstance(event, dict):
+            continue
+        converted = _event_to_envelopes(
+            event,
+            offset=line_offset,
+            source_key=source_key,
+            actor_fallback=actor_fallback,
+        )
+        envelopes.extend(converted)
+    return envelopes
+
+
 def _event_to_envelopes(
     event: dict[str, Any],
     *,
@@ -969,5 +1175,6 @@ __all__ = [
     "is_archive_stale",
     "lookup_transcript_path",
     "parse_events_jsonl",
+    "parse_events_jsonl_tail",
     "resolve_transcript_path",
 ]

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -44,6 +44,7 @@ from pollypm.web_api.chat import (
     enumerate_chat_surfaces,
     is_archive_stale,
     parse_events_jsonl,
+    parse_events_jsonl_tail,
 )
 from pollypm.web_api.errors import APIError, service_unavailable
 from pollypm.web_api.routes._deps import ConfigDep
@@ -62,6 +63,14 @@ router = APIRouter(tags=["Chat"])
 # Spec §2.2: ``limit`` default 100, cap 500.
 DEFAULT_MESSAGE_LIMIT = 100
 MAX_MESSAGE_LIMIT = 500
+
+# Issue #2070: ``desc`` + small-limit + no-cursor + ``source=auto`` is
+# the common cockpit-poll shape. For requests under this threshold we
+# tail-read the JSONL archive instead of forward-readlining the full
+# file. The forward parser stays authoritative for ``asc``, cursor
+# paging, ``include_thinking``-style large-window queries, and the
+# strict ``source=jsonl`` validation path.
+TAIL_READ_LIMIT_THRESHOLD = 200
 
 
 SourceMode = Literal["auto", "jsonl", "capture"]
@@ -510,11 +519,23 @@ def _load_envelopes(
     surface: ChatSurface,
     *,
     source: SourceMode,
+    tail_hint: int | None = None,
 ) -> tuple[list[MessageEnvelope], str | None, Path | None]:
     """Return ``(envelopes, transcript_source, transcript_path)``.
 
     ``transcript_source`` is one of ``"jsonl"`` / ``"capture"`` /
     ``None`` (no transcript yet, spec §4.8).
+
+    ``tail_hint`` (issue #2070): when set to a small positive integer,
+    the ``source=auto`` JSONL branch uses ``parse_events_jsonl_tail``
+    instead of the full forward parse. The hint is the smallest number
+    of envelopes the caller would consider returning (the route uses
+    ``limit + 1`` so ``has_more`` can still detect overflow). Strict
+    ``source=jsonl`` callers ignore the hint — they want the
+    authoritative full parse so unreadable-archive errors propagate
+    cleanly. The hint must be paired with ``direction=desc`` + no
+    cursor + small ``limit`` at the call site (the helper doesn't
+    re-check those conditions).
 
     NOTE: thinking-block filtering is no longer plumbed through this
     helper. The authoritative ``parse_events_jsonl`` on main does not
@@ -559,10 +580,23 @@ def _load_envelopes(
     # source == "auto" — prefer JSONL, fall back to capture when the
     # archive is missing or stale (spec §4.7).
     if archive is not None and not is_archive_stale(archive):
-        envelopes = parse_events_jsonl(
-            archive,
-            actor_fallback=actor_fallback,
-        )
+        if tail_hint is not None and tail_hint > 0:
+            # Issue #2070: short cockpit polls only need the last N
+            # envelopes; tail-read keeps cold-path latency proportional
+            # to the request size instead of the full archive size.
+            # The parser falls back to the forward parse on any
+            # decode/parse failure, so semantics match the forward
+            # path for malformed archives.
+            envelopes = parse_events_jsonl_tail(
+                archive,
+                limit=tail_hint,
+                actor_fallback=actor_fallback,
+            )
+        else:
+            envelopes = parse_events_jsonl(
+                archive,
+                actor_fallback=actor_fallback,
+            )
         if envelopes:
             return envelopes, "jsonl", archive
         # Empty result on a fresh (non-stale) archive could be a
@@ -857,8 +891,25 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
     surface = _find_surface(config, session_name)
     since_dt = _parse_since(since)
 
+    # Issue #2070: tail-read only when the request shape is safe —
+    # ``direction=desc`` returns the newest N envelopes (which live at
+    # the file tail), no ``since_id`` cursor (paging beyond the head
+    # walks into older history the tail can't see), small ``limit``
+    # (large ``limit`` defeats the optimization), and ``source=auto``
+    # (strict ``source=jsonl`` wants the full parse so OSError
+    # propagates cleanly). The pad of ``+1`` lets the route's
+    # ``has_more`` detection still fire on the boundary.
+    tail_hint: int | None = None
+    if (
+        source == "auto"
+        and direction == "desc"
+        and since_id is None
+        and limit <= TAIL_READ_LIMIT_THRESHOLD
+    ):
+        tail_hint = limit + 1
+
     envelopes, transcript_source, transcript_path = _load_envelopes(
-        surface, source=source,
+        surface, source=source, tail_hint=tail_hint,
     )
 
     rows, has_more, next_cursor = _apply_filters_and_paginate(

--- a/tests/test_chat_transcripts.py
+++ b/tests/test_chat_transcripts.py
@@ -34,6 +34,7 @@ from pollypm.web_api.chat import (
     STALE_THRESHOLD_SECONDS,
     is_archive_stale,
     parse_events_jsonl,
+    parse_events_jsonl_tail,
     resolve_transcript_path,
 )
 from pollypm.web_api.chat import transcripts as transcripts_module
@@ -780,6 +781,220 @@ def test_parse_cache_lru_evicts_oldest_when_full(tmp_path: Path) -> None:
     assert len(transcripts_module._PARSE_CACHE) == transcripts_module._PARSE_CACHE_MAX
     assert oldest_path not in transcripts_module._PARSE_CACHE
     assert overflow in transcripts_module._PARSE_CACHE
+
+
+# ---------------------------------------------------------------------------
+# Tail-read fast path (issue #2070)
+#
+# The cockpit polls ``?limit=50&direction=desc`` every few seconds.
+# Before tail-read, the parser forward-readlined the full archive
+# every call — for 2,800-line operator transcripts the cost dominated
+# poll latency. ``parse_events_jsonl_tail`` reads from EOF in chunks
+# so cost scales with the requested limit, not the file size.
+# ---------------------------------------------------------------------------
+
+
+def _write_user_turn_lines(path: Path, count: int) -> None:
+    """Write ``count`` single-line user_turn events to ``path``.
+
+    Each event payload is unique so the test can verify ordering
+    (event index encoded in the text).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for idx in range(count):
+            handle.write(
+                json.dumps(_claude_event("user_turn", text=f"line-{idx}"))
+                + "\n",
+            )
+
+
+def test_parse_tail_returns_last_n_envelopes(tmp_path: Path) -> None:
+    """Tail of a 1k-line archive matches ``parse_events_jsonl(...)[-N:]``."""
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_user_turn_lines(events_path, 1000)
+
+    tail = parse_events_jsonl_tail(events_path, limit=50)
+    full_tail = parse_events_jsonl(events_path)[-50:]
+
+    # Clear the cache so the next assertion isn't comparing a tail
+    # against a cached full parse from above (the tail short-circuits
+    # to cache when populated).
+    assert len(tail) == 50
+    assert [env.text for env in tail] == [env.text for env in full_tail]
+    # Last envelope is the newest line we wrote.
+    assert tail[-1].text == "line-999"
+    assert tail[0].text == "line-950"
+
+
+def test_parse_tail_handles_file_smaller_than_chunk(tmp_path: Path) -> None:
+    """Whole-file fits in the first chunk: still returns the last N."""
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_user_turn_lines(events_path, 10)
+
+    tail = parse_events_jsonl_tail(events_path, limit=5)
+    assert [env.text for env in tail] == [f"line-{i}" for i in range(5, 10)]
+
+
+def test_parse_tail_limit_exceeds_file_returns_all(tmp_path: Path) -> None:
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_user_turn_lines(events_path, 3)
+
+    tail = parse_events_jsonl_tail(events_path, limit=50)
+    assert [env.text for env in tail] == ["line-0", "line-1", "line-2"]
+
+
+def test_parse_tail_missing_file_returns_empty(tmp_path: Path) -> None:
+    transcripts_module._parse_cache_clear()
+    assert parse_events_jsonl_tail(tmp_path / "missing.jsonl", limit=50) == []
+
+
+def test_parse_tail_empty_file_returns_empty(tmp_path: Path) -> None:
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text("")
+    assert parse_events_jsonl_tail(events_path, limit=50) == []
+
+
+def test_parse_tail_zero_limit_returns_empty(tmp_path: Path) -> None:
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_user_turn_lines(events_path, 5)
+    assert parse_events_jsonl_tail(events_path, limit=0) == []
+
+
+def test_parse_tail_uses_mtime_cache_when_populated(tmp_path: Path) -> None:
+    """A populated mtime cache short-circuits the tail-read."""
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_user_turn_lines(events_path, 200)
+
+    # Populate the cache by calling the full parser.
+    parse_events_jsonl(events_path)
+    assert events_path in transcripts_module._PARSE_CACHE
+
+    # Tail should now read from the cached list, not the disk.
+    tail = parse_events_jsonl_tail(events_path, limit=10)
+    assert len(tail) == 10
+    assert tail[-1].text == "line-199"
+
+
+def test_parse_tail_does_not_populate_mtime_cache(tmp_path: Path) -> None:
+    """Tail returns a partial slice — caching it would poison the cache."""
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    _write_user_turn_lines(events_path, 100)
+
+    parse_events_jsonl_tail(events_path, limit=10)
+    assert events_path not in transcripts_module._PARSE_CACHE
+
+
+def test_parse_tail_falls_back_for_pretty_printed_event(tmp_path: Path) -> None:
+    """Pretty-printed JSON (multi-line event) trips the defensive fallback.
+
+    The tail parser is line-oriented (one JSON object per line). A
+    pretty-printed event spans multiple lines, so ``json.loads`` on
+    each line raises ``JSONDecodeError`` — the tail parser then sees
+    fewer than ``limit`` envelopes and either widens or falls back to
+    the forward parser. The forward parser also sees those lines as
+    malformed (the ingestor never emits pretty-printed events), but
+    the surrounding single-line events are still recovered. The
+    contract under test is "no exception escapes" — the route never
+    sees a parser crash for an oddly-shaped archive.
+    """
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    # Mix single-line + pretty-printed events. The pretty-printed
+    # block exercises the chunk-boundary code path: it spans multiple
+    # lines, none of which parse as standalone JSON.
+    pretty_event = json.dumps(
+        _claude_event("user_turn", text="pretty"),
+        indent=2,
+    )
+    single_lines = [
+        json.dumps(_claude_event("user_turn", text=f"good-{idx}"))
+        for idx in range(20)
+    ]
+    body = "\n".join(single_lines[:10]) + "\n" + pretty_event + "\n" + (
+        "\n".join(single_lines[10:]) + "\n"
+    )
+    events_path.write_text(body)
+
+    # Must not raise.
+    tail = parse_events_jsonl_tail(events_path, limit=5)
+    # The 5 most-recent valid envelopes are the last 5 good lines.
+    assert [env.text for env in tail] == [
+        f"good-{idx}" for idx in range(15, 20)
+    ]
+
+
+def test_parse_tail_falls_back_for_single_huge_line(tmp_path: Path) -> None:
+    """A single line larger than 1MB defeats the chunk progression.
+
+    The tail parser bails to the forward parser when even the largest
+    chunk lands inside one line (no newline in the chunk window).
+    """
+    transcripts_module._parse_cache_clear()
+    events_path = tmp_path / "events.jsonl"
+    # 1.5MB of single-line text (no newlines) — larger than the
+    # widest chunk in ``_TAIL_CHUNK_PROGRESSION``.
+    huge = "x" * (1_500_000)
+    events_path.write_text(huge + "\n")
+    # No valid envelopes, but must not raise.
+    tail = parse_events_jsonl_tail(events_path, limit=10)
+    assert tail == []
+
+
+def test_parse_tail_perf_beats_full_parse_on_10k_archive(tmp_path: Path) -> None:
+    """Tail must be ≥50× faster than the full forward parse on a 10k file.
+
+    The mtime cache is cleared between calls so we're comparing
+    cold-path cost (the exact case the optimization targets).
+    """
+    events_path = tmp_path / "events.jsonl"
+    _write_user_turn_lines(events_path, 10_000)
+
+    # Warm Python's I/O caches by reading the file once before
+    # measuring. The OS page cache makes the second read deterministic
+    # — we're measuring CPU + parse cost, not first-touch I/O.
+    transcripts_module._parse_cache_clear()
+    parse_events_jsonl(events_path)
+
+    # Cold-path full parse: cache cleared, must re-read + re-translate
+    # the entire file.
+    transcripts_module._parse_cache_clear()
+    full_start = time.perf_counter()
+    full_envelopes = parse_events_jsonl(events_path)
+    full_elapsed = time.perf_counter() - full_start
+    assert len(full_envelopes) == 10_000
+
+    # Cold-path tail: same cleared cache, must return the same final
+    # 50 envelopes as ``full_envelopes[-50:]``.
+    transcripts_module._parse_cache_clear()
+    tail_start = time.perf_counter()
+    tail_envelopes = parse_events_jsonl_tail(events_path, limit=50)
+    tail_elapsed = time.perf_counter() - tail_start
+    assert len(tail_envelopes) == 50
+    assert [env.text for env in tail_envelopes] == [
+        env.text for env in full_envelopes[-50:]
+    ]
+
+    # Issue #2070 acceptance: tail wall-clock under 5ms.
+    assert tail_elapsed < 0.005, (
+        f"tail took {tail_elapsed * 1000:.2f}ms — expected <5ms"
+    )
+    # And at least 50× faster than the full parse. We compare ratios
+    # rather than absolute times so the test stays robust on slower
+    # CI machines (full parse scales with file size; tail does not).
+    speedup = full_elapsed / max(tail_elapsed, 1e-9)
+    assert speedup >= 50.0, (
+        f"speedup was {speedup:.1f}× — expected ≥50× "
+        f"(full {full_elapsed * 1000:.2f}ms vs tail "
+        f"{tail_elapsed * 1000:.2f}ms)"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Cold-path miss for the cockpit's `?limit=50&direction=desc` polls used to scan the full transcript (2,800+ lines on the operator surface). This adds `parse_events_jsonl_tail` which seeks from EOF in 64KB → 256KB → 1MB chunks so cost scales with the requested limit, not the file size.
- Wires the route at `chat_messages._load_envelopes` to opt into tail-read only when the shape is safe: `direction=desc` + no `since_id` cursor + `limit <= 200` + `source=auto`. The strict `source=jsonl` path keeps the full forward parse so unreadable-archive errors still 503 cleanly.
- Defensive fallback to `parse_events_jsonl(path)[-limit:]` on `UnicodeDecodeError`, `OSError`, or any parse failure so multi-line / pretty-printed events can't break the route.

## Composition with #2069 (mtime cache)

The mtime cache covers steady-state polls; tail-read covers the cold-path miss + every post-write call. They compose cleanly:

- A populated mtime cache short-circuits the tail-read (the full cached list is strictly more accurate than what tail-read can synthesize). `parse_events_jsonl_tail` checks the cache first.
- The tail path deliberately does NOT populate the cache — a partial list would corrupt subsequent full parses. Only `parse_events_jsonl` seeds the cache.

This composes with PR #2079 (in-flight `_PARSE_CACHE` tuple-key for `include_thinking`); the tail-read also lives behind the same cache lookup, so when #2079 lands the conflict is a small key-shape merge.

## Observed perf (10,000-line fixture, cold cache)

```
full parse:        169.01 ms  (10000 envelopes)
tail-read limit=50:  2.67 ms  (50 envelopes)
speedup:           63.2x
```

Acceptance bars from #2070 (`<5ms`, `≥50x faster`) both clear.

## Test plan

- [x] `pytest tests/test_chat_transcripts.py tests/test_chat_messages_endpoint.py -x` — 114 passed
- [x] 10k-line fixture: tail returns the same last-50 envelopes as the full parser, <5ms, ≥50x faster
- [x] Pretty-printed (multi-line) JSON event does not raise; surrounding single-line events are recovered
- [x] Single >1MB line with no newline falls back without raising
- [x] Empty file / missing file / zero limit return `[]`
- [x] Populated mtime cache short-circuits the tail-read; tail does not populate the cache
- [ ] May need rebase if #2079 merges first (small `_PARSE_CACHE` key shape change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)