### PR TITLE
fix(onboarding): suffix duplicate provider account homes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ pm add-account claude       # Claude Code — anthropic.com auth
 pm add-account codex        # Codex CLI — openai.com auth
 ```
 
-Each runs the provider's native login flow (browser OAuth for Claude, API key or OAuth for Codex) in an isolated profile directory so accounts don't step on each other.
+Each runs the provider's native login flow (browser OAuth for Claude, API key or OAuth for Codex) in an isolated profile directory so accounts don't step on each other. If you add more than one account with the same provider and email, PollyPM assigns suffixed internal keys such as `claude_user_example_com_2` and keeps a separate profile directory for each account.
 
 **Which to pick?** If you have a Claude subscription, start with `claude` — PollyPM's default profiles are tuned for it. Add `codex` later if you want a second provider for failover or cost-splitting.
 

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -249,6 +249,62 @@ def _next_account_index(accounts: dict[str, ConnectedAccount], provider: Provide
     return len([account for account in accounts.values() if account.provider is provider]) + 1
 
 
+def _unique_account_name(base_name: str, accounts: dict[str, ConnectedAccount]) -> str:
+    account_name = base_name
+    n = 2
+    while account_name in accounts:
+        account_name = f"{base_name}_{n}"
+        n += 1
+    return account_name
+
+
+def _finalize_connected_account_home(
+    *,
+    root_dir: Path,
+    account: ConnectedAccount,
+    account_name: str,
+) -> ConnectedAccount:
+    if account.provider is ProviderKind.CLAUDE:
+        final_home = account.home
+    else:
+        final_home = (
+            _promote_onboarding_home(
+                account.home,
+                _final_account_home(root_dir, account_name),
+            )
+            if account.home is not None
+            else None
+        )
+    return ConnectedAccount(
+        provider=account.provider,
+        email=account.email,
+        account_name=account_name,
+        home=final_home,
+    )
+
+
+def _store_connected_account(
+    *,
+    root_dir: Path,
+    accounts: dict[str, ConnectedAccount],
+    account: ConnectedAccount,
+) -> ConnectedAccount:
+    account_name = _unique_account_name(account.account_name, accounts)
+    if account_name != account.account_name:
+        logger.info(
+            "onboarding: account %s already exists; adding as %s",
+            account.account_name,
+            account_name,
+        )
+    final_account = _finalize_connected_account_home(
+        root_dir=root_dir,
+        account=account,
+        account_name=account_name,
+    )
+    accounts[account_name] = final_account
+    return final_account
+
+
 def _connect_accounts_interactively(
     tmux: TmuxClient,
     *,
@@ -267,40 +323,11 @@ def _connect_accounts_interactively(
             provider=provider,
             index=_next_account_index(accounts, provider),
         )
-        base_account_name = account.account_name
-        final_account_name = base_account_name
-        if base_account_name in accounts:
-            if provider is ProviderKind.CLAUDE:
-                # Claude auth is keyed to the home directory path in the macOS Keychain;
-                # the home stays in place (temp dir not promoted), so it is safe to give
-                # the second account a suffixed key while reusing the existing home path.
-                an = 2
-                while final_account_name in accounts:
-                    final_account_name = f"{base_account_name}_{an}"
-                    an += 1
-                logger.info(
-                    "onboarding: Claude account %s already exists; adding as %s",
-                    base_account_name,
-                    final_account_name,
-                )
-                account = ConnectedAccount(
-                    provider=account.provider,
-                    email=account.email,
-                    account_name=final_account_name,
-                    home=account.home,
-                )
-            else:
-                # For non-Claude providers the home has already been promoted to a path
-                # derived from the account name.  Suffix-bumping the key AFTER promotion
-                # would leave the new account pointing at the original home, violating
-                # account isolation.  Reject the duplicate until a full fix is shipped.
-                raise typer.BadParameter(
-                    f"Account {base_account_name!r} is already connected. "
-                    "Adding a second account with the same email address is not yet "
-                    "supported for non-Claude providers. Use a different email to add "
-                    "another account, or remove the existing one first."
-                )
-        accounts[final_account_name] = account
+        account = _store_connected_account(
+            root_dir=root_dir,
+            accounts=accounts,
+            account=account,
+        )
         typer.echo("")
         _render_connected_account(account, len(accounts))
         typer.echo("")
@@ -1151,10 +1178,7 @@ def _connect_account_via_tmux(
         final_home = home
         _prime_claude_home(final_home)
     else:
-        final_home = _promote_onboarding_home(
-            home,
-            _final_account_home(root_dir, _slugify_email(provider, email)),
-        )
+        final_home = home
 
     return ConnectedAccount(
         provider=provider,

--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -41,6 +41,7 @@ from pollypm.onboarding import (
     _display_label,
     _detected_host_account,
     _recover_existing_accounts,
+    _store_connected_account,
     build_onboarded_config,
     demo_project_fallback_destination,
     discover_recent_project_candidates,
@@ -1023,10 +1024,11 @@ class OnboardingApp(App[OnboardingResult | None]):
             self._set_message(f"Login did not complete cleanly: {exc}")
             return
         self.refresh(repaint=True, layout=True)
-        if account.account_name in self.state.accounts:
-            self._set_message(f"{account.email} is already connected.")
-            return
-        self.state.accounts[account.account_name] = account
+        account = _store_connected_account(
+            root_dir=self.root_dir,
+            accounts=self.state.accounts,
+            account=account,
+        )
         if self.state.controller_account is None:
             self.state.controller_account = account.account_name
         self.state.failover_enabled = len(self.state.accounts) > 1

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -404,13 +404,11 @@ def test_connect_accounts_interactively_suffixes_duplicate_claude_key_and_preser
     )
 
 
-def test_connect_accounts_interactively_rejects_duplicate_codex_same_email(
+def test_connect_accounts_interactively_suffixes_duplicate_codex_key_and_promotes_distinct_home(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    """Non-Claude (Codex): duplicate same-email must raise BadParameter, not silently share a home."""
-    import typer
-
+    """Non-Claude: duplicate same-email gets a suffixed key and matching home."""
     root_dir = tmp_path / ".pollypm"
     first_home = root_dir / "homes" / "codex_user_example_com"
     first_home.mkdir(parents=True, exist_ok=True)
@@ -423,13 +421,16 @@ def test_connect_accounts_interactively_rejects_duplicate_codex_same_email(
     )
     accounts: dict[str, ConnectedAccount] = {"codex_user_example_com": first_account}
 
-    # The second login lands on the same email; by this point Codex has promoted the home to
-    # homes/codex_user_example_com — same path as the first account.
+    temp_home = root_dir / "homes" / "onboarding_codex_2"
+    temp_home.mkdir(parents=True, exist_ok=True)
+
+    # The second login lands on the same email. The caller should choose
+    # the final suffixed key before promoting this temporary home.
     duplicate_account = ConnectedAccount(
         provider=ProviderKind.CODEX,
         email="user@example.com",
         account_name="codex_user_example_com",
-        home=first_home,  # same home — the invariant that must be rejected
+        home=temp_home,
     )
 
     call_count = {"n": 0}
@@ -452,17 +453,20 @@ def test_connect_accounts_interactively_rejects_duplicate_codex_same_email(
     from pollypm.onboarding_models import CliAvailability
     available = [CliAvailability(provider=ProviderKind.CODEX, label="Codex", binary="codex", installed=True)]
 
-    with pytest.raises(typer.BadParameter) as exc_info:
-        _connect_accounts_interactively(
-            None,  # type: ignore[arg-type]  # tmux unused — mocked
-            root_dir=root_dir,
-            accounts=accounts,
-            available=available,
-        )
-
-    assert "already connected" in str(exc_info.value).lower() or "not yet supported" in str(exc_info.value).lower(), (
-        f"Expected a clear rejection message, got: {exc_info.value}"
+    result = _connect_accounts_interactively(
+        None,  # type: ignore[arg-type]  # tmux unused — mocked
+        root_dir=root_dir,
+        accounts=accounts,
+        available=available,
     )
+
+    assert "codex_user_example_com_2" in result
+    new_account = result["codex_user_example_com_2"]
+    assert new_account.account_name == "codex_user_example_com_2"
+    assert new_account.home == root_dir / "homes" / "codex_user_example_com_2"
+    assert new_account.home != first_home
+    assert new_account.home.exists()
+    assert not temp_home.exists()
 
 
 def test_launch_onboarding_experience_prepares_cockpit_before_attach(

--- a/tests/test_onboarding_tui.py
+++ b/tests/test_onboarding_tui.py
@@ -297,6 +297,68 @@ def test_connect_provider_cancel_returns_to_onboarding(monkeypatch, tmp_path: Pa
     assert messages[-1] == "Login cancelled. Returned to onboarding."
 
 
+def test_connect_provider_suffixes_duplicate_codex_home(monkeypatch, tmp_path: Path) -> None:
+    app = OnboardingApp(tmp_path / "pollypm.toml")
+    root_dir = app.root_dir
+    first_home = root_dir / "homes" / "codex_user_example_com"
+    temp_home = root_dir / "homes" / "onboarding_codex_2"
+    first_home.mkdir(parents=True, exist_ok=True)
+    temp_home.mkdir(parents=True, exist_ok=True)
+    (temp_home / "auth.json").write_text("{}")
+
+    first_account = ConnectedAccount(
+        provider=ProviderKind.CODEX,
+        email="user@example.com",
+        account_name="codex_user_example_com",
+        home=first_home,
+    )
+    app.state = type(
+        "State",
+        (),
+        {
+            "accounts": {"codex_user_example_com": first_account},
+            "login_preferences": None,
+            "controller_account": "codex_user_example_com",
+            "failover_enabled": False,
+            "open_permissions_by_default": True,
+            "known_projects": {},
+            "selected_project_paths": [],
+        },
+    )()
+    messages: list[str] = []
+    monkeypatch.setattr(app, "_set_message", lambda message="": messages.append(message))
+    monkeypatch.setattr(app, "_render_current_step", lambda: None)
+    monkeypatch.setattr(app, "refresh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(app, "_ensure_tmux_client", lambda: object())
+
+    class _Suspend:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(app, "suspend", lambda: _Suspend())
+    monkeypatch.setattr(
+        "pollypm.onboarding_tui._connect_account_via_tmux",
+        lambda *args, **kwargs: ConnectedAccount(
+            provider=ProviderKind.CODEX,
+            email="user@example.com",
+            account_name="codex_user_example_com",
+            home=temp_home,
+        ),
+    )
+
+    app._connect_provider(ProviderKind.CODEX)
+
+    new_account = app.state.accounts["codex_user_example_com_2"]
+    assert new_account.home == root_dir / "homes" / "codex_user_example_com_2"
+    assert new_account.home != first_home
+    assert (new_account.home / "auth.json").exists()
+    assert not temp_home.exists()
+    assert messages[-1] == "Connected user@example.com [codex]."
+
+
 def test_onboarding_progress_header_shows_step_count_and_bar() -> None:
     header = onboarding_step_header("projects")
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Defer non-Claude onboarding home promotion until after the final suffixed account key is known.
- Share the suffix-and-finalize path between terminal onboarding and the TUI account connector.
- Update the Codex duplicate-email regression from fail-closed to suffixed-key + distinct-home behavior.
- Document same-provider/same-email suffixed internal keys in getting started docs.

Fixes #2090
Issue: https://github.com/samhotchkiss/pollypm/issues/2090

## Verification
- `uv run --extra test pytest tests/test_onboarding.py::test_connect_accounts_interactively_suffixes_duplicate_claude_key_and_preserves_distinct_homes tests/test_onboarding.py::test_connect_accounts_interactively_suffixes_duplicate_codex_key_and_promotes_distinct_home tests/test_onboarding_tui.py::test_connect_provider_suffixes_duplicate_codex_home tests/test_onboarding_ux.py::test_connect_account_via_tmux_requires_verified_claude_auth`
- `uv run --extra dev ruff check --extend-ignore E402 src/pollypm/onboarding.py src/pollypm/onboarding_tui.py tests/test_onboarding.py tests/test_onboarding_tui.py tests/test_onboarding_ux.py`
- `uv run --extra test pytest tests/test_onboarding_tui.py -k 'not projects_step_can_offer_demo_repo_fallback and not demo_task_choice_keeps_seeded_task'`
- `uv run --extra test pytest tests/test_onboarding_ux.py`
- `git diff --check`

## Known Baseline Failures
- Full `tests/test_onboarding_tui.py` still fails in `test_projects_step_can_offer_demo_repo_fallback` and `test_demo_task_choice_keeps_seeded_task`; both failures reproduce on `origin/main`.
