### PR TITLE
feat(web-ui): add task surfaces to rail

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -18,10 +18,15 @@
   const POLL_DASHBOARD_MS = 15000;
   const POLL_MESSAGES_MS = 5000;
   const MAX_MESSAGES = 50;
+  const TASK_RAIL_LIMIT = 200;
 
   const state = {
     surfaces: [],
+    taskSurfaces: [],
+    taskLoadError: null,
+    selectedKind: null,
     selectedSurface: null,
+    selectedTaskKey: null,
     messageTimer: null,
   };
 
@@ -115,57 +120,180 @@
     return resp.json();
   }
 
+  async function apiJsonOptional(path) {
+    const resp = await fetch(path, {
+      credentials: "include",
+      headers: { "Accept": "application/json" },
+    });
+    if (resp.status === 401) {
+      setStatus("error", "auth required");
+      showAuthGate();
+      throw new Error("unauthorized");
+    }
+    if (!resp.ok) {
+      let body = null;
+      try { body = await resp.json(); } catch (e) { /* ignore */ }
+      const detail = body && body.error
+        ? body.error.message || body.error.code
+        : ("HTTP " + resp.status);
+      throw new Error(detail);
+    }
+    return resp.json();
+  }
+
   // ----- surfaces (left rail) --------------------------------------------
 
   async function loadSurfaces() {
     try {
       const data = await apiJson(API + "/chat/sessions");
       state.surfaces = Array.isArray(data.sessions) ? data.sessions : [];
-      renderSurfaces();
     } catch (err) {
       renderSurfaceError(err);
+      return;
     }
+
+    state.taskLoadError = null;
+    try {
+      const taskData = await apiJsonOptional(
+        API + "/tasks?limit=" + TASK_RAIL_LIMIT,
+      );
+      const items = Array.isArray(taskData.items) ? taskData.items : [];
+      state.taskSurfaces = items.map(normalizeTaskSurface);
+    } catch (err) {
+      state.taskSurfaces = [];
+      state.taskLoadError = err;
+    }
+    renderSurfaces();
+  }
+
+  function normalizeTaskSurface(task) {
+    const project = task.project || "";
+    const number = task.task_number == null ? "" : String(task.task_number);
+    const key = project && number ? project + "/" + number
+      : task.task_id || task.title || "task";
+    return {
+      key: key,
+      task_id: task.task_id || "",
+      project: project,
+      task_number: number,
+      title: task.title || key,
+      work_status: task.work_status || "unknown",
+      type: task.type || "task",
+      priority: task.priority || "",
+      assignee: task.assignee || "",
+      updated_at: task.updated_at || "",
+    };
+  }
+
+  function taskDotClass(status) {
+    if (status === "in_progress" || status === "rework") return "present";
+    if (status === "queued" || status === "review") return "waiting";
+    if (status === "blocked" || status === "on_hold") return "dead";
+    if (status === "done") return "done";
+    if (status === "cancelled") return "dead";
+    return "";
+  }
+
+  function appendRailGroup(list, label) {
+    list.appendChild(el("li", { class: "surface-group", text: label }));
+  }
+
+  function renderChatSurfaceItem(list, s) {
+    const dotClass =
+      s.window && s.window.pane_dead
+        ? "surface-dot dead"
+        : s.window && s.window.present
+          ? "surface-dot present"
+          : "surface-dot";
+    const labelParts = [];
+    if (s.surface_type) labelParts.push(s.surface_type);
+    if (s.persona && s.persona !== s.surface_type) labelParts.push(s.persona);
+    if (s.project) labelParts.push(s.project);
+    const li = el(
+      "li",
+      {
+        "data-session": s.session_name,
+        "class": (
+          state.selectedKind === "chat"
+          && state.selectedSurface === s.session_name
+        ) ? "active" : "",
+      },
+      [
+        el("span", { class: "surface-name" }, [
+          el("span", { class: dotClass }),
+          document.createTextNode(s.session_name),
+        ]),
+        el("span", {
+          class: "surface-meta",
+          text: labelParts.join(" · ") || "—",
+        }),
+      ],
+    );
+    li.addEventListener("click", () => selectSurface(s.session_name));
+    list.appendChild(li);
+  }
+
+  function renderTaskSurfaceItem(list, task) {
+    const meta = [
+      "task",
+      task.work_status,
+      task.project,
+    ].filter(Boolean);
+    if (task.assignee) meta.push("@" + task.assignee);
+    const li = el(
+      "li",
+      {
+        "data-task": task.key,
+        "class": (
+          "task-surface "
+          + (
+            state.selectedKind === "task"
+            && state.selectedTaskKey === task.key
+              ? "active" : ""
+          )
+        ).trim(),
+      },
+      [
+        el("span", { class: "surface-name" }, [
+          el("span", {
+            class: ("surface-dot " + taskDotClass(task.work_status)).trim(),
+          }),
+          document.createTextNode(task.title),
+        ]),
+        el("span", {
+          class: "surface-meta",
+          text: meta.join(" · "),
+        }),
+      ],
+    );
+    li.addEventListener("click", () => selectTask(task.key));
+    list.appendChild(li);
   }
 
   function renderSurfaces() {
     const list = $("surface-list");
     list.innerHTML = "";
-    if (state.surfaces.length === 0) {
+    const hasSurfaces = state.surfaces.length > 0;
+    const hasTasks = state.taskSurfaces.length > 0;
+    if (!hasSurfaces && !hasTasks && !state.taskLoadError) {
       list.appendChild(
         el("li", { class: "surface-empty", text: "no surfaces registered" }),
       );
       return;
     }
-    for (const s of state.surfaces) {
-      const dotClass =
-        s.window && s.window.pane_dead
-          ? "surface-dot dead"
-          : s.window && s.window.present
-            ? "surface-dot present"
-            : "surface-dot";
-      const labelParts = [];
-      if (s.surface_type) labelParts.push(s.surface_type);
-      if (s.persona && s.persona !== s.surface_type) labelParts.push(s.persona);
-      if (s.project) labelParts.push(s.project);
-      const li = el(
-        "li",
-        {
-          "data-session": s.session_name,
-          "class": state.selectedSurface === s.session_name ? "active" : "",
-        },
-        [
-          el("span", { class: "surface-name" }, [
-            el("span", { class: dotClass }),
-            document.createTextNode(s.session_name),
-          ]),
-          el("span", {
-            class: "surface-meta",
-            text: labelParts.join(" · ") || "—",
-          }),
-        ],
-      );
-      li.addEventListener("click", () => selectSurface(s.session_name));
-      list.appendChild(li);
+    if (hasSurfaces) {
+      appendRailGroup(list, "Chat surfaces");
+      for (const s of state.surfaces) renderChatSurfaceItem(list, s);
+    }
+    if (hasTasks || state.taskLoadError) {
+      appendRailGroup(list, "Tasks");
+      for (const task of state.taskSurfaces) renderTaskSurfaceItem(list, task);
+      if (state.taskLoadError) {
+        list.appendChild(el("li", {
+          class: "surface-empty",
+          text: "tasks unavailable: " + state.taskLoadError.message,
+        }));
+      }
     }
   }
 
@@ -178,7 +306,9 @@
   }
 
   function selectSurface(name) {
+    state.selectedKind = "chat";
     state.selectedSurface = name;
+    state.selectedTaskKey = null;
     $("pane-title").textContent = name;
     $("pane-meta").textContent = "";
     $("send-input").disabled = false;
@@ -186,6 +316,89 @@
     renderSurfaces();
     loadHistory(name);
     schedulePoll();
+  }
+
+  function selectTask(key) {
+    const task = state.taskSurfaces.find((item) => item.key === key);
+    if (!task) return;
+    state.selectedKind = "task";
+    state.selectedSurface = null;
+    state.selectedTaskKey = key;
+    if (state.messageTimer) clearInterval(state.messageTimer);
+    state.messageTimer = null;
+    $("pane-title").textContent = task.key;
+    $("pane-meta").textContent = [
+      task.work_status,
+      task.type,
+      task.priority,
+    ].filter(Boolean).join(" · ");
+    $("send-input").disabled = true;
+    $("send-button").disabled = true;
+    renderSurfaces();
+    renderTaskSummary(task);
+    loadTaskDetail(task);
+  }
+
+  function renderTaskSummary(task, detail) {
+    const data = detail || task;
+    const list = $("message-list");
+    list.innerHTML = "";
+    const rows = [
+      ["Status", data.work_status],
+      ["Project", data.project],
+      ["Task", data.task_number],
+      ["Assignee", data.assignee],
+      ["Priority", data.priority],
+      ["Updated", data.updated_at],
+    ].filter((row) => row[1] != null && row[1] !== "");
+    const children = [
+      el("div", { class: "task-detail-title", text: data.title || task.title }),
+    ];
+    if (data.description) {
+      children.push(el("div", {
+        class: "task-detail-description",
+        text: data.description,
+      }));
+    }
+    for (const row of rows) {
+      children.push(el("div", { class: "task-detail-row" }, [
+        el("span", { class: "task-detail-label", text: row[0] }),
+        el("span", { class: "task-detail-value", text: String(row[1]) }),
+      ]));
+    }
+    if (data.acceptance_criteria) {
+      children.push(el("div", {
+        class: "task-detail-description",
+        text: data.acceptance_criteria,
+      }));
+    }
+    list.appendChild(el("div", { class: "task-detail" }, children));
+  }
+
+  async function loadTaskDetail(task) {
+    if (!task.project || !task.task_number) return;
+    try {
+      const path = API + "/tasks/" + encodeURIComponent(task.project)
+        + "/" + encodeURIComponent(task.task_number);
+      const detail = await apiJson(path);
+      if (
+        state.selectedKind === "task"
+        && state.selectedTaskKey === task.key
+      ) {
+        renderTaskSummary(task, detail);
+      }
+    } catch (err) {
+      if (
+        state.selectedKind === "task"
+        && state.selectedTaskKey === task.key
+      ) {
+        const list = $("message-list");
+        list.appendChild(el("div", {
+          class: "error-banner",
+          text: "task detail error: " + err.message,
+        }));
+      }
+    }
   }
 
   // ----- history (center) ------------------------------------------------
@@ -405,6 +618,8 @@
 
   function schedulePoll() {
     if (state.messageTimer) clearInterval(state.messageTimer);
+    state.messageTimer = null;
+    if (state.selectedKind !== "chat") return;
     state.messageTimer = setInterval(() => {
       if (state.selectedSurface) loadHistory(state.selectedSurface);
     }, POLL_MESSAGES_MS);
@@ -418,7 +633,9 @@
     form.addEventListener("submit", (ev) => {
       ev.preventDefault();
       const text = input.value.trim();
-      if (!text || !state.selectedSurface) return;
+      if (!text || state.selectedKind !== "chat" || !state.selectedSurface) {
+        return;
+      }
       input.value = "";
       sendMessage(state.selectedSurface, text).catch((err) => {
         renderHistoryError(err);
@@ -445,7 +662,10 @@
     loadSurfaces: loadSurfaces,
     loadHistory: loadHistory,
     sendMessage: sendMessage,
+    selectSurface: selectSurface,
+    selectTask: selectTask,
     pollDashboard: pollDashboard,
+    renderSurfaces: renderSurfaces,
     renderDashboard: renderDashboard,
     state: state,
   };

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -167,14 +167,31 @@ aside#dashboard-rail {
   cursor: default;
   font-style: italic;
 }
+.surface-list li.surface-group {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-muted);
+  cursor: default;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 10px 0 4px;
+  padding: 4px 8px;
+  text-transform: uppercase;
+}
+.surface-list li.task-surface {
+  border-left: 2px solid var(--border-line);
+}
 .surface-name {
   color: var(--text-heading);
   font-weight: 500;
   font-size: 13px;
+  overflow-wrap: anywhere;
 }
 .surface-meta {
   color: var(--text-muted);
   font-size: 11px;
+  overflow-wrap: anywhere;
 }
 .surface-dot {
   display: inline-block;
@@ -186,6 +203,8 @@ aside#dashboard-rail {
   vertical-align: middle;
 }
 .surface-dot.present { background: var(--working); }
+.surface-dot.waiting { background: var(--waiting); }
+.surface-dot.done    { background: var(--info); }
 .surface-dot.dead    { background: var(--blocked); }
 
 section#message-pane {
@@ -252,6 +271,39 @@ section#message-pane {
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
     Monaco, Consolas, monospace;
   font-size: 12.5px;
+}
+
+.task-detail {
+  background: var(--bg-row);
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  padding: 12px;
+}
+.task-detail-title {
+  color: var(--text-heading-bright);
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.task-detail-description {
+  color: var(--text-body);
+  font-size: 12.5px;
+  margin: 8px 0;
+  white-space: pre-wrap;
+}
+.task-detail-row {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 8px;
+  padding: 3px 0;
+  font-size: 12px;
+}
+.task-detail-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+.task-detail-value {
+  color: var(--text-body);
+  overflow-wrap: anywhere;
 }
 
 .send-form {

--- a/tests/playwright/tests/edge_cases.spec.ts
+++ b/tests/playwright/tests/edge_cases.spec.ts
@@ -26,6 +26,16 @@ async function stubSurfaces(page: import("@playwright/test").Page) {
   );
 }
 
+async function stubTasks(page: import("@playwright/test").Page) {
+  await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
+}
+
 // Stub the dashboard read endpoint the UI fires on init so this spec
 // doesn't race live daemon state. Each test below additionally stubs
 // /chat/sessions to whatever shape it needs.
@@ -50,6 +60,7 @@ async function stubDashboard(page: import("@playwright/test").Page) {
 test.describe("edge cases", () => {
   test.beforeEach(async ({ page }) => {
     await stubDashboard(page);
+    await stubTasks(page);
   });
 
   test("409 unsafe_mid_tool surfaces in UI", async ({ page }) => {

--- a/tests/playwright/tests/keyboard.spec.ts
+++ b/tests/playwright/tests/keyboard.spec.ts
@@ -26,6 +26,13 @@ async function stubBasics(page: import("@playwright/test").Page) {
       body: JSON.stringify({ sessions: [FAKE_SURFACE] }),
     }),
   );
+  await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
   await page.route("**/api/v1/chat/operator/messages*", (route) =>
     route.fulfill({
       status: 200,

--- a/tests/playwright/tests/send_message.spec.ts
+++ b/tests/playwright/tests/send_message.spec.ts
@@ -23,6 +23,13 @@ async function stubSurfaces(page: import("@playwright/test").Page) {
       body: JSON.stringify({ sessions: [FAKE_SURFACE] }),
     }),
   );
+  await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
 }
 
 async function stubMessages(page: import("@playwright/test").Page) {

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -22,7 +22,10 @@ test.describe("surfaces", () => {
         const items = document.querySelectorAll(
           "#surface-list li[data-session]",
         ).length;
-        if (items > 0) return true;
+        const tasks = document.querySelectorAll(
+          "#surface-list li[data-task]",
+        ).length;
+        if (items > 0 || tasks > 0) return true;
         const empty = document.querySelector(
           "#surface-list .surface-empty",
         ) as HTMLElement | null;
@@ -115,6 +118,13 @@ test.describe("surfaces", () => {
         }),
       }),
     );
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      }),
+    );
     await page.goto("/ui/");
     await page.locator("li[data-session='fake-empty']").click();
     await expect(page.locator("#message-list .message-empty")).toHaveText(
@@ -127,5 +137,68 @@ test.describe("surfaces", () => {
     await expect(page.locator("#pane-title")).toHaveText("Select a surface");
     await expect(page.locator("#send-input")).toBeDisabled();
     await expect(page.locator("#send-button")).toBeDisabled();
+  });
+
+  test("task surfaces render in a separate rail group", async ({ page }) => {
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      }),
+    );
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            {
+              task_id: "task-queued",
+              project: "demo",
+              task_number: 4,
+              title: "Queued rail item",
+              work_status: "queued",
+              type: "task",
+              priority: "normal",
+              assignee: "agent-1",
+              updated_at: "2026-05-23T00:00:00Z",
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/tasks/demo/4", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          task_id: "task-queued",
+          project: "demo",
+          task_number: 4,
+          title: "Queued rail item",
+          work_status: "queued",
+          type: "task",
+          priority: "normal",
+          assignee: "agent-1",
+          updated_at: "2026-05-23T00:00:00Z",
+          description: "Visible task detail",
+          relationships: {},
+          transitions: [],
+          executions: [],
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await expect(page.locator("#surface-list .surface-group")).toHaveText([
+      "Tasks",
+    ]);
+    await page.locator("li[data-task='demo/4']").click();
+    await expect(page.locator("#pane-title")).toHaveText("demo/4");
+    await expect(page.locator("#send-input")).toBeDisabled();
+    await expect(page.locator("#message-list")).toContainText(
+      "Visible task detail",
+    );
   });
 });

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1062,6 +1062,192 @@ process.stdout.write(elements["dashboard-rollups"].innerHTML);
     return proc.stdout
 
 
