### PR TITLE
fix(sessions): plumb restart force lease override

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1680,6 +1680,14 @@ paths:
         `?safety=force` bypasses BOTH the mid-turn check and the
         probe-unknown check.
 
+        `?force=true` or `{"force": true}` bypasses a human-held
+        session lease only. It does not bypass the mid-turn safety
+        gate; combine with `?safety=force` only when the operator
+        intentionally wants both overrides.
+
+        Returns `409 session_leased` when the session is leased to
+        another owner and `force` was not requested.
+
         Returns `503 daemon_unavailable` when the supervisor or tmux
         session service can't be constructed, when no account can be
         resolved for the session, or when `restart_session` raises.
@@ -1695,6 +1703,28 @@ paths:
             mid-turn; `force` bypasses the mid-turn gate. `loose` is
             treated like `strict` for this verb (no warn-and-proceed
             semantics defined yet).
+        - in: query
+          name: force
+          schema:
+            type: boolean
+            default: false
+          description: |
+            Bypass a human-held session lease. This does not bypass the
+            mid-turn safety probe; use `safety=force` for that.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                  default: false
+                  description: |
+                    Bypass a human-held session lease. This does not
+                    bypass the mid-turn safety probe; use
+                    `safety=force` for that.
       responses:
         "200":
           description: Restart completed.
@@ -1708,9 +1738,12 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           description: |
-            Refused because the agent is mid-turn
-            (`code=unsafe_mid_turn`). Re-issue with `?safety=force` to
-            override.
+            One of:
+            * `code=unsafe_mid_turn` — refused because the agent is
+              mid-turn. Re-issue with `?safety=force` to override.
+            * `code=session_leased` — refused because the session is
+              leased to another owner. Re-issue with `?force=true` or
+              `{"force": true}` to override the lease.
           content:
             application/json:
               schema:

--- a/src/pollypm/session_leases.py
+++ b/src/pollypm/session_leases.py
@@ -1,0 +1,16 @@
+"""Shared session-lease control errors."""
+
+from __future__ import annotations
+
+
+class SessionLeaseConflictError(RuntimeError):
+    """Raised when an operation is blocked by another lease owner."""
+
+    def __init__(self, *, session_name: str, owner: str, action: str) -> None:
+        self.session_name = session_name
+        self.owner = owner
+        self.action = action
+        super().__init__(
+            f"Cannot {action} {session_name}: session is currently leased "
+            f"to {owner}; use --force to bypass"
+        )

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -93,6 +93,7 @@ from pollypm.providers.claude.resume import (
     transcript_matches_session as _claude_transcript_matches_session,
 )
 from pollypm.schedulers import ScheduledJob, get_scheduler_backend
+from pollypm.session_leases import SessionLeaseConflictError
 from pollypm.store.registry import get_store
 from pollypm.transcript_ledger import sync_token_ledger_for_config
 from pollypm import supervisor_alerts as _supervisor_alerts
@@ -3762,10 +3763,29 @@ class Supervisor:
             retry_at=(datetime.now(UTC) + timedelta(minutes=15)).isoformat(),
         )
 
-    def _restart_session(self, session_name: str, account_name: str, *, failure_type: str) -> None:
-        return self.restart_session(session_name, account_name, failure_type=failure_type)
+    def _restart_session(
+        self,
+        session_name: str,
+        account_name: str,
+        *,
+        failure_type: str,
+        force: bool = False,
+    ) -> None:
+        return self.restart_session(
+            session_name,
+            account_name,
+            failure_type=failure_type,
+            force=force,
+        )
 
