### PR TITLE
feat(sessions): add interrupt endpoint and UI stop

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1731,6 +1731,48 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /sessions/{name}/interrupt:
+    parameters:
+      - $ref: "#/components/parameters/SessionName"
+    post:
+      tags: [Sessions]
+      operationId: interruptSession
+      summary: Send Escape to a live session or worker pane
+      description: |
+        Sends the non-destructive interrupt key (`Escape`) to the live
+        tmux pane backing a configured session or active
+        `task-<project>-<n>` worker surface. The endpoint resolves
+        configured sessions through `config.sessions[].window_name`.
+        Worker surfaces are accepted only when the window name matches
+        the canonical task-worker pattern and the project is registered.
+
+        This intentionally does not send `Ctrl-C`: embedded agents
+        advertise `esc to interrupt`, and Escape is less likely to kill
+        the shell process underneath the agent.
+      responses:
+        "200":
+          description: Interrupt key sent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Pane is dead or missing a pane id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: tmux unavailable or target window missing.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /sessions/{name}/pause:
     parameters:
       - $ref: "#/components/parameters/SessionName"

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -102,6 +102,7 @@ Auth follows the standard bearer-dependency wiring in
 from __future__ import annotations
 
 import logging
+import subprocess
 from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Query
@@ -304,6 +305,36 @@ def _daemon_unavailable(name: str, detail: str) -> APIError:
             f"({detail})."
         ),
         hint="Confirm the daemon / cockpit is running, then retry.",
+    )
+
+
+def _window_missing(name: str, window_name: str, storage_session: str) -> APIError:
+    return APIError(
+        status_code=503,
+        code="window_missing",
+        message=(
+            f"Cannot interrupt {name!r}: tmux window {window_name!r} is "
+            f"not present in storage session {storage_session!r}."
+        ),
+        hint="Refresh the session list; the agent may have exited or moved.",
+    )
+
+
+def _pane_unavailable(name: str, detail: str) -> APIError:
+    return APIError(
+        status_code=409,
+        code="pane_unavailable",
+        message=f"Cannot interrupt {name!r}: {detail}.",
+        hint="Refresh the session list; the pane may have exited.",
+    )
+
+
+def _interrupt_failed(name: str, detail: str) -> APIError:
+    return APIError(
+        status_code=503,
+        code="interrupt_failed",
+        message=f"Failed to send interrupt to {name!r}: {detail}",
+        hint="Check tmux health and retry.",
     )
 
 
@@ -705,6 +736,72 @@ def _find_session(config: Any, name: str) -> Any:
     raise _session_not_found(name)
 
 
