### PR TITLE
refactor(cockpit): remove palette UI import backedges

### DIFF
--- a/src/pollypm/cockpit_palette.py
+++ b/src/pollypm/cockpit_palette.py
@@ -405,16 +405,12 @@ def _dispatch_palette_tag(app: App, tag: str | None) -> None:
         _palette_notify(app, f"Command failed: {exc}")
 
 
-def _resolve_palette_dispatch():
-    """Preserve the legacy ``pollypm.cockpit_ui`` monkeypatch seam."""
-    try:
-        from pollypm import cockpit_ui
-    except Exception:  # noqa: BLE001
-        return _dispatch_palette_tag
-    dispatch = getattr(cockpit_ui, "_dispatch_palette_tag", None)
+def _resolve_palette_dispatch(app: App):
+    """Return the host-owned palette dispatcher when one exists."""
+    dispatch = getattr(app, "dispatch_palette_tag", None)
     if callable(dispatch):
         return dispatch
-    return _dispatch_palette_tag
+    return lambda tag: _dispatch_palette_tag(app, tag)
 
 
 def _palette_nav(app: App, target: str, *, is_project: bool = False) -> None:
@@ -529,7 +525,7 @@ def _open_command_palette(app: App) -> None:
     def _on_dismiss(tag: str | None) -> None:
         if tag:
             _record_palette_command(app, tag)
