### PR TITLE
Fix doctor fix busy response

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -273,6 +273,16 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: |
+            A `fix=true` doctor run is already in progress. The typed
+            error code is `in_progress`; the body includes
+            `retry_after_seconds` and the response carries a matching
+            `Retry-After` header.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "422":
           $ref: "#/components/responses/ValidationError"
         "504":
@@ -2642,6 +2652,9 @@ components:
           description: Stable snake_case error code.
         message: { type: string }
         hint: { type: string }
+        retry_after_seconds:
+          type: integer
+          minimum: 1
     ErrorResponse:
       type: object
       required: [error]

--- a/src/pollypm/web_api/errors.py
+++ b/src/pollypm/web_api/errors.py
@@ -6,6 +6,8 @@ Every 4xx / 5xx response body in the Web API conforms to the
     {"error": {"code": "snake_case", "message": "...", "hint": "..."}}
 
 Plus an optional ``details[]`` array for ``validation_error``.
+Contention responses may also include ``retry_after_seconds`` inside
+``error`` and a matching ``Retry-After`` header.
 
 This module owns the canonical exception class
 (:class:`APIError`) and the FastAPI exception handler that renders
@@ -27,7 +29,9 @@ class APIError(Exception):
 
     Carries the spec's ``(code, message, hint?)`` triple plus the HTTP
     status code. ``details`` is optional and only surfaces on
-    ``validation_error`` (per §6).
+    ``validation_error`` (per §6). ``retry_after_seconds`` is optional
+    and surfaces on contention/back-pressure responses that have an
+    actionable retry window.
     """
 
     def __init__(
@@ -38,6 +42,7 @@ class APIError(Exception):
         message: str,
         hint: str | None = None,
         details: list[dict[str, str]] | None = None,
+        retry_after_seconds: int | None = None,
     ) -> None:
         super().__init__(message)
         self.status_code = status_code
@@ -45,6 +50,7 @@ class APIError(Exception):
         self.message = message
         self.hint = hint
         self.details = details
+        self.retry_after_seconds = retry_after_seconds
 
     def to_body(self) -> dict[str, Any]:
         body: dict[str, Any] = {
@@ -55,13 +61,22 @@ class APIError(Exception):
         }
         if self.hint is not None:
             body["error"]["hint"] = self.hint
+        if self.retry_after_seconds is not None:
+            body["error"]["retry_after_seconds"] = self.retry_after_seconds
         if self.details is not None:
             body["details"] = self.details
         return body
 
 
 def error_response(error: APIError) -> JSONResponse:
-    return JSONResponse(status_code=error.status_code, content=error.to_body())
+    headers: dict[str, str] | None = None
+    if error.retry_after_seconds is not None:
+        headers = {"Retry-After": str(error.retry_after_seconds)}
+    return JSONResponse(
+        status_code=error.status_code,
+        content=error.to_body(),
+        headers=headers,
+    )
 
 
 # Convenience constructors so endpoint code reads naturally:

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -25,6 +25,7 @@ class ErrorBody(BaseModel):
     code: str
     message: str
     hint: str | None = None
+    retry_after_seconds: int | None = None
 
 
 class ErrorResponse(BaseModel):

--- a/src/pollypm/web_api/routes/doctor.py
+++ b/src/pollypm/web_api/routes/doctor.py
@@ -48,7 +48,6 @@ from pollypm.doctor import (
 )
 from pollypm.web_api.errors import (
     APIError,
-    conflict,
     invalid_request,
     not_found,
     service_unavailable,
@@ -70,6 +69,7 @@ router = APIRouter(tags=["Doctor"])
 # the spec's 30s ceiling so the caller sees a typed 504 rather than the
 # generic uvicorn timeout.
 DEFAULT_RUN_TIMEOUT_SECONDS = 25.0
+DOCTOR_FIX_BUSY_RETRY_AFTER_SECONDS = 5
 
 
 # ---------------------------------------------------------------------------
@@ -431,15 +431,18 @@ def _fix_busy_error() -> APIError:
     Doctor fixes touch shared state (filesystem, tmux sessions, the
     Postgres heartbeat tables); we serialize the run+fix+verify
     sequence with ``app.state.doctor_fix_lock``. Callers that race a
-    second ``fix=true`` request get an immediate 409 ``busy`` rather
-    than blocking on the lock or running fixes a second time.
+    second ``fix=true`` request get an immediate 409 ``in_progress``
+    rather than blocking on the lock or running fixes a second time.
     """
