### PR TITLE
fix(state-cache): fold actionable alerts into cache entries; remove fallthrough workaround (closes #2049)

### DIFF
--- a/docs/design/move-a-state-cache.md
+++ b/docs/design/move-a-state-cache.md
@@ -5,7 +5,7 @@
 The shipped Move A behavior diverges from the original design in two places. This section is the source of truth; the original sections below are kept for historical context but should be read as superseded where they conflict.
 
 - `latest_heartbeat_by_session` is reserved on `ProjectStateCacheEntry` but NOT populated. Rail heartbeat sites read `pollypm.storage.pg_heartbeats.latest_heartbeat` directly via `CockpitRouter._latest_heartbeat_cached`. Bulk prefetch + cache invalidation deferred to [#2050](https://github.com/samhotchkiss/pollypm/issues/2050).
-- `_maybe_cache_route_rollups` declines (returns `None`) when any tracked project has a live actionable alert — cache cannot recompute the alert-to-rollup contract. Tracked in [#2049](https://github.com/samhotchkiss/pollypm/issues/2049).
+- Actionable-alert overlay is now folded into the cache: the refresher reads alerts via the `pollypm.storage.pg_alerts.open_alerts` facade (through `_open_alerts_for`) and stamps `ProjectStateCacheEntry.actionable_key` plus an `alerts_snapshot_valid` flag. `_maybe_cache_route_rollups` serves cached rollups when `alerts_snapshot_valid is True`, and declines (falls through to the direct path) only when the snapshot was marked invalid — i.e., the refresher's alert read failed and the entry can't speak to the live alert state. Closed by PR [#2085](https://github.com/samhotchkiss/pollypm/pull/2085) ([#2049](https://github.com/samhotchkiss/pollypm/issues/2049)).
 
 ### Workspace-root inbox is now cache-routed (#2051 — closed by PR #2078)
 
@@ -15,6 +15,14 @@ The third drift item from the original list (workspace-root inbox not represente
 - The refresher's project-keys provider always includes the sentinel, so the synthetic entry is computed on boot and on every full pass. `StateCacheRefresher._dispatch_event` invalidates `__workspace__` on every event in `_INVALIDATING_EVENTS` so workspace-root invalidations never lag the per-project ones.
 - The earlier `has_workspace_root_open_messages` probe and the forced fall-through it gated are **removed**. `_maybe_cache_route_awaits_user` / `_maybe_cache_count_awaits_user` now union the `__workspace__` entry with the per-project entries directly; the cache is authoritative for workspace-root rows.
 - The sentinel carries a **bounded-staleness TTL** (`WORKSPACE_ENTRY_TTL_SECONDS = 10s`). Several message-store paths (`PgStore.close_message`, `PgStore.clear_alert`, `service_api.v1.clear_alert`) mutate workspace-root awaits-user rows without emitting a state-cache audit event, so the refresher doesn't see those closes. The TTL caps the staleness window — once the sentinel ages past the TTL, the cache-read boundary falls through to the direct sweep. Full audit-event wiring for the message-store close/clear paths is deferred past v1 RC; the TTL is a documented bounded-staleness window, not an invariant.
+
+### Actionable alert overlay is cached (#2049 — closed by PR #2085)
+
+The second drift item from the original list (`_maybe_cache_route_rollups` declines on any live actionable alert) is closed by PR #2085. The shipped behavior:
+
+- `compute_entry_for_project` reads the workspace-wide alert snapshot via `pollypm.storage.pg_alerts.open_alerts` (through `_open_alerts_for`) and folds the per-project `actionable_task_alert_ids` into `rollup_project_state` at refresh time. The resulting `rail_state` / `rail_badge` / `rail_reason` / `actionable_key` already account for the live alert overlay.
+- New `ProjectStateCacheEntry.actionable_key` field carries the alert-driven issues-route id; new `alerts_snapshot_valid` flag records whether the refresher's alert read succeeded. `_maybe_cache_route_rollups` serves the cached rollup when `alerts_snapshot_valid is True` and declines only when the refresher couldn't read the alert state (degraded entry).
+- Sweep-level pre-fetch: `StateCacheRefresher` reads the workspace alert snapshot ONCE per multi-project sweep and threads `alerts_snapshot=(alerts, valid)` through each per-project `compute_entry_for_project` call. Single-project event-driven refreshes call without the kwarg and fall back to a per-project read, preserving the failure-degrade contract.
 
 Design document for issue [#1664](https://github.com/samhotchkiss/pollypm/issues/1664).
 Status: **implemented** (2026-05-20) — PR 1 #2000, PR 2 #2016, PR 3 #2026, PR 4 #2029.

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2160,10 +2160,11 @@ class CockpitRouter:
             # refresher's alert read failed, the entry's rail_state /
             # actionable_key were computed without alert overlay
             # (``_open_alerts_for`` returns ``([], False)`` on any
-            # supervisor/store failure). Serving that entry would hide
-            # an actionable RED alert from a later render whose
-            # ``supervisor.open_alerts()`` succeeds. Decline so the
-            # direct path can run with the live alerts argument.
+            # ``pollypm.storage.pg_alerts.open_alerts`` failure).
+            # Serving that entry would hide an actionable RED alert
+            # from a later direct-path render whose own
+            # ``supervisor.open_alerts()`` read succeeds. Decline so
+            # the direct path can run with the live alerts argument.
             if not getattr(entry, "alerts_snapshot_valid", True):
                 return None
             rollups[project_key] = ProjectStateRollup(

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2102,6 +2102,14 @@ class CockpitRouter:
         alert-present cases. ``alerts`` is still accepted so the
         signature matches the direct path; the cache fast-path
         ignores it and reads the entry directly.
+
+        #2049 follow-up (Codex blocker on PR #2085): when the
+        refresher's alert read itself failed (transient supervisor /
+        store failure), the entry stamps
+        ``alerts_snapshot_valid = False`` and the fast-path declines
+        so the live alerts argument drives the direct-path rollup
+        instead of serving a stale no-alert entry that would hide a
+        live RED alert.
         """
 
         try:
@@ -2147,6 +2155,16 @@ class CockpitRouter:
             rail_state = getattr(entry, "rail_state", None)
             if rail_state is None:
                 # Refresher hasn't filled in rail fields yet — defer.
+                return None
+            # #2049 follow-up (Codex blocker on PR #2085): if the
+            # refresher's alert read failed, the entry's rail_state /
+            # actionable_key were computed without alert overlay
+            # (``_open_alerts_for`` returns ``([], False)`` on any
+            # supervisor/store failure). Serving that entry would hide
+            # an actionable RED alert from a later render whose
+            # ``supervisor.open_alerts()`` succeeds. Decline so the
+            # direct path can run with the live alerts argument.
+            if not getattr(entry, "alerts_snapshot_valid", True):
                 return None
             rollups[project_key] = ProjectStateRollup(
                 state=rail_state,

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2090,24 +2090,18 @@ class CockpitRouter:
         """Cache fast-path for :meth:`_project_state_rollups`.
 
         Returns ``None`` when the env flag is off, the cache is cold,
-        the cache is missing any tracked project, OR any tracked
-        project has a live actionable task alert. The fall-through
-        path then runs the direct per-project rollup compute, which
-        re-derives RED / badge / reason from the alerts.
+        or the cache is missing any tracked project. The fall-through
+        path then runs the direct per-project rollup compute.
 
-        Alert fall-through rationale (PR #2026 review blocker 1):
-        ``rollup_project_state`` folds ``actionable_task_alert_ids``
-        into the final ``rail_state`` / ``rail_badge`` / ``rail_reason``
-        / ``actionable_key`` — a live ``stuck_on_task:<project>/<n>``
-        or ``no_session_for_assignment:<project>/<n>`` alert can flip
-        a WORKING project to RED and reshape ``actionable_key`` into
-        the issues-route id. The cache entry's ``rail_*`` fields were
-        computed by the refresher WITHOUT alert state, so we cannot
-        synthesize a rollup that matches the direct path when an
-        actionable alert exists. Decline the cache for that whole
-        rendering so the direct path produces the authoritative answer.
-        Follow-up issue: cache ``actionable_alert_task_ids`` into the
-        refresher so the fast-path stays available with alerts.
+        #2049: the actionable-alert fall-through has been removed —
+        :func:`compute_entry_for_project` now folds
+        ``actionable_alert_task_ids`` into the rail rollup at refresh
+        time (see ``state_cache/refresh_impl.py``) and stamps the
+        alert-driven ``actionable_key`` onto the entry. The cached
+        entry is therefore authoritative for both the no-alert and
+        alert-present cases. ``alerts`` is still accepted so the
+        signature matches the direct path; the cache fast-path
+        ignores it and reads the entry directly.
         """
 
         try:
@@ -2147,15 +2141,6 @@ class CockpitRouter:
         if not all(key in snapshot_keys for key in known_keys):
             return None
 
-        # PR #2026 review blocker 1: ANY tracked project with a live
-        # actionable task alert forces fall-through. We don't try to
-        # serve the unaffected projects from cache because callers
-        # consume the whole map at once and a partial answer would
-        # mix cached + direct semantics in a single render.
-        for project_key in known_keys:
-            if actionable_alert_task_ids(alerts, project_key=project_key):
-                return None
-
         rollups: dict[str, ProjectStateRollup] = {}
         for project_key in known_keys:
             entry = snapshot[project_key]
@@ -2167,11 +2152,12 @@ class CockpitRouter:
                 state=rail_state,
                 badge=getattr(entry, "rail_badge", None),
                 sort_rank=int(getattr(entry, "rail_sort_rank", 0) or 0),
-                # No actionable alerts in scope (gated above), so the
-                # actionable_key derived from alerts is always None
-                # here — matches the direct path's behavior when
-                # ``actionable_task_alert_ids`` is empty.
-                actionable_key=None,
+                # #2049 — alert-driven actionable_key is folded into
+                # the entry by the refresher. Empty alerts produce
+                # ``None`` (matching the direct path), and a live
+                # ``stuck_on_task:<project>/<n>`` non-user-waiting
+                # alert produces ``project:<key>:issues``.
+                actionable_key=getattr(entry, "actionable_key", None),
                 reason=str(getattr(entry, "rail_reason", "") or ""),
                 approvals_pending=int(
                     getattr(entry, "approvals_pending", 0) or 0

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2104,8 +2104,8 @@ class CockpitRouter:
         ignores it and reads the entry directly.
 
         #2049 follow-up (Codex blocker on PR #2085): when the
-        refresher's alert read itself failed (transient supervisor /
-        store failure), the entry stamps
+        refresher's alert read itself failed (transient
+        ``pg_alerts`` facade / pg pool failure), the entry stamps
         ``alerts_snapshot_valid = False`` and the fast-path declines
         so the live alerts argument drives the direct-path rollup
         instead of serving a stale no-alert entry that would hide a

--- a/src/pollypm/state_cache/__init__.py
+++ b/src/pollypm/state_cache/__init__.py
@@ -232,15 +232,21 @@ def get_cache() -> StateCacheLike:
 
                 refresh_fn = build_refresh_fn(_config_provider)
                 project_keys_provider = _project_keys_provider
+                refresher_config_provider: Callable[[], object] | None = (
+                    _config_provider
+                )
             except Exception:  # noqa: BLE001
                 logger.exception(
                     "state_cache: real refresh wiring failed; "
                     "falling back to stub",
                 )
                 refresh_fn = stub_refresh_fn
+                refresher_config_provider = None
             cache = ProjectStateCache(refresh_fn=refresh_fn)
             refresher = StateCacheRefresher(
-                cache, project_keys=project_keys_provider,
+                cache,
+                project_keys=project_keys_provider,
+                config_provider=refresher_config_provider,
             )
             try:
                 refresher.start()

--- a/src/pollypm/state_cache/entry.py
+++ b/src/pollypm/state_cache/entry.py
@@ -159,6 +159,18 @@ class ProjectStateCacheEntry:
     rail_reason: str = ""
     approvals_pending: int = 0
     plan_blocked: bool = False
+    # #2049 — ``actionable_key`` is the rail-route id
+    # (``project:<key>:issues``) that ``rollup_project_state`` returns
+    # when an alerted task drives the rollup. Stored on the entry so the
+    # cache fast-path can serve a rollup that matches the direct path
+    # even when a live ``stuck_on_task:`` / ``no_session_for_assignment:``
+    # alert is present. Without this field the alert overlay had to be
+    # re-applied at read time (which requires task-status info the entry
+    # didn't carry) — the PR #2026 workaround declined the cache for any
+    # render with a tracked-project actionable alert. The refresher now
+    # folds alerts into the entry at compute time so the read path is
+    # authoritative.
+    actionable_key: str | None = None
 
     # ── awaits-user list (the expensive one) ───────────────────────
     awaits_user_count: int = 0

--- a/src/pollypm/state_cache/entry.py
+++ b/src/pollypm/state_cache/entry.py
@@ -173,13 +173,15 @@ class ProjectStateCacheEntry:
     actionable_key: str | None = None
     # #2049 follow-up (Codex blocker on PR #2085): stamp whether the
     # alert snapshot used to compute ``rail_state`` / ``actionable_key``
-    # was successfully read. ``_open_alerts_for`` previously turned every
-    # supervisor/store/open-alerts failure into an empty list, which
-    # meant a transient refresher-side alert read failure could install
-    # a no-alert WORKING/NONE rollup; a later render whose
-    # ``supervisor.open_alerts()`` succeeds would still serve that
-    # stale-from-failure entry and hide the actionable RED alert. When
-    # this flag is ``False`` the cache fast-path
+    # was successfully read. ``_open_alerts_for`` routes through
+    # ``pollypm.storage.pg_alerts.open_alerts`` and returns
+    # ``([], False)`` on any read failure; previously the empty list
+    # was indistinguishable from a real "no alerts" result, which
+    # meant a transient refresher-side alert read failure could
+    # install a no-alert WORKING/NONE rollup. A later render whose
+    # own alert read succeeds would still serve that
+    # stale-from-failure entry and hide the actionable RED alert.
+    # When this flag is ``False`` the cache fast-path
     # (:meth:`_maybe_cache_route_rollups`) MUST decline — the entry
     # can't speak to the alert state, so falling through to the direct
     # path is the only way to honour the live alert read. Defaults to

--- a/src/pollypm/state_cache/entry.py
+++ b/src/pollypm/state_cache/entry.py
@@ -171,6 +171,21 @@ class ProjectStateCacheEntry:
     # folds alerts into the entry at compute time so the read path is
     # authoritative.
     actionable_key: str | None = None
+    # #2049 follow-up (Codex blocker on PR #2085): stamp whether the
+    # alert snapshot used to compute ``rail_state`` / ``actionable_key``
+    # was successfully read. ``_open_alerts_for`` previously turned every
+    # supervisor/store/open-alerts failure into an empty list, which
+    # meant a transient refresher-side alert read failure could install
+    # a no-alert WORKING/NONE rollup; a later render whose
+    # ``supervisor.open_alerts()`` succeeds would still serve that
+    # stale-from-failure entry and hide the actionable RED alert. When
+    # this flag is ``False`` the cache fast-path
+    # (:meth:`_maybe_cache_route_rollups`) MUST decline — the entry
+    # can't speak to the alert state, so falling through to the direct
+    # path is the only way to honour the live alert read. Defaults to
+    # ``True`` so legacy / hand-rolled fixtures (and the success path)
+    # serve normally.
+    alerts_snapshot_valid: bool = True
 
     # ── awaits-user list (the expensive one) ───────────────────────
     awaits_user_count: int = 0

--- a/src/pollypm/state_cache/project_state_cache.py
+++ b/src/pollypm/state_cache/project_state_cache.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from pollypm.state_cache.entry import ProjectStateCacheEntry, empty_entry
 
@@ -38,7 +38,13 @@ __all__ = ["ProjectStateCache", "RefreshFn"]
 # audit-event → recomputed entry. Kept as a callable injection point
 # (rather than a hard import of the per-project query) so PR 2 can
 # swap the real implementation in without touching the cache class.
-RefreshFn = Callable[[str], Optional[ProjectStateCacheEntry]]
+#
+# The callable accepts ``(project_key, **kwargs)`` so sweep-level
+# callers (``StateCacheRefresher._worker_once`` /
+# ``_initial_full_refresh``) can plumb a pre-fetched
+# ``alerts_snapshot`` through one refresh sweep — see
+# :meth:`ProjectStateCache.refresh` for the boundary contract.
+RefreshFn = Callable[..., Optional[ProjectStateCacheEntry]]
 
 
 def _default_refresh(project_key: str) -> Optional[ProjectStateCacheEntry]:
@@ -143,7 +149,9 @@ class ProjectStateCache:
                 return
             self._pending.add(project_key)
 
-    def refresh(self, project_key: str) -> ProjectStateCacheEntry | None:
+    def refresh(
+        self, project_key: str, **refresh_kwargs: Any,
+    ) -> ProjectStateCacheEntry | None:
         """Recompute and atomically install the entry for ``project_key``.
 
         Calls the injected :data:`RefreshFn`; on success the new
@@ -152,6 +160,16 @@ class ProjectStateCache:
         or raises) the existing entry is left in place and the
         pending flag is cleared (failures don't loop indefinitely;
         the next invalidation re-enqueues).
+
+        ``refresh_kwargs`` (PR #2085 round-2 boundary fix): the
+        sweep-level refresher (``StateCacheRefresher._worker_once`` /
+        ``_initial_full_refresh``) pre-fetches workspace-wide reads
+        (e.g. the actionable-alert snapshot) once per sweep and
+        plumbs them through here. Backward-compatible: when no
+        kwargs are passed (single-project event-triggered refreshes,
+        test callers) the underlying refresh function is called with
+        just ``project_key`` so legacy refresh fns
+        (``lambda k: empty_entry(k)``) still work.
         """
 
         with self._lock:
@@ -160,7 +178,10 @@ class ProjectStateCache:
             # will re-enqueue.
             self._pending.discard(project_key)
             try:
-                entry = self._refresh_fn(project_key)
+                if refresh_kwargs:
+                    entry = self._refresh_fn(project_key, **refresh_kwargs)
+                else:
+                    entry = self._refresh_fn(project_key)
             except Exception:  # noqa: BLE001 — refresher MUST be best-effort
                 logger.exception(
                     "state_cache: refresh failed for %s", project_key,

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -141,11 +141,20 @@ def compute_entry_for_project(
     tracked = bool(getattr(project, "tracked", True)) if project else False
 
     awaits_user_items = _awaits_user_items_for(project_key, config)
+    # #2049 — workspace-wide alert fetch, filtered to this project's
+    # actionable task alerts. ``rollup_project_state`` consumes the
+    # filtered set; folding it in here means the cached ``rail_*``
+    # fields match the direct path even when a live alert is present.
+    # Best-effort: on any failure we degrade to "no alerts," which
+    # matches the pre-fix workaround's worst-case (no RED bump) rather
+    # than crashing the refresh.
+    actionable_alert_ids = _actionable_alert_ids_for(project_key, config)
     state, glyph, detail, rail_rollup, session_names = _categorize_and_rollup(
         project_key=project_key,
         config=config,
         tracked=tracked,
         awaits_user_items=list(awaits_user_items),
+        actionable_alert_task_ids=actionable_alert_ids,
     )
 
     # #2050: bulk-prefetch heartbeats for every session known to this
@@ -172,6 +181,10 @@ def compute_entry_for_project(
         rail_sort_rank=rail_rollup[2] if rail_rollup else 0,
         rail_reason=rail_rollup[3] if rail_rollup else "",
         approvals_pending=rail_rollup[4] if rail_rollup else 0,
+        # #2049 — alert-driven actionable_key (issues-route id) is the
+        # 6th tuple slot. Empty actionable alerts produce ``None`` to
+        # match ``rollup_project_state``'s direct-path return.
+        actionable_key=rail_rollup[5] if rail_rollup else None,
         awaits_user_count=len(awaits_user_items),
         awaits_user_items=tuple(awaits_user_items),
         latest_heartbeat_by_session=latest_heartbeat_by_session,
@@ -330,29 +343,113 @@ def _compute_workspace_entry(config: Any) -> ProjectStateCacheEntry:
     )
 
 
+def _actionable_alert_ids_for(
+    project_key: str, config: Any,
+) -> frozenset[str]:
+    """Return the per-project actionable-task-alert ids.
+
+    #2049 — folds the live alert set into the cached entry's rail
+    rollup so the cache fast-path can serve a rollup that matches the
+    direct path even when a ``stuck_on_task:<project>/<n>`` or
+    ``no_session_for_assignment:<project>/<n>`` alert is present.
+    Pre-fix the cache declined for any render with a tracked-project
+    actionable alert (the PR #2026 workaround) which killed the cache
+    benefit during the most common rail state.
+
+    Best-effort: every failure path returns ``frozenset()`` so a broken
+    store / supervisor falls back to "no alerts." That matches the
+    legacy fallthrough's no-RED-bump behaviour rather than crashing
+    the refresh.
+    """
+
+    try:
+        from pollypm.cockpit_project_state import actionable_alert_task_ids
+    except Exception:  # noqa: BLE001
+        return frozenset()
+
+    alerts = _open_alerts_for(config)
+    try:
+        return actionable_alert_task_ids(
+            alerts, project_key=project_key,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "state_cache: actionable_alert_task_ids failed for %s",
+            project_key,
+            exc_info=True,
+        )
+        return frozenset()
+
+
+def _open_alerts_for(config: Any) -> list[Any]:
+    """Return the workspace's open alerts, or ``[]`` on any failure.
+
+    Reads :meth:`Supervisor.open_alerts` — the same source the cockpit
+    direct path uses (cockpit_rail constructs a supervisor and reads
+    ``supervisor.open_alerts()`` per render). The lazy import keeps
+    the leaf ``state_cache`` package light.
+
+    Construction is best-effort and read-only. Supervisor construction
+    can fail on first call (e.g. backend pool not yet warm during cold
+    start) — every failure path degrades to ``[]`` so a refresh tick
+    never hard-fails on the alert overlay; we just lose the RED-bump
+    for that one refresh cycle.
+    """
+
+    try:
+        from pollypm.supervisor import Supervisor
+    except Exception:  # noqa: BLE001
+        return []
+    supervisor = None
+    try:
+        supervisor = Supervisor(config, readonly_state=True)
+        return list(supervisor.open_alerts())
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "state_cache: supervisor.open_alerts() failed",
+            exc_info=True,
+        )
+        return []
+    finally:
+        # ``Supervisor`` opens a StateStore handle on construction; the
+        # leaf state_cache module shouldn't leak it across refresh ticks.
+        if supervisor is not None:
+            try:
+                close = getattr(getattr(supervisor, "store", None), "close", None)
+                if callable(close):
+                    close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
 def _categorize_and_rollup(
     *,
     project_key: str,
     config: Any,
     tracked: bool,
     awaits_user_items: list[Any],
+    actionable_alert_task_ids: frozenset[str] = frozenset(),
 ) -> tuple[
     Any, str, str,
-    tuple[Any, Any, int, str, int] | None,
+    tuple[Any, Any, int, str, int, str | None] | None,
     list[str],
 ]:
     """Run ``categorize_project`` + ``rollup_project_state`` for one project.
 
     Returns ``(state, glyph, detail, rollup_tuple_or_None, session_names)``.
     The rollup tuple is ``(rail_state, rail_badge, sort_rank, reason,
-    approvals_pending)`` — kept positional so the caller can ``zip``
-    it into the entry fields without a second import of the rollup
-    types here. ``session_names`` is every tmux session this project
-    is known to drive (canonical ``architect_<key>`` /
-    ``plan_gate-<key>`` / ``worker_<key>`` plus the per-task
-    ``worker_<key>/<n>`` rows the live worker_sessions table reports)
-    — passed to :func:`_fetch_latest_heartbeats` for the heartbeat
-    prefetch (#2050).
+    approvals_pending, actionable_key)`` — kept positional so the
+    caller can ``zip`` it into the entry fields without a second
+    import of the rollup types here. ``session_names`` is every tmux
+    session this project is known to drive (canonical
+    ``architect_<key>`` / ``plan_gate-<key>`` / ``worker_<key>`` plus
+    the per-task ``worker_<key>/<n>`` rows the live worker_sessions
+    table reports) — passed to :func:`_fetch_latest_heartbeats` for
+    the heartbeat prefetch (#2050).
+
+    #2049: takes ``actionable_alert_task_ids`` so the rail rollup
+    folds in the alert overlay (RED bump for non-user-waiting alerted
+    tasks, alert-driven ``actionable_key``) at compute time.
 
     Failures degrade silently — a broken work-service drops the
     project to IDLE (or PAUSED when not tracked) with no rollup and an
@@ -447,13 +544,18 @@ def _categorize_and_rollup(
         except Exception:  # noqa: BLE001
             project_tasks = []
         try:
-            rollup = rollup_project_state(project_key, project_tasks)
+            rollup = rollup_project_state(
+                project_key,
+                project_tasks,
+                actionable_task_alert_ids=actionable_alert_task_ids,
+            )
             rollup_tuple = (
                 rollup.state,
                 rollup.badge,
                 rollup.sort_rank,
                 rollup.reason,
                 rollup.approvals_pending,
+                rollup.actionable_key,
             )
         except Exception:  # noqa: BLE001
             logger.warning(

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -72,7 +72,7 @@ ConfigProvider = Callable[[], Any]
 
 def build_refresh_fn(
     config_provider: ConfigProvider,
-) -> Callable[[str], ProjectStateCacheEntry | None]:
+) -> Callable[..., ProjectStateCacheEntry | None]:
     """Return a :data:`RefreshFn` bound to ``config_provider``.
 
     The returned closure is the callable :class:`ProjectStateCache`
@@ -87,9 +87,18 @@ def build_refresh_fn(
     The PR #2026 v3 fast-path-disable workaround on
     ``cockpit_rail._latest_heartbeat_cached`` is reverted in tandem so
     rail reads serve from the snapshot again.
+
+    PR #2085 round-2 boundary fix: ``**kwargs`` are forwarded into
+    :func:`compute_entry_for_project` so a sweep-level
+    ``alerts_snapshot`` pre-fetched by
+    :class:`StateCacheRefresher` is used in place of a per-project
+    ``_open_alerts_for`` call. Single-project event-triggered
+    refreshes call without kwargs and continue to fetch on demand.
     """
 
-    def _refresh(project_key: str) -> ProjectStateCacheEntry | None:
+    def _refresh(
+        project_key: str, **kwargs: Any,
+    ) -> ProjectStateCacheEntry | None:
         try:
             config = config_provider()
         except Exception:  # noqa: BLE001
@@ -100,13 +109,16 @@ def build_refresh_fn(
                 exc_info=True,
             )
             return empty_entry(project_key)
-        return compute_entry_for_project(project_key, config)
+        return compute_entry_for_project(project_key, config, **kwargs)
 
     return _refresh
 
 
 def compute_entry_for_project(
-    project_key: str, config: Any,
+    project_key: str,
+    config: Any,
+    *,
+    alerts_snapshot: tuple[list[Any], bool] | None = None,
 ) -> ProjectStateCacheEntry:
     """Recompute the entry for ``project_key`` against ``config``.
 
@@ -131,6 +143,14 @@ def compute_entry_for_project(
     fast-path can union it with per-project entries without affecting
     rail / dashboard consumers (which iterate over tracked project
     keys and ignore extras).
+
+    PR #2085 round-2 boundary fix: ``alerts_snapshot`` lets the
+    sweep-level refresher pre-fetch the workspace-wide alert read
+    once and plumb the ``(alerts, valid)`` tuple through every
+    per-project compute. When ``None`` (single-project event-driven
+    refreshes, tests) the helper falls back to one
+    ``_open_alerts_for(config)`` call so legacy single-project paths
+    behave identically.
     """
 
     if project_key == WORKSPACE_PROJECT_KEY:
@@ -148,8 +168,12 @@ def compute_entry_for_project(
     # Best-effort: on any failure we degrade to "no alerts," which
     # matches the pre-fix workaround's worst-case (no RED bump) rather
     # than crashing the refresh.
+    #
+    # PR #2085 round-2: if the sweep-level refresher pre-fetched the
+    # workspace alert snapshot, reuse it (collapses N supervisor reads
+    # per sweep to 1). Otherwise fall back to the per-project read.
     actionable_alert_ids, alerts_valid = _actionable_alert_ids_for(
-        project_key, config,
+        project_key, config, alerts_snapshot=alerts_snapshot,
     )
     state, glyph, detail, rail_rollup, session_names = _categorize_and_rollup(
         project_key=project_key,
@@ -353,7 +377,10 @@ def _compute_workspace_entry(config: Any) -> ProjectStateCacheEntry:
 
 
 def _actionable_alert_ids_for(
-    project_key: str, config: Any,
+    project_key: str,
+    config: Any,
+    *,
+    alerts_snapshot: tuple[list[Any], bool] | None = None,
 ) -> tuple[frozenset[str], bool]:
     """Return ``(actionable_task_alert_ids, alerts_snapshot_valid)``.
 
@@ -380,6 +407,14 @@ def _actionable_alert_ids_for(
     alert read → empty set so the rollup doesn't bump to RED off a
     half-read snapshot. ``actionable_alert_task_ids`` failures are
     treated as failures too (valid=False) — same rationale.
+
+    PR #2085 round-2 boundary fix: ``alerts_snapshot`` is the
+    workspace-wide ``(alerts, valid)`` pair the sweep-level refresher
+    pre-fetches once and threads through every per-project compute.
+    When provided we skip the per-project ``_open_alerts_for`` call
+    entirely — that's where the N×Supervisor-construction perf cost
+    lived. When ``None`` we fall back to the on-demand read so
+    single-project event-triggered refreshes keep working unchanged.
     """
 
     try:
@@ -387,7 +422,10 @@ def _actionable_alert_ids_for(
     except Exception:  # noqa: BLE001
         return frozenset(), False
 
-    alerts, alerts_valid = _open_alerts_for(config)
+    if alerts_snapshot is not None:
+        alerts, alerts_valid = alerts_snapshot
+    else:
+        alerts, alerts_valid = _open_alerts_for(config)
     if not alerts_valid:
         return frozenset(), False
     try:

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -148,7 +148,9 @@ def compute_entry_for_project(
     # Best-effort: on any failure we degrade to "no alerts," which
     # matches the pre-fix workaround's worst-case (no RED bump) rather
     # than crashing the refresh.
-    actionable_alert_ids = _actionable_alert_ids_for(project_key, config)
+    actionable_alert_ids, alerts_valid = _actionable_alert_ids_for(
+        project_key, config,
+    )
     state, glyph, detail, rail_rollup, session_names = _categorize_and_rollup(
         project_key=project_key,
         config=config,
@@ -185,6 +187,13 @@ def compute_entry_for_project(
         # 6th tuple slot. Empty actionable alerts produce ``None`` to
         # match ``rollup_project_state``'s direct-path return.
         actionable_key=rail_rollup[5] if rail_rollup else None,
+        # #2049 follow-up (Codex blocker on PR #2085): stamp whether the
+        # alert read succeeded. When ``False`` the cache fast-path must
+        # decline so the direct path's live ``supervisor.open_alerts()``
+        # read can populate the RED bump; the refresher's
+        # rail_state/actionable_key would otherwise hide an alert that
+        # the live read can now see.
+        alerts_snapshot_valid=alerts_valid,
         awaits_user_count=len(awaits_user_items),
         awaits_user_items=tuple(awaits_user_items),
         latest_heartbeat_by_session=latest_heartbeat_by_session,
@@ -345,8 +354,8 @@ def _compute_workspace_entry(config: Any) -> ProjectStateCacheEntry:
 
 def _actionable_alert_ids_for(
     project_key: str, config: Any,
-) -> frozenset[str]:
-    """Return the per-project actionable-task-alert ids.
+) -> tuple[frozenset[str], bool]:
+    """Return ``(actionable_task_alert_ids, alerts_snapshot_valid)``.
 
     #2049 — folds the live alert set into the cached entry's rail
     rollup so the cache fast-path can serve a rollup that matches the
@@ -356,21 +365,35 @@ def _actionable_alert_ids_for(
     actionable alert (the PR #2026 workaround) which killed the cache
     benefit during the most common rail state.
 
-    Best-effort: every failure path returns ``frozenset()`` so a broken
-    store / supervisor falls back to "no alerts." That matches the
-    legacy fallthrough's no-RED-bump behaviour rather than crashing
-    the refresh.
+    #2049 follow-up (Codex blocker on PR #2085): callers need to
+    distinguish "no alerts" (success → empty set, valid=True) from
+    "alert read failed" (exception → empty set, valid=False). The
+    refresher stamps the validity flag onto the entry so
+    :meth:`cockpit_rail._maybe_cache_route_rollups` declines the
+    fast-path when alerts couldn't be read — a later render whose
+    ``supervisor.open_alerts()`` succeeds will then see the live alert
+    instead of the stale-from-failure WORKING/NONE rollup. The id-set
+    is still returned (empty on failure) so the rollup compute path
+    has a non-None argument; the validity flag is the source of truth.
+
+    The returned ids reflect the failure-degrade contract: a failed
+    alert read → empty set so the rollup doesn't bump to RED off a
+    half-read snapshot. ``actionable_alert_task_ids`` failures are
+    treated as failures too (valid=False) — same rationale.
     """
 
     try:
         from pollypm.cockpit_project_state import actionable_alert_task_ids
     except Exception:  # noqa: BLE001
-        return frozenset()
+        return frozenset(), False
 
-    alerts = _open_alerts_for(config)
+    alerts, alerts_valid = _open_alerts_for(config)
+    if not alerts_valid:
+        return frozenset(), False
     try:
-        return actionable_alert_task_ids(
-            alerts, project_key=project_key,
+        return (
+            actionable_alert_task_ids(alerts, project_key=project_key),
+            True,
         )
     except Exception:  # noqa: BLE001
         logger.warning(
@@ -378,38 +401,45 @@ def _actionable_alert_ids_for(
             project_key,
             exc_info=True,
         )
-        return frozenset()
+        return frozenset(), False
 
 
-def _open_alerts_for(config: Any) -> list[Any]:
-    """Return the workspace's open alerts, or ``[]`` on any failure.
+def _open_alerts_for(config: Any) -> tuple[list[Any], bool]:
+    """Return ``(open_alerts, valid)``.
 
     Reads :meth:`Supervisor.open_alerts` — the same source the cockpit
     direct path uses (cockpit_rail constructs a supervisor and reads
     ``supervisor.open_alerts()`` per render). The lazy import keeps
     the leaf ``state_cache`` package light.
 
-    Construction is best-effort and read-only. Supervisor construction
-    can fail on first call (e.g. backend pool not yet warm during cold
-    start) — every failure path degrades to ``[]`` so a refresh tick
-    never hard-fails on the alert overlay; we just lose the RED-bump
-    for that one refresh cycle.
+    #2049 follow-up (Codex blocker on PR #2085): every failure path
+    returns ``([], False)`` — the empty list is for callers that need
+    to keep computing a rollup without crashing, the ``False`` is the
+    signal the refresher stamps onto
+    :attr:`ProjectStateCacheEntry.alerts_snapshot_valid`. The cache
+    fast-path declines on ``False`` so a transient supervisor-side
+    failure doesn't install a no-alert rollup that masks a live RED
+    alert on the next render.
+
+    Construction failures: supervisor construction can fail on cold
+    start (backend pool not warm, etc.); these are real read failures,
+    not "no alerts," and are reported as such.
     """
 
     try:
         from pollypm.supervisor import Supervisor
     except Exception:  # noqa: BLE001
-        return []
+        return [], False
     supervisor = None
     try:
         supervisor = Supervisor(config, readonly_state=True)
-        return list(supervisor.open_alerts())
+        return list(supervisor.open_alerts()), True
     except Exception:  # noqa: BLE001
         logger.warning(
             "state_cache: supervisor.open_alerts() failed",
             exc_info=True,
         )
-        return []
+        return [], False
     finally:
         # ``Supervisor`` opens a StateStore handle on construction; the
         # leaf state_cache module shouldn't leak it across refresh ticks.

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -412,9 +412,10 @@ def _actionable_alert_ids_for(
     workspace-wide ``(alerts, valid)`` pair the sweep-level refresher
     pre-fetches once and threads through every per-project compute.
     When provided we skip the per-project ``_open_alerts_for`` call
-    entirely — that's where the N×Supervisor-construction perf cost
-    lived. When ``None`` we fall back to the on-demand read so
-    single-project event-triggered refreshes keep working unchanged.
+    entirely — that's where the N×pg-alerts-read perf cost lived
+    (one pg round-trip per project). When ``None`` we fall back to
+    the on-demand read so single-project event-triggered refreshes
+    keep working unchanged.
     """
 
     try:
@@ -445,49 +446,44 @@ def _actionable_alert_ids_for(
 def _open_alerts_for(config: Any) -> tuple[list[Any], bool]:
     """Return ``(open_alerts, valid)``.
 
-    Reads :meth:`Supervisor.open_alerts` — the same source the cockpit
-    direct path uses (cockpit_rail constructs a supervisor and reads
-    ``supervisor.open_alerts()`` per render). The lazy import keeps
-    the leaf ``state_cache`` package light.
+    Reads :func:`pollypm.storage.pg_alerts.open_alerts` — the canonical
+    pg facade for the cluster-B ``messages``-table alert read. This is
+    the same row source the cockpit's direct path ultimately queries
+    (via ``self._msg_store.query_messages(type='alert', state='open')``
+    on the unified Store); going to the facade directly keeps the leaf
+    ``state_cache`` package free of the broad runtime supervisor and
+    legacy sqlite-state boundary — see
+    ``tests/test_state_cache_no_sqlite_imports.py`` for the pinned
+    invariant (PR #2085 round-3 Codex blocker).
+
+    The lazy import keeps the leaf ``state_cache`` package light.
 
     #2049 follow-up (Codex blocker on PR #2085): every failure path
     returns ``([], False)`` — the empty list is for callers that need
     to keep computing a rollup without crashing, the ``False`` is the
     signal the refresher stamps onto
     :attr:`ProjectStateCacheEntry.alerts_snapshot_valid`. The cache
-    fast-path declines on ``False`` so a transient supervisor-side
-    failure doesn't install a no-alert rollup that masks a live RED
-    alert on the next render.
+    fast-path declines on ``False`` so a transient read failure
+    doesn't install a no-alert rollup that masks a live RED alert on
+    the next render.
 
-    Construction failures: supervisor construction can fail on cold
-    start (backend pool not warm, etc.); these are real read failures,
-    not "no alerts," and are reported as such.
+    Pool / cold-start failures: the pg pool can fail to warm on cold
+    start; these are real read failures (not "no alerts") and are
+    reported as such.
     """
 
     try:
-        from pollypm.supervisor import Supervisor
+        from pollypm.storage import pg_alerts
     except Exception:  # noqa: BLE001
         return [], False
-    supervisor = None
     try:
-        supervisor = Supervisor(config, readonly_state=True)
-        return list(supervisor.open_alerts()), True
+        return list(pg_alerts.open_alerts(config=config)), True
     except Exception:  # noqa: BLE001
         logger.warning(
-            "state_cache: supervisor.open_alerts() failed",
+            "state_cache: pg_alerts.open_alerts() failed",
             exc_info=True,
         )
         return [], False
-    finally:
-        # ``Supervisor`` opens a StateStore handle on construction; the
-        # leaf state_cache module shouldn't leak it across refresh ticks.
-        if supervisor is not None:
-            try:
-                close = getattr(getattr(supervisor, "store", None), "close", None)
-                if callable(close):
-                    close()
-            except Exception:  # noqa: BLE001
-                pass
 
 
 def _categorize_and_rollup(

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -170,8 +170,9 @@ def compute_entry_for_project(
     # than crashing the refresh.
     #
     # PR #2085 round-2: if the sweep-level refresher pre-fetched the
-    # workspace alert snapshot, reuse it (collapses N supervisor reads
-    # per sweep to 1). Otherwise fall back to the per-project read.
+    # workspace alert snapshot, reuse it (collapses N
+    # ``pg_alerts.open_alerts`` reads per sweep to 1). Otherwise fall
+    # back to the per-project read.
     actionable_alert_ids, alerts_valid = _actionable_alert_ids_for(
         project_key, config, alerts_snapshot=alerts_snapshot,
     )

--- a/src/pollypm/state_cache/refresher.py
+++ b/src/pollypm/state_cache/refresher.py
@@ -184,6 +184,7 @@ class StateCacheRefresher:
         tail_poll_seconds: float = _TAIL_POLL_SECONDS,
         refresh_tick_seconds: float = _REFRESH_TICK_SECONDS,
         project_keys: Callable[[], list[str]] | None = None,
+        config_provider: Callable[[], object] | None = None,
     ) -> None:
         self._cache = cache
         self._audit_dir = audit_dir if audit_dir is not None else default_audit_dir()
@@ -193,6 +194,15 @@ class StateCacheRefresher:
         # refresh — when supplied, the worker enqueues a refresh for
         # every key returned. PR 2 will pass the config-driven list.
         self._project_keys = project_keys
+        # PR #2085 round-2 boundary fix: optional config provider used
+        # to pre-fetch the workspace-wide actionable-alert snapshot
+        # ONCE per sweep (``_initial_full_refresh`` /
+        # ``_worker_once``). Without this each per-project refresh
+        # would call ``_open_alerts_for(config)`` — Supervisor
+        # construction + open_alerts read — N times per sweep, all
+        # under the cache lock. With it, every sweep that touches >1
+        # project pays for exactly one alert read.
+        self._config_provider = config_provider
         self._positions: dict[Path, _Position] = {}
         self._stop_event = threading.Event()
         self._tail_thread: threading.Thread | None = None
@@ -257,12 +267,19 @@ class StateCacheRefresher:
         startup-gap window. Provider-less refreshers (PR 1 tests)
         do nothing here, which is correct — there is no project set
         to refresh yet.
+
+        PR #2085 round-2 boundary fix: workspace-wide alert snapshot
+        is fetched ONCE before the per-project loop and threaded
+        through every ``cache.refresh`` call. Without this, a
+        workspace with N projects paid N × Supervisor construction
+        per sweep — all under the cache lock.
         """
 
         keys = self._candidate_keys()
+        refresh_kwargs = self._sweep_refresh_kwargs(len(keys))
         for key in keys:
             try:
-                self._cache.refresh(key)
+                self._cache.refresh(key, **refresh_kwargs)
             except Exception:  # noqa: BLE001
                 logger.exception(
                     "state_cache: initial refresh failed for %s", key,
@@ -403,13 +420,58 @@ class StateCacheRefresher:
             self._stop_event.wait(self._refresh_tick_seconds)
 
     def _worker_once(self) -> None:
-        for key in self._cache.drain_pending():
+        drained = self._cache.drain_pending()
+        refresh_kwargs = self._sweep_refresh_kwargs(len(drained))
+        for key in drained:
             try:
-                self._cache.refresh(key)
+                self._cache.refresh(key, **refresh_kwargs)
             except Exception:  # noqa: BLE001
                 logger.exception(
                     "state_cache: refresh failed for %s", key,
                 )
+
+    # ── sweep-level pre-fetch ────────────────────────────────────
+
+    def _sweep_refresh_kwargs(self, key_count: int) -> dict[str, object]:
+        """Return kwargs to plumb through every refresh in one sweep.
+
+        PR #2085 round-2 boundary fix: ``_open_alerts_for(config)``
+        constructs a :class:`Supervisor` + reads ``open_alerts()`` —
+        a workspace-wide read. When the sweep touches >1 project,
+        doing this once and passing the result through reduces the
+        per-sweep cost from N × Supervisor reads to 1.
+
+        Single-project sweeps (drain has one key, single-project
+        event-triggered refreshes) skip the pre-fetch — the
+        downstream ``compute_entry_for_project`` will do its own
+        on-demand read, identical cost to the pre-PR behaviour for
+        that path.
+
+        ``config_provider`` unset (PR 1 tests, refreshers without the
+        real refresh function wired in) → no kwargs, same as before.
+        """
+
+        if key_count <= 1 or self._config_provider is None:
+            return {}
+        try:
+            from pollypm.state_cache.refresh_impl import _open_alerts_for
+        except Exception:  # noqa: BLE001
+            return {}
+        try:
+            config = self._config_provider()
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "state_cache: config_provider raised during sweep pre-fetch",
+            )
+            return {}
+        try:
+            alerts_snapshot = _open_alerts_for(config)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "state_cache: _open_alerts_for raised during sweep pre-fetch",
+            )
+            return {}
+        return {"alerts_snapshot": alerts_snapshot}
 
 
 # ── test hooks ──────────────────────────────────────────────────

--- a/src/pollypm/state_cache/refresher.py
+++ b/src/pollypm/state_cache/refresher.py
@@ -198,10 +198,10 @@ class StateCacheRefresher:
         # to pre-fetch the workspace-wide actionable-alert snapshot
         # ONCE per sweep (``_initial_full_refresh`` /
         # ``_worker_once``). Without this each per-project refresh
-        # would call ``_open_alerts_for(config)`` — Supervisor
-        # construction + open_alerts read — N times per sweep, all
-        # under the cache lock. With it, every sweep that touches >1
-        # project pays for exactly one alert read.
+        # would call ``_open_alerts_for(config)`` —
+        # ``pollypm.storage.pg_alerts.open_alerts`` read — N times per
+        # sweep, all under the cache lock. With it, every sweep that
+        # touches >1 project pays for exactly one alert read.
         self._config_provider = config_provider
         self._positions: dict[Path, _Position] = {}
         self._stop_event = threading.Event()
@@ -271,8 +271,9 @@ class StateCacheRefresher:
         PR #2085 round-2 boundary fix: workspace-wide alert snapshot
         is fetched ONCE before the per-project loop and threaded
         through every ``cache.refresh`` call. Without this, a
-        workspace with N projects paid N × Supervisor construction
-        per sweep — all under the cache lock.
+        workspace with N projects paid N ×
+        ``pollypm.storage.pg_alerts.open_alerts`` reads per sweep —
+        all under the cache lock.
         """
 
         keys = self._candidate_keys()
@@ -436,10 +437,10 @@ class StateCacheRefresher:
         """Return kwargs to plumb through every refresh in one sweep.
 
         PR #2085 round-2 boundary fix: ``_open_alerts_for(config)``
-        constructs a :class:`Supervisor` + reads ``open_alerts()`` —
-        a workspace-wide read. When the sweep touches >1 project,
+        reads :func:`pollypm.storage.pg_alerts.open_alerts` — a
+        workspace-wide query. When the sweep touches >1 project,
         doing this once and passing the result through reduces the
-        per-sweep cost from N × Supervisor reads to 1.
+        per-sweep cost from N × pg_alerts reads to 1.
 
         Single-project sweeps (drain has one key, single-project
         event-triggered refreshes) skip the pre-fetch — the

--- a/tests/test_state_cache_env_flag.py
+++ b/tests/test_state_cache_env_flag.py
@@ -215,14 +215,16 @@ def test_singleton_wires_project_keys_provider_for_initial_refresh(
     from pollypm.state_cache.entry import empty_entry
     monkeypatch.setattr(
         "pollypm.state_cache.compute_entry_for_project",
-        lambda project_key, config: empty_entry(project_key),
+        lambda project_key, config, **kwargs: empty_entry(project_key),
     )
     # ``build_refresh_fn`` is imported into ``__init__`` at module
     # load — replace it on the module namespace so the singleton wiring
-    # picks up the stub.
+    # picks up the stub. Accept ``**kwargs`` because PR #2085 round-2's
+    # sweep-level pre-fetch plumbs ``alerts_snapshot`` through every
+    # multi-project refresh.
     monkeypatch.setattr(
         "pollypm.state_cache.build_refresh_fn",
-        lambda provider: (lambda key: empty_entry(key)),
+        lambda provider: (lambda key, **kwargs: empty_entry(key)),
     )
 
     cache = get_cache()
@@ -335,7 +337,7 @@ def test_singleton_provider_degrades_gracefully_on_config_failure(
     from pollypm.state_cache.entry import empty_entry
     monkeypatch.setattr(
         "pollypm.state_cache.build_refresh_fn",
-        lambda provider: (lambda key: empty_entry(key)),
+        lambda provider: (lambda key, **kwargs: empty_entry(key)),
     )
 
     cache = get_cache()

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -1503,7 +1503,9 @@ class TestActionableAlertRefresherParity:
         # Cached path: stub the refresher's task + alert sources so we
         # can drive ``compute_entry_for_project`` synchronously.
         monkeypatch.setattr(
-            refresh_impl, "_open_alerts_for", lambda config: [alert],
+            refresh_impl,
+            "_open_alerts_for",
+            lambda config: ([alert], True),
         )
 
         # Drive ``_categorize_and_rollup`` directly with the same task,
@@ -1553,6 +1555,193 @@ class TestActionableAlertRefresherParity:
         assert entry.rail_sort_rank == direct.sort_rank
         assert entry.rail_reason == direct.reason
         assert entry.actionable_key == direct.actionable_key
+        # Success path stamps the snapshot as valid so the cache
+        # fast-path is allowed to serve this entry.
+        assert entry.alerts_snapshot_valid is True
+
+
+class TestActionableAlertSnapshotValidity:
+    """#2049 follow-up (Codex blocker on PR #2085): a transient
+    refresher-side alert read failure must not let the cache fast-path
+    serve a no-alert WORKING/NONE rollup.
+
+    Pre-fix: ``_open_alerts_for`` turned every supervisor / store /
+    open-alerts failure into ``[]``. ``compute_entry_for_project``
+    happily folded that empty set into the rail rollup and the
+    resulting entry passed through ``_maybe_cache_route_rollups`` like
+    any other. A later render whose ``supervisor.open_alerts()``
+    succeeds would still serve that stale-from-failure entry and hide
+    the actionable RED alert.
+
+    Post-fix: ``_open_alerts_for`` returns ``(alerts, valid)``; on any
+    failure ``valid=False`` propagates up to the entry's
+    ``alerts_snapshot_valid`` field; ``_maybe_cache_route_rollups``
+    declines when that flag is ``False`` so the direct path's live
+    ``supervisor.open_alerts()`` read drives the rollup.
+    """
+
+    def _router(self, tmp_path: Path):
+        from pollypm.cockpit_rail import CockpitRouter
+
+        config_path = tmp_path / "pollypm.toml"
+        config_path.write_text(
+            "[project]\n"
+            'name = "PollyPM"\n'
+            f'root_dir = "{tmp_path}"\n'
+            'tmux_session = "pollypm"\n'
+            f'base_dir = "{tmp_path / ".pollypm"}"\n'
+        )
+        return CockpitRouter(config_path)
+
+    def test_open_alerts_failure_marks_entry_invalid(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """A failing ``supervisor.open_alerts()`` → ``alerts_snapshot_valid=False``.
+
+        Drives :func:`compute_entry_for_project` with a supervisor that
+        raises and asserts the resulting entry stamps invalidity onto
+        itself rather than silently producing a no-alert entry.
+        """
+
+        from pollypm.dashboard.categorization import ProjectState as _PS
+        from pollypm.state_cache import refresh_impl
+
+        project_key = "alpha"
+
+        class _ExplodingSupervisor:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            def open_alerts(self) -> list[Any]:
+                raise RuntimeError("transient store failure")
+
+            store = None
+
+        # Patch the lazy import inside _open_alerts_for. Importing the
+        # supervisor module first lets us monkeypatch its Supervisor
+        # attribute; refresh_impl does a fresh ``from pollypm.supervisor
+        # import Supervisor`` on every call so the patch is picked up.
+        import pollypm.supervisor as supervisor_mod
+        monkeypatch.setattr(
+            supervisor_mod, "Supervisor", _ExplodingSupervisor,
+        )
+
+        # Short-circuit the heavy categorize/rollup path: the
+        # validity-flag plumbing is what we're testing, not the
+        # work-service slice. We assert below that the rollup is
+        # computed against an EMPTY alert set (the failure-degrade
+        # contract) — what changes is the validity flag on the entry.
+        seen_alert_ids: dict[str, frozenset[str]] = {}
+
+        def _fake_categorize_and_rollup(**kwargs: Any):
+            seen_alert_ids["ids"] = kwargs["actionable_alert_task_ids"]
+            return (_PS.IDLE, "", "", None, [])
+
+        monkeypatch.setattr(
+            refresh_impl,
+            "_categorize_and_rollup",
+            _fake_categorize_and_rollup,
+        )
+        monkeypatch.setattr(
+            refresh_impl, "_awaits_user_items_for", lambda key, config: [],
+        )
+
+        config = _make_config([project_key], tmp_path)
+        entry = refresh_impl.compute_entry_for_project(project_key, config)
+
+        # Failure degrades to "no alert ids" so the rollup compute
+        # doesn't crash, but the entry stamps invalidity so readers
+        # know not to trust the no-alert outcome.
+        assert seen_alert_ids["ids"] == frozenset()
+        assert entry.alerts_snapshot_valid is False
+
+    def test_cache_fast_path_declines_on_invalid_snapshot(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """``_maybe_cache_route_rollups`` returns ``None`` when the
+        cached entry's alert snapshot is marked invalid.
+
+        Without this guard a transient refresher-side alert read
+        failure would install a no-alert WORKING/NONE rollup that
+        survives until the next refresh tick — masking a live RED
+        alert from any render that happens in between.
+        """
+
+        from pollypm.cockpit_project_state import ProjectRailState
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+        config = _make_config(["alpha"], tmp_path)
+
+        # Entry looks healthy (WORKING, no alert) but was computed
+        # against a failed alert read — the validity stamp is the only
+        # signal the cache has.
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WORKING, items=[],
+                rail_state=ProjectRailState.WORKING,
+                rail_badge=None,
+                rail_reason="worker active",
+            ),
+        }
+        # Hand-rolled _entry() defaults to alerts_snapshot_valid=True;
+        # rebuild the entry with the failure flag set so we exercise
+        # the new decline branch.
+        invalid_entry = ProjectStateCacheEntry(
+            project_key="alpha",
+            project_path=entries["alpha"].project_path,
+            tracked=True,
+            state=entries["alpha"].state,
+            rail_state=entries["alpha"].rail_state,
+            rail_badge=entries["alpha"].rail_badge,
+            rail_reason=entries["alpha"].rail_reason,
+            alerts_snapshot_valid=False,
+        )
+        _seed_cache(monkeypatch, {"alpha": invalid_entry})
+
+        # A live alert exists at render time; if the cache served the
+        # entry it would silently hide this from the rail rollup.
+        live_alert = SimpleNamespace(
+            alert_type="stuck_on_task:alpha/1",
+            severity="high",
+            message="stuck",
+        )
+        result = router._maybe_cache_route_rollups(
+            config, alerts=[live_alert],
+        )
+        assert result is None  # fall through to direct path
+
+    def test_valid_snapshot_still_serves_from_cache(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Sanity: the validity flag only declines on ``False``.
+
+        The healthy path (alert read succeeded; entry stamped valid)
+        continues to serve from the cache as before so the fast-path
+        is not regressed for the overwhelming-majority case.
+        """
+
+        from pollypm.cockpit_project_state import ProjectRailState
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+        config = _make_config(["alpha"], tmp_path)
+
+        entry = ProjectStateCacheEntry(
+            project_key="alpha",
+            project_path=Path("/tmp/alpha"),
+            tracked=True,
+            state=ProjectState.WORKING,
+            rail_state=ProjectRailState.WORKING,
+            rail_badge=None,
+            rail_reason="worker active",
+            alerts_snapshot_valid=True,
+        )
+        _seed_cache(monkeypatch, {"alpha": entry})
+
+        result = router._maybe_cache_route_rollups(config, alerts=[])
+        assert result is not None
+        assert result["alpha"].state is ProjectRailState.WORKING
 
 
 class TestPr2026ReviewBlocker2HeartbeatNoStale:

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -1596,11 +1596,17 @@ class TestActionableAlertSnapshotValidity:
     def test_open_alerts_failure_marks_entry_invalid(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """A failing ``supervisor.open_alerts()`` → ``alerts_snapshot_valid=False``.
+        """A failing pg-alerts read → ``alerts_snapshot_valid=False``.
 
-        Drives :func:`compute_entry_for_project` with a supervisor that
-        raises and asserts the resulting entry stamps invalidity onto
-        itself rather than silently producing a no-alert entry.
+        Drives :func:`compute_entry_for_project` with a pg-alerts
+        facade that raises and asserts the resulting entry stamps
+        invalidity onto itself rather than silently producing a
+        no-alert entry.
+
+        PR #2085 round-3: ``_open_alerts_for`` no longer constructs a
+        Supervisor — it reads through
+        :func:`pollypm.storage.pg_alerts.open_alerts`. The patch
+        target follows; the validity contract is unchanged.
         """
 
         from pollypm.dashboard.categorization import ProjectState as _PS
@@ -1608,22 +1614,16 @@ class TestActionableAlertSnapshotValidity:
 
         project_key = "alpha"
 
-        class _ExplodingSupervisor:
-            def __init__(self, *args: Any, **kwargs: Any) -> None:
-                pass
-
-            def open_alerts(self) -> list[Any]:
-                raise RuntimeError("transient store failure")
-
-            store = None
+        def _exploding_open_alerts(**kwargs: Any) -> list[Any]:
+            raise RuntimeError("transient store failure")
 
         # Patch the lazy import inside _open_alerts_for. Importing the
-        # supervisor module first lets us monkeypatch its Supervisor
-        # attribute; refresh_impl does a fresh ``from pollypm.supervisor
-        # import Supervisor`` on every call so the patch is picked up.
-        import pollypm.supervisor as supervisor_mod
+        # pg_alerts module first lets us monkeypatch its open_alerts
+        # attribute; refresh_impl does a fresh ``from pollypm.storage
+        # import pg_alerts`` on every call so the patch is picked up.
+        import pollypm.storage.pg_alerts as pg_alerts_mod
         monkeypatch.setattr(
-            supervisor_mod, "Supervisor", _ExplodingSupervisor,
+            pg_alerts_mod, "open_alerts", _exploding_open_alerts,
         )
 
         # Short-circuit the heavy categorize/rollup path: the

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -131,6 +131,7 @@ def _entry(
     rail_sort_rank: int = 0,
     rail_reason: str = "",
     approvals_pending: int = 0,
+    actionable_key: str | None = None,
     glyph: str = "",
     detail: str = "",
     latest_heartbeat_by_session: dict[str, Any] | None = None,
@@ -155,6 +156,7 @@ def _entry(
         rail_sort_rank=rail_sort_rank,
         rail_reason=rail_reason,
         approvals_pending=approvals_pending,
+        actionable_key=actionable_key,
         awaits_user_count=len(items),
         awaits_user_items=tuple(items),
         latest_heartbeat_by_session=dict(latest_heartbeat_by_session or {}),
@@ -1353,12 +1355,19 @@ class TestProjectCategorizationsNoTtl:
 # ── PR #2026 review blockers — fall-through regression tests ────────
 
 
-class TestPr2026ReviewBlocker1ActionableAlertFallthrough:
-    """Blocker 1: cache fast-path MUST defer when a live actionable
-    task alert exists, because the direct ``rollup_project_state``
-    folds alerts into ``rail_state`` / ``badge`` / ``reason`` /
-    ``actionable_key`` and the cache entry's ``rail_*`` fields were
-    computed without alert state.
+class TestActionableAlertCachedRollupParity:
+    """#2049: the refresher folds ``actionable_alert_task_ids`` into
+    the cached entry's rail rollup at compute time, so the cache
+    fast-path serves a rollup that matches the direct path even when
+    a live ``stuck_on_task:<project>/<n>`` /
+    ``no_session_for_assignment:<project>/<n>`` alert is present.
+
+    Inverts the original PR #2026 "fall-through" contract (kept under
+    the original class for archaeology): the cache MUST NOT decline
+    just because an alert exists — :func:`compute_entry_for_project`
+    is responsible for ensuring ``entry.rail_state`` /
+    ``entry.rail_badge`` / ``entry.rail_reason`` / ``entry.actionable_key``
+    already reflect the alert overlay.
     """
 
     def _router(self, tmp_path: Path):
@@ -1374,11 +1383,11 @@ class TestPr2026ReviewBlocker1ActionableAlertFallthrough:
         )
         return CockpitRouter(config_path)
 
-    def test_actionable_alert_forces_cache_fallthrough(
+    def test_actionable_alert_served_from_cache(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Cached base state WORKING, live actionable alert exists →
-        the cache MUST decline so the direct path can paint RED.
+        """A live actionable alert is reflected by the cached rollup
+        (refresher folded it in) — the fast-path no longer declines.
         """
 
         from pollypm.cockpit_project_state import ProjectRailState
@@ -1387,30 +1396,35 @@ class TestPr2026ReviewBlocker1ActionableAlertFallthrough:
         router = self._router(tmp_path)
         config = _make_config(["alpha"], tmp_path)
 
-        # Cache entry says WORKING / NONE — no idea about the alert.
+        # Cache entry was computed by the refresher AFTER folding in
+        # ``stuck_on_task:alpha/1`` — RED + issues-route actionable_key.
         entries = {
             "alpha": _entry(
                 "alpha", state=ProjectState.WORKING, items=[],
-                rail_state=ProjectRailState.WORKING,
-                rail_badge=None,
+                rail_state=ProjectRailState.RED,
+                rail_badge="🔴",
                 rail_sort_rank=0,
-                rail_reason="worker active",
+                rail_reason="operational alert needs review",
                 approvals_pending=0,
+                actionable_key="project:alpha:issues",
             ),
         }
         _seed_cache(monkeypatch, entries)
 
-        # Live actionable alert for alpha/1 — should turn alpha RED.
+        # Live alert still passed in (matches the direct-path
+        # signature); the cache reads the entry, not the alert list.
         alert = SimpleNamespace(
             alert_type="stuck_on_task:alpha/1",
             severity="high",
             message="stuck",
         )
+        rollups = router._maybe_cache_route_rollups(config, alerts=[alert])
 
-        # Cache fast-path declines (the gate fires).
-        assert (
-            router._maybe_cache_route_rollups(config, alerts=[alert]) is None
-        )
+        assert rollups is not None
+        assert rollups["alpha"].state is ProjectRailState.RED
+        assert rollups["alpha"].badge == "🔴"
+        assert rollups["alpha"].actionable_key == "project:alpha:issues"
+        assert rollups["alpha"].reason == "operational alert needs review"
 
     def test_no_alert_still_uses_cache_fast_path(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
@@ -1437,6 +1451,108 @@ class TestPr2026ReviewBlocker1ActionableAlertFallthrough:
         assert rollups["alpha"].state is ProjectRailState.WORKING
         # No alerts → actionable_key is None (matches direct path).
         assert rollups["alpha"].actionable_key is None
+
+
+class TestActionableAlertRefresherParity:
+    """#2049: parity between cached + direct paths for a project with
+    a live ``stuck_on_task:`` actionable alert.
+
+    Drives :func:`compute_entry_for_project` and :func:`rollup_project_state`
+    directly so the comparison doesn't depend on cockpit_rail's
+    consumer plumbing — what we're pinning is that the cache stores
+    the same rail_state/badge/reason/actionable_key the direct path
+    computes.
+    """
+
+    def test_refresher_folds_stuck_on_task_alert_into_entry(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        from pollypm.cockpit_project_state import (
+            ProjectRailState,
+            rollup_project_state,
+        )
+        from pollypm.state_cache import refresh_impl
+
+        project_key = "alpha"
+        # One in_progress task (not in waiting_on_user) so the alert
+        # bumps the rollup to RED via the non-user-waiting branch.
+        task = SimpleNamespace(
+            task_id=f"{project_key}/1",
+            project=project_key,
+            task_number=1,
+            work_status="in_progress",
+            current_node_id="working",
+            owner="worker",
+            actor_type="agent",
+        )
+        alert = SimpleNamespace(
+            alert_type=f"stuck_on_task:{project_key}/1",
+            severity="warning",
+            message="stuck",
+        )
+
+        # Direct path the cockpit takes: rollup with alert overlay.
+        direct = rollup_project_state(
+            project_key,
+            [task],
+            actionable_task_alert_ids=frozenset([f"{project_key}/1"]),
+        )
+        assert direct.state is ProjectRailState.RED
+        assert direct.actionable_key == f"project:{project_key}:issues"
+
+        # Cached path: stub the refresher's task + alert sources so we
+        # can drive ``compute_entry_for_project`` synchronously.
+        monkeypatch.setattr(
+            refresh_impl, "_open_alerts_for", lambda config: [alert],
+        )
+
+        # Drive ``_categorize_and_rollup`` directly with the same task,
+        # which exercises the alert-id wiring without spinning up the
+        # full work-service slice machinery.
+        from pollypm.dashboard.categorization import ProjectState as _PS
+
+        def _fake_categorize_and_rollup(**kwargs: Any):
+            assert kwargs["actionable_alert_task_ids"] == frozenset(
+                [f"{project_key}/1"],
+            )
+            rollup = rollup_project_state(
+                project_key,
+                [task],
+                actionable_task_alert_ids=kwargs["actionable_alert_task_ids"],
+            )
+            return (
+                _PS.WORKING,
+                "",
+                "",
+                (
+                    rollup.state,
+                    rollup.badge,
+                    rollup.sort_rank,
+                    rollup.reason,
+                    rollup.approvals_pending,
+                    rollup.actionable_key,
+                ),
+                [],
+            )
+
+        monkeypatch.setattr(
+            refresh_impl,
+            "_categorize_and_rollup",
+            _fake_categorize_and_rollup,
+        )
+        monkeypatch.setattr(
+            refresh_impl, "_awaits_user_items_for", lambda key, config: [],
+        )
+
+        config = _make_config([project_key], tmp_path)
+        entry = refresh_impl.compute_entry_for_project(project_key, config)
+
+        # Parity: cached entry mirrors the direct rollup.
+        assert entry.rail_state is direct.state
+        assert entry.rail_badge == direct.badge
+        assert entry.rail_sort_rank == direct.sort_rank
+        assert entry.rail_reason == direct.reason
+        assert entry.actionable_key == direct.actionable_key
 
 
 class TestPr2026ReviewBlocker2HeartbeatNoStale:

--- a/tests/test_state_cache_refresher.py
+++ b/tests/test_state_cache_refresher.py
@@ -412,6 +412,147 @@ class TestWorkspaceRootInvalidation:
         # Both keys refreshed by the workspace-scoped invalidation.
         assert cache.version("__workspace__") == 2
         assert cache.version("alpha") == 2
+def test_full_refresh_calls_open_alerts_once_per_sweep(
+    audit_dir: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #2085 round-2 boundary fix.
+
+    A workspace-wide sweep must read the actionable-alert snapshot
+    ONCE per sweep, not once per project. Pre-fix
+    ``_open_alerts_for`` was called inside every per-project
+    ``compute_entry_for_project`` call — N projects × Supervisor
+    construction + open_alerts read, all under the cache lock.
+
+    This test wires a refresh function that forwards
+    ``alerts_snapshot`` through to ``compute_entry_for_project``-
+    shaped logic and asserts the sweep-level pre-fetch threads the
+    snapshot through every per-project refresh — counter increments
+    EXACTLY once for an N=3 sweep.
+    """
+
+    from pollypm.state_cache import refresh_impl
+
+    open_alerts_calls = {"n": 0}
+
+    def _counting_open_alerts(config: object) -> tuple[list[object], bool]:
+        open_alerts_calls["n"] += 1
+        return [], True
+
+    monkeypatch.setattr(refresh_impl, "_open_alerts_for", _counting_open_alerts)
+
+    seen_kwargs: list[dict[str, object]] = []
+
+    def _recording_refresh(key: str, **kwargs: object):
+        seen_kwargs.append(kwargs)
+        return empty_entry(key)
+
+    cache = ProjectStateCache(refresh_fn=_recording_refresh)
+    refresher = StateCacheRefresher(
+        cache,
+        audit_dir=audit_dir,
+        project_keys=lambda: ["alpha", "beta", "gamma"],
+        config_provider=lambda: object(),
+    )
+
+    refresher._initial_full_refresh()  # noqa: SLF001
+
+    # Three project keys, one alert read — the boundary contract.
+    assert open_alerts_calls["n"] == 1
+    assert len(seen_kwargs) == 3
+    for kwargs in seen_kwargs:
+        assert "alerts_snapshot" in kwargs
+        assert kwargs["alerts_snapshot"] == ([], True)
+
+
+def test_worker_once_calls_open_alerts_once_per_sweep(
+    audit_dir: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The worker drain path obeys the same N→1 boundary as the
+    initial full refresh — invalidating three projects in one tick
+    must result in exactly one workspace alert read.
+    """
+
+    from pollypm.state_cache import refresh_impl
+
+    open_alerts_calls = {"n": 0}
+
+    def _counting_open_alerts(config: object) -> tuple[list[object], bool]:
+        open_alerts_calls["n"] += 1
+        return [], True
+
+    monkeypatch.setattr(refresh_impl, "_open_alerts_for", _counting_open_alerts)
+
+    seen_kwargs: list[dict[str, object]] = []
+
+    def _recording_refresh(key: str, **kwargs: object):
+        seen_kwargs.append(kwargs)
+        return empty_entry(key)
+
+    cache = ProjectStateCache(refresh_fn=_recording_refresh)
+    # Seed the cache so workspace-scope invalidation (or direct
+    # ``invalidate(key)`` calls) can drain three keys in one tick.
+    for key in ("alpha", "beta", "gamma"):
+        cache._install_for_test(key, empty_entry(key))  # noqa: SLF001
+        cache.invalidate(key)
+
+    refresher = StateCacheRefresher(
+        cache,
+        audit_dir=audit_dir,
+        config_provider=lambda: object(),
+    )
+
+    refresher._worker_once()  # noqa: SLF001
+
+    # Three drained keys, one alert read.
+    assert open_alerts_calls["n"] == 1
+    assert len(seen_kwargs) == 3
+
+
+def test_single_project_sweep_skips_prefetch(
+    audit_dir: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One-project sweeps must NOT pay the sweep pre-fetch overhead.
+
+    Boundary contract: the pre-fetch only saves work when N > 1.
+    For a single-project drain (the common event-triggered case),
+    skipping the pre-fetch lets ``compute_entry_for_project`` do its
+    own on-demand read — identical cost to the pre-PR behaviour and
+    keeps the failure-degrade contract intact.
+    """
+
+    from pollypm.state_cache import refresh_impl
+
+    open_alerts_calls = {"n": 0}
+
+    def _counting_open_alerts(config: object) -> tuple[list[object], bool]:
+        open_alerts_calls["n"] += 1
+        return [], True
+
+    monkeypatch.setattr(refresh_impl, "_open_alerts_for", _counting_open_alerts)
+
+    seen_kwargs: list[dict[str, object]] = []
+
+    def _recording_refresh(key: str, **kwargs: object):
+        seen_kwargs.append(kwargs)
+        return empty_entry(key)
+
+    cache = ProjectStateCache(refresh_fn=_recording_refresh)
+    cache._install_for_test("alpha", empty_entry("alpha"))  # noqa: SLF001
+    cache.invalidate("alpha")
+
+    refresher = StateCacheRefresher(
+        cache,
+        audit_dir=audit_dir,
+        config_provider=lambda: object(),
+    )
+
+    refresher._worker_once()  # noqa: SLF001
+
+    # Single-key drain → sweep pre-fetch skipped, refresh function
+    # called without ``alerts_snapshot`` (the per-project path will
+    # do its own read).
+    assert open_alerts_calls["n"] == 0
+    assert seen_kwargs == [{}]
 
 
 def test_concurrent_writes_and_reads_during_tail(audit_dir: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #2049 — PR #2026 review blocker 1 follow-up.

PR #2026 introduced a workaround in ``cockpit_rail._maybe_cache_route_rollups``
that declined the state-cache fast-path for the *entire* rail render
whenever any tracked project had a live actionable task alert
(``stuck_on_task:<project>/<n>`` or
``no_session_for_assignment:<project>/<n>``). The workaround killed the
cache benefit during the most common rail state.

This PR implements Option 1 from the issue: cache the alert overlay
in the refresher so the cached entry is authoritative.

- ``compute_entry_for_project`` gathers workspace alerts via
  ``Supervisor.open_alerts()`` and folds the per-project
  ``actionable_task_alert_ids`` into ``rollup_project_state`` at
  compute time.
- New ``actionable_key`` field on ``ProjectStateCacheEntry`` carries
  the alert-driven ``project:<key>:issues`` route id.
- The rollup tuple grows from 5 to 6 slots — the new slot is opt-in
  (``None`` when the compute fails) so legacy paths stay safe.
- ``_maybe_cache_route_rollups`` no longer declines on alert presence;
  it reads ``entry.actionable_key`` and ``entry.rail_*`` as the
  authoritative answer.

## Tests

- Inverted ``TestPr2026ReviewBlocker1ActionableAlertFallthrough`` →
  ``TestActionableAlertCachedRollupParity``: the cache now serves the
  alert-informed rollup instead of declining.
- Added ``TestActionableAlertRefresherParity`` pinning that
  ``compute_entry_for_project`` produces ``rail_state`` /
  ``rail_badge`` / ``rail_sort_rank`` / ``rail_reason`` /
  ``actionable_key`` identical to ``rollup_project_state``'s direct
  return for a project with a ``stuck_on_task:`` alert.

Local run: ``pytest tests/test_state_cache_parity.py tests/test_state_cache.py tests/test_state_cache_refresher.py tests/test_state_cache_config_identity.py tests/test_cockpit_project_state.py`` — **all green** (102 passed).

## Known limitation

Alert-state changes that don't accompany a task event don't fire an
audit-log event today, so the cache may serve a stale ``rail_state``
for up to one sweep cycle when alerts change orthogonally. In practice
the operational alerts in scope (``stuck_on_task:`` /
``no_session_for_assignment:``) co-occur with task / session events
that already invalidate the cache. Wiring alert-lifecycle audit events
into ``_INVALIDATING_EVENTS`` is a separate follow-up — adding emit
calls to the store backends would touch sensitive code paths during V1
RC stability.

## Heads-up

This branch is based on current ``main`` (2330e97d7). PR #2078
(``state_cache/refresh_impl.py``) and PR #2080 (``cockpit_rail.py``)
have open conflicts in the same regions — if either merges first, this
PR will need a rebase. That's expected; the human resolves at
integration.

## Test plan

- [x] Targeted: ``pytest tests/test_state_cache_parity.py`` (42 passed)
- [x] Targeted: ``pytest tests/test_state_cache.py tests/test_state_cache_refresher.py`` (27 passed)
- [x] Cross-cutting: ``pytest tests/test_state_cache_config_identity.py tests/test_cockpit_project_state.py`` (33 passed)
- [ ] CI on PR run