### PR TITLE
fix(chat-api): honor send safety query param

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -823,6 +823,15 @@ paths:
         `ask_user` envelope, `selections[]` must match one of the
         question's option labels exactly; `notes` are appended
         after the selections joined by newlines.
+      parameters:
+        - in: query
+          name: safety
+          schema:
+            type: string
+            enum: [strict, loose, force]
+          description: |
+            Optional query-string safety override. When present, this
+            takes precedence over the JSON body `safety` field.
       requestBody:
         required: true
         content:

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -76,9 +76,9 @@ import subprocess
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, Query, Response
 from pydantic import BaseModel, Field
 
 from pollypm.tmux.client import DeadPaneError, TmuxClient
@@ -1264,8 +1264,19 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
     body: ChatSendRequest,
     config: ConfigDep,
     response: Response,
+    safety: Annotated[
+        Literal["strict", "loose", "force"] | None,
+        Query(
+            description=(
+                "Optional query-string safety override. When present, "
+                "this takes precedence over the JSON body safety field."
+            )
+        ),
+    ] = None,
 ) -> ChatSendResponse:
     """POST /api/v1/chat/{session_name}/send — push text into a tmux pane."""
+    safety_mode = safety or body.safety
+
     # 1. Resolve session via the P1 facade (validates workers against
     # the work-service — see Codex review block 2).
     surface = _resolve_surface(config, session_name)
@@ -1321,7 +1332,7 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
             # without the transcript. Force still proceeds (no
             # ask_envelope means selections-only sends will fail
             # later — that's fine; force is "I know what I'm doing").
-            if body.safety == "strict":
+            if safety_mode == "strict":
                 raise _unsafe_unavailable_transcript(str(exc)) from exc
             # loose: continue; the answer_to branch below will surface
             # ``answer_to_missing`` if the envelope can't be found, and
@@ -1338,7 +1349,7 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
 
     # 3. Safety gates (§4.1, §4.3) — use the exact session transcript
     # (Codex review block 3).
-    if body.safety != "force":
+    if safety_mode != "force":
         if resolution == "absent_but_others_exist":
             # Strict and loose both require an exact transcript
             # mapping. Other transcripts exist for the project but
@@ -1353,26 +1364,26 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
             transcript_unavailable_detail = (
                 transcript_unavailable_detail or str(exc)
             )
-            if body.safety == "strict":
+            if safety_mode == "strict":
                 raise _unsafe_unavailable_transcript(str(exc)) from exc
             # loose: continue — warning header is set below.
         try:
             age = _heartbeat_age_seconds(config, session_name)
         except HeartbeatUnavailable as exc:
             # Strict: fail closed; loose: continue with warning header.
-            if body.safety == "strict":
+            if safety_mode == "strict":
                 raise _unsafe_unavailable_heartbeat(str(exc)) from exc
             # loose
             response.headers["X-PollyPM-Warning"] = "heartbeat-unavailable"
             streaming = False
         else:
             streaming = age is not None and age < _MID_STREAM_WINDOW_SECONDS
-        if body.safety == "strict" and streaming:
+        if safety_mode == "strict" and streaming:
             raise _unsafe_mid_stream()
-        if body.safety == "loose" and streaming:
+        if safety_mode == "loose" and streaming:
             response.headers["X-PollyPM-Warning"] = "agent-may-be-streaming"
         if (
-            body.safety == "loose"
+            safety_mode == "loose"
             and transcript_unavailable_detail is not None
             and "X-PollyPM-Warning" not in response.headers
         ):

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -827,6 +827,28 @@ def test_safety_force_bypasses_mid_tool(
     assert response.status_code == 200
 
 
+def test_safety_force_query_param_bypasses_mid_tool(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, 0.5)  # also fresh heartbeat
+    _write_events_jsonl(
+        project_root, "session-open", _assistant_with_open_tool(),
+        cwd=workspace_root,
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send?safety=force",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+
+
 def test_safety_loose_still_enforces_mid_tool(
     client: TestClient,
     auth_headers: dict[str, str],


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds a real `safety` query parameter to `POST /api/v1/chat/{session_name}/send`.
- Uses query-string safety as an override when present while preserving the existing JSON body safety field.
- Documents the query parameter in the static OpenAPI spec and covers the force query form in chat-send safety tests.

## Issue
Closes #2108

## Tests
- `uv run ruff check src/pollypm/web_api/routes/chat_send.py tests/test_chat_send_endpoint.py`
- `env HOME=/tmp/pollypm-codex-2108-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2108-home/.config uv run pytest tests/test_chat_send_endpoint.py -k 'safety_force_bypasses_mid_tool or safety_force_query_param_bypasses_mid_tool or safety_force_bypasses_mid_stream or safety_loose_still_enforces_mid_tool'`
- `env HOME=/tmp/pollypm-codex-2108-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2108-home/.config uv run pytest tests/web_api/test_openapi_conformance.py`
- `git diff --check`
