### PR TITLE
fix(chat): bound sessions tmux discovery

### DIFF
--- a/src/pollypm/tmux/client.py
+++ b/src/pollypm/tmux/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re as _re
 import shlex
 import subprocess
 from dataclasses import dataclass
@@ -37,8 +38,6 @@ class TmuxPane:
     pane_left: int
     pane_width: int
 
-
-import re as _re
 
 # Safe characters for tmux session/window names
 _NAME_RE = _re.compile(r"^[a-zA-Z0-9_.-]+$")
@@ -98,7 +97,7 @@ class TmuxClient:
                 capture_output=True,
                 timeout=effective_timeout,
             )
-        except subprocess.TimeoutExpired as exc:
+        except subprocess.TimeoutExpired:
             # When the tmux server itself is wedged (Sam's screenshot
             # 2026-04-26 14:08), even tiny calls like ``has-session``
             # block past the 15s timeout and raise. ``check=False``
@@ -526,12 +525,21 @@ class TmuxClient:
             return []
         return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
-    def list_windows(self, name: str) -> list[TmuxWindow]:
+    def list_windows(
+        self, name: str, *, timeout: int | None = None
+    ) -> list[TmuxWindow]:
         fmt = (
             "#{session_name}\t#{window_index}\t#{window_name}\t#{window_active}\t#{pane_id}\t"
             "#{pane_current_command}\t#{pane_current_path}\t#{pane_dead}\t#{pane_pid}"
         )
-        result = self.run("list-windows", "-t", self._exact_target(name), "-F", fmt)
+        result = self.run(
+            "list-windows",
+            "-t",
+            self._exact_target(name),
+            "-F",
+            fmt,
+            timeout=timeout,
+        )
         windows: list[TmuxWindow] = []
         for line in result.stdout.splitlines():
             parts = line.split("\t", 8)

--- a/src/pollypm/web_api/chat/registry.py
+++ b/src/pollypm/web_api/chat/registry.py
@@ -44,6 +44,7 @@ _OPERATOR_ROLES = frozenset({"operator-pm", "operator"})
 _OPERATOR_NAMES = frozenset({"operator", "polly"})
 _ARCHITECT_ROLES = frozenset({"architect"})
 _ADVISOR_ROLES = frozenset({"advisor"})
+_TMUX_DISCOVERY_TIMEOUT_SECONDS = 1
 
 
 class SurfaceType(StrEnum):
@@ -448,7 +449,13 @@ def _build_tmux_state_cache(
         return cache
     target = config.project.tmux_session
     try:
-        windows = list_windows(target)
+        try:
+            windows = list_windows(target, timeout=_TMUX_DISCOVERY_TIMEOUT_SECONDS)
+        except TypeError:
+            # Test doubles and older TmuxClient-compatible adapters may
+            # not accept the timeout keyword. Keep the registry protocol
+            # permissive while the real client uses the bounded probe.
+            windows = list_windows(target)
     except Exception as exc:  # noqa: BLE001
         logger.debug(
             "chat.registry: tmux list_windows(%s) failed: %s",

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -14,6 +14,7 @@ skipped — these tests are self-contained.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -27,8 +28,15 @@ from pollypm.config import (
     PollyPMSettings,
     ProjectSettings,
 )
-from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+from pollypm.models import (
+    KnownProject,
+    ProjectKind,
+    ProviderKind,
+    RuntimeKind,
+    SessionConfig,
+)
 from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.auth import SESSION_COOKIE_NAME
 from pollypm.web_api.chat.envelope import (
     MessageEnvelope,
     MessageRole,
@@ -322,6 +330,53 @@ def test_sessions_endpoint_surfaces_window_state(
     assert op["window"]["window_name"] == "operator"
     assert op["window"]["pane_id"] == "%99"
     assert op["transcript"]["source"] is None  # no archive in this fixture
+
+
+def test_sessions_endpoint_cookie_auth_uses_bounded_tmux_probe(
+    client, auth_headers, config, workspace, monkeypatch,
+):
+    class SlowTmuxClient:
+        timeout: int | None = None
+
+        def list_windows(self, name: str, *, timeout: int | None = None):
+            self.timeout = timeout
+            raise subprocess.TimeoutExpired(
+                cmd=["tmux", "list-windows", "-t", name],
+                timeout=timeout,
+            )
+
+    tmux = SlowTmuxClient()
+    token = auth_headers["Authorization"].removeprefix("Bearer ")
+    config.sessions["operator"] = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=workspace,
+        project="myproj",
+        window_name="pm-operator",
+    )
+    monkeypatch.setattr(
+        chat_messages_routes, "_build_tmux_client", lambda: tmux,
+    )
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_work_service_stub",
+        lambda _config, **_kw: None,
+    )
+
+    boot = client.get("/ui/", headers=auth_headers)
+    assert boot.status_code == 200
+    assert boot.cookies.get(SESSION_COOKIE_NAME) == token
+
+    response = client.get("/api/v1/chat/sessions")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [session["session_name"] for session in body["sessions"]] == [
+        "operator",
+    ]
+    assert body["sessions"][0]["window"]["present"] is False
+    assert tmux.timeout == 1
 
 
 def test_sessions_endpoint_requires_bearer_auth(client, patch_registry):


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Bound chat surface tmux discovery to a one-second probe so `/api/v1/chat/sessions` stays responsive when tmux is wedged.
- Kept discovery best-effort: configured chat surfaces are still returned with `window.present=false` if tmux cannot answer.
- Added a cookie-auth regression test for the `/ui/` bootstrap plus `/api/v1/chat/sessions` path that was timing out in Playwright.

Fixes #2115.

## Tests
- `uv run ruff check src/pollypm/tmux/client.py src/pollypm/web_api/chat/registry.py tests/test_chat_messages_endpoint.py`
- `env HOME=/tmp/pollypm-codex-2115-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2115-home/.config uv run pytest tests/test_chat_messages_endpoint.py -k 'sessions_endpoint_cookie_auth_uses_bounded_tmux_probe or sessions_endpoint_lists_all_four_surface_types or sessions_endpoint_surfaces_window_state'`
- `env HOME=/tmp/pollypm-codex-2115-home XDG_CONFIG_HOME=/tmp/pollypm-codex-2115-home/.config uv run pytest tests/web_api/test_web_ui.py -k 'auth_via_cookie_works or ui_root_returns_html_and_sets_session_cookie'`
- `git diff --check`
