### PR TITLE
feat(web-ui): refresh from SSE events

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -15,14 +15,21 @@
   "use strict";
 
   const API = "/api/v1";
-  const POLL_DASHBOARD_MS = 15000;
-  const POLL_MESSAGES_MS = 5000;
+  const FALLBACK_POLL_MS = 15000;
+  const SSE_RETRY_MS = 30000;
+  const SSE_FAILURE_LIMIT = 3;
+  const PUSH_REFRESH_DEBOUNCE_MS = 150;
   const MAX_MESSAGES = 50;
 
   const state = {
     surfaces: [],
     selectedSurface: null,
-    messageTimer: null,
+    eventSource: null,
+    fallbackTimer: null,
+    pushRefreshTimer: null,
+    sseFailures: 0,
+    sseRetryTimer: null,
+    lastEventId: null,
   };
 
   // ----- DOM helpers ------------------------------------------------------
@@ -185,7 +192,6 @@
     $("send-button").disabled = false;
     renderSurfaces();
     loadHistory(name);
-    schedulePoll();
   }
 
   // ----- history (center) ------------------------------------------------
@@ -401,13 +407,103 @@
     );
   }
 
-  // ----- timers -----------------------------------------------------------
+  // ----- push refresh / fallback polling ---------------------------------
 
-  function schedulePoll() {
-    if (state.messageTimer) clearInterval(state.messageTimer);
-    state.messageTimer = setInterval(() => {
-      if (state.selectedSurface) loadHistory(state.selectedSurface);
-    }, POLL_MESSAGES_MS);
+  function refreshFromPush() {
+    pollDashboard();
+    loadSurfaces();
+    if (state.selectedSurface) loadHistory(state.selectedSurface);
+  }
+
+  function refreshFromFallback() {
+    pollDashboard();
+    if (state.selectedSurface) loadHistory(state.selectedSurface);
+  }
+
+  function requestPushRefresh() {
+    if (state.pushRefreshTimer !== null) return;
+    state.pushRefreshTimer = setTimeout(() => {
+      state.pushRefreshTimer = null;
+      refreshFromPush();
+    }, PUSH_REFRESH_DEBOUNCE_MS);
+  }
+
+  function startFallbackPolling() {
+    if (state.fallbackTimer !== null) return;
+    refreshFromFallback();
+    state.fallbackTimer = setInterval(refreshFromFallback, FALLBACK_POLL_MS);
+  }
+
+  function stopFallbackPolling() {
+    if (state.fallbackTimer === null) return;
+    clearInterval(state.fallbackTimer);
+    state.fallbackTimer = null;
+  }
+
+  function closeEventStream() {
+    if (!state.eventSource) return;
+    state.eventSource.close();
+    state.eventSource = null;
+  }
+
+  function eventStreamUrl() {
+    if (!state.lastEventId) return API + "/events";
+    return API + "/events?since=" + encodeURIComponent(state.lastEventId);
+  }
+
+  function handleSseEvent(ev) {
+    state.sseFailures = 0;
+    if (ev && ev.lastEventId) {
+      state.lastEventId = ev.lastEventId;
+    } else if (ev && ev.data) {
+      try {
+        const data = JSON.parse(ev.data);
+        if (data && data.ts) state.lastEventId = data.ts;
+      } catch (e) { /* ignore malformed event payloads */ }
+    }
+    requestPushRefresh();
+  }
+
+  function scheduleEventStreamRetry() {
+    if (state.sseRetryTimer !== null) return;
+    state.sseRetryTimer = setTimeout(() => {
+      state.sseRetryTimer = null;
+      startEventStream();
+    }, SSE_RETRY_MS);
+  }
+
+  function startEventStream() {
+    if (!("EventSource" in window)) {
+      startFallbackPolling();
+      return;
+    }
+
+    if (state.sseRetryTimer !== null) {
+      clearTimeout(state.sseRetryTimer);
+      state.sseRetryTimer = null;
+    }
+    closeEventStream();
+
+    const source = new window.EventSource(eventStreamUrl());
+    state.eventSource = source;
+    source.onopen = () => {
+      if (state.eventSource !== source) return;
+      state.sseFailures = 0;
+      stopFallbackPolling();
+      setStatus("ok", "online");
+    };
+    source.addEventListener("audit", handleSseEvent);
+    source.onmessage = handleSseEvent;
+    source.onerror = () => {
+      if (state.eventSource !== source) return;
+      state.sseFailures += 1;
+      setStatus("warn", "SSE reconnecting");
+      if (state.sseFailures >= SSE_FAILURE_LIMIT) {
+        closeEventStream();
+        startFallbackPolling();
+        scheduleEventStreamRetry();
+      }
+    };
   }
 
   // ----- wire-up ----------------------------------------------------------
@@ -431,8 +527,8 @@
     setStatus("warn", "connecting…");
     loadSurfaces();
     pollDashboard();
+    startEventStream();
     setInterval(loadSurfaces, 30000);
-    setInterval(pollDashboard, POLL_DASHBOARD_MS);
   }
 
   // Expose for tests / debugging. ``renderDashboard`` is exported so
