### PR TITLE
feat(health): report auth posture

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2564,7 +2564,7 @@ components:
     # ---- Health -----------------------------------------------------
     HealthResponse:
       type: object
-      required: [status, version, schema_version, started_at]
+      required: [status, version, schema_version, started_at, auth_mode, tailnet_trust_enabled]
       properties:
         status:
           type: string
@@ -2578,6 +2578,13 @@ components:
         started_at:
           type: string
           format: date-time
+        auth_mode:
+          type: string
+          enum: [tailnet_trust, bearer_only]
+          description: Authentication posture for this server process.
+        tailnet_trust_enabled:
+          type: boolean
+          description: Whether Tailscale CGNAT peers are accepted without bearer or cookie credentials.
 
     DoctorCheck:
       type: object

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -411,6 +411,7 @@ def create_app(
         # frontend can read it, defeating the documented contract.
         expose_headers=["Last-Event-ID", "X-PollyPM-Warning"],
     )
+    app.state.tailnet_trust_enabled = tailnet_trust_enabled
 
     # Wire the config provider. When the loaded config carries the
     # on-disk ``config_path`` (always true for ``pm serve``), re-invoke

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -50,6 +50,8 @@ class HealthResponse(BaseModel):
     version: str
     schema_version: int
     started_at: datetime
+    auth_mode: Literal["tailnet_trust", "bearer_only"]
+    tailnet_trust_enabled: bool
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/web_api/routes/health.py
+++ b/src/pollypm/web_api/routes/health.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from pollypm.audit.log import SCHEMA_VERSION
 from pollypm.web_api.models import HealthResponse
@@ -44,10 +44,17 @@ _STARTED_AT = datetime.now(timezone.utc)
     summary="Liveness + version info",
     operation_id="getHealth",
 )
-def get_health() -> HealthResponse:
+def get_health(request: Request) -> HealthResponse:
+    tailnet_trust_enabled = bool(
+        getattr(request.app.state, "tailnet_trust_enabled", False)
+    )
     return HealthResponse(
         status="ok",
         version=_server_version(),
         schema_version=SCHEMA_VERSION,
         started_at=_STARTED_AT,
+        auth_mode=(
+            "tailnet_trust" if tailnet_trust_enabled else "bearer_only"
+        ),
+        tailnet_trust_enabled=tailnet_trust_enabled,
     )

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -197,6 +197,24 @@ def test_ui_static_css_served(client: TestClient) -> None:
     assert "--info" in body or "#5b8aff" in body
 
 
+def test_health_reports_bearer_only_auth_mode(client: TestClient) -> None:
+    """Default app health reports the closed-by-default auth posture."""
+    response = client.get("/api/v1/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["auth_mode"] == "bearer_only"
+    assert body["tailnet_trust_enabled"] is False
+
+
+def test_health_reports_tailnet_trust_mode(tailnet_app) -> None:
+    """Tailnet-bound app health reports credential-free tailnet trust."""
+    response = TestClient(tailnet_app).get("/api/v1/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["auth_mode"] == "tailnet_trust"
+    assert body["tailnet_trust_enabled"] is True
+
+
 def test_auth_via_cookie_works(client: TestClient, token: str) -> None:
     """A request that carries only the session cookie authenticates.
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- store `tailnet_trust_enabled` on the FastAPI app state at startup
- return `auth_mode` and `tailnet_trust_enabled` from `/api/v1/health`
- update the OpenAPI schema and add tests for bearer-only and tailnet-trust modes

Refs #2117

## Tests
- `uv run ruff check src/pollypm/web_api/app.py src/pollypm/web_api/routes/health.py src/pollypm/web_api/models.py tests/web_api/test_web_ui.py`
- `TMP_HOME=$(mktemp -d); HOME="$TMP_HOME" XDG_CONFIG_HOME="$TMP_HOME/.config" uv run pytest tests/web_api/test_web_ui.py`
- `TMP_HOME=$(mktemp -d); HOME="$TMP_HOME" XDG_CONFIG_HOME="$TMP_HOME/.config" uv run pytest tests/web_api/test_openapi_conformance.py`
- `git diff --check`