### PR TITLE
Add quick smoke automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: perf-measure perf-poll perf-snapshot
+.PHONY: smoke perf-measure perf-poll perf-snapshot
+
+smoke:
+	python scripts/smoke.py
 
 perf-measure:
 	scripts/perf/measure_http.sh --scenarios dashboard,sessions,messages,task-list,task-detail,inbox

--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Lane F smoke automation for PollyPM.
+
+This harness intentionally stays outside ``src/pollypm`` and talks to PollyPM
+only through public REST endpoints and the ``pm`` CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+GREEN = "\033[32m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    name: str
+    argv: tuple[str, ...]
+    timeout_seconds: float = 30.0
+    fail_on_stdout: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+    elapsed_seconds: float = 0.0
+    skipped: bool = False
+
+
+def read_token(explicit_token: str | None = None) -> str | None:
+    if explicit_token:
+        return explicit_token
+    if token := os.environ.get("TOKEN"):
+        return token
+    token_file = Path.home() / ".pollypm" / "api-token"
+    if token_file.exists():
+        return token_file.read_text(encoding="utf-8").strip()
+    return None
+
+
+def git_sha() -> str:
+    result = subprocess.run(
+        ("git", "rev-parse", "HEAD"),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip()
+
+
+def smoke_task_title(now: datetime) -> str:
+    return f"smoke-{now.strftime('%H%M%S')}"
+
+
+def task_command_specs(project: str, title: str) -> list[CommandSpec]:
+    return [
+        CommandSpec(
+            name="task create",
+            argv=("pm", "task", "create", "--project", project, title, "--json"),
+            timeout_seconds=30,
+        ),
+        CommandSpec(
+            name="task queue",
+            argv=("pm", "task", "queue", "{task_id}"),
+            timeout_seconds=30,
+        ),
+        CommandSpec(
+            name="task get",
+            argv=("pm", "task", "get", "{task_id}"),
+            timeout_seconds=30,
+        ),
+    ]
+
+
+def fixed_command_specs() -> list[CommandSpec]:
+    return [
+        CommandSpec(
+            name="doctor",
+            argv=("pm", "doctor"),
+            timeout_seconds=120,
+            fail_on_stdout=("[FAIL]",),
+        ),
+        CommandSpec(
+            name="sessions health",
+            argv=("pm", "sessions", "--health"),
+            timeout_seconds=60,
+        ),
+    ]
+
+
+def extract_task_id(stdout: str) -> str | None:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    for key in ("task_id", "id", "ref"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    project = payload.get("project")
+    number = payload.get("number")
+    if isinstance(project, str) and isinstance(number, int):
+        return f"{project}/{number}"
+    return None
+
+
+def run_command(spec: CommandSpec, *, dry_run: bool = False) -> tuple[CheckResult, str]:
+    rendered = " ".join(spec.argv)
+    if dry_run:
+        return CheckResult(spec.name, True, f"DRY RUN {rendered}", skipped=True), ""
+
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            spec.argv,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=spec.timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - started
+        return CheckResult(spec.name, False, f"timed out after {spec.timeout_seconds:g}s", elapsed), ""
+
+    elapsed = time.monotonic() - started
+    output = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode != 0:
+        detail = f"exit {proc.returncode}: {output.strip()[:300]}"
+        return CheckResult(spec.name, False, detail, elapsed), proc.stdout
+    for marker in spec.fail_on_stdout:
+        if marker.lower() in output.lower():
+            return CheckResult(
+                spec.name,
+                False,
+                f"found disallowed marker {marker!r}",
+                elapsed,
+            ), proc.stdout
+    return CheckResult(spec.name, True, f"ok in {elapsed:.3f}s", elapsed), proc.stdout
+
+
+def get_json(url: str, *, token: str | None, timeout_seconds: float = 5.0) -> tuple[int, Any]:
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        body = response.read().decode("utf-8")
+        return response.status, json.loads(body)
+
+
+def run_rest_check(
+    name: str,
+    url: str,
+    *,
+    token: str | None,
+    required_key: str | None = None,
+    expected_value: tuple[str, Any] | None = None,
+    require_nonempty_sessions: bool = False,
+    dry_run: bool = False,
+) -> CheckResult:
+    if dry_run:
+        auth = " with bearer token" if token else ""
+        return CheckResult(name, True, f"DRY RUN GET {url}{auth}", skipped=True)
+
+    started = time.monotonic()
+    try:
+        status, payload = get_json(url, token=token)
+    except urllib.error.HTTPError as exc:
+        elapsed = time.monotonic() - started
+        return CheckResult(name, False, f"HTTP {exc.code}", elapsed)
+    except Exception as exc:
+        elapsed = time.monotonic() - started
+        return CheckResult(name, False, f"{type(exc).__name__}: {exc}", elapsed)
+
+    elapsed = time.monotonic() - started
+    if status != 200:
+        return CheckResult(name, False, f"HTTP {status}", elapsed)
+    if required_key and required_key not in payload:
+        return CheckResult(name, False, f"missing JSON key {required_key!r}", elapsed)
+    if expected_value:
+        key, expected = expected_value
+        if payload.get(key) != expected:
+            return CheckResult(
+                name,
+                False,
+                f"expected JSON {key}={expected!r}",
+                elapsed,
+            )
+    if require_nonempty_sessions:
+        sessions = payload.get("sessions")
+        if not isinstance(sessions, list) or not sessions:
+            return CheckResult(name, False, "expected non-empty sessions list", elapsed)
+    if elapsed > 1.0 and name in {"dashboard", "sessions"}:
+        return CheckResult(name, False, f"slow response {elapsed:.3f}s", elapsed)
+    return CheckResult(name, True, f"HTTP 200 in {elapsed:.3f}s", elapsed)
+
+
+def print_result(result: CheckResult, *, color: bool = True) -> None:
+    if result.ok:
+        label = "SKIP" if result.skipped else "PASS"
+        hue = YELLOW if result.skipped else GREEN
+    else:
+        label = "FAIL"
+        hue = RED
+    prefix = f"{hue}{label}{RESET}" if color else label
+    print(f"{prefix} {result.name}: {result.detail}")
+
+
+def summary_block(sha: str, timestamp: str, results: list[CheckResult]) -> str:
+    failed = [result.name for result in results if not result.ok]
+    result_text = "all green" if not failed else f"red on {', '.join(failed)}"
+    failed_text = "none" if not failed else ", ".join(failed)
+    return "\n".join(
+        [
+            "Smoke summary:",
+            f"Smoke pass: {timestamp}",
+            f"SHA: {sha}",
+            f"Result: {result_text}",
+            f"Failed checks: {failed_text}",
+        ]
+    )
+
+
+def run_smoke(args: argparse.Namespace) -> int:
+    timestamp = datetime.now(timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+    sha = git_sha()
+    token = read_token(args.token)
+    base = args.base.rstrip("/")
+    results: list[CheckResult] = []
+
+    rest_checks = [
+        ("health", f"{base}/api/v1/health", None, ("status", "ok"), False, None),
+        ("dashboard", f"{base}/api/v1/dashboard", "daemon_status", None, False, token),
+        ("sessions", f"{base}/api/v1/chat/sessions", None, None, True, token),
+    ]
+    for name, url, required_key, expected_value, require_sessions, auth_token in rest_checks:
+        result = run_rest_check(
+            name,
+            url,
+            token=auth_token,
+            required_key=required_key,
+            expected_value=expected_value,
+            require_nonempty_sessions=require_sessions,
+            dry_run=args.dry_run,
+        )
+        results.append(result)
+        print_result(result, color=not args.no_color)
+
+    now = datetime.now()
+    task_id = "{task_id}"
+    for spec in task_command_specs(args.project, smoke_task_title(now)):
+        argv = tuple(part.format(task_id=task_id) for part in spec.argv)
+        result, stdout = run_command(
+            CommandSpec(spec.name, argv, spec.timeout_seconds, spec.fail_on_stdout),
+            dry_run=args.dry_run,
+        )
+        if spec.name == "task create" and result.ok and not args.dry_run:
+            parsed_task_id = extract_task_id(stdout)
+            if not parsed_task_id:
+                result = CheckResult("task create", False, "could not parse task id from JSON")
+            else:
+                task_id = parsed_task_id
+        results.append(result)
+        print_result(result, color=not args.no_color)
+        if not result.ok:
+            break
+        if spec.name == "task queue" and args.task_wait_seconds > 0 and not args.dry_run:
+            time.sleep(args.task_wait_seconds)
+
+    if all(result.ok for result in results):
+        for spec in fixed_command_specs():
+            result, _stdout = run_command(spec, dry_run=args.dry_run)
+            results.append(result)
+            print_result(result, color=not args.no_color)
+
+    print()
+    if args.no_color:
+        print(summary_block(sha, timestamp, results))
+    else:
+        block = summary_block(sha, timestamp, results)
+        color = GREEN if all(result.ok for result in results) else RED
+        print(f"{BOLD}{color}{block}{RESET}")
+    return 0 if all(result.ok for result in results) else 1
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run PollyPM lane F smoke checks.")
+    parser.add_argument("--base", default=os.environ.get("BASE", "http://127.0.0.1:8765"))
+    parser.add_argument("--token", default=None, help="API bearer token; defaults to TOKEN or ~/.pollypm/api-token")
+    parser.add_argument("--project", default="pollypm", help="project for task create/queue/get")
+    parser.add_argument("--task-wait-seconds", type=float, default=60.0)
+    parser.add_argument("--dry-run", action="store_true", help="print planned checks without hitting daemon or CLI")
+    parser.add_argument("--no-color", action="store_true", help="disable ANSI color output")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_smoke(parse_args(argv if argv is not None else sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_script.py
+++ b/tests/test_smoke_script.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "smoke.py"
+SPEC = importlib.util.spec_from_file_location("smoke_script", SCRIPT_PATH)
+assert SPEC is not None
+smoke = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = smoke
+assert SPEC.loader is not None
+SPEC.loader.exec_module(smoke)
+
+
+def test_task_command_construction() -> None:
+    title = smoke.smoke_task_title(datetime(2026, 5, 23, 9, 8, 7))
+
+    specs = smoke.task_command_specs("pollypm", title)
+
+    assert title == "smoke-090807"
+    assert specs[0].argv == (
+        "pm",
+        "task",
+        "create",
+        "--project",
+        "pollypm",
+        "smoke-090807",
+        "--json",
+    )
+    assert specs[1].argv == ("pm", "task", "queue", "{task_id}")
+    assert specs[2].argv == ("pm", "task", "get", "{task_id}")
+
+
+def test_fixed_command_construction_uses_public_cli() -> None:
+    specs = smoke.fixed_command_specs()
+
+    assert specs[0].argv == ("pm", "doctor")
+    assert specs[0].fail_on_stdout == ("[FAIL]",)
+    assert specs[1].name == "sessions health"
+    assert specs[1].argv == ("pm", "sessions", "--health")
+
+
+def test_summary_block_lists_failed_checks() -> None:
+    results = [
+        smoke.CheckResult("health", True, "ok"),
+        smoke.CheckResult("dashboard", False, "HTTP 500"),
+        smoke.CheckResult("doctor", False, "found [FAIL]"),
+    ]
+
+    summary = smoke.summary_block("abc123", "2026-05-23 10:00:00 MDT", results)
+
+    assert "SHA: abc123" in summary
+    assert "Result: red on dashboard, doctor" in summary
+    assert "Failed checks: dashboard, doctor" in summary
+
+
+def test_summary_block_all_green() -> None:
+    summary = smoke.summary_block(
+        "abc123",
+        "2026-05-23 10:00:00 MDT",
+        [smoke.CheckResult("health", True, "ok")],
+    )
+
+    assert "Result: all green" in summary
+    assert "Failed checks: none" in summary
+
+
+def test_dry_run_avoids_command_execution() -> None:
+    result, stdout = smoke.run_command(
+        smoke.CommandSpec("doctor", ("pm", "doctor")),
+        dry_run=True,
+    )
+
+    assert result.ok
+    assert result.skipped
+    assert "DRY RUN pm doctor" == result.detail
+    assert stdout == ""
+
+
+def test_dry_run_rest_check_avoids_http() -> None:
+    result = smoke.run_rest_check(
+        "dashboard",
+        "http://127.0.0.1:8765/api/v1/dashboard",
+        token="secret",
+        required_key="daemon_status",
+        dry_run=True,
+    )
+
+    assert result.ok
+    assert result.skipped
+    assert "DRY RUN GET http://127.0.0.1:8765/api/v1/dashboard with bearer token" == result.detail
+
+
+def test_extract_task_id_accepts_common_public_json_shapes() -> None:
+    assert smoke.extract_task_id('{"task_id": "pollypm/1"}') == "pollypm/1"
+    assert smoke.extract_task_id('{"project": "pollypm", "number": 2}') == "pollypm/2"
+    assert smoke.extract_task_id("{}") is None


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add `scripts/smoke.py` as the repeatable quick-smoke runner.
- Add `make smoke` wiring for the documented operator workflow.
- Cover dry-run planning, failure reporting, and command construction with focused tests.

Closes #2150.

## Verification
- `uv run --extra test pytest tests/test_smoke_script.py`
- `python scripts/smoke.py --dry-run --no-color --task-wait-seconds 0`
- `uv run --extra dev ruff check scripts/smoke.py tests/test_smoke_script.py`
- `make -n smoke`

## Notes
- `uv run pytest tests/test_smoke_script.py` without test extras failed because `pytest` is not installed in the base environment.
- Live smoke was not run in this watcher pass; dry-run and command/test coverage were verified.