+def _task_surface_known(config: Any, name: str) -> bool:
+    """Return True for syntactically valid task worker window names."""
+    try:
+        from pollypm.work.task_state import parse_task_window_name
+    except Exception:  # noqa: BLE001
+        return False
+    parsed = parse_task_window_name(name)
+    if parsed is None:
+        return False
+    project, _number = parsed
+    projects = getattr(config, "projects", None) or {}
+    return project in projects
+
+
+def _interrupt_window_name(config: Any, name: str) -> str:
+    """Resolve ``name`` to a storage-closet window name.
+
+    Configured sessions use their configured ``window_name``. Active
+    task-worker chat surfaces are not part of ``config.sessions``; for
+    those we accept the canonical ``task-<project>-<n>`` window name
+    only when the project is registered.
+    """
+    try:
+        session = _find_session(config, name)
+    except APIError:
+        if _task_surface_known(config, name):
+            return name
+        raise
+    return session.window_name or session.name
+
+
+def _find_interrupt_pane(
+    tmux: Any,
+    *,
+    name: str,
+    storage_session: str,
+    window_name: str,
+) -> str:
+    """Return the pane id backing ``window_name`` or raise a typed API error."""
+    try:
+        windows = tmux.list_windows(storage_session)
+    except FileNotFoundError as exc:
+        raise _interrupt_failed(name, f"tmux binary not found: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise _interrupt_failed(
+            name, f"tmux command timed out after {exc.timeout}s",
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise _interrupt_failed(
+            name,
+            f"tmux list-windows failed with exit {exc.returncode}: {exc.stderr}",
+        ) from exc
+    except Exception as exc:  # noqa: BLE001
+        raise _interrupt_failed(name, str(exc)) from exc
+    for window in windows or []:
+        if getattr(window, "name", None) != window_name:
+            continue
+        if getattr(window, "pane_dead", False):
+            raise _pane_unavailable(name, "pane is dead")
+        pane_id = getattr(window, "pane_id", None)
+        if not pane_id:
+            raise _pane_unavailable(name, "pane id missing")
+        return str(pane_id)
+    raise _window_missing(name, window_name, storage_session)
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -1005,6 +1102,60 @@ def restart_session_endpoint(
         _close_supervisor_quietly(supervisor)
 
     return ActionResult(ok=True, message=f"restarted {name}")
+
+
+@router.post(
+    "/sessions/{name}/interrupt",
+    response_model=ActionResult,
+    summary="Send Escape to a live session/worker tmux pane",
+    operation_id="interruptSession",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Configured session or task worker not found."},
+        "409": {"description": "Pane is dead or missing a pane id."},
+        "503": {"description": "tmux unavailable or target window missing."},
+    },
+)
+def interrupt_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
+    """POST /api/v1/sessions/{name}/interrupt — send Escape to the pane.
+
+    This is intentionally non-destructive: it sends the key the
+    embedded agents advertise as their interruption path
+    (``esc to interrupt``) instead of ``Ctrl-C``. Configured sessions
+    resolve through ``config.sessions`` and their ``window_name``;
+    per-task worker surfaces resolve only via the canonical
+    ``task-<project>-<n>`` window name for registered projects.
+    """
+    window_name = _interrupt_window_name(config, name)
+    storage_session = _storage_session_name(config)
+    try:
+        from pollypm.tmux.client import TmuxClient
+
+        tmux = TmuxClient()
+    except Exception as exc:  # noqa: BLE001
+        raise _interrupt_failed(name, f"tmux client unavailable: {exc}") from exc
+    pane_id = _find_interrupt_pane(
+        tmux,
+        name=name,
+        storage_session=storage_session,
+        window_name=window_name,
+    )
+    try:
+        tmux.run("send-keys", "-t", pane_id, "Escape")
+    except FileNotFoundError as exc:
+        raise _interrupt_failed(name, f"tmux binary not found: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise _interrupt_failed(
+            name, f"tmux command timed out after {exc.timeout}s",
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise _interrupt_failed(
+            name,
+            f"tmux send-keys failed with exit {exc.returncode}: {exc.stderr}",
+        ) from exc
+    except Exception as exc:  # noqa: BLE001
+        raise _interrupt_failed(name, str(exc)) from exc
+    return ActionResult(ok=True, message=f"sent Escape to {name}")
 
 
 @router.post(

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -23,6 +23,7 @@
     surfaces: [],
     selectedSurface: null,
     messageTimer: null,
+    surfaceMidStream: {},
   };
 
   // ----- DOM helpers ------------------------------------------------------
@@ -75,6 +76,16 @@
       "`Authorization: Bearer …` header.";
     const layout = document.getElementById("layout") || document.body;
     layout.parentNode.insertBefore(banner, layout);
+  }
+
+  function showToast(level, text) {
+    const toast = document.createElement("div");
+    toast.className = "toast toast-" + level;
+    toast.textContent = text;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+      if (toast.parentNode) toast.parentNode.removeChild(toast);
+    }, 4000);
   }
 
   // ----- fetch wrapper ----------------------------------------------------
@@ -183,9 +194,30 @@
     $("pane-meta").textContent = "";
     $("send-input").disabled = false;
     $("send-button").disabled = false;
+    updateStopAgentButton();
     renderSurfaces();
     loadHistory(name);
     schedulePoll();
+  }
+
+  function messageLooksMidStream(message) {
+    const text = String(message && message.text ? message.text : "")
+      .toLowerCase();
+    return (
+      text.includes("esc to interrupt")
+      || text.includes("working (")
+      || text.includes("unsafe_mid_tool")
+    );
+  }
+
+  function updateStopAgentButton() {
+    const btn = $("stop-agent-button");
+    if (!btn) return;
+    const active = Boolean(
+      state.selectedSurface && state.surfaceMidStream[state.selectedSurface],
+    );
+    btn.hidden = !active;
+    btn.disabled = !active;
   }
 
   // ----- history (center) ------------------------------------------------
