### PR TITLE
Coalesce UI refresh requests

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -36,6 +36,12 @@
     eventSource: null,
     fallbackTimer: null,
     pushRefreshTimer: null,
+    surfacesInFlight: false,
+    surfacesRefreshQueued: false,
+    dashboardInFlight: false,
+    dashboardRefreshQueued: false,
+    historyInFlight: {},
+    historyRefreshQueued: {},
     sseFailures: 0,
     sseRetryTimer: null,
     lastEventId: null,
@@ -216,26 +222,39 @@
   // ----- surfaces (left rail) --------------------------------------------
 
   async function loadSurfaces() {
-    try {
-      const data = await apiJson(API + "/chat/sessions");
-      state.surfaces = Array.isArray(data.sessions) ? data.sessions : [];
-    } catch (err) {
-      renderSurfaceError(err);
+    if (state.surfacesInFlight) {
+      state.surfacesRefreshQueued = true;
       return;
     }
-
-    state.taskLoadError = null;
+    state.surfacesInFlight = true;
     try {
-      const taskData = await apiJsonOptional(
-        API + "/tasks?limit=" + TASK_RAIL_LIMIT,
-      );
-      const items = Array.isArray(taskData.items) ? taskData.items : [];
-      state.taskSurfaces = items.map(normalizeTaskSurface);
-    } catch (err) {
-      state.taskSurfaces = [];
-      state.taskLoadError = err;
+      try {
+        const data = await apiJson(API + "/chat/sessions");
+        state.surfaces = Array.isArray(data.sessions) ? data.sessions : [];
+      } catch (err) {
+        renderSurfaceError(err);
+        return;
+      }
+
+      state.taskLoadError = null;
+      try {
+        const taskData = await apiJsonOptional(
+          API + "/tasks?limit=" + TASK_RAIL_LIMIT,
+        );
+        const items = Array.isArray(taskData.items) ? taskData.items : [];
+        state.taskSurfaces = items.map(normalizeTaskSurface);
+      } catch (err) {
+        state.taskSurfaces = [];
+        state.taskLoadError = err;
+      }
+      renderSurfaces();
+    } finally {
+      state.surfacesInFlight = false;
+      if (state.surfacesRefreshQueued) {
+        state.surfacesRefreshQueued = false;
+        loadSurfaces();
+      }
     }
-    renderSurfaces();
   }
 
   function normalizeTaskSurface(task) {
@@ -643,14 +662,31 @@
 
   async function loadHistory(name) {
     if (!name) return;
+    if (state.historyInFlight[name]) {
+      state.historyRefreshQueued[name] = true;
+      return;
+    }
+    state.historyInFlight[name] = true;
     try {
       const path =
         API + "/chat/" + encodeURIComponent(name) + "/messages?limit="
         + MAX_MESSAGES + "&direction=desc";
       const data = await apiJson(path);
-      renderHistory(data);
+      if (state.selectedKind === "chat" && state.selectedSurface === name) {
+        renderHistory(data);
+      }
     } catch (err) {
-      renderHistoryError(err);
+      if (state.selectedKind === "chat" && state.selectedSurface === name) {
+        renderHistoryError(err);
+      }
+    } finally {
+      state.historyInFlight[name] = false;
+      if (state.historyRefreshQueued[name]) {
+        state.historyRefreshQueued[name] = false;
+        if (state.selectedKind === "chat" && state.selectedSurface === name) {
+          loadHistory(name);
+        }
+      }
     }
   }
 
@@ -729,11 +765,22 @@
   // ----- dashboard rollups (right rail) ----------------------------------
 
   async function pollDashboard() {
+    if (state.dashboardInFlight) {
+      state.dashboardRefreshQueued = true;
+      return;
+    }
+    state.dashboardInFlight = true;
     try {
       const data = await apiJson(API + "/dashboard");
       renderDashboard(data);
     } catch (err) {
       renderDashboardError(err);
+    } finally {
+      state.dashboardInFlight = false;
+      if (state.dashboardRefreshQueued) {
+        state.dashboardRefreshQueued = false;
+        pollDashboard();
+      }
     }
   }
 

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -40,6 +40,81 @@ test.describe("surfaces", () => {
     );
   }
 
+  async function installHealthyEventSource(page: import("@playwright/test").Page) {
+    await page.addInitScript(() => {
+      const instances: any[] = [];
+      class MockEventSource {
+        url: string;
+        listeners: Record<string, EventListenerOrEventListenerObject>;
+        onopen: ((event: Event) => void) | null;
+        onmessage: ((event: MessageEvent) => void) | null;
+        onerror: ((event: Event) => void) | null;
+        closed: boolean;
+
+        constructor(url: string) {
+          this.url = url;
+          this.listeners = {};
+          this.onopen = null;
+          this.onmessage = null;
+          this.onerror = null;
+          this.closed = false;
+          instances.push(this);
+          setTimeout(() => {
+            if (!this.closed && typeof this.onopen === "function") {
+              this.onopen(new Event("open"));
+            }
+          }, 0);
+        }
+
+        addEventListener(
+          type: string,
+          handler: EventListenerOrEventListenerObject,
+        ) {
+          this.listeners[type] = handler;
+        }
+
+        close() {
+          this.closed = true;
+        }
+      }
+
+      (window as any).__pollypmEventSources = instances;
+      (window as any).EventSource = MockEventSource as any;
+    });
+  }
+
+  function dashboardPayload(count: number) {
+    return {
+      rollups: { message_count_24h: count },
+      daemon_status: "up",
+      active_sessions: [],
+      recent_messages: [],
+      projects: [],
+      generated_at: "2026-05-23T00:00:00Z",
+      scoped_fields: [],
+    };
+  }
+
+  async function stubEmptyTasks(page: import("@playwright/test").Page) {
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      }),
+    );
+  }
+
+  async function stubEmptySessions(page: import("@playwright/test").Page) {
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      }),
+    );
+  }
+
   test("left rail renders surface list after load", async ({ page }) => {
     await page.goto("/ui/");
     const list = page.locator("#surface-list");
@@ -227,6 +302,92 @@ test.describe("surfaces", () => {
     await expect(page.locator("#message-list .message-text")).toContainText(
       "refresh",
     );
+  });
+
+  test("dashboard refreshes coalesce while a request is in flight", async ({ page }) => {
+    await installHealthyEventSource(page);
+    await stubEmptySessions(page);
+    await stubEmptyTasks(page);
+
+    let dashboardRequests = 0;
+    let releaseFirst: (() => void) | null = null;
+    const firstRequestGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    await page.route("**/api/v1/dashboard", async (route) => {
+      dashboardRequests += 1;
+      if (dashboardRequests === 1) {
+        await firstRequestGate;
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(dashboardRequests)),
+      });
+    });
+
+    await page.goto("/ui/");
+    await expect.poll(() => dashboardRequests).toBe(1);
+
+    await page.evaluate(() => {
+      (window as any).PollyPM.pollDashboard();
+      (window as any).PollyPM.pollDashboard();
+    });
+    await page.waitForTimeout(250);
+    expect(dashboardRequests).toBe(1);
+
+    releaseFirst!();
+    await expect.poll(() => dashboardRequests).toBe(2);
+    await page.waitForTimeout(250);
+    expect(dashboardRequests).toBe(2);
+  });
+
+  test("surface refreshes coalesce while a request is in flight", async ({ page }) => {
+    await installHealthyEventSource(page);
+    await stubEmptyTasks(page);
+
+    let dashboardRequests = 0;
+    await page.route("**/api/v1/dashboard", (route) => {
+      dashboardRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(dashboardRequests)),
+      });
+    });
+
+    let sessionRequests = 0;
+    let releaseFirst: (() => void) | null = null;
+    const firstRequestGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    await page.route("**/api/v1/chat/sessions", async (route) => {
+      sessionRequests += 1;
+      if (sessionRequests === 1) {
+        await firstRequestGate;
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await expect.poll(() => sessionRequests).toBe(1);
+
+    await page.evaluate(() => {
+      (window as any).PollyPM.loadSurfaces();
+      (window as any).PollyPM.loadSurfaces();
+    });
+    await page.waitForTimeout(250);
+    expect(sessionRequests).toBe(1);
+
+    releaseFirst!();
+    await expect.poll(() => sessionRequests).toBe(2);
+    await page.waitForTimeout(250);
+    expect(sessionRequests).toBe(2);
   });
 
   test("initial center-pane state shows 'Select a surface'", async ({ page }) => {


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds single-flight/coalescing guards for UI dashboard, surface-list, and selected-history refreshes.
- Keeps SSE push refreshes responsive while preventing duplicate `/dashboard`, `/chat/sessions`, and `/chat/{session}/messages` fetches from stacking while a prior request is still in flight.
- Adds Playwright coverage for coalescing dashboard and surface refresh calls under a healthy mocked EventSource.

Fixes #2134.

## Tests
- `node --check src/pollypm/web_api/ui/app.js`
- `npx playwright test tests/surfaces.spec.ts -g "coalesce" --project=chromium`
- `npx playwright test tests/surfaces.spec.ts --project=chromium` (7 passed; 3 live-daemon, un-stubbed rail-load cases timed out waiting for a terminal rail state)

## Notes
- First Playwright attempt failed because no local `pm serve` was listening on `127.0.0.1:8765`; reran after starting `uv run pm serve --host 127.0.0.1 --port 8765`.
