### PR TITLE
feat(web-ui): add surface audit panel

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -18,11 +18,16 @@
   const POLL_DASHBOARD_MS = 15000;
   const POLL_MESSAGES_MS = 5000;
   const MAX_MESSAGES = 50;
+  const AUDIT_LIMIT = 25;
 
   const state = {
     surfaces: [],
     selectedSurface: null,
     messageTimer: null,
+    auditExpanded: {},
+    auditEntries: {},
+    auditErrors: {},
+    auditLoading: {},
   };
 
   // ----- DOM helpers ------------------------------------------------------
@@ -185,7 +190,130 @@
     $("send-button").disabled = false;
     renderSurfaces();
     loadHistory(name);
+    if (state.auditExpanded[name]) loadAuditForSurface(name);
     schedulePoll();
+  }
+
+  function surfaceByName(name) {
+    return state.surfaces.find((s) => s.session_name === name) || null;
+  }
+
+  function auditPatternForSurface(surface, name) {
+    if (
+      surface
+      && surface.surface_type === "worker"
+      && surface.project
+      && surface.task_id != null
+    ) {
+      return surface.project + "/" + surface.task_id;
+    }
+    return name;
+  }
+
+  function auditPathForSurface(name) {
+    const surface = surfaceByName(name);
+    const params = new URLSearchParams();
+    params.set("limit", String(AUDIT_LIMIT));
+    params.set("since", "7d");
+    params.set("pattern", auditPatternForSurface(surface, name));
+    if (surface && surface.project) params.set("project", surface.project);
+    return API + "/audit/grep?" + params.toString();
+  }
+
+  function auditSummary(entry) {
+    const parts = [entry.event || "audit"];
+    if (entry.subject) parts.push(entry.subject);
+    if (entry.status) parts.push(entry.status);
+    if (entry.actor) parts.push("by " + entry.actor);
+    return parts.join(" · ");
+  }
+
+  function removeExistingAuditPanel(list) {
+    const existing = list.querySelector(".audit-panel");
+    if (existing) existing.remove();
+  }
+
+  function renderAuditPanel(name) {
+    if (!name) return;
+    const list = $("message-list");
+    removeExistingAuditPanel(list);
+    const expanded = Boolean(state.auditExpanded[name]);
+    const entries = state.auditEntries[name] || [];
+    const loading = Boolean(state.auditLoading[name]);
+    const error = state.auditErrors[name];
+    const children = [];
+    const toggle = el("button", {
+      class: "audit-toggle",
+      type: "button",
+      "aria-expanded": expanded ? "true" : "false",
+      text: expanded ? "Hide audit log" : "Show audit log",
+    });
+    toggle.addEventListener("click", () => {
+      state.auditExpanded[name] = !state.auditExpanded[name];
+      renderAuditPanel(name);
+      if (state.auditExpanded[name]) loadAuditForSurface(name);
+    });
+    const headerChildren = [
+      el("div", { class: "audit-title", text: "Audit log" }),
+      toggle,
+    ];
+    if (expanded) {
+      const refresh = el("button", {
+        class: "audit-refresh",
+        type: "button",
+        text: "Refresh",
+      });
+      refresh.addEventListener("click", () => loadAuditForSurface(name));
+      headerChildren.push(refresh);
+    }
+    children.push(el("div", { class: "audit-header" }, headerChildren));
+    if (expanded) {
+      const bodyChildren = [];
+      if (loading) {
+        bodyChildren.push(el("div", {
+          class: "audit-empty",
+          text: "loading audit entries...",
+        }));
+      } else if (error) {
+        bodyChildren.push(el("div", {
+          class: "audit-empty",
+          text: "audit error: " + error.message,
+        }));
+      } else if (entries.length === 0) {
+        bodyChildren.push(el("div", {
+          class: "audit-empty",
+          text: "no audit entries",
+        }));
+      } else {
+        for (const entry of entries.slice(0, AUDIT_LIMIT)) {
+          bodyChildren.push(el("div", { class: "audit-entry" }, [
+            el("span", { class: "audit-ts", text: entry.ts || "" }),
+            el("span", { class: "audit-line", text: auditSummary(entry) }),
+          ]));
+        }
+      }
+      children.push(el("div", { class: "audit-body" }, bodyChildren));
+    }
+    list.appendChild(el("div", { class: "audit-panel" }, children));
+  }
+
+  async function loadAuditForSurface(name) {
+    if (!name) return;
+    state.auditLoading[name] = true;
+    state.auditErrors[name] = null;
+    renderAuditPanel(name);
+    try {
+      const data = await apiJson(auditPathForSurface(name));
+      state.auditEntries[name] = Array.isArray(data.events) ? data.events : [];
+    } catch (err) {
+      state.auditEntries[name] = [];
+      state.auditErrors[name] = err;
+    } finally {
+      state.auditLoading[name] = false;
+      if (state.selectedSurface === name && state.auditExpanded[name]) {
+        renderAuditPanel(name);
+      }
+    }
   }
 
   // ----- history (center) ------------------------------------------------
@@ -215,6 +343,7 @@
       list.appendChild(
         el("div", { class: "message-empty", text: "no messages yet" }),
       );
+      renderAuditPanel(data.session_name);
       return;
     }
     // API returned newest-first; render oldest-first so the latest is
@@ -234,6 +363,7 @@
       );
     }
     list.scrollTop = list.scrollHeight;