@@ -211,6 +243,10 @@
     if (data.transcript_source) meta.push("src=" + data.transcript_source);
     $("pane-meta").textContent = meta.join(" · ");
     const msgs = Array.isArray(data.messages) ? data.messages.slice() : [];
+    state.surfaceMidStream[data.session_name] = (
+      msgs.length > 0 && messageLooksMidStream(msgs[0])
+    );
+    updateStopAgentButton();
     if (msgs.length === 0) {
       list.appendChild(
         el("div", { class: "message-empty", text: "no messages yet" }),
@@ -242,6 +278,7 @@
     list.appendChild(
       el("div", { class: "error-banner", text: "history error: " + err.message }),
     );
+    updateStopAgentButton();
   }
 
   // ----- send (bottom) ---------------------------------------------------
@@ -256,6 +293,15 @@
     });
     // Refresh after a short delay so the new line shows up.
     setTimeout(() => loadHistory(name), 400);
+  }
+
+  async function interruptSurface(name) {
+    if (!name) return;
+    const path = API + "/sessions/" + encodeURIComponent(name) + "/interrupt";
+    await apiFetch(path, { method: "POST" });
+    state.surfaceMidStream[name] = false;
+    updateStopAgentButton();
+    showToast("ok", "sent interrupt to " + name);
   }
 
   // ----- dashboard rollups (right rail) ----------------------------------
@@ -426,8 +472,23 @@
     });
   }
 
