### PR TITLE
docs(chat-api): clarify unknown session error

### DIFF
--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -368,6 +368,11 @@ It does **not** bypass pane/window validation: `409 pane_invalid`,
 | 400 | `invalid_request` | Catch-all for body-shape problems: missing `text` when `answer_to` is unset; `answer_to` set but no `selections`/`text`/`notes` supplied; etc. The message body identifies the specific problem. |
 | 422 | `validation_error` | FastAPI Pydantic rejection — malformed JSON, wrong field types, `safety` not in `{strict, loose, force}`, etc. Default FastAPI envelope shape (`{"detail": [...]}`). |
 
+Smoke tests should not expect `window_missing` for a nonexistent
+`session_name`: that request fails before tmux resolution and returns
+`404 session_unknown`. Use a configured session with its tmux window
+stopped to exercise `503 window_missing`.
+
 **Curl examples:**
 
 ```bash

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -345,6 +345,12 @@ safety gates only. Pane and window existence + liveness errors
 `safety=loose` keeps the mid-tool gate but allows mid-stream sends
 with a response header.
 
+Smoke tests should distinguish the two address-resolution failures:
+use an unregistered `session_name` to assert `404 session_unknown`, and
+use a registered session whose tmux window is absent to assert
+`503 window_missing`. A nonexistent session never reaches the tmux
+window probe.
+
 Explicit `pane` (including `pane=0`) always validates via
 `list_panes()` and routes to the indexed target (`session:window.N`);
 only an omitted `pane` falls back to the window-level (active-pane)

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -525,11 +525,18 @@ def test_ended_worker_session_returns_404(
 # ---------------------------------------------------------------------------
 
 
-def test_unknown_session_returns_404(
+def test_unknown_session_returns_404_session_unknown_not_window_missing(
     client: TestClient,
     auth_headers: dict[str, str],
     patched_tmux: type[FakeTmuxClient],  # noqa: ARG001
 ) -> None:
+    """Unknown names fail at the registry layer, not tmux resolution.
+
+    ``window_missing`` is reserved for a registered chat surface whose
+    tmux window is absent. A name that is neither a configured session
+    nor an active worker should stay ``session_unknown`` so clients can
+    distinguish typos from runtime process loss.
+    """
     response = client.post(
         "/api/v1/chat/nope/send",
         json={"text": "hello"},


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Clarifies that nonexistent chat sessions return `404 session_unknown`, while `503 window_missing` is reserved for registered sessions whose tmux window is absent.
- Adds explicit smoke-test guidance in the chat API docs and web API spec.
- Renames/docstrings the existing regression test so the contract is visible in the test suite.

## Decision
I kept the current API behavior instead of making unknown sessions return `503 window_missing`. A nonexistent session fails at the registry/surface boundary and never reaches tmux window resolution; returning `window_missing` would conflate a typo or stale client surface with runtime process loss.

## Issue
Closes #2109

## Tests
- `uv run ruff check tests/test_chat_send_endpoint.py`
- `env HOME=/tmp/pollypm-codex-2109-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2109-home/.config uv run pytest tests/test_chat_send_endpoint.py -k 'unknown_session_returns_404_session_unknown_not_window_missing or missing_window_returns_503'`
- `git diff --check`
