### PR TITLE
feat(failover): proactively swap controller account

### DIFF
--- a/docs/test-plan/05-resilience-recovery.md
+++ b/docs/test-plan/05-resilience-recovery.md
@@ -1,0 +1,21 @@
+# Resilience And Recovery Test Plan
+
+## 5.5.2 Claude Failover
+
+### Proactive Usage Swap
+
+The account usage refresh sweep should protect primary Claude controller
+headroom before a hard limit is reached:
+
+- With `[pollypm].failover_usage_threshold_pct = 85`, primary `used_pct = 84`
+  does not switch the operator account.
+- Primary `used_pct >= 85` switches the operator session to the first
+  configured `failover_accounts` entry with `used_pct < 85`.
+- The sweep emits `account.failover.proactive` with `from`, `to`, `reason`,
+  and `threshold`.
+- A successful soft swap raises `proactive_failover_active` while the operator
+  is on the backup account, and returning to primary clears it.
+- If every failover account is also at or above the threshold, the sweep raises
+  the `proactive_failover_no_capacity` alert.
+- When the primary drops below the threshold again, the next sweep switches the
+  operator session back to the configured primary account.

--- a/docs/v1/02-configuration-accounts-and-isolation.md
+++ b/docs/v1/02-configuration-accounts-and-isolation.md
@@ -319,6 +319,28 @@ Probes run:
 - On the configured `refresh_schedule`
 - After any launch failure
 
+### Proactive Controller Failover
+
+The account usage refresh sweep also protects the configured primary controller
+account before it is fully exhausted. `[pollypm].failover_usage_threshold_pct`
+defaults to `85`. When `failover_enabled = true` and the primary controller
+account's cached `used_pct` is at or above that threshold, PollyPM switches the
+operator session to the first configured `failover_accounts` entry whose
+`used_pct` is still below the threshold. The configured
+`controller_account` remains the primary source of truth; the soft swap is held
+as a session-runtime effective-account override so the next sweep can switch
+back to the primary when its usage drops below the threshold after reset.
+
+Successful soft swaps emit an `account.failover.proactive` audit event and
+raise a low-severity `proactive_failover_active` cockpit alert while the
+operator is running on the failover account. Returning to the primary clears
+that active alert.
+
+If every failover account is also at or above the threshold, the sweep raises a
+`proactive_failover_no_capacity` alert and emits an
+`account.failover.proactive` event with `reason =
+"no_failover_account_below_threshold"` instead of failing silently.
+
 ### Failure Classification
 
 When an account fails, PollyPM classifies the failure to determine the correct response.

