### PR TITLE
feat(projects): add unpause alias

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -391,6 +391,32 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
+  /projects/{key}/unpause:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    post:
+      tags: [Projects]
+      operationId: unpauseProject
+      summary: Unpause a project (set tracked=true)
+      description: |
+        Alias for `POST /projects/{key}/resume`. Flips
+        `KnownProject.tracked=true` and re-renders the global TOML.
+        Idempotent — a second call against an already-tracked project
+        returns 200 with the same snapshot and skips the disk write.
+      responses:
+        "200":
+          description: Project unpaused (or already was).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
   /projects/{key}/archive:
     parameters:
       - $ref: "#/components/parameters/ProjectKey"

--- a/src/pollypm/web_api/routes/projects.py
+++ b/src/pollypm/web_api/routes/projects.py
@@ -8,6 +8,7 @@ Implements:
 - ``GET /api/v1/projects/{key}/plan`` — structured plan body.
 - ``POST /api/v1/projects/{key}/pause`` — mark project ``tracked=false``.
 - ``POST /api/v1/projects/{key}/resume`` — mark project ``tracked=true``.
+- ``POST /api/v1/projects/{key}/unpause`` — alias for ``resume``.
 - ``POST /api/v1/projects/{key}/archive`` — remove project from config
   (per spec §6.2; source data on disk is untouched).
 - ``POST /api/v1/projects/{key}/init-guide`` — seed a project-local
@@ -21,6 +22,7 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
+from pollypm.config import PollyPMConfig
 from pollypm.web_api.errors import not_found
 from pollypm.web_api.models import (
     ActionResult,
@@ -213,6 +215,28 @@ def resume_project_endpoint(
     key: str,
     config: ConfigDep,
 ) -> Project:
+    return _resume_project(config, key)
+
+
+@router.post(
+    "/projects/{key}/unpause",
+    response_model=Project,
+    summary="Unpause a project (set tracked=true)",
+    operation_id="unpauseProject",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project not registered."},
+        "503": {"description": "Backing store unreachable (failed to persist)."},
+    },
+)
+def unpause_project_endpoint(
+    key: str,
+    config: ConfigDep,
+) -> Project:
+    return _resume_project(config, key)
+
+
+def _resume_project(config: PollyPMConfig, key: str) -> Project:
     # Idempotency lives in ``set_project_tracked`` (Codex round 2 on
     # #2063): deciding "already tracked" against the long-lived
     # ``ConfigDep`` snapshot was returning 200 with a stale value when

--- a/tests/test_projects_writes_endpoint.py
+++ b/tests/test_projects_writes_endpoint.py
@@ -2,6 +2,7 @@
 
 Covers ``POST /api/v1/projects/{key}/pause``,
 ``POST /api/v1/projects/{key}/resume``,
+``POST /api/v1/projects/{key}/unpause``,
 ``POST /api/v1/projects/{key}/archive``, and
 ``POST /api/v1/projects/{key}/init-guide`` per the Phase 2 endpoints
 spec §6.2.
@@ -237,6 +238,42 @@ def test_resume_is_idempotent_on_already_tracked(
     assert config.projects["myproj"].tracked is True
 
 
+def test_unpause_alias_sets_tracked_true(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config_path: Path,
+) -> None:
+    paused = load_config(config_path)
+    paused.projects["myproj"].tracked = False
+    write_config(paused, config_path, force=True)
+
+    response = client.post(
+        "/api/v1/projects/myproj/unpause", headers=auth_headers, json={}
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["key"] == "myproj"
+    assert body["tracked"] is True
+
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is True
+
+
+def test_unpause_alias_is_idempotent_on_already_tracked(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    config_path: Path,
+) -> None:
+    response = client.post(
+        "/api/v1/projects/myproj/unpause", headers=auth_headers, json={}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["tracked"] is True
+
+    reloaded = load_config(config_path)
+    assert reloaded.projects["myproj"].tracked is True
+
+
 # ---------------------------------------------------------------------------
 # Archive
 # ---------------------------------------------------------------------------
@@ -283,6 +320,12 @@ def test_archive_irreversible_resume_after_archive_returns_404(
     )
     assert resume_attempt.status_code == 404
     assert resume_attempt.json()["error"]["code"] == "not_found"
+
+    unpause_attempt = client.post(
+        "/api/v1/projects/myproj/unpause", headers=auth_headers, json={}
+    )
+    assert unpause_attempt.status_code == 404
+    assert unpause_attempt.json()["error"]["code"] == "not_found"
 
     pause_attempt = client.post(
         "/api/v1/projects/myproj/pause", headers=auth_headers, json={}
@@ -391,6 +434,11 @@ def test_archive_requires_auth(client: TestClient) -> None:
     assert response.status_code == 401
 
 
+def test_unpause_requires_auth(client: TestClient) -> None:
+    response = client.post("/api/v1/projects/myproj/unpause", json={})
+    assert response.status_code == 401
+
+
 def test_init_guide_requires_auth(client: TestClient) -> None:
     response = client.post(
         "/api/v1/projects/myproj/init-guide", json={"role": "architect"}
@@ -419,6 +467,18 @@ def test_resume_unknown_project_returns_404(
         json={},
     )
     assert response.status_code == 404
+
+
+def test_unpause_unknown_project_returns_404(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    response = client.post(
+        "/api/v1/projects/no-such-project/unpause",
+        headers=auth_headers,
+        json={},
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
 
 
 def test_archive_unknown_project_returns_404(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds `POST /api/v1/projects/{key}/unpause` as an alias for the existing resume behavior.
- Documents the new REST path in the static OpenAPI spec.
- Covers success, idempotent, auth, unknown-project, and post-archive behavior in project write endpoint tests.

## Issue
Closes #2113

## Tests
- `uv run ruff check src/pollypm/web_api/routes/projects.py tests/test_projects_writes_endpoint.py`
- `env HOME=/tmp/pollypm-codex-2113-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2113-home/.config uv run pytest tests/test_projects_writes_endpoint.py -k 'unpause or resume_happy_path or resume_unknown_project or archive_irreversible'`
- `env HOME=/tmp/pollypm-codex-2113-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2113-home/.config uv run pytest tests/web_api/test_openapi_conformance.py`
- `git diff --check`