+  function wireStopAgentButton() {
+    const btn = $("stop-agent-button");
+    if (!btn) return;
+    btn.addEventListener("click", () => {
+      const name = state.selectedSurface;
+      if (!name || btn.disabled) return;
+      btn.disabled = true;
+      interruptSurface(name).catch((err) => {
+        btn.disabled = false;
+        showToast("error", "interrupt failed: " + err.message);
+      });
+    });
+  }
+
   function init() {
     wireSendForm();
+    wireStopAgentButton();
     setStatus("warn", "connecting…");
     loadSurfaces();
     pollDashboard();
@@ -445,6 +506,7 @@
     loadSurfaces: loadSurfaces,
     loadHistory: loadHistory,
     sendMessage: sendMessage,
+    interruptSurface: interruptSurface,
     pollDashboard: pollDashboard,
     renderDashboard: renderDashboard,
     state: state,

--- a/src/pollypm/web_api/ui/index.html
+++ b/src/pollypm/web_api/ui/index.html
@@ -45,6 +45,13 @@
         disabled
         aria-label="Send message"
       />
+      <button
+        id="stop-agent-button"
+        class="stop-agent-button"
+        type="button"
+        hidden
+        disabled
+      >Stop</button>
       <button id="send-button" class="send-button" type="submit" disabled>Send</button>
     </form>
   </section>

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -296,6 +296,23 @@ section#message-pane {
 .send-button:not(:disabled):hover {
   background: #4a78e0;
 }
+.stop-agent-button {
+  padding: 8px 12px;
+  background: transparent;
+  color: var(--blocked);
+  border: 1px solid var(--blocked);
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+.stop-agent-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.stop-agent-button:not(:disabled):hover {
+  background: rgba(255, 95, 109, 0.12);
+}
 
 .dashboard-rollups {
   padding: 0 12px 16px;
@@ -344,6 +361,29 @@ section#message-pane {
   background: rgba(240, 160, 48, 0.10);
   color: var(--attention);
   line-height: 1.5;
+}
+
+.toast {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 20;
+  max-width: min(360px, calc(100vw - 32px));
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-line);
+  background: var(--bg-elevated);
+  color: var(--text-body);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+  font-size: 12.5px;
+}
+.toast-ok {
+  border-color: var(--working);
+  color: var(--working);
+}
+.toast-error {
+  border-color: var(--blocked);
+  color: var(--blocked);
 }
 
 /* Mobile / tablet — collapse the three-column grid into a single
@@ -416,5 +456,8 @@ section#message-pane {
   }
   .send-button {
     padding: 8px 12px;
+  }
+  .stop-agent-button {
+    padding: 8px 10px;
   }
 }

--- a/tests/playwright/tests/send_message.spec.ts
+++ b/tests/playwright/tests/send_message.spec.ts
@@ -110,10 +110,55 @@ test.describe("send message", () => {
     await stubMessages(page);
     await page.goto("/ui/");
     await expect(page.locator("#send-input")).toBeDisabled();
+    await expect(page.locator("#stop-agent-button")).toBeHidden();
     await expect(page.locator("#send-button")).toBeDisabled();
     await page.locator("li[data-session='operator']").click();
     await expect(page.locator("#send-input")).toBeEnabled();
     await expect(page.locator("#send-button")).toBeEnabled();
+  });
+
+  test("stop-agent button interrupts mid-stream surface", async ({ page }) => {
+    await stubSurfaces(page);
+    await page.route("**/api/v1/chat/operator/messages*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session_name: "operator",
+          surface_type: "operator",
+          transcript_source: "capture",
+          messages: [
+            {
+              id: "m1",
+              ts: "2026-05-23T00:00:00Z",
+              role: "assistant",
+              actor: "Polly",
+              type: "text",
+              text: "Working (0s · esc to interrupt)",
+              metadata: {},
+            },
+          ],
+        }),
+      }),
+    );
+    let interrupted = false;
+    await page.route("**/api/v1/sessions/operator/interrupt", (route, req) => {
+      interrupted = req.method() === "POST";
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, message: "sent Escape to operator" }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    const stop = page.locator("#stop-agent-button");
+    await expect(stop).toBeVisible();
+    await stop.click();
+    await expect.poll(() => interrupted).toBe(true);
+    await expect(page.locator(".toast")).toContainText("sent interrupt");
+    await expect(stop).toBeHidden();
   });
 
   test("empty / whitespace-only text does not POST", async ({ page }) => {

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -262,6 +262,29 @@ class _FakeSupervisor:
             raise self.restart_raises
 
 
+class _FakeInterruptTmux:
+    def __init__(
+        self,
+        windows: list[Any],
+        *,
+        run_raises: Exception | None = None,
+    ) -> None:
+        self.windows = windows
+        self.run_raises = run_raises
+        self.list_calls: list[str] = []
+        self.run_calls: list[tuple[tuple[str, ...], dict[str, Any]]] = []
+
+    def list_windows(self, name: str) -> list[Any]:
+        self.list_calls.append(name)
+        return list(self.windows)
+
+    def run(self, *args: str, **kwargs: Any) -> Any:
+        self.run_calls.append((args, kwargs))
+        if self.run_raises is not None:
+            raise self.run_raises
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
 @pytest.fixture
 def patch_heartbeat(monkeypatch: pytest.MonkeyPatch):
     """Install a stub for ``_latest_heartbeat`` on the route module."""
@@ -357,6 +380,17 @@ def patch_supervisor(monkeypatch: pytest.MonkeyPatch):
             lambda _config: supervisor,
         )
         return supervisor
+    return install
+
+
+@pytest.fixture
+def patch_interrupt_tmux(monkeypatch: pytest.MonkeyPatch):
+    def install(tmux: _FakeInterruptTmux) -> _FakeInterruptTmux:
+        from pollypm.tmux import client as tmux_client_module
+
+        monkeypatch.setattr(tmux_client_module, "TmuxClient", lambda: tmux)
+        return tmux
+
     return install
 
 
@@ -1301,6 +1335,69 @@ def test_restart_strict_supervisor_closed_after_use(
         "legacy sqlite state.db connection (Codex PR #2061 round 6 "
         "lifecycle note)."
     )
+
+
+# ---------------------------------------------------------------------------
+# POST /sessions/{name}/interrupt
+# ---------------------------------------------------------------------------
+
+
+def test_interrupt_sends_escape_to_configured_session(
+    client, auth_headers, patch_interrupt_tmux,
+):
+    tmux = patch_interrupt_tmux(_FakeInterruptTmux([
+        _fake_window("operator"),
+    ]))
+    response = client.post(
+        "/api/v1/sessions/operator/interrupt", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["message"] == "sent Escape to operator"
+    assert tmux.list_calls == ["pollypm-test-storage-closet"]
+    assert tmux.run_calls == [
+        (("send-keys", "-t", "%9", "Escape"), {}),
+    ]
+
+
+def test_interrupt_allows_registered_task_worker_window(
+    client, auth_headers, patch_interrupt_tmux,
+):
+    tmux = patch_interrupt_tmux(_FakeInterruptTmux([
+        _fake_window("task-myproj-7"),
+    ]))
+    response = client.post(
+        "/api/v1/sessions/task-myproj-7/interrupt", headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["message"] == "sent Escape to task-myproj-7"
+    assert tmux.run_calls == [
+        (("send-keys", "-t", "%9", "Escape"), {}),
+    ]
+
+
+def test_interrupt_returns_503_when_window_missing(
+    client, auth_headers, patch_interrupt_tmux,
+):
+    patch_interrupt_tmux(_FakeInterruptTmux([]))
+    response = client.post(
+        "/api/v1/sessions/operator/interrupt", headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "window_missing"
+
+
+def test_interrupt_unknown_non_task_session_404(
+    client, auth_headers, patch_interrupt_tmux,
+):
+    patch_interrupt_tmux(_FakeInterruptTmux([
+        _fake_window("not-a-config-session"),
+    ]))
+    response = client.post(
+        "/api/v1/sessions/not-a-config-session/interrupt",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -43,6 +43,8 @@ PHASE_1_PATHS: set[tuple[str, str]] = {
     ("GET", "/chat/{session_name}/messages"),
     # Chat-endpoints P3 (#2043) — POST send path.
     ("POST", "/chat/{session_name}/send"),
+    # Sessions admin interrupt (web UI stop-agent button).
+    ("POST", "/sessions/{name}/interrupt"),
     # Phase 6 P0 — cross-project flat task list (spec §5.1).
     ("GET", "/tasks"),
 }

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -168,7 +168,13 @@ def test_ui_no_cookie_with_invalid_bearer(app, token: str) -> None:
 def test_ui_index_contains_required_anchors(client: TestClient) -> None:
     """The HTML must carry the IDs ``app.js`` queries for."""
     html = client.get("/ui/").text
-    for anchor in ("surface-list", "message-list", "send-input", "send-button"):
+    for anchor in (
+        "surface-list",
+        "message-list",
+        "send-input",
+        "stop-agent-button",
+        "send-button",
+    ):
         assert f'id="{anchor}"' in html, f"missing anchor #{anchor} in index.html"
     # The cookie-based credentials assumption is baked into app.js; the
     # HTML must reference it so cache-busting / rename doesn't silently


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Added `POST /api/v1/sessions/{name}/interrupt`, documented in OpenAPI, returning `ActionResult` on success and typed envelopes for unknown sessions, missing/dead panes, window absence, and tmux failures.
- Chose `Escape` instead of `Ctrl-C` because the embedded agents advertise `esc to interrupt`; this avoids sending SIGINT into the shell unless a future route explicitly needs that behavior.
- Supports configured sessions via `window_name` and active task-worker windows via canonical `task-<project>-<n>` names for registered projects.
- Added a stop-agent UI button that appears only when the newest message indicates a mid-stream turn, calls the interrupt endpoint, and surfaces success/failure toasts.

Fixes #2099.

## Tests
- `uv run ruff check --ignore E402,F401 src/pollypm/web_api/routes/sessions_admin.py tests/test_sessions_admin_endpoint.py tests/web_api/test_web_ui.py tests/web_api/test_openapi_conformance.py`
- `uv run pytest tests/test_sessions_admin_endpoint.py -k 'interrupt_'`
- `uv run pytest tests/web_api/test_web_ui.py -k 'ui_index_contains_required_anchors'`
- `uv run pytest tests/web_api/test_openapi_conformance.py -k 'contract_lists_phase_1_paths or implementation_serves_phase_1_paths'`
- `cd tests/playwright && npx playwright test tests/send_message.spec.ts --list`
- `git diff --check`