-    def restart_session(self, session_name: str, account_name: str, *, failure_type: str) -> None:
+    def restart_session(
+        self,
+        session_name: str,
+        account_name: str,
+        *,
+        failure_type: str,
+        force: bool = False,
+    ) -> None:
         """Restart ``session_name`` on ``account_name`` after a failure.
 
         Inputs: the session name, the target account to switch to, and the
@@ -3777,6 +3797,7 @@ class Supervisor:
         self._assert_lease_available(
             session_name,
             owner="pollypm",
+            force=force,
             action="restart",
         )
         tmux_session = self._tmux_session_for_launch(launch)
@@ -4141,8 +4162,10 @@ class Supervisor:
         lease = self._get_lease(session_name)
         if lease is None or lease.owner == owner or force:
             return
-        raise RuntimeError(
-            f"Cannot {action} {session_name}: session is currently leased to {lease.owner}; use --force to bypass"
+        raise SessionLeaseConflictError(
+            session_name=session_name,
+            owner=lease.owner,
+            action=action,
         )
 
     def _release_session_locks(self, launch: SessionLaunchSpec) -> None:

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -140,6 +140,7 @@ from pollypm.session_paused import (
 from pollypm.session_paused import (
     save_paused_names as _save_paused_names,
 )
+from pollypm.session_leases import SessionLeaseConflictError
 from pollypm.web_api.errors import APIError, service_unavailable
 from pollypm.web_api.models import ActionResult
 from pollypm.web_api.routes._deps import ConfigDep
@@ -241,6 +242,18 @@ class SessionDetail(BaseModel):
     is_turn_active: bool = False
 
 
+class RestartSessionRequest(BaseModel):
+    """Optional body for ``POST /sessions/{name}/restart``."""
+
+    force: bool = Field(
+        default=False,
+        description=(
+            "Bypass a human-held session lease. This does not bypass the "
+            "mid-turn safety probe; use safety=force for that."
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Typed errors (spec §10.3)
 # ---------------------------------------------------------------------------
@@ -291,6 +304,18 @@ def _unsafe_mid_turn_unknown(name: str, detail: str) -> APIError:
         hint=(
             "Retry once the tmux service is healthy, or pass "
             "?safety=force to override the probe (destructive)."
+        ),
+    )
+
+
+def _session_leased(name: str, detail: str) -> APIError:
+    return APIError(
+        status_code=409,
+        code="session_leased",
+        message=f"Cannot restart {name!r}: {detail}.",
+        hint=(
+            "Wait for the lease holder to release the session, or pass "
+            "?force=true / {\"force\": true} to override the lease."
         ),
     )
 
@@ -875,6 +900,7 @@ def get_session_endpoint(name: str, config: ConfigDep) -> SessionDetail:
 def restart_session_endpoint(
     name: str,
     config: ConfigDep,
+    body: RestartSessionRequest | None = None,
     safety: Annotated[SafetyMode, Query(
         description=(
             "Safety gate. 'strict' (default) refuses restart while the "
@@ -883,6 +909,12 @@ def restart_session_endpoint(
             "restart (no warning-emit semantics defined yet)."
         ),
     )] = "strict",
+    force: Annotated[bool, Query(
+        description=(
+            "Bypass a human-held session lease. This does not bypass the "
+            "mid-turn safety probe; use safety=force for that."
+        ),
+    )] = False,
 ) -> ActionResult:
     """POST /api/v1/sessions/{name}/restart — facade-driven relaunch.
 