-        _resolve_palette_dispatch()(app, tag)
+        _resolve_palette_dispatch(app)(tag)
 
     try:
         commands = build_palette_commands(
@@ -659,54 +655,22 @@ def _right_pane_help_section_for_cockpit(
 ) -> tuple[str, list[tuple[str, str]]] | None:
     """Return a help section for whatever the cockpit's right pane is showing.
 
-    Resolves ``selected_key`` to the right-pane App class, walks its
-    ``BINDINGS`` the same way ``_collect_keybindings_for_screen`` does
-    for the host app, and labels the resulting section by surface name
-    so the user can tell which keys belong to the right pane vs the
-    rail (#860).
+    The host app owns right-pane routing, so it provides the selected
+    pane class/label. The palette only walks that class's ``BINDINGS``
+    the same way ``_collect_keybindings_for_screen`` does for the host
+    app, and labels the resulting section by surface name so the user
+    can tell which keys belong to the right pane vs the rail (#860).
     """
-    selected = getattr(app, "selected_key", "") or ""
-
-    # Late imports keep cockpit_palette free of the cockpit_ui import
-    # graph; only matters when the rail-help dialog opens.
+    resolve_target = getattr(app, "right_pane_help_target", None)
+    if not callable(resolve_target):
+        return None
     try:
-        from pollypm.cockpit_ui import (
-            PollyActivityFeedApp,
-            PollyDashboardApp,
-            PollyInboxApp,
-            PollyProjectDashboardApp,
-            PollyProjectSettingsApp,
-            PollySettingsPaneApp,
-            PollyWorkerRosterApp,
-        )
+        target = resolve_target()
     except Exception:  # noqa: BLE001
         return None
-
-    target_cls = None
-    surface_label = ""
-    if selected == "inbox":
-        target_cls, surface_label = PollyInboxApp, "Inbox"
-    elif selected == "activity":
-        target_cls, surface_label = PollyActivityFeedApp, "Activity feed"
-    elif selected == "settings":
-        target_cls, surface_label = PollySettingsPaneApp, "Settings"
-    elif selected == "workers":
-        target_cls, surface_label = PollyWorkerRosterApp, "Workers"
-    elif selected in {"polly", "dashboard"}:
-        target_cls, surface_label = PollyDashboardApp, "Home dashboard"
-    elif selected.startswith("project:"):
-        # ``project:<key>:settings`` vs ``project:<key>[:dashboard]``.
-        if selected.endswith(":settings"):
-            target_cls, surface_label = (
-                PollyProjectSettingsApp, "Project settings",
-            )
-        else:
-            target_cls, surface_label = (
-                PollyProjectDashboardApp, "Project dashboard",
-            )
-
-    if target_cls is None:
+    if target is None:
         return None
+    target_cls, surface_label = target
 
     rows: list[tuple[int, int, str, str]] = []
     for order, binding in enumerate(getattr(target_cls, "BINDINGS", None) or []):

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -625,6 +625,29 @@ class PollyCockpitApp(App[None]):
     def action_show_keyboard_help(self) -> None:
         _open_keyboard_help(self)
 
+    def dispatch_palette_tag(self, tag: str | None) -> None:
+        """Dispatch command-palette selections through the UI module seam."""
+        _dispatch_palette_tag(self, tag)
+
+    def right_pane_help_target(self) -> tuple[type[App], str] | None:
+        """Return the selected right-pane App class for keyboard help."""
+        selected = self.selected_key or ""
+        if selected == "inbox":
+            return PollyInboxApp, "Inbox"
+        if selected == "activity":
+            return PollyActivityFeedApp, "Activity feed"
+        if selected == "settings":
+            return PollySettingsPaneApp, "Settings"
+        if selected == "workers":
+            return PollyWorkerRosterApp, "Workers"
+        if selected in {"polly", "dashboard"}:
+            return PollyDashboardApp, "Home dashboard"
+        if selected.startswith("project:"):
+            if selected.endswith(":settings"):
+                return PollyProjectSettingsApp, "Project settings"
+            return PollyProjectDashboardApp, "Project dashboard"
+        return None
+
     # Keys the App's BINDINGS treat as priority. When KeyboardHelpModal
     # is on the screen stack we must yield these to the modal so it can
     # dismiss / scroll itself (#917). Textual's priority pass walks from

--- a/tests/test_cockpit_palette_boundary.py
+++ b/tests/test_cockpit_palette_boundary.py
@@ -1,0 +1,70 @@
+"""Regression coverage for the cockpit palette import boundary (#1367)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from textual.binding import Binding
+
+from pollypm.cockpit_palette import (
+    _resolve_palette_dispatch,
+    _right_pane_help_section_for_cockpit,
+)
+
+
+def test_cockpit_palette_does_not_import_cockpit_ui() -> None:
+    """The palette must not import the UI module that imports the palette."""
+    root = Path(__file__).resolve().parents[1]
+    source_path = root / "src" / "pollypm" / "cockpit_palette.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "pollypm.cockpit_ui":
+                offenders.append(f"from {module} import ...")
+            if module == "pollypm":
+                offenders.extend(
+                    f"from pollypm import {alias.name}"
+                    for alias in node.names
+                    if alias.name == "cockpit_ui"
+                )
+        elif isinstance(node, ast.Import):
+            offenders.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "pollypm.cockpit_ui"
+            )
+
+    assert offenders == []
+
+
+def test_right_pane_help_uses_host_resolver() -> None:
+    class _Pane:
+        BINDINGS = [
+            Binding("x", "demo", "Demo action"),
+            Binding("question_mark", "help", "Help"),
+        ]
+
+    class _Host:
+        def right_pane_help_target(self):
+            return _Pane, "Demo pane"
+
+    assert _right_pane_help_section_for_cockpit(_Host()) == (
+        "Right pane: Demo pane",
+        [("x", "Demo action")],
+    )
+
+
+def test_palette_dispatch_uses_host_resolver() -> None:
+    seen: list[str | None] = []
+
+    class _Host:
+        def dispatch_palette_tag(self, tag: str | None) -> None:
+            seen.append(tag)
+
+    _resolve_palette_dispatch(_Host())("project.open")
+
+    assert seen == ["project.open"]


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

Refs https://github.com/samhotchkiss/pollypm/issues/1367

## Summary
- Remove the remaining `cockpit_palette -> cockpit_ui` lazy imports used by palette dispatch and right-pane keyboard help.
- Move selected right-pane help resolution behind `PollyCockpitApp.right_pane_help_target()`, keeping routing knowledge in the host app.
- Preserve the historical `pollypm.cockpit_ui._dispatch_palette_tag` monkeypatch path through `PollyCockpitApp.dispatch_palette_tag()`.
- Add a source-level boundary test so `cockpit_palette.py` cannot import `cockpit_ui` again.

## Verification
- `uv run --extra dev ruff check src/pollypm/cockpit_palette.py tests/test_cockpit_palette_boundary.py`
- `uv run --extra dev ruff check --select F821 src/pollypm/cockpit_ui.py`
- `python -m py_compile src/pollypm/cockpit_palette.py src/pollypm/cockpit_ui.py tests/test_cockpit_palette_boundary.py`
- `uv run --extra dev pytest tests/test_cockpit_palette_boundary.py`
- `git diff --check`

Note: full-file `ruff check src/pollypm/cockpit_ui.py` still reports pre-existing import-order/unused-symbol debt unrelated to this slice; this PR uses focused syntax and F821 checks for the touched UI file.