### PR TITLE
fix(accounts): force fresh login + accept --email override for Claude Max plans

### DIFF
--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -558,6 +558,17 @@ def add_account_via_login(
     detected_is_sentinel = ":" in detected_email and "@" not in detected_email
 
     if email_hint is not None:
+        if not detected_is_sentinel and email_hint != detected_email:
+            # Detection returned a real email but the hint disagrees — this is
+            # a mismatch. The hint is only valid as a fallback for Max-plan
+            # sentinels. A disagreement here means either the wrong account
+            # was logged in or the hint is mistyped.
+            raise typer.BadParameter(
+                f"Email hint {email_hint!r} does not match detected logged-in "
+                f"email {detected_email!r}. The hint is for Claude Max plans "
+                f"(where detection returns no email). Remove the --email flag, "
+                f"or re-log in as the intended account."
+            )
         email = email_hint
     elif detected_is_sentinel:
         raise typer.BadParameter(

--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -503,25 +503,72 @@ def list_cached_account_statuses(config_path: Path) -> list[AccountStatus]:
     return items
 
 
-def add_account_via_login(config_path: Path, provider: ProviderKind) -> tuple[str, str]:
+def add_account_via_login(
+    config_path: Path,
+    provider: ProviderKind,
+    *,
+    email_hint: str | None = None,
+) -> tuple[str, str]:
+    """Add a new provider account by running an interactive login.
+
+    ``email_hint`` lets the caller supply the email up-front. Required for
+    Claude Max plans on CLI 2.x: ``claude auth status --json`` returns
+    ``email: null`` for Max subscribers, so ``_detect_account_email`` falls
+    back to a sentinel like ``claude.ai:max`` that is NOT unique per account.
+    Without a hint, two Max plans would collide and share a Keychain entry.
+    """
     config = load_config(config_path)
     tmux = create_tmux_client()
+
+    if email_hint is not None:
+        normalized_hint = email_hint.strip().lower()
+        if not normalized_hint or "@" not in normalized_hint:
+            raise typer.BadParameter(
+                f"--email must be a valid email address (got {email_hint!r})."
+            )
+        email_hint = normalized_hint
 
     existing = [account for account in config.accounts.values() if account.provider is provider]
     next_index = len(existing) + 1
     agent_homes = GLOBAL_CONFIG_DIR / "agent_homes"
     agent_homes.mkdir(parents=True, exist_ok=True)
     home = agent_homes / f"{provider.value}_{next_index}"
+    # Force a fresh login flow. Without this, the macOS Keychain auto-fills
+    # the new home from the existing logged-in session, so "Add Claude"
+    # would silently create a duplicate of the operator's primary account.
     _run_login_window(
         tmux,
         provider=provider,
         home=home,
         window_label=f"add-{provider.value}-{next_index}",
+        allow_existing_auth_shortcut=False,
+        force_fresh_auth=True,
     )
 
-    email = _detect_account_email(provider, home)
-    if email is None:
-        raise typer.BadParameter(f"Could not detect the logged-in email for the new {provider.value} account.")
+    detected_email = _detect_account_email(provider, home)
+    if detected_email is None:
+        raise typer.BadParameter(
+            f"Could not detect the logged-in email for the new {provider.value} account."
+        )
+
+    # `_detect_account_email` returns a sentinel like "claude.ai:max" for
+    # Claude Max plans on CLI 2.x (which expose loggedIn:true with
+    # email:null). The sentinel is not unique per account — every Max plan
+    # returns the same string — so it cannot be used as the account key.
+    detected_is_sentinel = ":" in detected_email and "@" not in detected_email
+
+    if email_hint is not None:
+        email = email_hint
+    elif detected_is_sentinel:
+        raise typer.BadParameter(
+            f"Could not derive a unique email for the new {provider.value} "
+            f"account (detected sentinel: {detected_email!r}). Claude Max "
+            f"plans on CLI 2.x do not expose the email via `claude auth "
+            f"status`. Re-run with --email <your_email> to identify this "
+            f"account explicitly."
+        )
+    else:
+        email = detected_email
 
     base_key = _slugify_email(provider, email)
     key = base_key

--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -230,10 +230,15 @@ def _probe_account_usage(config_path: Path, account: str):
     return probe_account_usage(config_path, account)
 
 
-def _add_account_via_login(config_path: Path, provider_kind: ProviderKind):
+def _add_account_via_login(
+    config_path: Path,
+    provider_kind: ProviderKind,
+    *,
+    email: str | None = None,
+):
     from pollypm.accounts import add_account_via_login
 
-    return add_account_via_login(config_path, provider_kind)
+    return add_account_via_login(config_path, provider_kind, email_hint=email)
 
 
 def _relogin_account(config_path: Path, account: str):
@@ -608,11 +613,21 @@ def worktrees(
 
 def add_account(
     provider: str = typer.Argument(..., help="Provider to add: codex or claude."),
+    email: str | None = typer.Option(
+        None,
+        "--email",
+        help=(
+            "Email to use as the account key. Required for Claude Max plans "
+            "on CLI 2.x which expose loggedIn:true but email:null."
+        ),
+    ),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
     provider_kind = ProviderKind(provider.lower())
-    key, email = _add_account_via_login(config_path, provider_kind)
-    typer.echo(f"Added {email} as {key}")
+    key, resolved_email = _add_account_via_login(
+        config_path, provider_kind, email=email
+    )
+    typer.echo(f"Added {resolved_email} as {key}")
 
 def relogin(
     account: str = typer.Argument(..., help="Account key or email."),

--- a/src/pollypm/cockpit_settings_email_prompt.py
+++ b/src/pollypm/cockpit_settings_email_prompt.py
@@ -1,0 +1,121 @@
+"""Email-input modal used by cockpit settings to identify a new account.
+
+Contract:
+- Inputs: ``title`` and ``prompt`` strings; optional ``confirm_label``.
+- Outputs: a ``ModalScreen[str | None]`` that resolves to the lowercased
+  trimmed email string on confirm, or ``None`` on cancel/escape.
+- Side effects: pushes/dismisses a Textual modal; no I/O of its own.
+- Invariants: this module owns one widget class and nothing else; it has
+  no dependency on cockpit state or services.
+- Allowed dependencies: Textual primitives only.
+
+Used by the cockpit settings "Add Claude" flow. Claude Max plans on CLI
+2.x report ``loggedIn: true`` with ``email: null``, so we cannot detect
+the email automatically — the operator must supply it.
+
+Wedge of the cockpit_ui.py god-module split tracked by #1354.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Static
+
+
+class _SettingsEmailPromptModal(ModalScreen[str | None]):
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+    #settings-email-prompt {
+        width: 72;
+        height: auto;
+        padding: 1 2;
+        background: $panel;
+        border: heavy $primary;
+    }
+    #settings-email-prompt-title {
+        padding-bottom: 1;
+        text-style: bold;
+    }
+    #settings-email-prompt-input {
+        margin-top: 1;
+        margin-bottom: 1;
+    }
+    #settings-email-prompt-buttons {
+        height: auto;
+        align-horizontal: right;
+        padding-top: 1;
+    }
+    #settings-email-prompt-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        prompt: str,
+        confirm_label: str = "Add",
+        cancel_label: str = "Cancel",
+        placeholder: str = "you@example.com",
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._prompt = prompt
+        self._confirm_label = confirm_label
+        self._cancel_label = cancel_label
+        self._placeholder = placeholder
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="settings-email-prompt"):
+            yield Static(self._title, id="settings-email-prompt-title")
+            yield Static(self._prompt)
+            yield Input(
+                placeholder=self._placeholder,
+                id="settings-email-prompt-input",
+            )
+            with Horizontal(id="settings-email-prompt-buttons"):
+                yield Button(self._cancel_label, id="cancel")
+                yield Button(
+                    self._confirm_label, variant="primary", id="confirm"
+                )
+
+    def on_mount(self) -> None:
+        try:
+            self.query_one("#settings-email-prompt-input", Input).focus()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "confirm":
+            self._submit()
+        else:
+            self.dismiss(None)
+
+    def on_input_submitted(self, _event: Input.Submitted) -> None:
+        self._submit()
+
+    def _submit(self) -> None:
+        try:
+            value = self.query_one("#settings-email-prompt-input", Input).value
+        except Exception:  # noqa: BLE001
+            value = ""
+        cleaned = (value or "").strip().lower()
+        if not cleaned or "@" not in cleaned:
+            # Invalid input — leave the modal open so the operator can fix.
+            # No error styling yet; could add a Static error label later.
+            return
+        self.dismiss(cleaned)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+__all__ = ["_SettingsEmailPromptModal"]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -102,6 +102,9 @@ from pollypm.cockpit_settings_account_reassign import (  # noqa: F401  (re-expor
 from pollypm.cockpit_settings_confirm import (  # noqa: F401  (re-exported)
     _SettingsConfirmModal,
 )
+from pollypm.cockpit_settings_email_prompt import (  # noqa: F401  (re-exported)
+    _SettingsEmailPromptModal,
+)
 from pollypm.cockpit_inbox_rollup_item import (  # noqa: F401  (re-exported)
     _RollupItem,
 )
@@ -5676,8 +5679,43 @@ class PollySettingsPaneApp(App[None]):
         remover = getattr(self.service, "remove_account", None)
         if adder is None or remover is None:
             return
+        if provider is ProviderKind.CLAUDE:
+            # Claude Max plans on CLI 2.x report loggedIn:true with
+            # email:null, so detection alone can't disambiguate two Max
+            # plans. Prompt the operator for the email up-front; pass it
+            # to the service as email_hint.
+            self.push_screen(
+                _SettingsEmailPromptModal(
+                    title="Add Claude account",
+                    prompt=(
+                        "Enter the email for this Claude account. Required "
+                        "for Max plans (CLI 2.x exposes loggedIn but not the "
+                        "email). The login window opens after you confirm."
+                    ),
+                    confirm_label="Add",
+                ),
+                lambda email: self._complete_add_account(
+                    provider, email, adder, remover
+                ),
+            )
+            return
+        self._complete_add_account(provider, None, adder, remover)
+
+    def _complete_add_account(
+        self,
+        provider: ProviderKind,
+        email_hint: str | None,
+        adder,
+        remover,
+    ) -> None:
+        if provider is ProviderKind.CLAUDE and not email_hint:
+            # Operator cancelled the email modal.
+            return
         try:
-            key, email = adder(provider)
+            if email_hint is not None:
+                key, email = adder(provider, email_hint=email_hint)
+            else:
+                key, email = adder(provider)
             self._selected_account_key = key
             self._record_undo(
                 f"add account {key}",

--- a/src/pollypm/control_tui.py
+++ b/src/pollypm/control_tui.py
@@ -1395,7 +1395,21 @@ class PollyPMApp(App[None]):
     def action_add_claude_account(self) -> None:
         if self._active_tab() != "accounts-tab":
             return
-        self._run("Add Claude account", lambda: self.service.add_account(ProviderKind.CLAUDE))
+        # Claude Max plans on CLI 2.x report loggedIn:true with email:null,
+        # so add_account requires an explicit email_hint (see #2088). This
+        # legacy control TUI has no modal infrastructure to prompt for one;
+        # redirect to the cockpit Settings flow or the CLI which both
+        # support the new contract.
+        try:
+            self.notify(
+                "Add Claude requires an email for Max plans. Use "
+                "`pm cockpit` → Settings → Add Claude (modal prompts for email), "
+                "or `pm account add claude --email <your-email>`.",
+                severity="warning",
+                timeout=8.0,
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
     def action_context_action_r(self) -> None:
         active = self._active_tab()

--- a/src/pollypm/control_tui.py
+++ b/src/pollypm/control_tui.py
@@ -1404,7 +1404,7 @@ class PollyPMApp(App[None]):
             self.notify(
                 "Add Claude requires an email for Max plans. Use "
                 "`pm cockpit` → Settings → Add Claude (modal prompts for email), "
-                "or `pm account add claude --email <your-email>`.",
+                "or `pm add-account claude --email <your-email>`.",
                 severity="warning",
                 timeout=8.0,
             )

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -610,9 +610,21 @@ class PollyPMService:
         supervisor.ensure_heartbeat_schedule()
         return supervisor.config.pollypm.controller_account
 
-    def add_account(self, provider: ProviderKind) -> tuple[str, str]:
-        """Drive the provider login flow and register a new account."""
-        return add_account_via_login(self.config_path, provider)
+    def add_account(
+        self,
+        provider: ProviderKind,
+        *,
+        email_hint: str | None = None,
+    ) -> tuple[str, str]:
+        """Drive the provider login flow and register a new account.
+
+        ``email_hint`` lets callers (CLI ``--email`` flag, future TUI modal)
+        supply the email up-front. Required for Claude Max plans which return
+        ``email: null`` from ``claude auth status --json``.
+        """
+        return add_account_via_login(
+            self.config_path, provider, email_hint=email_hint
+        )
 
     def relogin_account(self, identifier: str) -> tuple[str, str]:
         """Re-run the login flow for an existing account to refresh credentials."""

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -38,7 +38,7 @@ def test_add_account_reuses_orphaned_home_with_same_email(monkeypatch, tmp_path:
     agent_homes = tmp_path / ".pollypm" / "agent_homes"
     monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
 
-    def fake_login_window(_tmux, provider, home, window_label):  # noqa: ANN001
+    def fake_login_window(_tmux, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
         (home / "fresh.txt").write_text("fresh")
         return "done"
@@ -70,7 +70,7 @@ def test_add_account_replaces_orphaned_home_when_stale(monkeypatch, tmp_path: Pa
     agent_homes = tmp_path / ".pollypm" / "agent_homes"
     monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
 
-    def fake_login_window(_tmux, provider, home, window_label):  # noqa: ANN001
+    def fake_login_window(_tmux, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
         (home / "fresh.txt").write_text("fresh")
         return "done"
@@ -102,7 +102,7 @@ def test_add_second_account_same_email_gets_suffix_key(monkeypatch, tmp_path: Pa
     )
     write_config(config, config_path)
 
-    def fake_login_window(_tmux, provider, home, window_label):  # noqa: ANN001
+    def fake_login_window(_tmux, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
         return "done"
 
@@ -139,7 +139,7 @@ def test_add_third_account_same_email_gets_sequential_suffix(monkeypatch, tmp_pa
         )
     write_config(config, config_path)
 
-    def fake_login_window(_tmux, provider, home, window_label):  # noqa: ANN001
+    def fake_login_window(_tmux, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
         return "done"
 
@@ -158,3 +158,116 @@ def test_add_third_account_same_email_gets_sequential_suffix(monkeypatch, tmp_pa
     # name is always reconstructed from the key on load (config.py:_parse_accounts)
     assert saved.accounts["claude_s_example_com_3"].name == "claude_s_example_com_3"
     assert saved.accounts["claude_s_example_com_3"].email == "s@example.com"
+
+
+def test_add_account_forces_fresh_auth_and_disables_shortcut(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The add path must force fresh auth so the Keychain shortcut can't mask a real login (closes #2088)."""
+    import pytest
+
+    config_path = tmp_path / "pollypm.toml"
+    write_config(_config(tmp_path), config_path)
+    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+
+    captured: dict = {}
+
+    def fake_login_window(_tmux, *, provider, home, window_label, **kwargs):  # noqa: ANN001
+        captured.update(kwargs)
+        captured["window_label"] = window_label
+        home.mkdir(parents=True, exist_ok=True)
+        return "done"
+
+    monkeypatch.setattr("pollypm.accounts._run_login_window", fake_login_window)
+    monkeypatch.setattr(
+        "pollypm.accounts._detect_account_email",
+        lambda provider, home: "fresh@example.com",
+    )
+    monkeypatch.setattr("pollypm.accounts._prime_claude_home", lambda home: None)
+
+    key, email = add_account_via_login(config_path, ProviderKind.CLAUDE)
+
+    assert key == "claude_fresh_example_com"
+    assert email == "fresh@example.com"
+    assert captured.get("allow_existing_auth_shortcut") is False
+    assert captured.get("force_fresh_auth") is True
+
+
+def test_add_account_sentinel_without_hint_raises(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """When detection returns a Max-plan sentinel and no email_hint is supplied, raise."""
+    import typer
+
+    config_path = tmp_path / "pollypm.toml"
+    write_config(_config(tmp_path), config_path)
+    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+
+    def fake_login_window(_tmux, *, provider, home, window_label, **_kwargs):  # noqa: ANN001
+        home.mkdir(parents=True, exist_ok=True)
+        return "done"
+
+    monkeypatch.setattr("pollypm.accounts._run_login_window", fake_login_window)
+    # Sentinel: contains ":" but no "@"
+    monkeypatch.setattr(
+        "pollypm.accounts._detect_account_email",
+        lambda provider, home: "claude.ai:max",
+    )
+    monkeypatch.setattr("pollypm.accounts._prime_claude_home", lambda home: None)
+
+    import pytest
+
+    with pytest.raises(typer.BadParameter) as excinfo:
+        add_account_via_login(config_path, ProviderKind.CLAUDE)
+    assert "--email" in str(excinfo.value)
+    assert "claude.ai:max" in str(excinfo.value)
+
+
+def test_add_account_with_email_hint_normalizes_and_uses_it(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """email_hint overrides detection and is normalized to lowercase + trimmed."""
+    config_path = tmp_path / "pollypm.toml"
+    write_config(_config(tmp_path), config_path)
+    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+
+    def fake_login_window(_tmux, *, provider, home, window_label, **_kwargs):  # noqa: ANN001
+        home.mkdir(parents=True, exist_ok=True)
+        return "done"
+
+    monkeypatch.setattr("pollypm.accounts._run_login_window", fake_login_window)
+    # Detection would return a sentinel, but the hint takes precedence.
+    monkeypatch.setattr(
+        "pollypm.accounts._detect_account_email",
+        lambda provider, home: "claude.ai:max",
+    )
+    monkeypatch.setattr("pollypm.accounts._prime_claude_home", lambda home: None)
+
+    key, email = add_account_via_login(
+        config_path,
+        ProviderKind.CLAUDE,
+        email_hint="  BACKUP@Example.COM  ",
+    )
+    assert key == "claude_backup_example_com"
+    assert email == "backup@example.com"
+
+
+def test_add_account_invalid_email_hint_raises(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """An email_hint without '@' is rejected with a clear error."""
+    import typer
+
+    config_path = tmp_path / "pollypm.toml"
+    write_config(_config(tmp_path), config_path)
+    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+
+    import pytest
+
+    with pytest.raises(typer.BadParameter) as excinfo:
+        add_account_via_login(
+            config_path,
+            ProviderKind.CLAUDE,
+            email_hint="not-an-email",
+        )
+    assert "email" in str(excinfo.value).lower()

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -34,9 +34,12 @@ def test_add_account_reuses_orphaned_home_with_same_email(monkeypatch, tmp_path:
     orphan_home.mkdir(parents=True, exist_ok=True)
     (orphan_home / "stale.txt").write_text("keep me")
 
-    # Agent homes now live at ~/.pollypm/agent_homes/<provider>_<n>
+    # Agent homes now live at <GLOBAL_CONFIG_DIR>/agent_homes/<provider>_<n>.
+    # GLOBAL_CONFIG_DIR is captured at import time, so patching Path.home() is
+    # too late — patch the module constant directly to keep this test from
+    # writing to the operator's real ~/.pollypm.
     agent_homes = tmp_path / ".pollypm" / "agent_homes"
-    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
 
     def fake_login_window(_tmux, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
@@ -66,9 +69,12 @@ def test_add_account_replaces_orphaned_home_when_stale(monkeypatch, tmp_path: Pa
     orphan_home.mkdir(parents=True, exist_ok=True)
     (orphan_home / "stale.txt").write_text("stale")
 
-    # Agent homes now live at ~/.pollypm/agent_homes/<provider>_<n>
+    # Agent homes now live at <GLOBAL_CONFIG_DIR>/agent_homes/<provider>_<n>.
+    # GLOBAL_CONFIG_DIR is captured at import time, so patching Path.home() is
+    # too late — patch the module constant directly to keep this test from
+    # writing to the operator's real ~/.pollypm.
     agent_homes = tmp_path / ".pollypm" / "agent_homes"
-    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
 
     def fake_login_window(_tmux, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
@@ -102,6 +108,8 @@ def test_add_second_account_same_email_gets_suffix_key(monkeypatch, tmp_path: Pa
     )
     write_config(config, config_path)
 
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
+
     def fake_login_window(_tmux, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
         return "done"
@@ -115,6 +123,10 @@ def test_add_second_account_same_email_gets_suffix_key(monkeypatch, tmp_path: Pa
 
     assert key == "claude_s_example_com_2"
     assert email == "s@example.com"
+    # Test-boundary regression: the new home must be under tmp_path, not the
+    # operator's real ~/.pollypm.
+    new_home = tmp_path / ".pollypm" / "agent_homes" / "claude_2"
+    assert new_home.exists(), f"expected {new_home} to exist under tmp_path"
 
     from pollypm.config import load_config
 
@@ -139,6 +151,8 @@ def test_add_third_account_same_email_gets_sequential_suffix(monkeypatch, tmp_pa
         )
     write_config(config, config_path)
 
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
+
     def fake_login_window(_tmux, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
         return "done"
@@ -151,6 +165,8 @@ def test_add_third_account_same_email_gets_sequential_suffix(monkeypatch, tmp_pa
 
     assert key == "claude_s_example_com_3"
     assert email == "s@example.com"
+    # Test-boundary regression: the new home must be under tmp_path.
+    assert (tmp_path / ".pollypm" / "agent_homes" / "claude_3").exists()
 
     from pollypm.config import load_config
 
@@ -164,17 +180,16 @@ def test_add_account_forces_fresh_auth_and_disables_shortcut(
     monkeypatch, tmp_path: Path
 ) -> None:
     """The add path must force fresh auth so the Keychain shortcut can't mask a real login (closes #2088)."""
-    import pytest
-
     config_path = tmp_path / "pollypm.toml"
     write_config(_config(tmp_path), config_path)
-    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
 
     captured: dict = {}
 
     def fake_login_window(_tmux, *, provider, home, window_label, **kwargs):  # noqa: ANN001
         captured.update(kwargs)
         captured["window_label"] = window_label
+        captured["home"] = home
         home.mkdir(parents=True, exist_ok=True)
         return "done"
 
@@ -191,17 +206,21 @@ def test_add_account_forces_fresh_auth_and_disables_shortcut(
     assert email == "fresh@example.com"
     assert captured.get("allow_existing_auth_shortcut") is False
     assert captured.get("force_fresh_auth") is True
+    # Test-boundary regression: the new home is under tmp_path, not the
+    # operator's real ~/.pollypm.
+    assert str(captured["home"]).startswith(str(tmp_path))
 
 
 def test_add_account_sentinel_without_hint_raises(
     monkeypatch, tmp_path: Path
 ) -> None:
     """When detection returns a Max-plan sentinel and no email_hint is supplied, raise."""
+    import pytest
     import typer
 
     config_path = tmp_path / "pollypm.toml"
     write_config(_config(tmp_path), config_path)
-    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
 
     def fake_login_window(_tmux, *, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
@@ -215,8 +234,6 @@ def test_add_account_sentinel_without_hint_raises(
     )
     monkeypatch.setattr("pollypm.accounts._prime_claude_home", lambda home: None)
 
-    import pytest
-
     with pytest.raises(typer.BadParameter) as excinfo:
         add_account_via_login(config_path, ProviderKind.CLAUDE)
     assert "--email" in str(excinfo.value)
@@ -229,7 +246,7 @@ def test_add_account_with_email_hint_normalizes_and_uses_it(
     """email_hint overrides detection and is normalized to lowercase + trimmed."""
     config_path = tmp_path / "pollypm.toml"
     write_config(_config(tmp_path), config_path)
-    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
 
     def fake_login_window(_tmux, *, provider, home, window_label, **_kwargs):  # noqa: ANN001
         home.mkdir(parents=True, exist_ok=True)
@@ -256,13 +273,12 @@ def test_add_account_invalid_email_hint_raises(
     monkeypatch, tmp_path: Path
 ) -> None:
     """An email_hint without '@' is rejected with a clear error."""
+    import pytest
     import typer
 
     config_path = tmp_path / "pollypm.toml"
     write_config(_config(tmp_path), config_path)
-    monkeypatch.setattr("pollypm.accounts.Path.home", lambda: tmp_path)
-
-    import pytest
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
 
     with pytest.raises(typer.BadParameter) as excinfo:
         add_account_via_login(

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -287,3 +287,96 @@ def test_add_account_invalid_email_hint_raises(
             email_hint="not-an-email",
         )
     assert "email" in str(excinfo.value).lower()
+
+
+def test_add_account_email_hint_matching_detected_email_succeeds(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """email_hint that matches detected email (case-insensitive) succeeds."""
+    config_path = tmp_path / "pollypm.toml"
+    write_config(_config(tmp_path), config_path)
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
+
+    def fake_login_window(_tmux, *, provider, home, window_label, **_kwargs):  # noqa: ANN001
+        home.mkdir(parents=True, exist_ok=True)
+        return "done"
+
+    monkeypatch.setattr("pollypm.accounts._run_login_window", fake_login_window)
+    # Detection returns a real email; hint differs only in case
+    monkeypatch.setattr(
+        "pollypm.accounts._detect_account_email",
+        lambda provider, home: "real@example.com",
+    )
+    monkeypatch.setattr("pollypm.accounts._prime_claude_home", lambda home: None)
+
+    # Hint is same email with different casing — should succeed
+    key, email = add_account_via_login(
+        config_path,
+        ProviderKind.CLAUDE,
+        email_hint="Real@Example.com",
+    )
+    assert key == "claude_real_example_com"
+    assert email == "real@example.com"
+
+
+def test_add_account_email_hint_disagrees_with_detected_email_raises(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """email_hint that disagrees with a real detected email raises BadParameter."""
+    import pytest
+    import typer
+
+    config_path = tmp_path / "pollypm.toml"
+    write_config(_config(tmp_path), config_path)
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
+
+    def fake_login_window(_tmux, *, provider, home, window_label, **_kwargs):  # noqa: ANN001
+        home.mkdir(parents=True, exist_ok=True)
+        return "done"
+
+    monkeypatch.setattr("pollypm.accounts._run_login_window", fake_login_window)
+    # Detection returns a real email
+    monkeypatch.setattr(
+        "pollypm.accounts._detect_account_email",
+        lambda provider, home: "real@example.com",
+    )
+    monkeypatch.setattr("pollypm.accounts._prime_claude_home", lambda home: None)
+
+    with pytest.raises(typer.BadParameter) as excinfo:
+        add_account_via_login(
+            config_path,
+            ProviderKind.CLAUDE,
+            email_hint="other@example.com",
+        )
+    assert "does not match" in str(excinfo.value)
+    assert "other@example.com" in str(excinfo.value)
+    assert "real@example.com" in str(excinfo.value)
+
+
+def test_add_account_email_hint_with_sentinel_detection_succeeds(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """email_hint is accepted when detection returns a Max-plan sentinel."""
+    config_path = tmp_path / "pollypm.toml"
+    write_config(_config(tmp_path), config_path)
+    monkeypatch.setattr("pollypm.accounts.GLOBAL_CONFIG_DIR", tmp_path / ".pollypm")
+
+    def fake_login_window(_tmux, *, provider, home, window_label, **_kwargs):  # noqa: ANN001
+        home.mkdir(parents=True, exist_ok=True)
+        return "done"
+
+    monkeypatch.setattr("pollypm.accounts._run_login_window", fake_login_window)
+    # Sentinel: contains ":" but no "@"
+    monkeypatch.setattr(
+        "pollypm.accounts._detect_account_email",
+        lambda provider, home: "claude.ai:max",
+    )
+    monkeypatch.setattr("pollypm.accounts._prime_claude_home", lambda home: None)
+
+    key, email = add_account_via_login(
+        config_path,
+        ProviderKind.CLAUDE,
+        email_hint="backup@example.com",
+    )
+    assert key == "claude_backup_example_com"
+    assert email == "backup@example.com"

--- a/tests/test_settings_ui.py
+++ b/tests/test_settings_ui.py
@@ -292,10 +292,15 @@ class _FakeService:
         self._config.pollypm.failover_accounts = accounts
         return key, enabled
 
-    def add_account(self, provider: ProviderKind) -> tuple[str, str]:
-        self.add_calls.append(provider)
+    def add_account(
+        self,
+        provider: ProviderKind,
+        *,
+        email_hint: str | None = None,
+    ) -> tuple[str, str]:
+        self.add_calls.append((provider, email_hint))
         key = f"{provider.value}_new"
-        email = f"{key}@example.com"
+        email = email_hint or f"{key}@example.com"
         self._statuses.append(
             _fake_status(
                 key,
@@ -778,17 +783,24 @@ def test_add_and_remove_account_actions(settings_env, monkeypatch) -> None:
     app = settings_env["app"]
     service = settings_env["service"]
 
-    def _auto_confirm(_screen, callback):
-        callback(True)
+    # Two modal types are involved:
+    #   _SettingsEmailPromptModal — Add Claude opens this; callback wants a str.
+    #   _SettingsConfirmModal     — Remove account opens this; callback wants a bool.
+    def _auto_modal_response(screen, callback):
+        name = type(screen).__name__
+        if "EmailPrompt" in name:
+            callback("backup@example.com")
+        else:
+            callback(True)
 
-    monkeypatch.setattr(app, "push_screen", _auto_confirm)
+    monkeypatch.setattr(app, "push_screen", _auto_modal_response)
 
     async def body() -> None:
         async with app.run_test(size=(140, 40)) as pilot:
             await pilot.pause()
             await pilot.press("c")
             await pilot.pause()
-            assert service.add_calls == [ProviderKind.CLAUDE]
+            assert service.add_calls == [(ProviderKind.CLAUDE, "backup@example.com")]
             assert "claude_new" in [a["key"] for a in app.data.accounts]
             app._selected_account_key = "claude_new"
             app._render_section("accounts")


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Claude
- Authoring persona: Claude Builder
- Creator label: claude-created
- Reviewer/merge agent: Codex
- Reviewer persona: Codex Reviewer
- Ownership label: needs-codex
- Self-merge prohibited: yes

## Symptom

After #2089 merged, Sam tried to add his backup Claude account. The TUI \"Add Claude\" button silently created a third row labeled \`claude_claude_ai_max\` with email \`claude.ai/max\` — no login flow opened, the row just appeared. The new row pointed at the same Keychain entry as the primary, so it wasn't actually a backup account.

## Root cause

Two interacting bugs:

1. **Keychain auto-shortcut.** \`add_account_via_login\` called \`_run_login_window\` with default \`allow_existing_auth_shortcut=True, force_fresh_auth=False\`. The macOS Keychain inherited the operator's existing logged-in session into the new home, the shortcut fired before any real login happened, and the window closed immediately.

2. **Max-plan sentinel masquerading as email.** \`_detect_account_email\` ran against the inherited login. For Claude CLI 2.x Max subscribers, \`claude auth status --json\` returns \`loggedIn: true\` with \`email: null\`. The detect fallback (\`providers/claude/detect.py:84-88\`) returns a sentinel like \`claude.ai:max\` that is identical for every Max plan. That sentinel then became the \"email\" field of the new account, producing key \`claude_claude_ai_max\`.

The docstring on \`detect_claude_email\` even calls this out: *\"The real email is already pinned in \`AccountConfig.email\` at registration; this return value is used downstream only as a presence check.\"* But \`add_account_via_login\` was using the sentinel AS the email — contract violation.

## Fix

1. **Force fresh auth** in \`_run_login_window\` for the add-account path (\`allow_existing_auth_shortcut=False, force_fresh_auth=True\`), matching the precedent set by \`relogin_account\` at \`accounts.py:596-597\`. The Keychain shortcut can no longer mask a real login.

2. **Accept an optional \`email_hint\` parameter** on \`add_account_via_login\`. When detection returns a sentinel (\`:\` in result, \`@\` absent), the hint is required — without it, raise a clear BadParameter telling the operator to re-run with \`--email\`.

3. **Expose \`--email\`** on \`pm account add\` CLI and \`email_hint\` on the ServiceAPI v1 \`add_account\` method so the CLI works today and the TUI can wire a modal later.

After this PR, the working flow for Sam's backup is:

\`\`\`bash
pm account add claude --email backup@swh.me
\`\`\`

The TUI button remains a known gap (it can't supply \`--email\`); follow-up needs a Textual modal for the email input.

## Test plan

- [x] Built locally; signatures parse.
- [ ] Manual test by operator (Sam): \`pm account add claude --email <backup-email>\` succeeds, creates a distinct key, distinct Keychain entry.
- [ ] Manual test by operator: \`pm account add claude\` without \`--email\` against a Max plan raises a clear BadParameter pointing at \`--email\`.
- [ ] Regression test added: TBD (will add after manual verification confirms the behavior).
- [ ] Follow-up: Textual modal for TUI Add-Claude flow that prompts for email when detection returns a sentinel.

Refs #2088

## Architecture
- [x] Preserves plugin/module boundaries.
- [x] Uses public contracts/facades.
- [x] Adds optional kwarg-only param; existing callers unchanged.
- [x] Does not add a test-only switch; \`--email\` is a real operator-facing flag.