### PR TITLE
feat(web-ui): filter surface rail

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -23,6 +23,7 @@
     surfaces: [],
     selectedSurface: null,
     messageTimer: null,
+    surfaceFilter: "",
   };
 
   // ----- DOM helpers ------------------------------------------------------
@@ -130,13 +131,25 @@
   function renderSurfaces() {
     const list = $("surface-list");
     list.innerHTML = "";
+    const filter = state.surfaceFilter.trim().toLowerCase();
+    const surfaces = filter
+      ? state.surfaces.filter((s) => (
+        String(s.session_name || "").toLowerCase().includes(filter)
+      ))
+      : state.surfaces;
     if (state.surfaces.length === 0) {
       list.appendChild(
         el("li", { class: "surface-empty", text: "no surfaces registered" }),
       );
       return;
     }
-    for (const s of state.surfaces) {
+    if (surfaces.length === 0) {
+      list.appendChild(
+        el("li", { class: "surface-empty", text: "no matching surfaces" }),
+      );
+      return;
+    }
+    for (const s of surfaces) {
       const dotClass =
         s.window && s.window.pane_dead
           ? "surface-dot dead"
@@ -426,7 +439,17 @@
     });
   }
 
+  function wireSurfaceFilter() {
+    const input = $("surface-filter");
+    if (!input) return;
+    input.addEventListener("input", () => {
+      state.surfaceFilter = input.value || "";
+      renderSurfaces();
+    });
+  }
+
   function init() {
+    wireSurfaceFilter();
     wireSendForm();
     setStatus("warn", "connecting…");
     loadSurfaces();

--- a/src/pollypm/web_api/ui/index.html
+++ b/src/pollypm/web_api/ui/index.html
@@ -22,6 +22,16 @@
 <main id="layout">
   <aside id="surface-rail" aria-label="Chat surfaces">
     <h2 class="rail-title">Surfaces</h2>
+    <div class="surface-filter-wrap">
+      <input
+        id="surface-filter"
+        class="surface-filter"
+        type="search"
+        placeholder="Filter surfaces"
+        aria-label="Filter surfaces"
+        autocomplete="off"
+      />
+    </div>
     <ul id="surface-list" class="surface-list">
       <li class="surface-empty">loading…</li>
     </ul>

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -138,6 +138,27 @@ aside#dashboard-rail {
   color: var(--text-muted);
 }
 
+.surface-filter-wrap {
+  padding: 0 12px 8px;
+}
+.surface-filter {
+  width: 100%;
+  padding: 7px 9px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-body);
+  font: inherit;
+  font-size: 12.5px;
+}
+.surface-filter::placeholder {
+  color: var(--text-muted);
+}
+.surface-filter:focus {
+  outline: none;
+  border-color: var(--info);
+}
+
 .surface-list {
   list-style: none;
   margin: 0;

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -810,6 +810,25 @@ def test_styles_have_mobile_media_query(client: TestClient) -> None:
     )
 
 
+# -------- Section 9: surface rail filter --------------------------------
+
+
+def test_ui_surface_filter_input_rendered(client: TestClient) -> None:
+    """The web UI renders a search input above the surface rail."""
+    body = client.get("/ui/").text
+    assert 'id="surface-filter"' in body
+    assert 'type="search"' in body
+    assert 'aria-label="Filter surfaces"' in body
+
+
+def test_ui_app_js_filters_surfaces_case_insensitive(client: TestClient) -> None:
+    """Surface filtering is client-side and case-insensitive."""
+    body = client.get("/ui/app.js").text
+    assert "state.surfaceFilter" in body
+    assert ".toLowerCase().includes(filter)" in body
+    assert 'addEventListener("input"' in body
+
+
 # -------- Round-4: renderDashboard ↔ real /dashboard schema -------------
 
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- add a native search input above the left-rail surface list
- filter surfaces by case-insensitive substring match on `session_name`
- keep empty-query and no-match states explicit

Refs #2098

## Tests
- `uv run ruff check tests/web_api/test_web_ui.py`
- `TMP_HOME=$(mktemp -d); HOME="$TMP_HOME" XDG_CONFIG_HOME="$TMP_HOME/.config" uv run pytest tests/web_api/test_web_ui.py`
- `git diff --check`