@@ -897,6 +929,8 @@ def restart_session_endpoint(
     * **404** ``not_found`` if the session isn't configured.
     * **409** ``unsafe_mid_turn`` if strict-mode and the agent is
       actively streaming a turn.
+    * **409** ``session_leased`` if the session is leased to another
+      owner and ``force`` was not requested.
     * **503** ``unsafe_mid_turn_unknown`` if strict-mode and the
       mid-turn safety probe itself failed (fail-closed — Codex PR
       #2061 P0 #2).
@@ -904,6 +938,7 @@ def restart_session_endpoint(
       can't be constructed, or if ``restart_session`` raises.
     """
     session = _find_session(config, name)
+    force_restart = force or (body.force if body is not None else False)
 
     # Safety gate (Codex PR #2061 P0 #2 + rounds 6+7). Strict mode (the
     # default) fails *closed* — a probe that cannot answer "is this
@@ -977,8 +1012,16 @@ def restart_session_endpoint(
 
         try:
             supervisor.restart_session(
-                name, account_name, failure_type="api_restart",
+                name,
+                account_name,
+                failure_type="api_restart",
+                force=force_restart,
             )
+        except SessionLeaseConflictError as exc:
+            logger.debug(
+                "restart_session lease conflict for %s", name, exc_info=True,
+            )
+            raise _session_leased(name, str(exc)) from exc
         except KeyError as exc:
             # ``Supervisor.restart_session`` raises ``KeyError`` for an
             # unknown account; surface as 503 because the API contract is

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -36,6 +36,7 @@ from pollypm.models import (
     RuntimeKind,
     SessionConfig,
 )
+from pollypm.session_leases import SessionLeaseConflictError
 from pollypm.web_api import create_app, ensure_token
 from pollypm.web_api.routes import sessions_admin as sessions_admin_routes
 
@@ -236,9 +237,11 @@ class _FakeSupervisor:
         *,
         restart_raises: Exception | None = None,
         effective_account: str | None = None,
+        lease_owner: str | None = None,
     ) -> None:
         self.restart_raises = restart_raises
         self.effective_account = effective_account
+        self.lease_owner = lease_owner
         self.restart_calls: list[dict[str, Any]] = []
 
     def get_session_runtime(self, name: str) -> Any:  # noqa: ARG002
@@ -251,13 +254,25 @@ class _FakeSupervisor:
         return SimpleNamespace(effective_account=self.effective_account)
 
     def restart_session(
-        self, session_name: str, account_name: str, *, failure_type: str,
+        self,
+        session_name: str,
+        account_name: str,
+        *,
+        failure_type: str,
+        force: bool = False,
     ) -> None:
         self.restart_calls.append({
             "session_name": session_name,
             "account_name": account_name,
             "failure_type": failure_type,
+            "force": force,
         })
+        if self.lease_owner is not None and not force:
+            raise SessionLeaseConflictError(
+                session_name=session_name,
+                owner=self.lease_owner,
+                action="restart",
+            )
         if self.restart_raises is not None:
             raise self.restart_raises
 
@@ -604,6 +619,7 @@ def test_restart_routes_through_supervisor_facade(
     assert call["session_name"] == "operator"
     assert call["account_name"] == "claude_primary"
     assert call["failure_type"] == "api_restart"
+    assert call["force"] is False
 
 
 def test_restart_prefers_effective_account_over_configured(
@@ -730,6 +746,60 @@ def test_restart_force_overrides_mid_turn(
     assert response.status_code == 200, response.text
     assert len(sup.restart_calls) == 1
     assert sup.restart_calls[0]["session_name"] == "operator"
+
+
+def test_restart_lease_conflict_returns_409_session_leased(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_strict_probe, patch_supervisor,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_strict_probe(mid_turn=False)
+    sup = patch_supervisor(_FakeSupervisor(lease_owner="human"))
+    response = client.post(
+        "/api/v1/sessions/operator/restart", headers=auth_headers,
+    )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "session_leased"
+    assert "force" in body["error"]["hint"]
+    assert len(sup.restart_calls) == 1
+    assert sup.restart_calls[0]["force"] is False
+
+
+def test_restart_query_force_bypasses_lease_conflict(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_strict_probe, patch_supervisor,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_strict_probe(mid_turn=False)
+    sup = patch_supervisor(_FakeSupervisor(lease_owner="human"))
+    response = client.post(
+        "/api/v1/sessions/operator/restart?force=true",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert len(sup.restart_calls) == 1
+    assert sup.restart_calls[0]["force"] is True
+
+
+def test_restart_body_force_bypasses_lease_conflict(
+    client, auth_headers, patch_heartbeat, patch_tmux_windows,
+    patch_strict_probe, patch_supervisor,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator"])
+    patch_strict_probe(mid_turn=False)
+    sup = patch_supervisor(_FakeSupervisor(lease_owner="human"))
+    response = client.post(
+        "/api/v1/sessions/operator/restart",
+        headers=auth_headers,
+        json={"force": True},
+    )
+    assert response.status_code == 200, response.text
+    assert len(sup.restart_calls) == 1
+    assert sup.restart_calls[0]["force"] is True
 
 
 def test_restart_404_unknown_session(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -28,6 +28,7 @@ from pollypm.models import (
     SessionConfig,
     SessionLaunchSpec,
 )
+from pollypm.session_leases import SessionLeaseConflictError
 from pollypm.supervisor import (
     Supervisor,
     _extract_claude_model_name,
@@ -2518,6 +2519,53 @@ def test_restart_session_skips_recovery_prompt_for_heartbeat(
     runtime = supervisor.store.get_session_runtime("heartbeat")
     assert runtime is not None
     assert runtime.status == "healthy"
+
+
+def test_restart_session_rejects_conflicting_lease_by_default(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    supervisor.claim_lease("operator", "human", "manual takeover")
+    monkeypatch.setattr(
+        supervisor.session_service.tmux, "has_session", lambda _name: False,
+    )
+
+    try:
+        supervisor.restart_session(
+            "operator", "claude_controller", failure_type="api_restart",
+        )
+    except SessionLeaseConflictError as exc:
+        assert exc.owner == "human"
+        assert "currently leased to human" in str(exc)
+    else:
+        raise AssertionError("expected restart to fail while human lease is active")
+
+
+def test_restart_session_force_bypasses_conflicting_lease(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    supervisor.claim_lease("operator", "human", "manual takeover")
+    monkeypatch.setattr(
+        supervisor.session_service.tmux, "has_session", lambda _name: False,
+    )
+    launched: list[str] = []
+    monkeypatch.setattr(
+        supervisor, "launch_session", lambda name: launched.append(name),
+    )
+
+    supervisor.restart_session(
+        "operator",
+        "claude_controller",
+        failure_type="api_restart",
+        force=True,
+    )
+
+    assert launched == ["operator"]
 
 
 def test_identity_preamble_threads_project_persona_for_architect() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds a shared `SessionLeaseConflictError` and has `Supervisor.restart_session(..., force=True)` pass the lease override into the canonical lease guard.
- Adds `force` support to `POST /api/v1/sessions/{name}/restart` via both `?force=true` and `{"force": true}` while keeping `safety=force` scoped to the mid-turn probe.
- Maps restart lease conflicts to `409 session_leased` instead of `503 daemon_unavailable` and documents the new contract in OpenAPI.

## Issues
Closes #2110
Closes #2111

## Tests
- `uv run ruff check src/pollypm/session_leases.py src/pollypm/web_api/routes/sessions_admin.py tests/test_sessions_admin_endpoint.py`
- `uv run ruff check --ignore E402,F401 src/pollypm/session_leases.py src/pollypm/supervisor.py src/pollypm/web_api/routes/sessions_admin.py tests/test_sessions_admin_endpoint.py tests/test_supervisor.py`
- `env HOME=/tmp/pollypm-codex-2110-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2110-home/.config uv run pytest tests/test_sessions_admin_endpoint.py -k 'restart_routes_through_supervisor_facade or restart_lease_conflict_returns_409_session_leased or restart_query_force_bypasses_lease_conflict or restart_body_force_bypasses_lease_conflict or restart_force_overrides_mid_turn'`
- `env HOME=/tmp/pollypm-codex-2110-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2110-home/.config uv run pytest tests/test_supervisor.py -k 'restart_session_rejects_conflicting_lease_by_default or restart_session_force_bypasses_conflicting_lease'`
- `env HOME=/tmp/pollypm-codex-2110-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2110-home/.config uv run pytest tests/web_api/test_openapi_conformance.py`
- `git diff --check`

Note: the supervisor module/test still require the repo's existing E402/F401 lint ignore; the route and new module pass ruff without ignores.
