### PR TITLE
fix(inbox): report double archive as invalid state

### DIFF
--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -30,7 +30,7 @@ import psycopg_pool
 from pollypm.audit.log import AuditEvent, read_events
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.models import KnownProject
-from pollypm.work.inbox_view import is_inbox_task
+from pollypm.work.inbox_view import is_inbox_task, is_inbox_task_identity
 from pollypm.web_api.errors import (
     APIError,
     not_found,
@@ -1849,6 +1849,15 @@ def patch_task(
 _ALREADY_ARCHIVED_STATUSES: frozenset[str] = frozenset({"done", "cancelled"})
 
 
+def _inbox_already_archived(item_id: str, status: str) -> APIError:
+    return APIError(
+        status_code=409,
+        code="invalid_state",
+        message=f"Inbox item {item_id} is already {status}; cannot archive.",
+        hint="Items in a terminal state cannot be re-archived.",
+    )
+
+
 def _project_key_from_inbox_id(item_id: str) -> str:
     """Pull the project key off an inbox item id (``project/n``).
 
@@ -1930,6 +1939,14 @@ def archive_inbox_item(
             # cannot drift open relative to the read surface (Codex
             # round-5 blocker on #2060).
             if not is_inbox_task(src_task, svc):
+                status = getattr(
+                    src_task.work_status, "value", str(src_task.work_status)
+                )
+                if (
+                    status in _ALREADY_ARCHIVED_STATUSES
+                    and is_inbox_task_identity(src_task, svc)
+                ):
+                    raise _inbox_already_archived(item_id, status)
                 raise not_found(f"Inbox item not found: {item_id}")
             # Run the strict transition FIRST so the reason note is
             # only persisted on a successful archive (#2060 round-4
@@ -1946,10 +1963,11 @@ def archive_inbox_item(
             except InvalidTransitionError as exc:
                 # The atomic UPDATE asserted the row was non-terminal;
                 # losing the race means another caller archived first.
+                message = str(exc)
                 raise APIError(
                     status_code=409,
                     code="invalid_state",
-                    message=str(exc) or (
+                    message=message or (
                         f"Inbox item {item_id} is already terminal."
                     ),
                     hint="Items in a terminal state cannot be re-archived.",

--- a/src/pollypm/work/inbox_view.py
+++ b/src/pollypm/work/inbox_view.py
@@ -175,6 +175,28 @@ def _is_plan_review_label(task: Task) -> bool:
     return any(label == "plan_review" for label in labels)
 
 
+def is_inbox_task_identity(
+    task: Task,
+    service: _FlowLookup,
+    *,
+    flow_cache: dict[tuple[str, int], FlowTemplate] | None = None,
+) -> bool:
+    """Return True if ``task`` has the non-status inbox identity.
+
+    This intentionally ignores terminal status. Write endpoints use it
+    only after the normal :func:`is_inbox_task` predicate rejects a
+    terminal row, so they can distinguish "already archived inbox item"
+    from "ordinary task that never belonged to the inbox" without
+    duplicating membership rules.
+    """
+    if _roles_match_user(task):
+        return True
+    if _is_plan_review_label(task):
+        return True
+    cache = flow_cache if flow_cache is not None else {}
+    return _current_node_is_human(task, service, flow_cache=cache)
+
+
 def is_inbox_task(
     task: Task,
     service: _FlowLookup,
@@ -193,12 +215,7 @@ def is_inbox_task(
     """
     if getattr(task, "work_status", None) in TERMINAL_STATUSES:
         return False
-    if _roles_match_user(task):
-        return True
-    if _is_plan_review_label(task):
-        return True
-    cache = flow_cache if flow_cache is not None else {}
-    return _current_node_is_human(task, service, flow_cache=cache)
+    return is_inbox_task_identity(task, service, flow_cache=flow_cache)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -1512,6 +1512,100 @@ class _ArchiveRaceLoserSvc:
         self.add_context_calls.append((args, kwargs))
 
 
+class _AlreadyArchivedInboxTask(_ConcurrentLoserStubTask):
+    @property
+    def work_status(self):  # noqa: D401
+        from pollypm.work.models import WorkStatus
+        return WorkStatus.DONE
+
+
+class _TerminalNonInboxTask(_NonInboxStubTask):
+    @property
+    def work_status(self):  # noqa: D401
+        from pollypm.work.models import WorkStatus
+        return WorkStatus.DONE
+
+
+class _AlreadyArchivedSvc:
+    def __init__(self, task) -> None:
+        self._task = task
+        self.archive_calls = 0
+        self.add_context_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, item_id):
+        return self._task
+
+    def archive_task(self, *args, **kwargs):
+        self.archive_calls += 1
+        raise AssertionError("already-archived rows should fail before mutation")
+
+    def add_context(self, *args, **kwargs):
+        self.add_context_calls += 1
+        raise AssertionError("already-archived rows should not write reason notes")
+
+
+def test_archive_already_archived_inbox_item_returns_409(
+    config, monkeypatch,
+) -> None:
+    """A terminal row that still has inbox identity is already archived.
+
+    Regression for #2112: after the first successful archive, the row
+    exits the open inbox set, so the normal read-surface predicate
+    returns false. The write path still needs to distinguish that from
+    "never was an inbox item" and return 409 ``invalid_state`` instead
+    of 404 ``not_found``.
+    """
+    from pollypm.web_api import service as web_service
+
+    svc = _AlreadyArchivedSvc(_AlreadyArchivedInboxTask())
+
+    def fake_factory(*, config, project_key, project_path):
+        return svc
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+
+    with pytest.raises(APIError) as excinfo:
+        web_service.archive_inbox_item(
+            config, "myproj/1", reason="second click", actor="api",
+        )
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.code == "invalid_state"
+    assert "already done" in excinfo.value.message
+    assert svc.archive_calls == 0
+    assert svc.add_context_calls == 0
+
+
+def test_archive_terminal_non_inbox_task_still_returns_404(
+    config, monkeypatch,
+) -> None:
+    """Terminal status alone must not widen the inbox write surface."""
+    from pollypm.web_api import service as web_service
+
+    svc = _AlreadyArchivedSvc(_TerminalNonInboxTask())
+
+    def fake_factory(*, config, project_key, project_path):
+        return svc
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+
+    with pytest.raises(APIError) as excinfo:
+        web_service.archive_inbox_item(config, "myproj/1", reason="x")
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.code == "not_found"
+    assert svc.archive_calls == 0
+    assert svc.add_context_calls == 0
+
+
 def test_archive_strict_loser_does_not_persist_reason_note(
     config, monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Splits inbox membership into the normal open-inbox predicate and a status-independent identity predicate.
- Uses the identity predicate to classify already-terminal inbox rows as `409 invalid_state` on archive, while keeping ordinary non-inbox rows as `404 not_found`.
- Adds regression coverage for double archive and for terminal non-inbox rows staying protected from inbox writes.

## Issue
Closes #2112

## Tests
- `uv run ruff check --ignore E402,F401 src/pollypm/work/inbox_view.py src/pollypm/web_api/service.py tests/test_inbox_writes_endpoint.py`
- `env HOME=/tmp/pollypm-codex-2112-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2112-home/.config uv run pytest tests/test_inbox_writes_endpoint.py -k 'archive_already_archived_inbox_item_returns_409 or archive_terminal_non_inbox_task_still_returns_404 or archive_strict_loser_does_not_persist_reason_note or archive_rejects_non_inbox_task'`
- `git diff --check`

Note: `src/pollypm/web_api/service.py` still has pre-existing E402/F401 lint noise, so the targeted ruff run used the repo's existing ignore pattern for that file.