+def _node_render_surface_rail(payload: dict) -> dict:
+    """Render the left rail under node and optionally select a task."""
+    node_bin = shutil.which("node")
+    if node_bin is None:
+        pytest.skip("node binary not available; cannot run executable JS harness")
+    app_js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "pollypm"
+        / "web_api"
+        / "ui"
+        / "app.js"
+    )
+    harness = r"""
+const fs = require("fs");
+const path = process.argv[1];
+const payload = JSON.parse(process.argv[2]);
+
+function makeNode(tag) {
+  const node = {
+    tagName: (tag || "div").toUpperCase(),
+    children: [],
+    attrs: {},
+    className: "",
+    textContent: "",
+    disabled: false,
+  };
+  Object.defineProperty(node, "innerHTML", {
+    get() {
+      function render(n) {
+        if (n.__text != null) return String(n.__text);
+        const tag = n.tagName.toLowerCase();
+        const parts = [];
+        for (const k of Object.keys(n.attrs)) {
+          parts.push(k + '="' + n.attrs[k] + '"');
+        }
+        if (n.className) parts.push('class="' + n.className + '"');
+        const open = parts.length
+          ? "<" + tag + " " + parts.join(" ") + ">"
+          : "<" + tag + ">";
+        const inner = n.textContent && n.children.length === 0
+          ? String(n.textContent)
+          : n.children.map(render).join("");
+        return open + inner + "</" + tag + ">";
+      }
+      return node.children.map(render).join("");
+    },
+    set(v) {
+      if (v === "") {
+        node.children = [];
+        node.textContent = "";
+      }
+    },
+  });
+  node.setAttribute = function (k, v) { node.attrs[k] = v; };
+  node.appendChild = function (child) { node.children.push(child); return child; };
+  node.querySelector = function () { return null; };
+  node.addEventListener = function () {};
+  return node;
+}
+
+const elements = {
+  "dashboard-rollups": makeNode("div"),
+  "surface-list": makeNode("ul"),
+  "message-list": makeNode("div"),
+  "send-input": makeNode("input"),
+  "send-button": makeNode("button"),
+  "send-form": makeNode("form"),
+  "pane-title": makeNode("div"),
+  "pane-meta": makeNode("div"),
+  "conn-status": makeNode("div"),
+  "layout": makeNode("div"),
+};
+
+global.document = {
+  getElementById: (id) => elements[id] || null,
+  createElement: (tag) => makeNode(tag),
+  createTextNode: (text) => {
+    const n = makeNode("span");
+    n.__text = text;
+    return n;
+  },
+  addEventListener: function () {},
+  readyState: "complete",
+  body: makeNode("body"),
+};
+global.window = {};
+global.setInterval = function () { return 0; };
+global.clearInterval = function () {};
+global.setTimeout = function () { return 0; };
+global.fetch = function () { return Promise.reject(new Error("no network")); };
+
+const source = fs.readFileSync(path, "utf8");
+// eslint-disable-next-line no-eval
+eval(source);
+
+global.window.PollyPM.state.surfaces = payload.surfaces || [];
+global.window.PollyPM.state.taskSurfaces = payload.tasks || [];
+global.window.PollyPM.renderSurfaces();
+if (payload.selectTask) {
+  global.window.PollyPM.selectTask(payload.selectTask);
+}
+process.stdout.write(JSON.stringify({
+  rail: elements["surface-list"].innerHTML,
+  title: elements["pane-title"].textContent,
+  meta: elements["pane-meta"].textContent,
+  messages: elements["message-list"].innerHTML,
+  sendInputDisabled: elements["send-input"].disabled,
+  sendButtonDisabled: elements["send-button"].disabled,
+}));
+"""
+    proc = subprocess.run(
+        [node_bin, "-e", harness, str(app_js_path), json.dumps(payload)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"node harness failed (rc={proc.returncode}):\n"
+            f"STDOUT: {proc.stdout}\nSTDERR: {proc.stderr}"
+        )
+    return json.loads(proc.stdout)
+
+
+def test_render_surface_rail_groups_chat_and_task_surfaces() -> None:
+    rendered = _node_render_surface_rail({
+        "surfaces": [
+            {
+                "session_name": "operator",
+                "surface_type": "operator",
+                "persona": "Polly",
+                "project": None,
+                "window": {"present": True, "pane_dead": False},
+            },
+        ],
+        "tasks": [
+            {
+                "key": "myproj/2",
+                "task_id": "task-2",
+                "project": "myproj",
+                "task_number": "2",
+                "title": "Queued work",
+                "work_status": "queued",
+                "type": "task",
+                "priority": "normal",
+                "assignee": "agent-1",
+                "updated_at": "2026-05-23T00:00:00Z",
+            },
+        ],
+    })
+    rail = rendered["rail"]
+    assert "Chat surfaces" in rail
+    assert "Tasks" in rail
+    assert 'data-session="operator"' in rail
+    assert 'data-task="myproj/2"' in rail
+    assert "Queued work" in rail
+    assert "queued" in rail
+
+
+def test_selecting_task_surface_disables_chat_send() -> None:
+    rendered = _node_render_surface_rail({
+        "tasks": [
+            {
+                "key": "myproj/7",
+                "task_id": "task-7",
+                "project": "myproj",
+                "task_number": "7",
+                "title": "Historical fix",
+                "work_status": "done",
+                "type": "bug",
+                "priority": "high",
+                "assignee": "",
+                "updated_at": "2026-05-23T00:00:00Z",
+            },
+        ],
+        "selectTask": "myproj/7",
+    })
+    assert rendered["title"] == "myproj/7"
+    assert "done" in rendered["meta"]
+    assert "Historical fix" in rendered["messages"]
+    assert rendered["sendInputDisabled"] is True
+    assert rendered["sendButtonDisabled"] is True
+
+
 def test_render_dashboard_real_payload_executes() -> None:
     """Feed a representative DashboardResponse through ``renderDashboard``.
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Added a separate Tasks group to the left rail, populated from the existing public `GET /api/v1/tasks?limit=200` contract so queued, running, and historical tasks are reachable without pretending they are chat sessions.
- Kept `GET /api/v1/chat/sessions` focused on chat-capable operator/architect/advisor/worker surfaces; this avoids duplicating task state in a parallel task-sessions endpoint and preserves the task API as the single source of truth for task status.
- Selecting a task renders task detail/summary in the center pane and disables chat send controls, while chat surface behavior remains on `data-session` items.
- Updated Playwright stubs so existing rail/send/edge specs stay isolated from live task state.

Fixes #2101.

## Tests
- `uv run ruff check tests/web_api/test_web_ui.py`
- `uv run pytest tests/web_api/test_web_ui.py -k 'render_surface_rail_groups_chat_and_task_surfaces or selecting_task_surface_disables_chat_send'`
- `uv run pytest tests/web_api/test_web_ui.py -k 'ui_root_returns_html_and_sets_session_cookie or auth_via_cookie_works or render_surface_rail_groups_chat_and_task_surfaces or selecting_task_surface_disables_chat_send'`
- `cd tests/playwright && npx playwright test --list`
- `git diff --check`