--- a/src/pollypm/capacity.py
+++ b/src/pollypm/capacity.py
@@ -43,6 +43,10 @@ FAILOVER_TRIGGERS = frozenset({
 # limit. 10% left = 90% used — matches the #103 requirement.
 PROACTIVE_ROLLOVER_THRESHOLD_PCT = 10
 
+# Controller-account soft failover defaults to 85% used so the primary
+# keeps enough headroom for late operator approvals and emergency dispatch.
+DEFAULT_FAILOVER_USAGE_THRESHOLD_PCT = 85
+
 # Recovery priority: which sessions to recover first when capacity returns
 RECOVERY_PRIORITY = (
     "heartbeat",
@@ -60,6 +64,7 @@ class CapacityProbeResult:
     account_name: str
     provider: ProviderKind
     state: CapacityState
+    used_pct: int | None = None
     remaining_pct: int | None = None
     reset_time: str | None = None
     reason: str = ""
@@ -83,6 +88,19 @@ class FailoverDecision:
     failed_account: str
     selected_account: str | None = None
     reason: str = ""
+    candidates_evaluated: int = 0
+
+
+@dataclass(slots=True)
+class ProactiveFailoverDecision:
+    """Soft controller failover decision from cached account usage."""
+
+    action: str
+    primary_account: str
+    current_account: str
+    selected_account: str | None = None
+    reason: str = ""
+    threshold_pct: int = DEFAULT_FAILOVER_USAGE_THRESHOLD_PCT
     candidates_evaluated: int = 0
 
 
@@ -138,11 +156,13 @@ def probe_capacity(
         if usage.remaining_pct is not None
         else _parse_remaining_pct(usage.usage_summary)
     )
+    used = usage.used_pct if usage.used_pct is not None else _used_pct_from_remaining(remaining)
 
     return CapacityProbeResult(
         account_name=account_name,
         provider=account.provider,
         state=state,
+        used_pct=used,
         remaining_pct=remaining,
         reason=usage.usage_summary,
     )
@@ -207,6 +227,116 @@ def account_needs_proactive_rollover(
     if probe.remaining_pct is None:
         return False, probe  # unknown usage — don't gamble
     return probe.remaining_pct <= threshold_pct, probe
+
+
+def evaluate_proactive_controller_failover(
+    config: PollyPMConfig,
+    store: object | None,
+    *,
+    current_account: str | None = None,
+    threshold_pct: int | None = None,
+) -> ProactiveFailoverDecision:
+    """Choose whether the controller should soft-swap accounts.
+
+    ``config.pollypm.controller_account`` remains the primary source of truth.
+    Callers pass the currently-running controller account, usually the
+    operator session's runtime effective account. When the primary drops back
+    under the threshold, the returned action is ``"return"`` so the caller can
+    clear the effective-account override by switching back to the primary.
+    """
+    primary = config.pollypm.controller_account
+    current = current_account or primary
+    threshold = _coerce_usage_threshold(
+        threshold_pct
+        if threshold_pct is not None
+        else getattr(config.pollypm, "failover_usage_threshold_pct", DEFAULT_FAILOVER_USAGE_THRESHOLD_PCT)
+    )
+
+    if not config.pollypm.failover_enabled:
+        return ProactiveFailoverDecision(
+            action="none",
+            primary_account=primary,
+            current_account=current,
+            reason="Failover is not enabled",
+            threshold_pct=threshold,
+        )
+    if not primary or primary not in config.accounts:
+        return ProactiveFailoverDecision(
+            action="none",
+            primary_account=primary,
+            current_account=current,
+            reason="Controller account not found in config",
+            threshold_pct=threshold,
+        )
+
+    primary_probe = probe_capacity(config, store, primary)
+    primary_used = _probe_used_pct(primary_probe)
+    if primary_used is None:
+        return ProactiveFailoverDecision(
+            action="none",
+            primary_account=primary,
+            current_account=current,
+            reason="Primary usage is unknown",
+            threshold_pct=threshold,
+        )
+
+    if primary_used < threshold:
+        if current != primary:
+            return ProactiveFailoverDecision(
+                action="return",
+                primary_account=primary,
+                current_account=current,
+                selected_account=primary,
+                reason="primary_below_threshold",
+                threshold_pct=threshold,
+            )
+        return ProactiveFailoverDecision(
+            action="none",
+            primary_account=primary,
+            current_account=current,
+            reason="Primary usage below threshold",
+            threshold_pct=threshold,
+        )
+
+    candidates_evaluated = 0
+    for candidate_name in config.pollypm.failover_accounts:
+        if candidate_name == primary or candidate_name not in config.accounts:
+            continue
+        candidates_evaluated += 1
+        candidate_probe = probe_capacity(config, store, candidate_name)
+        if candidate_probe.state in FAILOVER_TRIGGERS:
+            continue
+        candidate_used = _probe_used_pct(candidate_probe)
+        if candidate_used is None or candidate_used >= threshold:
+            continue
+        if current == candidate_name:
+            return ProactiveFailoverDecision(
+                action="none",
+                primary_account=primary,
+                current_account=current,
+                selected_account=candidate_name,
+                reason="Already on threshold-safe failover account",
+                threshold_pct=threshold,
+                candidates_evaluated=candidates_evaluated,
+            )
+        return ProactiveFailoverDecision(
+            action="switch",
+            primary_account=primary,
+            current_account=current,
+            selected_account=candidate_name,
+            reason="used_pct_threshold",
+            threshold_pct=threshold,
+            candidates_evaluated=candidates_evaluated,
+        )
+
+    return ProactiveFailoverDecision(
+        action="alert",
+        primary_account=primary,
+        current_account=current,
+        reason="no_failover_account_below_threshold",
+        threshold_pct=threshold,
+        candidates_evaluated=candidates_evaluated,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -416,9 +546,9 @@ def persist_capacity_probe(
         raw_text="",
         remaining_pct=result.remaining_pct,
         used_pct=(
-            None
-            if result.remaining_pct is None
-            else max(0, 100 - result.remaining_pct)
+            result.used_pct
+            if result.used_pct is not None
+            else _used_pct_from_remaining(result.remaining_pct)
         ),
         reset_at=result.reset_time,
     )
@@ -450,3 +580,25 @@ def _parse_remaining_pct(summary: str) -> int | None:
     if match:
         return int(match.group(1))
     return None
+
+
+def _used_pct_from_remaining(remaining_pct: int | None) -> int | None:
+    if remaining_pct is None:
+        return None
+    return max(0, min(100, 100 - int(remaining_pct)))
+
+
+def _probe_used_pct(probe: CapacityProbeResult) -> int | None:
+    if probe.used_pct is not None:
+        return max(0, min(100, int(probe.used_pct)))
+    return _used_pct_from_remaining(probe.remaining_pct)
+
+
+def _coerce_usage_threshold(value: object) -> int:
+    try:
+        threshold = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_FAILOVER_USAGE_THRESHOLD_PCT
+    if isinstance(value, bool) or not 1 <= threshold <= 100:
+        return DEFAULT_FAILOVER_USAGE_THRESHOLD_PCT
+    return threshold

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -382,11 +382,19 @@ def _parse_pollypm_settings(raw: dict[str, object], sessions: dict[str, SessionC
     failover_accounts = [str(item) for item in pollypm_raw.get("failover_accounts", [])]
     failover_enabled = bool(pollypm_raw.get("failover_enabled", bool(failover_accounts)))
     open_permissions_by_default = bool(pollypm_raw.get("open_permissions_by_default", True))
+    threshold_raw = pollypm_raw.get("failover_usage_threshold_pct", 85)
+    try:
+        failover_usage_threshold_pct = int(threshold_raw)
+    except (TypeError, ValueError):
+        failover_usage_threshold_pct = 85
+    if isinstance(threshold_raw, bool) or not 1 <= failover_usage_threshold_pct <= 100:
+        failover_usage_threshold_pct = 85
     return PollyPMSettings(
         controller_account=controller_account,
         open_permissions_by_default=open_permissions_by_default,
         failover_enabled=failover_enabled,
         failover_accounts=failover_accounts,
+        failover_usage_threshold_pct=failover_usage_threshold_pct,
         heartbeat_backend=str(pollypm_raw.get("heartbeat_backend", "local")),
         scheduler_backend=str(pollypm_raw.get("scheduler_backend", "inline")),
         lease_timeout_minutes=max(1, int(pollypm_raw.get("lease_timeout_minutes", 30))),
@@ -1114,6 +1122,7 @@ def _render_global_config(config: PollyPMConfig) -> str:
         f'controller_account = "{config.pollypm.controller_account}"',
         f"open_permissions_by_default = {'true' if config.pollypm.open_permissions_by_default else 'false'}",
         f"failover_enabled = {'true' if config.pollypm.failover_enabled else 'false'}",
+        f"failover_usage_threshold_pct = {config.pollypm.failover_usage_threshold_pct}",
         f'heartbeat_backend = "{config.pollypm.heartbeat_backend}"',
         f'scheduler_backend = "{config.pollypm.scheduler_backend}"',
         f"lease_timeout_minutes = {config.pollypm.lease_timeout_minutes}",

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -143,6 +143,7 @@ class PollyPMSettings:
     open_permissions_by_default: bool = True
     failover_enabled: bool = False
     failover_accounts: list[str] = field(default_factory=list)
+    failover_usage_threshold_pct: int = 85
     heartbeat_backend: str = "local"
     scheduler_backend: str = "inline"
     lease_timeout_minutes: int = 30

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -18,6 +18,10 @@ from .shared import (
 
 logger = logging.getLogger(__name__)
 
+_PROACTIVE_FAILOVER_ACTIVE_ALERT = "proactive_failover_active"
+_PROACTIVE_FAILOVER_NO_CAPACITY_ALERT = "proactive_failover_no_capacity"
+_PROACTIVE_FAILOVER_FAILED_ALERT = "proactive_failover_failed"
+
 
 def capacity_probe_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Probe capacity for every configured account."""
@@ -33,13 +37,24 @@ def account_usage_refresh_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Refresh cached usage snapshots for configured accounts."""
     from pollypm.account_usage_sampler import refresh_all_account_usage
 
+    config_path = _resolve_config_path(payload)
     account_names = payload.get("accounts")
     if not isinstance(account_names, list):
         account_names = None
     samples = refresh_all_account_usage(
-        _resolve_config_path(payload),
+        config_path,
         account_names=account_names,
     )
+    config = _load_config(payload)
+    msg_store = _open_msg_store(config)
+    try:
+        proactive = _run_proactive_controller_failover(
+            config_path,
+            config,
+            msg_store=msg_store,
+        )
+    finally:
+        _close_msg_store(msg_store)
     return {
         "sampled": len(samples),
         "accounts": {
@@ -50,7 +65,320 @@ def account_usage_refresh_handler(payload: dict[str, Any]) -> dict[str, Any]:
             }
             for sample in samples
         },
+        "proactive_failover": proactive,
     }
+
+
+def _run_proactive_controller_failover(
+    config_path: Path,
+    config: Any,
+    *,
+    msg_store: Any | None,
+    switcher: Any | None = None,
+) -> dict[str, Any]:
+    """Apply the soft controller failover decision after usage refresh."""
+    from pollypm.capacity import evaluate_proactive_controller_failover
+
+    current_account = _current_operator_account(config)
+    decision = evaluate_proactive_controller_failover(
+        config,
+        None,
+        current_account=current_account,
+    )
+    return _apply_proactive_controller_failover(
+        config_path,
+        config,
+        decision,
+        msg_store=msg_store,
+        switcher=switcher,
+    )
+
+
+def _current_operator_account(config: Any) -> str:
+    session = _operator_session(config)
+    if session is None:
+        return str(getattr(getattr(config, "pollypm", None), "controller_account", "") or "")
+    try:
+        from pollypm.storage.pg_sessions import get_session_runtime
+
+        runtime = get_session_runtime(session.name)
+    except Exception:  # noqa: BLE001
+        runtime = None
+    effective = getattr(runtime, "effective_account", None) if runtime is not None else None
+    if effective:
+        return str(effective)
+    return str(getattr(session, "account", "") or getattr(config.pollypm, "controller_account", "") or "")
+
+
+def _operator_session(config: Any) -> Any | None:
+    sessions = getattr(config, "sessions", {}) or {}
+    if "operator" in sessions:
+        return sessions["operator"]
+    for session in sessions.values():
+        if getattr(session, "role", "") == "operator-pm":
+            return session
+    return None
+
+
+def _apply_proactive_controller_failover(
+    config_path: Path,
+    config: Any,
+    decision: Any,
+    *,
+    msg_store: Any | None,
+    switcher: Any | None = None,
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "action": decision.action,
+        "from": decision.current_account,
+        "to": decision.selected_account,
+        "reason": decision.reason,
+        "threshold": decision.threshold_pct,
+        "candidates_evaluated": decision.candidates_evaluated,
+    }
+    if decision.action == "none":
+        if (
+            decision.current_account != decision.primary_account
+            and decision.selected_account == decision.current_account
+        ):
+            _clear_proactive_failover_alerts(
+                msg_store,
+                alert_types=(
+                    _PROACTIVE_FAILOVER_NO_CAPACITY_ALERT,
+                    _PROACTIVE_FAILOVER_FAILED_ALERT,
+                ),
+            )
+            _upsert_proactive_failover_active_alert(msg_store, decision)
+        else:
+            _clear_proactive_failover_alerts(msg_store)
+        return summary
+
+    if decision.action == "alert":
+        _clear_proactive_failover_alerts(
+            msg_store,
+            alert_types=(
+                _PROACTIVE_FAILOVER_ACTIVE_ALERT,
+                _PROACTIVE_FAILOVER_FAILED_ALERT,
+            ),
+        )
+        _upsert_proactive_failover_no_capacity_alert(
+            msg_store,
+            (
+                f"Primary account {decision.primary_account} is at or above "
+                f"{decision.threshold_pct}% usage, but no failover account is below "
+                "that threshold."
+            ),
+        )
+        _append_proactive_failover_event(
+            msg_store,
+            from_account=decision.primary_account,
+            to_account=None,
+            reason=decision.reason,
+            threshold=decision.threshold_pct,
+            current_account=decision.current_account,
+        )
+        return summary
+
+    target = decision.selected_account
+    operator = _operator_session(config)
+    if target is None or operator is None:
+        summary["error"] = "No operator session or selected account available"
+        _upsert_proactive_failover_failed_alert(msg_store, summary["error"])
+        return summary
+
+    try:
+        _switch_operator_account(
+            config_path,
+            operator.name,
+            target,
+            switcher=switcher,
+        )
+    except Exception as exc:  # noqa: BLE001
+        summary["error"] = str(exc)
+        _upsert_proactive_failover_failed_alert(
+            msg_store,
+            f"Proactive controller failover to {target} failed: {exc}",
+        )
+        return summary
+
+    _clear_proactive_failover_alerts(
+        msg_store,
+        alert_types=(
+            _PROACTIVE_FAILOVER_NO_CAPACITY_ALERT,
+            _PROACTIVE_FAILOVER_FAILED_ALERT,
+        ),
+    )
+    if target == decision.primary_account:
+        _clear_proactive_failover_alerts(
+            msg_store,
+            alert_types=(_PROACTIVE_FAILOVER_ACTIVE_ALERT,),
+        )
+    else:
+        _upsert_proactive_failover_active_alert(msg_store, decision)
+    _append_proactive_failover_event(
+        msg_store,
+        from_account=(
+            decision.primary_account
+            if decision.action == "switch"
+            else decision.current_account
+        ),
+        to_account=target,
+        reason=decision.reason,
+        threshold=decision.threshold_pct,
+        current_account=decision.current_account,
+    )
+    summary["applied"] = True
+    return summary
+
+
+def _switch_operator_account(
+    config_path: Path,
+    session_name: str,
+    account_name: str,
+    *,
+    switcher: Any | None,
+) -> None:
+    if switcher is not None:
+        switcher(session_name, account_name)
+        return
+    from pollypm.service_api import PollyPMService
+
+    PollyPMService(config_path).switch_session_account(session_name, account_name)
+
+
+def _append_proactive_failover_event(
+    msg_store: Any | None,
+    *,
+    from_account: str,
+    to_account: str | None,
+    reason: str,
+    threshold: int,
+    current_account: str,
+) -> None:
+    if msg_store is None:
+        return
+    try:
+        msg_store.append_event(
+            scope="pollypm",
+            sender="account.failover",
+            subject="account.failover.proactive",
+            payload={
+                "from": from_account,
+                "to": to_account,
+                "reason": reason,
+                "threshold": threshold,
+                "current": current_account,
+                "message": (
+                    f"Proactive account failover {from_account} -> "
+                    f"{to_account or 'none'} ({reason}, threshold={threshold}%)"
+                ),
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "account.usage_refresh: failed to append proactive failover event",
+            exc_info=True,
+        )
+
+
+def _upsert_proactive_failover_active_alert(
+    msg_store: Any | None,
+    decision: Any,
+) -> None:
+    if msg_store is None:
+        return
+    try:
+        msg_store.upsert_alert(
+            "pollypm",
+            _PROACTIVE_FAILOVER_ACTIVE_ALERT,
+            "info",
+            (
+                f"Primary account {decision.primary_account} is at or above "
+                f"{decision.threshold_pct}% usage; operator is using "
+                f"{decision.selected_account or decision.current_account}."
+            ),
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "account.usage_refresh: failed to upsert proactive failover "
+            "active alert",
+            exc_info=True,
+        )
+
+
+def _upsert_proactive_failover_no_capacity_alert(
+    msg_store: Any | None,
+    message: str,
+) -> None:
+    if msg_store is None:
+        return
+    try:
+        msg_store.upsert_alert(
+            "pollypm",
+            _PROACTIVE_FAILOVER_NO_CAPACITY_ALERT,
+            "warn",
+            message,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "account.usage_refresh: failed to upsert proactive failover alert",
+            exc_info=True,
+        )
+
+
+def _upsert_proactive_failover_failed_alert(
+    msg_store: Any | None,
+    message: str,
+) -> None:
+    if msg_store is None:
+        return
+    try:
+        msg_store.upsert_alert(
+            "pollypm",
+            _PROACTIVE_FAILOVER_FAILED_ALERT,
+            "warn",
+            message,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "account.usage_refresh: failed to upsert proactive failover "
+            "failure alert",
+            exc_info=True,
+        )
+
+
+def _clear_proactive_failover_alerts(
+    msg_store: Any | None,
+    *,
+    alert_types: tuple[str, ...] = (
+        _PROACTIVE_FAILOVER_ACTIVE_ALERT,
+        _PROACTIVE_FAILOVER_NO_CAPACITY_ALERT,
+        _PROACTIVE_FAILOVER_FAILED_ALERT,
+    ),
+) -> None:
+    if msg_store is None:
+        return
+    for alert_type in alert_types:
+        try:
+            msg_store.clear_alert(
+                "pollypm",
+                alert_type,
+                who_cleared="auto:account.usage_refresh",
+            )
+        except TypeError:
+            try:
+                msg_store.clear_alert("pollypm", alert_type)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "account.usage_refresh: clear proactive failover alert "
+                    "failed",
+                    exc_info=True,
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "account.usage_refresh: clear proactive failover alert failed",
+                exc_info=True,
+            )
 
 
 def transcript_ingest_handler(payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -2624,8 +2624,13 @@ class Supervisor:
                 return
         try:
             from pollypm.capacity import account_needs_proactive_rollover
+            used_threshold = getattr(
+                self.config.pollypm, "failover_usage_threshold_pct", 85,
+            )
+            remaining_threshold = max(0, 100 - int(used_threshold))
             needs_roll, probe = account_needs_proactive_rollover(
                 self.config, self.store, launch.account.name,
+                threshold_pct=remaining_threshold,
             )
         except Exception:  # noqa: BLE001
             logger.warning(

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -7,14 +7,14 @@ import pytest
 from pollypm.capacity import (
     CapacityProbeResult,
     CapacityState,
-    FailoverCandidate,
-    FailoverDecision,
+    DEFAULT_FAILOVER_USAGE_THRESHOLD_PCT,
     FAILOVER_TRIGGERS,
     PROACTIVE_ROLLOVER_THRESHOLD_PCT,
     RECOVERY_PRIORITY,
     _health_to_state,
     _parse_remaining_pct,
     account_needs_proactive_rollover,
+    evaluate_proactive_controller_failover,
     probe_capacity,
     probe_all_accounts,
     select_failover_account,
@@ -24,10 +24,8 @@ from pollypm.capacity import (
 )
 from pollypm.models import (
     AccountConfig,
-    KnownProject,
     PollyPMConfig,
     PollyPMSettings,
-    ProjectKind,
     ProjectSettings,
     ProviderKind,
     SessionConfig,
@@ -98,6 +96,21 @@ def _config(tmp_path: Path) -> PollyPMConfig:
 def _store(tmp_path: Path) -> StateStore:
     db_path = tmp_path / "state.db"
     return StateStore(db_path)
+
+
+def _usage(store: StateStore, account_name: str, used_pct: int) -> None:
+    remaining_pct = max(0, 100 - used_pct)
+    provider = "codex" if account_name.startswith("codex") else "claude"
+    store.upsert_account_usage(
+        account_name=account_name,
+        provider=provider,
+        plan="max",
+        health="healthy",
+        usage_summary=f"{remaining_pct}% left",
+        raw_text="",
+        used_pct=used_pct,
+        remaining_pct=remaining_pct,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +292,86 @@ class TestAccountNeedsProactiveRollover:
         assert account_needs_proactive_rollover(
             config, store, "claude_main", threshold_pct=20,
         )[0] is True
+
+
+class TestEvaluateProactiveControllerFailover:
+    def test_default_used_threshold_is_85(self) -> None:
+        assert DEFAULT_FAILOVER_USAGE_THRESHOLD_PCT == 85
+
+    @pytest.mark.parametrize(
+        ("used_pct", "expected_action"),
+        [
+            (84, "none"),
+            (85, "switch"),
+            (86, "switch"),
+        ],
+    )
+    def test_primary_usage_threshold(self, tmp_path: Path, used_pct: int, expected_action: str) -> None:
+        config = _config(tmp_path)
+        store = _store(tmp_path)
+        _usage(store, "claude_main", used_pct)
+        _usage(store, "claude_backup", 10)
+
+        decision = evaluate_proactive_controller_failover(
+            config,
+            store,
+            current_account="claude_main",
+        )
+
+        assert decision.action == expected_action
+        if expected_action == "switch":
+            assert decision.selected_account == "claude_backup"
+            assert decision.reason == "used_pct_threshold"
+
+    def test_all_failover_accounts_over_threshold_alerts(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        store = _store(tmp_path)
+        _usage(store, "claude_main", 90)
+        _usage(store, "claude_backup", 90)
+        _usage(store, "codex_main", 90)
+
+        decision = evaluate_proactive_controller_failover(
+            config,
+            store,
+            current_account="claude_main",
+        )
+
+        assert decision.action == "alert"
+        assert decision.selected_account is None
+        assert decision.reason == "no_failover_account_below_threshold"
+
+    def test_primary_below_threshold_returns_from_backup(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        store = _store(tmp_path)
+        _usage(store, "claude_main", 50)
+        _usage(store, "claude_backup", 10)
+
+        decision = evaluate_proactive_controller_failover(
+            config,
+            store,
+            current_account="claude_backup",
+        )
+
+        assert decision.action == "return"
+        assert decision.selected_account == "claude_main"
+        assert decision.reason == "primary_below_threshold"
+
+    def test_selects_first_failover_under_threshold(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        store = _store(tmp_path)
+        _usage(store, "claude_main", 90)
+        _usage(store, "claude_backup", 90)
+        _usage(store, "codex_main", 40)
+
+        decision = evaluate_proactive_controller_failover(
+            config,
+            store,
+            current_account="claude_main",
+        )
+
+        assert decision.action == "switch"
+        assert decision.selected_account == "codex_main"
+        assert decision.candidates_evaluated == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,6 +53,7 @@ def test_load_example_config(tmp_path: Path) -> None:
     assert config.pollypm.open_permissions_by_default is True
     assert config.pollypm.failover_enabled is True
     assert config.pollypm.failover_accounts == ["claude_primary"]
+    assert config.pollypm.failover_usage_threshold_pct == 85
     assert config.pollypm.lease_timeout_minutes == 30
     assert config.memory.backend == "file"
     assert set(config.accounts) == {"codex_primary", "claude_primary"}
@@ -83,7 +84,32 @@ def test_example_config_documents_storage_block(tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(rendered)
     config = load_config(config_path)
-    assert config.storage.backend == "sqlite"  # default until uncommented
+    assert config.storage.backend == "postgres"
+
+
+def test_failover_usage_threshold_round_trips(tmp_path: Path) -> None:
+    config = PollyPMConfig(
+        project=ProjectSettings(root_dir=tmp_path),
+        pollypm=PollyPMSettings(
+            controller_account="claude_primary",
+            failover_usage_threshold_pct=72,
+        ),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+            )
+        },
+        sessions={},
+        projects={},
+    )
+    config_path = tmp_path / "pollypm.toml"
+
+    write_config(config, config_path)
+    loaded = load_config(config_path)
+
+    assert loaded.pollypm.failover_usage_threshold_pct == 72
+    assert "failover_usage_threshold_pct = 72" in config_path.read_text()
 
 
 def test_write_example_config_uses_fresh_install_session_name(tmp_path: Path) -> None:

--- a/tests/test_core_recurring_proactive_failover.py
+++ b/tests/test_core_recurring_proactive_failover.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pollypm.capacity import ProactiveFailoverDecision
+from pollypm.models import (
+    AccountConfig,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+    ProviderKind,
+    SessionConfig,
+)
+from pollypm.plugins_builtin.core_recurring.maintenance import (
+    _apply_proactive_controller_failover,
+)
+
+
+class _MsgStore:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self.alerts: list[tuple[str, str, str, str]] = []
+        self.cleared: list[tuple[str, str, str]] = []
+
+    def append_event(self, *, scope, sender, subject, payload):  # noqa: ANN001
+        self.events.append(
+            {
+                "scope": scope,
+                "sender": sender,
+                "subject": subject,
+                "payload": payload,
+            }
+        )
+
+    def upsert_alert(self, session_name, alert_type, severity, message):  # noqa: ANN001
+        self.alerts.append((session_name, alert_type, severity, message))
+
+    def clear_alert(self, session_name, alert_type, *, who_cleared="system"):  # noqa: ANN001
+        self.cleared.append((session_name, alert_type, who_cleared))
+
+
+def _config(tmp_path: Path) -> PollyPMConfig:
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="Test",
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="claude_main",
+            failover_enabled=True,
+            failover_accounts=["claude_backup"],
+            failover_usage_threshold_pct=85,
+        ),
+        accounts={
+            "claude_main": AccountConfig(
+                name="claude_main",
+                provider=ProviderKind.CLAUDE,
+                home=tmp_path / "homes" / "claude_main",
+            ),
+            "claude_backup": AccountConfig(
+                name="claude_backup",
+                provider=ProviderKind.CLAUDE,
+                home=tmp_path / "homes" / "claude_backup",
+            ),
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_main",
+                cwd=tmp_path,
+            )
+        },
+        projects={},
+    )
+
+
+def test_proactive_failover_switches_operator_and_emits_audit_event(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    msg_store = _MsgStore()
+    switched: list[tuple[str, str]] = []
+
+    summary = _apply_proactive_controller_failover(
+        tmp_path / "pollypm.toml",
+        config,
+        ProactiveFailoverDecision(
+            action="switch",
+            primary_account="claude_main",
+            current_account="claude_main",
+            selected_account="claude_backup",
+            reason="used_pct_threshold",
+            threshold_pct=85,
+            candidates_evaluated=1,
+        ),
+        msg_store=msg_store,
+        switcher=lambda session_name, account_name: switched.append(
+            (session_name, account_name)
+        ),
+    )
+
+    assert switched == [("operator", "claude_backup")]
+    assert summary["applied"] is True
+    assert msg_store.events[-1]["subject"] == "account.failover.proactive"
+    assert msg_store.events[-1]["payload"] == {
+        "from": "claude_main",
+        "to": "claude_backup",
+        "reason": "used_pct_threshold",
+        "threshold": 85,
+        "current": "claude_main",
+        "message": (
+            "Proactive account failover claude_main -> claude_backup "
+            "(used_pct_threshold, threshold=85%)"
+        ),
+    }
+    assert msg_store.alerts[-1] == (
+        "pollypm",
+        "proactive_failover_active",
+        "info",
+        (
+            "Primary account claude_main is at or above 85% usage; "
+            "operator is using claude_backup."
+        ),
+    )
+    assert (
+        "pollypm",
+        "proactive_failover_no_capacity",
+        "auto:account.usage_refresh",
+    ) in msg_store.cleared
+
+
+def test_proactive_failover_alerts_when_no_account_is_under_threshold(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    msg_store = _MsgStore()
+
+    summary = _apply_proactive_controller_failover(
+        tmp_path / "pollypm.toml",
+        config,
+        ProactiveFailoverDecision(
+            action="alert",
+            primary_account="claude_main",
+            current_account="claude_main",
+            selected_account=None,
+            reason="no_failover_account_below_threshold",
+            threshold_pct=85,
+            candidates_evaluated=1,
+        ),
+        msg_store=msg_store,
+        switcher=lambda *_args: None,
+    )
+
+    assert summary["action"] == "alert"
+    assert msg_store.alerts[-1][0:3] == (
+        "pollypm",
+        "proactive_failover_no_capacity",
+        "warn",
+    )
+    assert "no failover account is below" in msg_store.alerts[-1][3]
+    assert msg_store.events[-1]["payload"]["to"] is None
+
+
+def test_proactive_failover_return_clears_active_alert(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    msg_store = _MsgStore()
+    switched: list[tuple[str, str]] = []
+
+    summary = _apply_proactive_controller_failover(
+        tmp_path / "pollypm.toml",
+        config,
+        ProactiveFailoverDecision(
+            action="return",
+            primary_account="claude_main",
+            current_account="claude_backup",
+            selected_account="claude_main",
+            reason="primary_below_threshold",
+            threshold_pct=85,
+            candidates_evaluated=0,
+        ),
+        msg_store=msg_store,
+        switcher=lambda session_name, account_name: switched.append(
+            (session_name, account_name)
+        ),
+    )
+
+    assert summary["applied"] is True
+    assert switched == [("operator", "claude_main")]
+    assert (
+        "pollypm",
+        "proactive_failover_active",
+        "auto:account.usage_refresh",
+    ) in msg_store.cleared
+    assert msg_store.events[-1]["payload"]["from"] == "claude_backup"
+    assert msg_store.events[-1]["payload"]["to"] == "claude_main"


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- add `[pollypm].failover_usage_threshold_pct` with a default of 85
- evaluate primary controller `used_pct` during account usage refresh and soft-switch the operator session to the first failover account below the threshold
- emit `account.failover.proactive` audit events, raise visible active/no-capacity alerts, and return to the primary when its usage drops below threshold

Refs #2095

## Tests
- `uv run ruff check src/pollypm/capacity.py src/pollypm/plugins_builtin/core_recurring/maintenance.py src/pollypm/config.py src/pollypm/models.py tests/test_capacity.py tests/test_config.py tests/test_core_recurring_proactive_failover.py`
- `uv run ruff check --ignore E402 src/pollypm/supervisor.py`
- `TMP_HOME=$(mktemp -d); HOME="$TMP_HOME" XDG_CONFIG_HOME="$TMP_HOME/.config" uv run pytest tests/test_capacity.py tests/test_config.py tests/test_core_recurring_proactive_failover.py`
- `TMP_HOME=$(mktemp -d); HOME="$TMP_HOME" XDG_CONFIG_HOME="$TMP_HOME/.config" uv run pytest tests/test_import_boundary.py`
- `uv run pytest tests/test_account_usage_sampler.py tests/test_core_recurring_migration.py tests/integration/test_capacity_integration.py` *(fails: `tests/test_account_usage_sampler.py` still expects legacy `StateStore` usage rows while the sampler writes/reads pg facade state; migration and capacity integration tests pass)*
- `uv run pytest tests/test_supervisor.py -k 'capacity_low or proactive or switch_session_account'` *(fails in existing pg/legacy state mismatch: `test_switch_session_account_restarts_in_place` expects `supervisor.store.get_session_runtime` after runtime is written through pg facade)*
- `git diff --check`