### PR TITLE
feat(web-ui): warn before session cookie expires

### DIFF
--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -29,6 +29,7 @@ from fastapi.staticfiles import StaticFiles
 
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.web_api.auth import (
+    SESSION_ISSUED_COOKIE_NAME,
     SESSION_COOKIE_NAME,
     _extract_token,
     is_tailscale_ip,
@@ -790,6 +791,15 @@ def _mount_web_ui(
                 secure=False,
                 path="/",
                 max_age=60 * 60 * 24 * 7,  # 7 days
+            )
+            response.set_cookie(
+                key=SESSION_ISSUED_COOKIE_NAME,
+                value=str(int(time.time())),
+                httponly=False,
+                samesite="lax",
+                secure=False,
+                path="/",
+                max_age=60 * 60 * 24 * 7,
             )
         # If the token file doesn't exist yet, or the caller isn't on
         # a trusted path, we still serve the HTML — the SPA will

--- a/src/pollypm/web_api/auth.py
+++ b/src/pollypm/web_api/auth.py
@@ -57,6 +57,7 @@ _TAILSCALE_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
 
 # Cookie name used by ``GET /ui/`` to seed the browser session.
 SESSION_COOKIE_NAME = "pollypm-session"
+SESSION_ISSUED_COOKIE_NAME = "pollypm-session-issued-at"
 
 
 def is_tailscale_ip(host: str | None) -> bool:

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -18,11 +18,14 @@
   const POLL_DASHBOARD_MS = 15000;
   const POLL_MESSAGES_MS = 5000;
   const MAX_MESSAGES = 50;
+  const SESSION_ISSUED_COOKIE = "pollypm-session-issued-at";
+  const SESSION_EXPIRY_WARNING_MS = 6 * 24 * 60 * 60 * 1000;
 
   const state = {
     surfaces: [],
     selectedSurface: null,
     messageTimer: null,
+    sessionExpiryDismissed: false,
   };
 
   // ----- DOM helpers ------------------------------------------------------
@@ -74,6 +77,51 @@
       "`pm api regen-token` and send the value in an " +
       "`Authorization: Bearer …` header.";
     const layout = document.getElementById("layout") || document.body;
+    layout.parentNode.insertBefore(banner, layout);
+  }
+
+  function cookieValue(name) {
+    const prefix = name + "=";
+    const parts = document.cookie ? document.cookie.split(";") : [];
+    for (const rawPart of parts) {
+      const part = rawPart.trim();
+      if (part.indexOf(prefix) === 0) {
+        return decodeURIComponent(part.slice(prefix.length));
+      }
+    }
+    return "";
+  }
+
+  function maybeShowSessionExpiryBanner() {
+    if (state.sessionExpiryDismissed || $("session-expiry-banner")) return;
+    const issuedRaw = cookieValue(SESSION_ISSUED_COOKIE);
+    const issuedSeconds = Number.parseInt(issuedRaw, 10);
+    if (!Number.isFinite(issuedSeconds)) return;
+    const ageMs = Date.now() - issuedSeconds * 1000;
+    if (ageMs < SESSION_EXPIRY_WARNING_MS) return;
+
+    const banner = el("div", {
+      id: "session-expiry-banner",
+      class: "session-expiry-banner",
+    }, [
+      el("span", {
+        text: "Session expires soon; refresh page to renew.",
+      }),
+      el("button", {
+        type: "button",
+        class: "session-expiry-dismiss",
+        text: "Dismiss",
+        "aria-label": "Dismiss session expiry warning",
+      }),
+    ]);
+    const dismiss = banner.querySelector("button");
+    if (dismiss) {
+      dismiss.addEventListener("click", () => {
+        state.sessionExpiryDismissed = true;
+        banner.remove();
+      });
+    }
+    const layout = $("layout") || document.body;
     layout.parentNode.insertBefore(banner, layout);
   }
 
@@ -427,6 +475,7 @@
   }
 
   function init() {
+    maybeShowSessionExpiryBanner();
     wireSendForm();
     setStatus("warn", "connecting…");
     loadSurfaces();

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -346,6 +346,34 @@ section#message-pane {
   line-height: 1.5;
 }
 
+.session-expiry-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 12px 16px;
+  padding: 9px 12px;
+  border: 1px solid var(--waiting);
+  border-radius: 6px;
+  background: rgba(240, 196, 90, 0.10);
+  color: var(--waiting);
+  font-size: 12.5px;
+}
+.session-expiry-dismiss {
+  flex: 0 0 auto;
+  padding: 5px 9px;
+  border: 1px solid var(--waiting);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-heading);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+.session-expiry-dismiss:hover {
+  background: rgba(240, 196, 90, 0.14);
+}
+
 /* Mobile / tablet — collapse the three-column grid into a single
  * stacked column so 360–768px viewports (phones in portrait, small
  * tablets) don't horizontally overflow. The cockpit-tinted message

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -37,7 +37,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 from pollypm.cli_features.web_api import detect_tailscale_ip
-from pollypm.web_api.auth import SESSION_COOKIE_NAME, is_tailscale_ip
+from pollypm.web_api.auth import (
+    SESSION_COOKIE_NAME,
+    SESSION_ISSUED_COOKIE_NAME,
+    is_tailscale_ip,
+)
 
 
 def _ui_get_with_peer(app, peer_ip: str, *, headers: dict[str, str] | None = None) -> httpx.Response:
@@ -87,6 +91,10 @@ def test_ui_root_returns_html_and_sets_session_cookie(client: TestClient, token:
     assert response.headers["content-type"].startswith("text/html")
     cookie = response.cookies.get(SESSION_COOKIE_NAME)
     assert cookie == token, "session cookie should mirror on-disk token"
+    issued = response.cookies.get(SESSION_ISSUED_COOKIE_NAME)
+    assert issued is not None and issued.isdigit(), (
+        "session issue-time cookie should be readable by JS for expiry warnings"
+    )
 
 
 # -------- P0 #1: cookie issuance gating ---------------------------------
@@ -195,6 +203,15 @@ def test_ui_static_css_served(client: TestClient) -> None:
     body = response.text
     # Sanity-check that the palette wired through (not an empty file).
     assert "--info" in body or "#5b8aff" in body
+
+
+def test_ui_app_js_warns_when_session_cookie_is_near_expiry(client: TestClient) -> None:
+    """The SPA has a day-6 warning path based on the readable issue cookie."""
+    body = client.get("/ui/app.js").text
+    assert "pollypm-session-issued-at" in body
+    assert "SESSION_EXPIRY_WARNING_MS = 6 * 24 * 60 * 60 * 1000" in body
+    assert "Session expires soon; refresh page to renew." in body
+    assert "sessionExpiryDismissed" in body
 
 
 def test_auth_via_cookie_works(client: TestClient, token: str) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- set a non-sensitive readable `pollypm-session-issued-at` companion cookie when `/ui/` mints the HttpOnly session cookie
- show a dismissible banner when the browser sees the cookie age reach 6 days
- add focused web UI tests for the companion cookie and SPA warning path

Refs #2097

## Tests
- `uv run ruff check src/pollypm/web_api/app.py src/pollypm/web_api/auth.py tests/web_api/test_web_ui.py`
- `TMP_HOME=$(mktemp -d); HOME="$TMP_HOME" XDG_CONFIG_HOME="$TMP_HOME/.config" uv run pytest tests/web_api/test_web_ui.py`
- `git diff --check`