+    renderAuditPanel(data.session_name);
   }
 
   function renderHistoryError(err) {
@@ -242,6 +372,7 @@
     list.appendChild(
       el("div", { class: "error-banner", text: "history error: " + err.message }),
     );
+    renderAuditPanel(state.selectedSurface);
   }
 
   // ----- send (bottom) ---------------------------------------------------
@@ -446,6 +577,7 @@
     loadHistory: loadHistory,
     sendMessage: sendMessage,
     pollDashboard: pollDashboard,
+    renderAuditPanel: renderAuditPanel,
     renderDashboard: renderDashboard,
     state: state,
   };

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -254,6 +254,68 @@ section#message-pane {
   font-size: 12.5px;
 }
 
+.audit-panel {
+  margin-top: 14px;
+  padding: 10px 12px;
+  background: var(--bg-row);
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+}
+.audit-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.audit-title {
+  flex: 1;
+  color: var(--text-heading);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.audit-toggle,
+.audit-refresh {
+  padding: 4px 8px;
+  background: var(--bg-elevated);
+  color: var(--text-label);
+  border: 1px solid var(--border-line);
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 11px;
+}
+.audit-toggle:hover,
+.audit-refresh:hover {
+  border-color: var(--info);
+  color: var(--text-heading-bright);
+}
+.audit-body {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.audit-empty {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+.audit-entry {
+  display: grid;
+  grid-template-columns: 164px minmax(0, 1fr);
+  gap: 8px;
+  font-size: 11px;
+}
+.audit-ts {
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+    Monaco, Consolas, monospace;
+}
+.audit-line {
+  color: var(--text-body);
+  overflow-wrap: anywhere;
+}
+
 .send-form {
   display: flex;
   gap: 8px;
@@ -378,6 +440,10 @@ section#message-pane {
   }
   .message-list {
     padding: 10px 14px;
+  }
+  .audit-entry {
+    grid-template-columns: 1fr;
+    gap: 2px;
   }
   .send-form {
     padding: 10px 14px;

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from "@playwright/test";
  * Surface list (left rail) scenarios.
  *
  * Anchors: #surface-list, .surface-empty, [data-session], #pane-title,
- * #pane-meta, #message-list, .message-empty.
+ * #pane-meta, #message-list, .message-empty, .audit-panel.
  */
 
 test.describe("surfaces", () => {
@@ -127,5 +127,73 @@ test.describe("surfaces", () => {
     await expect(page.locator("#pane-title")).toHaveText("Select a surface");
     await expect(page.locator("#send-input")).toBeDisabled();
     await expect(page.locator("#send-button")).toBeDisabled();
+  });
+
+  test("audit panel expands and queries current surface scope", async ({ page }) => {
+    await page.route("**/api/v1/chat/*/messages*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session_name: "task-demo-4",
+          surface_type: "worker",
+          transcript_source: "jsonl",
+          messages: [],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessions: [
+            {
+              session_name: "task-demo-4",
+              surface_type: "worker",
+              persona: "worker",
+              project: "demo",
+              task_id: 4,
+              window: { present: true, pane_dead: false },
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/audit/grep**", (route) => {
+      const url = new URL(route.request().url());
+      expect(url.searchParams.get("project")).toBe("demo");
+      expect(url.searchParams.get("pattern")).toBe("demo/4");
+      expect(url.searchParams.get("limit")).toBe("25");
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          events: [
+            {
+              schema: 1,
+              ts: "2026-05-23T00:00:00Z",
+              project: "demo",
+              event: "task.status_changed",
+              subject: "demo/4",
+              actor: "agent-1",
+              status: "ok",
+              metadata: {},
+            },
+          ],
+          next_cursor: null,
+        }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='task-demo-4']").click();
+    await page.locator(".audit-toggle").click();
+    await expect(page.locator(".audit-entry")).toContainText(
+      "task.status_changed",
+    );
+    await expect(page.locator(".audit-entry")).toContainText(
+      "2026-05-23T00:00:00Z",
+    );
   });
 });

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -905,6 +905,20 @@ def test_ui_app_js_renderdashboard_uses_buildcard_helper(
     assert "(filtered)" in body
 
 
+def test_ui_app_js_has_surface_audit_panel_hooks(client: TestClient) -> None:
+    """The selected-surface pane exposes the audit grep panel."""
+    body = client.get("/ui/app.js").text
+    for expected in (
+        "/audit/grep",
+        "AUDIT_LIMIT = 25",
+        "renderAuditPanel",
+        "loadAuditForSurface",
+        "auditPatternForSurface",
+        "audit-toggle",
+    ):
+        assert expected in body
+
+
 # -------- Round-5: executable renderDashboard coverage ------------------
 #
 # Codex round-5 blocker: the prior three tests (static greps over


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Added a collapsible audit-log panel to the selected surface pane.
- On expand/refresh, the panel calls the existing public `GET /api/v1/audit/grep` endpoint with `limit=25`, `since=7d`, the surface project when available, and a literal pattern for the selected surface (`project/task` for workers, session name otherwise).
- Renders timestamp plus event/subject/status/actor lines and keeps the panel refreshed when switching back to an already-expanded surface.
- Added styling and Playwright coverage for the audit grep query scope.

Fixes #2100.

## Tests
- `uv run ruff check tests/web_api/test_web_ui.py`
- `uv run pytest tests/web_api/test_web_ui.py -k 'surface_audit_panel_hooks or render_dashboard_real_payload_executes'`
- `cd tests/playwright && npx playwright test tests/surfaces.spec.ts --list`
- `git diff --check`
