### PR TITLE
feat(chat-api): wire include_thinking through route + OpenAPI (closes #2082)

### DIFF
--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -219,21 +219,13 @@ Pull a window of messages from a single session's transcript.
 | `limit` | `100` | Max messages, must be `1..500`. Values outside that range return `422 validation_error` (FastAPI Pydantic-level rejection). |
 | `direction` | `desc` | `desc` (newest first) or `asc`. Pagination cursors assume the same direction. |
 | `include_subagents` | `false` | When `true`, each `subagent_result` envelope's `metadata.subagent_transcript` is populated by parsing the raw Claude JSONL the parent `task-notification.output-file` points at. Paths outside the project/workspace transcript allowlist are silently skipped. Capped per envelope. (#2052) |
+| `include_thinking` | `false` | When `true`, Anthropic extended-thinking blocks are emitted as `type=thinking` envelopes alongside the normal turns. Default `false` preserves the historical envelope contract so existing clients see no new types unless they opt in. See §4 type catalog and #2082. |
 | `source` | `auto` | `auto` (JSONL with capture fallback when archive is missing or >60s stale), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). Any other value returns `422 validation_error`. |
 
-> Note: Anthropic extended-thinking blocks are preserved by the
-> ingestor and surfaced by `parse_events_jsonl(include_thinking=True)`
-> as a **parser-internal** discriminator
-> (`ParserInternalType.THINKING`, see #2048). They are intentionally
-> NOT part of the HTTP-public `ChatMessageType` enum — the route calls
-> the parser with the default (`include_thinking=False`) and
-> additionally filters out any parser-internal-type envelopes before
-> serialization. Promoting `thinking` into the public catalog +
-> wiring an `include_thinking` query param through the route + OpenAPI
-> schema is tracked in
-> [#2082](https://github.com/samhotchkiss/pollypm/issues/2082). Until
-> that lands, clients of `GET /messages` will never see
-> `type="thinking"` envelopes regardless of query string.
+> Note: `thinking` envelopes are gated behind `?include_thinking=true`.
+> Clients that do not pass the flag will not see `type="thinking"`
+> rows in the response, preserving the historical envelope contract
+> (see #2048 / #2082).
 
 **Response:**
 
@@ -405,7 +397,7 @@ which variant the envelope represents and what shape `metadata` takes.
   "ts": "2026-05-21T20:53:12.123Z",
   "role": "user" | "assistant" | "tool" | "system",
   "actor": "Sam" | "Polly" | "Archie" | "Codex" | "system",
-  "type": "text" | "tool_use" | "tool_result" | "ask_user" | "file" | "subagent_spawn" | "subagent_result" | "system_event",
+  "type": "text" | "tool_use" | "tool_result" | "ask_user" | "file" | "subagent_spawn" | "subagent_result" | "system_event" | "thinking",
   "text": "...display-ready string...",
   "metadata": { "...": "type-specific" }
 }
@@ -428,16 +420,7 @@ structured original lives in `metadata`.
 | `subagent_spawn` | assistant | `Task` tool call | `metadata`: `subagent_id`, `subagent_type`, `description`, `prompt`, `isolation`. |
 | `subagent_result` | tool | `Task` tool return | `metadata`: `subagent_id`, `summary`, `duration_ms`, `total_tokens`, `worktree_path`, `output_file`. With `?include_subagents=true`: `metadata.subagent_transcript` carries envelopes parsed from the raw subagent JSONL at `output_file` (#2052). |
 | `system_event` | system | Compaction, session-start, error | `metadata.subtype` ∈ `compaction`, `session_start`, `session_resume`, `error`. |
-
-> Parser-internal discriminator: Anthropic extended-thinking blocks
-> are preserved by the ingestor and surfaced by
-> `parse_events_jsonl(include_thinking=True)` as
-> `ParserInternalType.THINKING` (`src/pollypm/web_api/chat/envelope.py`).
-> This is **not** an HTTP response `type` value — the chat-messages
-> route filters parser-internal-type envelopes out before serialization,
-> and the OpenAPI `ChatMessageType` enum does not include it. Promoting
-> `thinking` into the public catalog is tracked in
-> [#2082](https://github.com/samhotchkiss/pollypm/issues/2082).
+| `thinking` | assistant | Anthropic extended-thinking block (#2048) | Only emitted when the request passes `?include_thinking=true`. `metadata`: `provider`, `model`, `signature` (opaque). Default `include_thinking=false` drops these so historical clients see no new types. See #2082. |
 
 ### Example payloads
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -726,6 +726,18 @@ paths:
             subagent transcript should query its own session via
             `/api/v1/chat/sessions`. See issue #2052.
         - in: query
+          name: include_thinking
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: |
+            When `true`, Anthropic extended-thinking blocks are emitted
+            as `type=thinking` envelopes alongside the normal turns.
+            Default `false` preserves the historical envelope contract
+            so existing clients see no new types unless they opt in.
+            See issues #2048 / #2082.
+        - in: query
           name: source
           schema:
             type: string
@@ -3158,15 +3170,10 @@ components:
         `tests/web_api/test_openapi_conformance.py::test_chat_message_type_enum_matches_runtime`
         asserts set equality so future drift trips CI.
 
-        `thinking` is intentionally **not** in this enum. The
-        transcript ingestor preserves Anthropic extended-thinking
-        blocks and the parser exposes them under
-        `parse_events_jsonl(include_thinking=True)`, but as a
-        parser-internal discriminator
-        (`ParserInternalType.THINKING`) that the chat-messages route
-        filters out before serialization. Promoting `thinking` into
-        this public enum + wiring an `include_thinking` query param
-        through the route is tracked in follow-up #2082.
+        `thinking` envelopes carry Anthropic extended-thinking blocks
+        and are only emitted when the request opts in via
+        `?include_thinking=true` (default: false). See issues #2048 /
+        #2082.
       enum:
         - text
         - tool_use
@@ -3176,6 +3183,7 @@ components:
         - subagent_spawn
         - subagent_result
         - system_event
+        - thinking
 
     ChatMessageEnvelope:
       type: object

--- a/src/pollypm/web_api/chat/__init__.py
+++ b/src/pollypm/web_api/chat/__init__.py
@@ -5,13 +5,11 @@ P1 ships the read-side primitives the chat endpoints (P2) compose:
 - :mod:`envelope` — the uniform :class:`MessageEnvelope` dataclass and
   the HTTP-public type discriminators (``text``, ``tool_use``,
   ``tool_result``, ``ask_user``, ``file``, ``subagent_spawn``,
-  ``subagent_result``, ``system_event``) per spec §3, plus the
-  parser-internal :class:`ParserInternalType` enum (today:
-  ``thinking``). :func:`parse_events_jsonl` may emit envelopes whose
-  ``type`` is a :class:`ParserInternalType` member under explicit
-  opt-in flags (``include_thinking=True``); the chat-messages route
-  filters those out before serialization so the wire catalog stays
-  closed to :class:`MessageType`. See GitHub #2048 / #2082.
+  ``subagent_result``, ``system_event``, ``thinking``) per spec §3.
+  ``thinking`` envelopes are emitted by :func:`parse_events_jsonl` only
+  under explicit ``include_thinking=True`` opt-in (see GitHub #2048 /
+  #2082); the chat-messages route surfaces this as the
+  ``include_thinking`` query param so default callers never see them.
 - :mod:`registry` — enumerates every live chat surface (operator,
   architect, advisor, worker) into :class:`ChatSurface` dataclasses,
   resolving the tmux window + transcript path for each.
@@ -29,11 +27,9 @@ router be a thin adapter.
 from __future__ import annotations
 
 from pollypm.web_api.chat.envelope import (
-    PARSER_INTERNAL_TYPE_VALUES,
     MessageEnvelope,
     MessageRole,
     MessageType,
-    ParserInternalType,
 )
 from pollypm.web_api.chat.registry import (
     ChatSurface,
@@ -56,13 +52,11 @@ from pollypm.web_api.chat.transcripts import (
 )
 
 __all__ = [
-    "PARSER_INTERNAL_TYPE_VALUES",
     "STALE_THRESHOLD_SECONDS",
     "ChatSurface",
     "MessageEnvelope",
     "MessageRole",
     "MessageType",
-    "ParserInternalType",
     "SurfaceType",
     "capture_envelopes",
     "enumerate_chat_surfaces",

--- a/src/pollypm/web_api/chat/envelope.py
+++ b/src/pollypm/web_api/chat/envelope.py
@@ -6,27 +6,15 @@ shape mirrors spec §3 verbatim so the JSON serialization (handled by
 :mod:`pollypm.web_api.chat` consumers / the P2 router) is a direct
 ``dataclasses.asdict`` away.
 
-Nine discriminators are defined in :class:`MessageType`. Each
+The HTTP-public discriminators are defined in :class:`MessageType`. Each
 envelope's ``metadata`` payload is type-specific; callers branch on
 ``envelope.type`` to interpret it.
 
-Parser-internal discriminators
-------------------------------
-
-:class:`ParserInternalType` mirrors the public ``MessageType`` shape
-(``StrEnum`` with ``.value`` semantics) but is intentionally NOT part
-of the HTTP-public catalog. ``parse_events_jsonl`` may emit envelopes
-whose ``type`` is a :class:`ParserInternalType` member when the caller
-asks for it (today: ``include_thinking=True`` surfaces Anthropic
-extended-thinking blocks under
-:attr:`ParserInternalType.THINKING`). The chat-messages route
-defensively drops these before serialization so the wire contract — and
-the ``ChatMessageType`` enum in ``docs/api/openapi.yaml`` — stays
-exactly equal to the public :class:`MessageType` value set. Follow-up
-#2082 will wire ``thinking`` through the public route + OpenAPI; until
-then keeping the parser/route catalogs split is the documented
-invariant pinned by
-``tests/web_api/test_openapi_conformance.py::test_chat_message_type_enum_matches_runtime``.
+``thinking`` envelopes (Anthropic extended-thinking blocks) are emitted
+by :func:`parse_events_jsonl` only when callers pass
+``include_thinking=True``; the chat-messages route exposes this as the
+``include_thinking`` query param (default ``False``) so callers opt in
+explicitly. See GitHub #2048 / #2082.
 """
 
 from __future__ import annotations
@@ -53,10 +41,12 @@ class MessageType(StrEnum):
     updating the OpenAPI contract (and vice-versa) trips
     ``test_chat_message_type_enum_matches_runtime``.
 
-    Parser-only discriminators (today: ``thinking``) live on
-    :class:`ParserInternalType` instead so the public/wire enum stays
-    closed until follow-up issues (#2082 for thinking) wire them through
-    the endpoint contract.
+    ``thinking`` envelopes (Anthropic extended-thinking blocks, see
+    GitHub #2048 / #2082) are only emitted by
+    :func:`parse_events_jsonl` when callers pass ``include_thinking=True``;
+    the chat-messages route exposes this via the ``include_thinking``
+    query param. Clients that do not opt in never see this type in the
+    wire response.
     """
 
     TEXT = "text"
@@ -67,37 +57,7 @@ class MessageType(StrEnum):
     SUBAGENT_SPAWN = "subagent_spawn"
     SUBAGENT_RESULT = "subagent_result"
     SYSTEM_EVENT = "system_event"
-
-
-class ParserInternalType(StrEnum):
-    """Parser-internal envelope discriminators.
-
-    Values here are emitted by :func:`parse_events_jsonl` under explicit
-    opt-in flags but are NOT part of the HTTP-public response catalog
-    (``ChatMessageType`` in ``docs/api/openapi.yaml``). The
-    chat-messages route filters envelopes whose ``type`` is in
-    :data:`PARSER_INTERNAL_TYPE_VALUES` before serialization so generated
-    HTTP clients never see them.
-
-    Today this enum holds the single value ``thinking`` (Anthropic
-    extended-thinking blocks, GitHub #2048). Follow-up #2082 will
-    promote ``thinking`` into the public :class:`MessageType` and wire
-    the matching ``include_thinking`` query param + OpenAPI enum entry
-    through the route. At that point this enum can shrink (or be
-    removed) and the route filter relaxed accordingly.
-    """
-
     THINKING = "thinking"
-
-
-# Frozen string set of parser-internal type values — used by the
-# chat-messages route to drop envelopes that should not cross the HTTP
-# boundary. Keeping it as a ``frozenset[str]`` (rather than reaching
-# back to the enum) means callers can compare against a serialized
-# envelope's ``type`` field without re-importing the enum.
-PARSER_INTERNAL_TYPE_VALUES: frozenset[str] = frozenset(
-    member.value for member in ParserInternalType
-)
 
 
 @dataclass(slots=True)
@@ -121,9 +81,7 @@ class MessageEnvelope:
     ``"system"``, etc.). The registry layer fills this in based on
     surface type when the event itself doesn't carry it.
 
-    ``type`` — one of :class:`MessageType` (HTTP-public) or
-    :class:`ParserInternalType` (parser-only; filtered by the route).
-    Chooses the metadata shape.
+    ``type`` — one of :class:`MessageType`. Chooses the metadata shape.
 
     ``text`` — always populated with a display-ready string. For
     tool calls this is a one-liner like ``"[Bash] git status"``; for
@@ -138,7 +96,7 @@ class MessageEnvelope:
     ts: str
     role: MessageRole
     actor: str
-    type: MessageType | ParserInternalType
+    type: MessageType
     text: str
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -158,6 +116,4 @@ __all__ = [
     "MessageEnvelope",
     "MessageRole",
     "MessageType",
-    "PARSER_INTERNAL_TYPE_VALUES",
-    "ParserInternalType",
 ]

--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -36,13 +36,12 @@ the following non-trivial mappings:
 - Claude ``SendUserFile`` tool calls become ``file`` envelopes.
 - Compaction / session-start markers become ``system_event``.
 - ``thinking`` ingestor events (Anthropic extended-thinking content
-  blocks; see GitHub #2048) become :class:`ParserInternalType.THINKING`
+  blocks; see GitHub #2048) become :attr:`MessageType.THINKING`
   envelopes, but ONLY when callers pass ``include_thinking=True`` —
   default drops them so the historical envelope contract is preserved.
-  Thinking is a parser-internal discriminator (not part of the public
-  ``MessageType`` enum / ``ChatMessageType`` OpenAPI schema); the
-  chat-messages route additionally filters it out before serialization
-  until follow-up #2082 wires the HTTP-public path.
+  The chat-messages route exposes this as the ``include_thinking``
+  query parameter (default ``False``), and ``thinking`` is part of the
+  public ``ChatMessageType`` OpenAPI enum (#2082).
 
 The parser is pure: takes a file path + flags, returns a list of
 envelopes. The P2 router layers pagination / filtering on top.
@@ -63,7 +62,6 @@ from pollypm.web_api.chat.envelope import (
     MessageEnvelope,
     MessageRole,
     MessageType,
-    ParserInternalType,
 )
 
 logger = logging.getLogger(__name__)
@@ -354,15 +352,13 @@ def parse_events_jsonl(
     callers also skip the mtime cache so validation paths always see a
     fresh parse.
 
-    ``include_thinking`` (default ``False``; see GitHub #2048) — when
-    ``True``, Anthropic extended-thinking content blocks preserved by
-    the ingestor as ``event_type="thinking"`` are surfaced as
-    :class:`ParserInternalType.THINKING` envelopes — a parser-internal
-    discriminator that is intentionally NOT in the HTTP-public
-    :class:`MessageType` catalog. The chat-messages route filters these
-    out before serialization until follow-up #2082 wires the public
-    route. The default keeps the historical envelope contract: existing
-    callers (and HTTP clients) see no new types.
+    ``include_thinking`` (default ``False``; see GitHub #2048 / #2082)
+    — when ``True``, Anthropic extended-thinking content blocks
+    preserved by the ingestor as ``event_type="thinking"`` are surfaced
+    as :attr:`MessageType.THINKING` envelopes. The chat-messages route
+    exposes this as the ``include_thinking`` query parameter; the
+    default keeps the historical envelope contract so existing callers
+    (and HTTP clients) see no new types.
 
     Caching (issue #2069): for ``strict=False`` callers we memoize on
     ``(events_path, include_thinking, mtime, actor_fallback)``. The
@@ -835,10 +831,11 @@ def _envelope_thinking(
     thinking content directly so the same "dumb client renders ``text``
     without parsing metadata" contract holds.
 
-    The envelope's ``type`` is :class:`ParserInternalType.THINKING`, a
-    parser-internal discriminator intentionally NOT in the HTTP-public
-    :class:`MessageType` enum. The chat-messages route drops these
-    envelopes before serialization (see #2082).
+    The envelope's ``type`` is :attr:`MessageType.THINKING`, which is
+    part of the HTTP-public ``ChatMessageType`` enum. The chat-messages
+    route gates emission on the ``include_thinking`` query parameter
+    (#2082); the parser itself only emits thinking envelopes when its
+    own ``include_thinking=True`` flag is set.
     """
     text = str(payload.get("text") or "")
     signature = str(payload.get("signature") or "")
@@ -847,7 +844,7 @@ def _envelope_thinking(
         ts=timestamp,
         role=MessageRole.ASSISTANT,
         actor=actor_fallback,
-        type=ParserInternalType.THINKING,
+        type=MessageType.THINKING,
         text=text,
         metadata={
             "provider": event.get("provider", ""),

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -37,7 +37,6 @@ from pydantic import BaseModel, Field
 
 from pollypm.tmux.client import TmuxClient
 from pollypm.web_api.chat import (
-    PARSER_INTERNAL_TYPE_VALUES,
     STALE_THRESHOLD_SECONDS,
     ChatSurface,
     MessageEnvelope,
@@ -71,8 +70,7 @@ MAX_MESSAGE_LIMIT = 500
 # the common cockpit-poll shape. For requests under this threshold we
 # tail-read the JSONL archive instead of forward-readlining the full
 # file. The forward parser stays authoritative for ``asc``, cursor
-# paging, ``include_thinking``-style large-window queries, and the
-# strict ``source=jsonl`` validation path.
+# paging, and the strict ``source=jsonl`` validation path.
 TAIL_READ_LIMIT_THRESHOLD = 200
 
 
@@ -523,6 +521,7 @@ def _load_envelopes(
     *,
     source: SourceMode,
     tail_hint: int | None = None,
+    include_thinking: bool = False,
 ) -> tuple[list[MessageEnvelope], str | None, Path | None]:
     """Return ``(envelopes, transcript_source, transcript_path)``.
 
@@ -540,15 +539,13 @@ def _load_envelopes(
     cursor + small ``limit`` at the call site (the helper doesn't
     re-check those conditions).
 
-    NOTE: this helper calls ``parse_events_jsonl`` /
-    ``parse_events_jsonl_tail`` with the default
-    ``include_thinking=False`` (the public ``include_thinking`` query
-    param is still parked until #2082 wires it through the route +
-    OpenAPI). Any thinking envelopes that slip past the parser are
-    additionally dropped downstream in
-    :func:`_apply_filters_and_paginate` via the parser-internal-type
-    filter, so the HTTP response catalog stays equal to the public
-    :class:`MessageType` enum.
+    ``include_thinking`` (issue #2082): forwarded straight to
+    :func:`parse_events_jsonl` / :func:`parse_events_jsonl_tail`. When
+    ``True``, Anthropic extended-thinking blocks are surfaced as
+    ``MessageType.THINKING`` envelopes; when ``False`` (default), they
+    are dropped at parse time. The parser caches separately for each
+    flag value, so a default-False request never sees a thinking-True
+    cache hit and vice versa.
     """
     archive = surface.transcript_path
     actor_fallback = surface.persona or "agent"
@@ -561,6 +558,7 @@ def _load_envelopes(
                 archive,
                 actor_fallback=actor_fallback,
                 strict=True,
+                include_thinking=include_thinking,
             )
         except OSError as exc:
             # The archive exists but we can't read it (permissions,
@@ -597,11 +595,13 @@ def _load_envelopes(
                 archive,
                 limit=tail_hint,
                 actor_fallback=actor_fallback,
+                include_thinking=include_thinking,
             )
         else:
             envelopes = parse_events_jsonl(
                 archive,
                 actor_fallback=actor_fallback,
+                include_thinking=include_thinking,
             )
         if envelopes:
             return envelopes, "jsonl", archive
@@ -619,6 +619,7 @@ def _load_envelopes(
                 archive,
                 actor_fallback=actor_fallback,
                 strict=True,
+                include_thinking=include_thinking,
             )
         except OSError:
             logger.debug(
@@ -641,6 +642,7 @@ def _load_envelopes(
         envelopes = parse_events_jsonl(
             archive,
             actor_fallback=actor_fallback,
+            include_thinking=include_thinking,
         )
         return envelopes, "jsonl", archive
     return [], None, None
@@ -714,26 +716,21 @@ def _apply_filters_and_paginate(
     direction — applying ``since_id`` in source order would slice the
     wrong half for ``direction=desc``, duplicating page 1 on page 2):
 
-    1. Drop envelopes whose ``type`` is in
-       :data:`PARSER_INTERNAL_TYPE_VALUES` — these are parser-internal
-       discriminators (today: ``thinking``, from
-       ``parse_events_jsonl(include_thinking=True)``, #2048) that are
-       intentionally NOT part of the HTTP-public ``MessageType`` /
-       ``ChatMessageType`` catalog. Filtering here keeps the public
-       wire enum exactly equal to the OpenAPI ``ChatMessageType`` enum
-       (pinned by ``test_chat_message_type_enum_matches_runtime``)
-       until follow-up #2082 promotes ``thinking`` into the public
-       catalog and wires the ``include_thinking`` query param.
-    2. ``since`` lower-bound on envelope ``ts``.
-    3. Sort by timestamp + position. JSONL ordering is already
+    1. ``since`` lower-bound on envelope ``ts``.
+    2. Sort by timestamp + position. JSONL ordering is already
        chronological; we re-sort defensively so the response is
        deterministic even when the parser returns shuffled rows.
-    4. Reverse for ``direction=desc``.
-    5. ``since_id`` cursor walk — strictly after the matching id in
+    3. Reverse for ``direction=desc``.
+    4. ``since_id`` cursor walk — strictly after the matching id in
        the ordered sequence (the cursor itself is excluded from the
        slice, matching the ``next_cursor`` semantics of the inbox
        endpoint).
-    6. Slice to ``limit`` and compute ``has_more`` / ``next_cursor``.
+    5. Slice to ``limit`` and compute ``has_more`` / ``next_cursor``.
+
+    NOTE: ``thinking`` envelopes are gated upstream in
+    :func:`_load_envelopes` via the ``include_thinking`` flag on the
+    parser (#2082) — they never reach this helper unless the caller
+    opted in.
 
     NOTE: subagent inlining lives in
     :func:`_inline_subagent_transcript` and runs in the endpoint after
@@ -752,8 +749,6 @@ def _apply_filters_and_paginate(
 
     filtered: list[MessageEnvelope] = []
     for envelope in envelopes:
-        if str(envelope.type) in PARSER_INTERNAL_TYPE_VALUES:
-            continue
         if since_aware is not None:
             ts = _parse_envelope_ts(envelope.ts)
             if ts is None:
@@ -1041,6 +1036,14 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
             "workspace transcript roots (issue #2052)."
         ),
     )] = False,
+    include_thinking: Annotated[bool, Query(
+        description=(
+            "When true, Anthropic extended-thinking blocks are emitted "
+            "as `type=thinking` envelopes alongside the normal turns. "
+            "Default false preserves the historical envelope contract — "
+            "callers must opt in explicitly. See issues #2048 / #2082."
+        ),
+    )] = False,
 ) -> ChatMessagesResponse:
     """GET /api/v1/chat/{session_name}/messages per spec §2.2."""
     surface = _find_surface(config, session_name)
@@ -1064,7 +1067,10 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
         tail_hint = limit + 1
 
     envelopes, transcript_source, transcript_path = _load_envelopes(
-        surface, source=source, tail_hint=tail_hint,
+        surface,
+        source=source,
+        tail_hint=tail_hint,
+        include_thinking=include_thinking,
     )
 
     post_process: Any = None

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -234,22 +234,27 @@ def patch_registry(monkeypatch: pytest.MonkeyPatch):
 def patch_parser(monkeypatch: pytest.MonkeyPatch):
     """Factory installing a stub for ``parse_events_jsonl``.
 
-    Signature mirrors what the chat-messages route actually calls
-    today (:func:`pollypm.web_api.chat.transcripts.parse_events_jsonl`
-    with ``actor_fallback`` + ``strict`` only). The real parser also
-    accepts an ``include_thinking`` kwarg (restored in #2048 — this
-    PR), but the route does not pass it: thinking promotion to the
-    HTTP surface is deferred to #2082. Tests that need real parser
-    behavior (Blocker 1) drive the on-disk parser directly via a JSONL
-    fixture instead of installing this stub.
+    Signature mirrors the real parser on main
+    (:func:`pollypm.web_api.chat.transcripts.parse_events_jsonl`),
+    including the ``include_thinking`` knob the route plumbs through
+    (#2082). Tests that need real parser behavior (Blocker 1) drive
+    the on-disk parser directly via a JSONL fixture instead of
+    installing this stub.
     """
     def install(envelopes_by_path: dict[Path, list[MessageEnvelope]]) -> None:
-        def fake(path, *, actor_fallback="agent", strict=False):
+        def fake(
+            path, *, actor_fallback="agent", strict=False,
+            include_thinking=False,
+        ):
             # ``strict`` is accepted for forward-compat with the
             # ``source=auto`` unreadable-archive fallback added in the
             # round-6 fix; this stub treats it as a no-op (returns the
-            # same envelopes regardless of strict mode).
-            del strict
+            # same envelopes regardless of strict mode). Likewise the
+            # ``include_thinking`` flag is accepted so the route's
+            # plumbing path (#2082) doesn't trip a TypeError; the stub
+            # returns the same list either way and individual tests
+            # assert the route's filtering / non-filtering behavior.
+            del strict, include_thinking
             return list(envelopes_by_path.get(Path(path), []))
         monkeypatch.setattr(
             chat_messages_routes, "parse_events_jsonl", fake,
@@ -579,32 +584,63 @@ def test_messages_endpoint_accepts_limit_500(
 # ---------------------------------------------------------------------------
 
 
-def test_messages_endpoint_drops_thinking_envelopes(
-    client, auth_headers, patch_registry, patch_parser, tmp_path,
+def test_messages_endpoint_drops_thinking_envelopes_by_default(
+    client, auth_headers, patch_registry, tmp_path,
 ):
-    """Thinking blocks are filtered out at the HTTP route boundary.
+    """Default ``include_thinking=false`` — thinking envelopes are
+    gated at the parser layer and never reach the response.
 
-    As of #2048 (this PR) the parser CAN emit
-    :class:`ParserInternalType.THINKING` envelopes when callers pass
-    ``include_thinking=True`` to ``parse_events_jsonl``. The
-    ``GET /messages`` route, however, still calls the parser with the
-    default ``include_thinking=False`` AND defensively drops any
-    parser-internal types downstream, so the public response catalog
-    stays equal to the public :class:`MessageType` enum. Promoting
-    thinking blocks onto the HTTP surface (route query param + OpenAPI
-    enum entry) is parked until follow-up #2082.
+    Drives the real parser via an on-disk JSONL fixture so the route's
+    default-False call to ``parse_events_jsonl`` is exercised end-to-end.
     """
+    import json as _json
+
     archive = tmp_path / "events.jsonl"
-    archive.write_text("x")
-    envelopes = [
-        _env("t", type_="thinking", text="(thinking)"),
-        _env("text", type_=MessageType.TEXT, text="visible"),
+    events = [
+        {
+            "timestamp": "2026-05-21T10:00:00Z",
+            "event_type": "thinking",
+            "session_id": "s",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": "/tmp/raw.jsonl",
+            "source_offset": 0,
+            "cwd": "/tmp/repo",
+            "model_name": "claude-opus-4-7",
+            "payload": {
+                "text": "I should think first.",
+                "signature": "opaque",
+                "raw": {
+                    "type": "thinking",
+                    "thinking": "I should think first.",
+                    "signature": "opaque",
+                },
+            },
+        },
+        {
+            "timestamp": "2026-05-21T10:00:01Z",
+            "event_type": "assistant_turn",
+            "session_id": "s",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": "/tmp/raw.jsonl",
+            "source_offset": 1,
+            "cwd": "/tmp/repo",
+            "model_name": "claude-opus-4-7",
+            "payload": {"text": "Public reply."},
+        },
     ]
+    archive.write_text("\n".join(_json.dumps(ev) for ev in events) + "\n")
     patch_registry([_surface(
         "operator", SurfaceType.OPERATOR, persona="Polly",
         transcript_path=archive,
     )])
-    patch_parser({archive: envelopes})
+    # NOTE: no patch_parser — drive the real parser so the
+    # default-False include_thinking branch is exercised.
+    from pollypm.web_api.chat.transcripts import _parse_cache_clear
+    _parse_cache_clear()
     body = client.get(
         "/api/v1/chat/operator/messages?direction=asc",
         headers=auth_headers,
@@ -614,39 +650,73 @@ def test_messages_endpoint_drops_thinking_envelopes(
     assert "text" in types
 
 
-def test_messages_endpoint_rejects_include_thinking_query_param(
-    client, auth_headers, patch_registry, patch_parser, tmp_path,
+def test_messages_endpoint_emits_thinking_envelopes_when_include_thinking_true(
+    client, auth_headers, patch_registry, tmp_path,
 ):
-    """``include_thinking`` is not yet exposed on the HTTP route.
+    """Opt-in ``include_thinking=true`` — thinking envelopes appear in
+    the response alongside normal turns (#2082).
 
-    #2048 (this PR) restored parser-level support for thinking blocks
-    via :class:`ParserInternalType.THINKING`, but promoting them onto
-    the HTTP surface — wiring an ``include_thinking`` query param and
-    adding ``thinking`` to the OpenAPI ``MessageType`` enum — is
-    deferred to follow-up #2082. FastAPI ignores unknown query params
-    by default, so we confirm passing the param has no effect: the
-    route still calls the parser with ``include_thinking=False`` and
-    filters parser-internal types, so ``thinking`` never appears in
-    the response.
+    Drives the real parser via an on-disk JSONL fixture so the route's
+    plumbing of the flag into ``parse_events_jsonl`` is exercised
+    end-to-end.
     """
+    import json as _json
+
     archive = tmp_path / "events.jsonl"
-    archive.write_text("x")
-    envelopes = [
-        _env("t", type_="thinking", text="(thinking)"),
-        _env("text", type_=MessageType.TEXT, text="visible"),
+    events = [
+        {
+            "timestamp": "2026-05-21T10:00:00Z",
+            "event_type": "thinking",
+            "session_id": "s",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": "/tmp/raw.jsonl",
+            "source_offset": 0,
+            "cwd": "/tmp/repo",
+            "model_name": "claude-opus-4-7",
+            "payload": {
+                "text": "I should think first.",
+                "signature": "opaque",
+                "raw": {
+                    "type": "thinking",
+                    "thinking": "I should think first.",
+                    "signature": "opaque",
+                },
+            },
+        },
+        {
+            "timestamp": "2026-05-21T10:00:01Z",
+            "event_type": "assistant_turn",
+            "session_id": "s",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": "/tmp/raw.jsonl",
+            "source_offset": 1,
+            "cwd": "/tmp/repo",
+            "model_name": "claude-opus-4-7",
+            "payload": {"text": "Public reply."},
+        },
     ]
+    archive.write_text("\n".join(_json.dumps(ev) for ev in events) + "\n")
     patch_registry([_surface(
         "operator", SurfaceType.OPERATOR, persona="Polly",
         transcript_path=archive,
     )])
-    patch_parser({archive: envelopes})
+    from pollypm.web_api.chat.transcripts import _parse_cache_clear
+    _parse_cache_clear()
     body = client.get(
         "/api/v1/chat/operator/messages?include_thinking=true&direction=asc",
         headers=auth_headers,
     ).json()
     types = [m["type"] for m in body["messages"]]
-    # include_thinking has no effect — thinking is still filtered out.
-    assert "thinking" not in types
+    # Both the thinking envelope and the assistant turn surface, in order.
+    assert types == ["thinking", "text"]
+    thinking_msg = body["messages"][0]
+    assert thinking_msg["role"] == "assistant"
+    assert thinking_msg["text"] == "I should think first."
+    assert thinking_msg["metadata"]["signature"] == "opaque"
 
 
 def test_messages_endpoint_no_subagent_inlining_by_default(
@@ -1432,11 +1502,10 @@ def test_messages_endpoint_source_auto_still_fail_soft_on_capture_error(
 #
 # The fixtures above monkeypatch ``parse_events_jsonl`` /
 # ``capture_envelopes`` for speed and isolation. The two tests below
-# pin the production wiring by driving the REAL helpers — a
-# monkeypatch with a stale signature (e.g. accepting an
-# ``include_thinking`` kwarg the route doesn't pass) or a fake
-# capture that raised instead of the real fail-soft helper previously
-# hid two TypeError / silent-empty bugs in production.
+# pin the production wiring by driving the REAL helpers — a fake
+# capture that raised instead of the real fail-soft helper (or a
+# parser-stub signature mismatch like the one Blocker 1 caught)
+# previously hid TypeError / silent-empty bugs in production.
 # ---------------------------------------------------------------------------
 
 
@@ -1445,16 +1514,12 @@ def test_messages_endpoint_jsonl_uses_real_parser_no_typeerror(
 ):
     """REAL ``parse_events_jsonl`` call — Blocker 1 regression.
 
-    Historically the route's call signature drifted from the real
-    parser's (e.g. the route briefly passed ``include_thinking=...``
-    when the parser had dropped the kwarg in #2044). Tests passed
-    because the fixture stub silently accepted the extra kwarg; in
-    production every ``source=jsonl`` request raised ``TypeError``.
-    #2048 (this PR) restored ``include_thinking`` on the parser, but
-    the route still does NOT pass it — promoting thinking blocks to
-    the HTTP surface is deferred to #2082. This test drives the real
-    parser via an on-disk JSONL fixture so the wiring is exercised
-    end-to-end and any future signature drift fails loudly.
+    Pins the route → parser kwarg surface. Historically this test caught
+    a ``include_thinking=...`` plumbing mismatch where the fixture stub
+    accepted a kwarg the real parser did not (#2044). Today the parser
+    accepts ``include_thinking`` (#2082) and the route forwards it
+    through; the test still pins the real wiring so any future
+    signature drift trips here instead of in production.
     """
     import json as _json
 
@@ -1661,7 +1726,8 @@ def test_messages_endpoint_operator_lookup_skips_work_service(
     )
     monkeypatch.setattr(
         chat_messages_routes, "parse_events_jsonl",
-        lambda path, *, actor_fallback="agent", strict=False: [],
+        lambda path, *, actor_fallback="agent", strict=False,
+        include_thinking=False: [],
     )
     response = client.get(
         "/api/v1/chat/operator/messages",
@@ -1704,7 +1770,8 @@ def test_messages_endpoint_architect_lookup_skips_work_service(
     )
     monkeypatch.setattr(
         chat_messages_routes, "parse_events_jsonl",
-        lambda path, *, actor_fallback="agent", strict=False: [],
+        lambda path, *, actor_fallback="agent", strict=False,
+        include_thinking=False: [],
     )
     response = client.get(
         "/api/v1/chat/architect_myproj/messages",
@@ -1758,7 +1825,8 @@ def test_messages_endpoint_worker_lookup_opens_work_service(
     )
     monkeypatch.setattr(
         chat_messages_routes, "parse_events_jsonl",
-        lambda path, *, actor_fallback="agent", strict=False: [],
+        lambda path, *, actor_fallback="agent", strict=False,
+        include_thinking=False: [],
     )
     response = client.get(
         "/api/v1/chat/task-myproj-7/messages",

--- a/tests/test_chat_transcripts.py
+++ b/tests/test_chat_transcripts.py
@@ -31,7 +31,6 @@ from pathlib import Path
 from pollypm.web_api.chat import (
     MessageRole,
     MessageType,
-    ParserInternalType,
     STALE_THRESHOLD_SECONDS,
     is_archive_stale,
     parse_events_jsonl,
@@ -180,11 +179,12 @@ def test_thinking_envelope_emitted_when_flag_true(tmp_path: Path) -> None:
     )
     assert len(envelopes) == 1
     env = envelopes[0]
-    assert env.type == ParserInternalType.THINKING
-    # ParserInternalType is deliberately separate from the public
-    # MessageType catalog (#2082); the route filters it out before
-    # serialization so the wire enum stays closed.
-    assert env.type not in {member for member in MessageType}
+    assert env.type == MessageType.THINKING
+    # ``thinking`` is part of the HTTP-public MessageType catalog
+    # (promoted in #2082). The chat-messages route gates emission on
+    # the ``include_thinking`` query parameter; the parser itself only
+    # emits these when ``include_thinking=True`` is passed.
+    assert env.type.value == "thinking"
     assert env.role == MessageRole.ASSISTANT
     assert env.actor == "Polly"
     assert env.text == "Let me think about this..."
@@ -232,7 +232,7 @@ def test_thinking_cache_does_not_leak_between_flag_values(tmp_path: Path) -> Non
     # envelope, not the cached non-thinking list.
     with_thinking = parse_events_jsonl(events_path, include_thinking=True)
     assert [env.type for env in with_thinking] == [
-        ParserInternalType.THINKING, MessageType.TEXT,
+        MessageType.THINKING, MessageType.TEXT,
     ]
 
 
@@ -347,7 +347,7 @@ def test_include_thinking_preserves_content_block_order_via_ingestor(
     # replay tooling can rely on the normalized stream matching the
     # provider content array.
     assert [env.type for env in envelopes] == [
-        ParserInternalType.THINKING,
+        MessageType.THINKING,
         MessageType.TEXT,
     ]
     assert envelopes[0].text == "think first"


### PR DESCRIPTION
## Summary

- Promote `thinking` from parser-internal `ParserInternalType` into the public `MessageType` enum.
- Add `include_thinking` query parameter to `GET /api/v1/chat/{session}/messages` (default `false`); plumb through `_load_envelopes` → `parse_events_jsonl` / `parse_events_jsonl_tail`.
- Drop the defensive `PARSER_INTERNAL_TYPE_VALUES` filter in `_apply_filters_and_paginate` — gating now lives at parse time, exactly mirroring the flag.
- Update OpenAPI (`docs/api/openapi.yaml`) — add `thinking` to `ChatMessageType` enum, add `include_thinking` query param to the messages endpoint.
- Update markdown spec (`docs/api-chat-endpoints.md`) — re-add `include_thinking` to §3.2 query-params table, add `thinking` row to §4 type catalog, drop the "deferral / parser-only" notes added in #2079.
- Invert `test_messages_endpoint_rejects_include_thinking_query_param` into a positive emit-when-true assertion; add a "drops by default" companion. Both drive the real parser via on-disk Claude-shaped JSONL fixtures so the route → parser kwarg plumbing is exercised end-to-end. Update `tests/test_chat_transcripts.py` to assert against `MessageType.THINKING`.

## Context

- Builds on PR #2079 (parser-level thinking support — `ParserInternalType`, ingestor block ordering, route-level filter).
- Closes #2082.
- Once #2079 merges, this PR's base will need to be retargeted from `feat/chat-api-thinking-blocks` to `main`.

## Test plan

- [x] `pytest tests/web_api/test_openapi_conformance.py tests/test_chat_messages_endpoint.py tests/test_chat_transcripts.py tests/test_transcript_ingest.py` — 133 passed, 1 deselected (pre-existing wall-clock perf flake, unrelated).
- [x] `ruff check` clean on every touched file.
- [x] `test_chat_message_type_enum_matches_runtime` still passes — public enum and OpenAPI mirror each other (now both contain `thinking`).
- [ ] Manual: `curl ".../api/v1/chat/operator/messages?include_thinking=true"` returns `type=thinking` envelopes when the archive has them; default request does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)