-    return conflict(
-        "Doctor fix already in progress",
+    return APIError(
+        status_code=409,
+        code="in_progress",
+        message="Doctor fix already in progress",
         hint=(
             "Wait for the in-flight POST /doctor/run (fix=true) to complete, "
             "then retry. Doctor fixes are single-flight."
         ),
+        retry_after_seconds=DOCTOR_FIX_BUSY_RETRY_AFTER_SECONDS,
     )
 
 
@@ -737,6 +740,17 @@ def get_doctor_report_endpoint(
     response_model=DoctorRunResponse,
     summary="Run doctor checks (optionally with --fix)",
     operation_id="runDoctor",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Unknown doctor check."},
+        "409": {
+            "description": (
+                "A fix=true doctor run is already in progress; the error "
+                "body includes retry_after_seconds."
+            )
+        },
+        "504": {"description": "Run exceeded the timeout budget."},
+    },
 )
 def run_doctor_endpoint(
     config: ConfigDep,

--- a/tests/test_doctor_endpoint.py
+++ b/tests/test_doctor_endpoint.py
@@ -500,7 +500,7 @@ def test_fix_retry_after_504_returns_busy_while_first_still_running(
          budget so the first POST times out with 504.
       2. Asserts the first request returns 504 within budget + slack.
       3. Fires a second POST while the worker is still blocked, asserts
-         it returns 409 ``conflict`` (NOT 504 from a second hang, which
+         it returns 409 ``in_progress`` (NOT 504 from a second hang, which
          is what round-3 would have produced).
       4. Releases the worker so the suite shuts down cleanly.
     """
@@ -543,7 +543,7 @@ def test_fix_retry_after_504_returns_busy_while_first_still_running(
     assert in_flight.is_set(), "test setup bug: worker never entered apply_fixes"
 
     # Second request fired immediately: the worker is still alive
-    # holding shared state, so the route MUST refuse with 409 busy
+    # holding shared state, so the route MUST refuse with 409 in_progress
     # rather than start a second concurrent fix (which would either
     # interleave mutations or — pre-fix — also hang for another 1s and
     # return a second 504).
@@ -565,8 +565,10 @@ def test_fix_retry_after_504_returns_busy_while_first_still_running(
         "a second concurrent fix while the first worker was still alive."
     )
     body = second.json()
-    assert body["error"]["code"] == "conflict"
+    assert body["error"]["code"] == "in_progress"
     assert "in progress" in body["error"]["message"].lower()
+    assert body["error"]["retry_after_seconds"] == 5
+    assert second.headers["retry-after"] == "5"
 
     # Wait for the worker's done callback to release the per-app lock
     # before the next test runs (otherwise we leak across the suite).
@@ -588,10 +590,10 @@ def test_run_fix_serialized_under_concurrency(
 ):
     """Two concurrent ``fix=true`` calls: one succeeds, one returns 409.
 
-    Single-flight is enforced via ``_FIX_OPERATION_LOCK`` on the
-    route module. We hold ``apply_fixes`` long enough for the second
+    Single-flight is enforced via ``app.state.doctor_fix_lock``.
+    We hold ``apply_fixes`` long enough for the second
     request to race in, then assert exactly one 200 and one 409
-    ``conflict`` (Codex round-1 P0 on PR #2058).
+    ``in_progress`` (Codex round-1 P0 on PR #2058).
     """
     import threading
 
@@ -645,7 +647,8 @@ def test_run_fix_serialized_under_concurrency(
 
     assert sorted(results) == [200, 409], f"expected one 200 + one 409, got {results}"
     busy_body = next(b for b, code in zip(bodies, results) if code == 409)
-    assert busy_body["error"]["code"] == "conflict"
+    assert busy_body["error"]["code"] == "in_progress"
+    assert busy_body["error"]["retry_after_seconds"] == 5
 
 
 def test_run_rejected_for_non_default_config(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Changes concurrent `POST /api/v1/doctor/run` `fix=true` contention from a generic `conflict` to typed `in_progress`.
- Adds `retry_after_seconds` to the shared API error envelope and emits a matching `Retry-After` header.
- Documents the 409 doctor-run response in the static OpenAPI contract and runtime route metadata.

Fixes #2135.

## Tests
- `uv run pytest tests/test_doctor_endpoint.py::test_fix_retry_after_504_returns_busy_while_first_still_running tests/test_doctor_endpoint.py::test_run_fix_serialized_under_concurrency -q`
- `uv run pytest tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31 tests/web_api/test_openapi_conformance.py::test_implementation_openapi_validates_as_31 -q`

## Notes
- Full `tests/test_doctor_endpoint.py -q` and full `tests/web_api/test_openapi_conformance.py -q` both hit the existing #1902 real-`~/.pollypm` home-write guard in unrelated tests after passing the covered assertions.