@@ -446,6 +542,9 @@
     loadHistory: loadHistory,
     sendMessage: sendMessage,
     pollDashboard: pollDashboard,
+    startEventStream: startEventStream,
+    startFallbackPolling: startFallbackPolling,
+    handleSseEvent: handleSseEvent,
     renderDashboard: renderDashboard,
     state: state,
   };

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -122,6 +122,103 @@ test.describe("surfaces", () => {
     );
   });
 
+  test("SSE audit event refreshes dashboard and selected history", async ({ page }) => {
+    let dashboardRequests = 0;
+    let messageRequests = 0;
+    let eventResponses = 0;
+    let releaseEvent: (() => void) | null = null;
+    const eventGate = new Promise<void>((resolve) => {
+      releaseEvent = resolve;
+    });
+
+    await page.route("**/api/v1/dashboard", (route) => {
+      dashboardRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          rollups: { message_count_24h: dashboardRequests },
+          daemon_status: "up",
+          active_sessions: [],
+          recent_messages: [],
+          projects: [],
+          generated_at: "2026-05-23T00:00:00Z",
+          scoped_fields: [],
+        }),
+      });
+    });
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessions: [
+            {
+              session_name: "operator",
+              surface_type: "operator",
+              persona: "polly",
+              project: "pollypm",
+              window: { present: true, pane_dead: false },
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/chat/operator/messages*", (route) => {
+      messageRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session_name: "operator",
+          surface_type: "operator",
+          transcript_source: "jsonl",
+          messages: [
+            {
+              role: "assistant",
+              actor: "codex",
+              ts: "2026-05-23T00:00:00Z",
+              type: "message",
+              text: "refresh " + messageRequests,
+            },
+          ],
+        }),
+      });
+    });
+    await page.route("**/api/v1/events**", async (route) => {
+      await eventGate;
+      eventResponses += 1;
+      if (eventResponses > 1) {
+        return route.fulfill({
+          status: 200,
+          contentType: "text/event-stream",
+          body: "",
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body:
+          "event: audit\n" +
+          "id: 2026-05-23T00:00:01Z\n" +
+          'data: {"ts":"2026-05-23T00:00:01Z","event":"message"}\n\n',
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    await expect.poll(() => dashboardRequests).toBeGreaterThanOrEqual(1);
+    await expect.poll(() => messageRequests).toBe(1);
+
+    releaseEvent!();
+
+    await expect.poll(() => dashboardRequests).toBeGreaterThanOrEqual(2);
+    await expect.poll(() => messageRequests).toBeGreaterThanOrEqual(2);
+    await expect(page.locator("#message-list .message-text")).toContainText(
+      "refresh",
+    );
+  });
+
   test("initial center-pane state shows 'Select a surface'", async ({ page }) => {
     await page.goto("/ui/");
     await expect(page.locator("#pane-title")).toHaveText("Select a surface");

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -188,6 +188,21 @@ def test_ui_static_js_served(client: TestClient) -> None:
     assert "sendMessage" in body
 
 
+def test_ui_app_js_uses_sse_refresh_with_polling_fallback(
+    client: TestClient,
+) -> None:
+    """The SPA refresh loop is driven by ``/events`` with a bounded fallback."""
+    body = client.get("/ui/app.js").text
+    assert "EventSource" in body
+    assert 'API + "/events"' in body
+    assert "SSE_FAILURE_LIMIT" in body
+    assert "startFallbackPolling" in body
+    assert "handleSseEvent" in body
+    assert "POLL_MESSAGES_MS" not in body
+    assert "POLL_DASHBOARD_MS" not in body
+    assert "setInterval(pollDashboard" not in body
+
+
 def test_ui_static_css_served(client: TestClient) -> None:
     """``GET /ui/styles.css`` returns the dark-theme stylesheet."""
     response = client.get("/ui/styles.css")


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

Fixes https://github.com/samhotchkiss/pollypm/issues/2096

## Summary
- Replace dashboard/message polling intervals with an EventSource subscription to `/api/v1/events`.
- Debounce push-triggered refreshes through the existing dashboard, surface, and history fetch/render paths.
- Re-enable bounded fallback polling after repeated SSE failures, with a retry loop to restore the stream later.
- Add static and Playwright coverage for the SSE refresh contract.

## Verification
- `uv run ruff check tests/web_api/test_web_ui.py`
- `uv run pytest tests/web_api/test_web_ui.py -k 'sse_refresh_with_polling_fallback or render_dashboard_real_payload_executes'`\n- `cd tests/playwright && npx playwright test tests/surfaces.spec.ts --list`\n- `POLLYPM_BASE_URL=http://127.0.0.1:9876 npx playwright test tests/surfaces.spec.ts -g "SSE audit event" --project=chromium`\n- `cd tests/playwright && npx playwright test --list`\n- `git diff --check`\n\nNote: a broader `uv run pytest tests/web_api/test_web_ui.py` run executed all 43 tests but failed at teardown because the repo home-write guard detected unrelated live background checkpoint writes under `/Users/sam/.pollypm/artifacts/checkpoints/...`; the test assertions themselves passed before that environment guard error.