### PR TITLE
Make dashboard rail cards interactive and recoverable

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -20,6 +20,7 @@
   const SSE_FAILURE_LIMIT = 3;
   const SSE_STABLE_OPEN_MS = 5000;
   const PUSH_REFRESH_DEBOUNCE_MS = 150;
+  const FETCH_RETRY_MS = 3000;
   const MAX_MESSAGES = 50;
   const SESSION_ISSUED_COOKIE = "pollypm-session-issued-at";
   const SESSION_EXPIRY_WARNING_MS = 6 * 24 * 60 * 60 * 1000;
@@ -58,6 +59,7 @@
     dashboardRefreshQueued: false,
     historyInFlight: {},
     historyRefreshQueued: {},
+    fetchStates: {},
     sseFailures: 0,
     sseRetryTimer: null,
     lastEventId: null,
@@ -206,6 +208,108 @@
 
   // ----- fetch wrapper ----------------------------------------------------
 
+  function isAbortError(err) {
+    return err && (
+      err.name === "AbortError"
+      || err.message === "aborted"
+      || err.code === 20
+    );
+  }
+
+  function ensureFetchState(name) {
+    if (!state.fetchStates[name]) {
+      state.fetchStates[name] = {
+        name: name,
+        seq: 0,
+        stage: "idle",
+        controller: null,
+        timers: [],
+        retry: null,
+        label: name,
+        hasSettled: false,
+      };
+    }
+    return state.fetchStates[name];
+  }
+
+  function clearFetchTimers(fetchState) {
+    for (const timer of fetchState.timers) clearTimeout(timer);
+    fetchState.timers = [];
+  }
+
+  function beginFetchState(name, label, render, retry, opts) {
+    const options = opts || {};
+    const fetchState = ensureFetchState(name);
+    fetchState.seq += 1;
+    fetchState.stage = "loading";
+    fetchState.label = label;
+    fetchState.retry = retry;
+    fetchState.controller = new AbortController();
+    clearFetchTimers(fetchState);
+    const seq = fetchState.seq;
+    fetchState.timers.push(setTimeout(() => {
+      if (fetchState.seq !== seq) return;
+      fetchState.stage = "slow";
+      render();
+    }, FETCH_RETRY_MS));
+    if (!(options.preserveSettled && fetchState.hasSettled)) {
+      render();
+    }
+    return {
+      seq: seq,
+      signal: fetchState.controller.signal,
+    };
+  }
+
+  function finishFetchState(name, seq) {
+    const fetchState = ensureFetchState(name);
+    if (fetchState.seq !== seq) return false;
+    clearFetchTimers(fetchState);
+    fetchState.stage = "idle";
+    fetchState.controller = null;
+    fetchState.hasSettled = true;
+    return true;
+  }
+
+  function abortFetchState(name) {
+    const fetchState = ensureFetchState(name);
+    if (fetchState.controller) fetchState.controller.abort();
+    clearFetchTimers(fetchState);
+    fetchState.seq += 1;
+    fetchState.stage = "idle";
+    fetchState.controller = null;
+  }
+
+  function retryFetchState(name) {
+    const fetchState = ensureFetchState(name);
+    const retry = fetchState.retry;
+    abortFetchState(name);
+    if (retry) retry();
+  }
+
+  function loadingText(fetchState, fallback) {
+    if (!fetchState || fetchState.stage === "loading") return fallback;
+    return fetchState.label + " is taking longer than expected.";
+  }
+
+  function fetchAffordance(fetchName, tag, className, fallback) {
+    const fetchState = ensureFetchState(fetchName);
+    const children = [
+      document.createTextNode(loadingText(fetchState, fallback)),
+    ];
+    if (fetchState.stage === "slow") {
+      const retry = el("button", {
+        type: "button",
+        class: "fetch-retry",
+        text: "Retry",
+        "aria-label": "Retry loading " + fetchState.label,
+      });
+      retry.addEventListener("click", () => retryFetchState(fetchName));
+      children.push(retry);
+    }
+    return el(tag, { class: className + " fetch-state" }, children);
+  }
+
   async function apiFetch(path, opts) {
     const init = Object.assign({ credentials: "include" }, opts || {});
     init.headers = Object.assign(
@@ -216,6 +320,7 @@
     try {
       resp = await fetch(path, init);
     } catch (err) {
+      if (isAbortError(err)) throw err;
       setStatus("error", "offline");
       throw err;
     }
@@ -244,11 +349,13 @@
     return resp.json();
   }
 
-  async function apiJsonOptional(path) {
-    const resp = await fetch(path, {
-      credentials: "include",
-      headers: { "Accept": "application/json" },
-    });
+  async function apiJsonOptional(path, opts) {
+    const init = Object.assign({ credentials: "include" }, opts || {});
+    init.headers = Object.assign(
+      { "Accept": "application/json" },
+      init.headers || {},
+    );
+    const resp = await fetch(path, init);
     if (resp.status === 401) {
       setStatus("error", "auth required");
       showAuthGate();
@@ -281,22 +388,51 @@
     return API + "/projects" + (query ? "?" + query : "");
   }
 
-  async function loadSurfaces() {
+  async function loadSurfaces(opts) {
+    const force = opts && opts.force;
     if (state.surfacesInFlight) {
-      state.surfacesRefreshQueued = true;
-      return;
+      if (force) {
+        abortFetchState("surfaces");
+        state.surfacesInFlight = false;
+      } else {
+        state.surfacesRefreshQueued = true;
+        return;
+      }
     }
     state.surfacesInFlight = true;
     state.surfaceLoading = true;
     state.taskLoading = true;
+    const request = beginFetchState(
+      "surfaces",
+      "surfaces",
+      renderSurfacesLoading,
+      () => loadSurfaces({ force: true }),
+      { preserveSettled: true },
+    );
     renderSurfaces();
     try {
       const [sessionsResult, tasksResult, projectsResult] =
         await Promise.allSettled([
-          apiJson(API + "/chat/sessions"),
-          apiJsonOptional(API + "/tasks?limit=" + TASK_RAIL_LIMIT),
-          apiJsonOptional(projectListPath()),
+          apiJson(API + "/chat/sessions", { signal: request.signal }),
+          apiJsonOptional(
+            API + "/tasks?limit=" + TASK_RAIL_LIMIT,
+            { signal: request.signal },
+          ),
+          apiJsonOptional(projectListPath(), { signal: request.signal }),
         ]);
+
+      // If any leg aborted because a newer load took over, bail without
+      // mutating shared state — the newer load owns the render path.
+      if (
+        (sessionsResult.status === "rejected"
+          && isAbortError(sessionsResult.reason))
+        || (tasksResult.status === "rejected"
+          && isAbortError(tasksResult.reason))
+        || (projectsResult.status === "rejected"
+          && isAbortError(projectsResult.reason))
+      ) {
+        return;
+      }
 
       if (sessionsResult.status === "rejected") {
         state.surfaces = [];
@@ -308,6 +444,7 @@
           ? sessionsResult.reason
           : new Error(String(sessionsResult.reason));
         state.surfaceLoadError = err;
+        renderSurfaceError(err);
         renderProjects();
         return;
       }
@@ -345,6 +482,7 @@
     } finally {
       state.surfaceLoading = false;
       state.taskLoading = false;
+      if (!finishFetchState("surfaces", request.seq)) return;
       state.surfacesInFlight = false;
       renderSurfaces();
       if (state.surfacesRefreshQueued) {
@@ -352,6 +490,15 @@
         loadSurfaces();
       }
     }
+  }
+
+  function renderSurfacesLoading() {
+    const list = $("surface-list");
+    if (!list) return;
+    list.innerHTML = "";
+    list.appendChild(
+      fetchAffordance("surfaces", "li", "surface-empty", "loading..."),
+    );
   }
 
   function normalizeTaskSurface(task) {
@@ -1288,26 +1435,46 @@
     renderLocalEchoes(name);
   }
 
-  async function loadHistory(name) {
+  async function loadHistory(name, opts) {
     if (!name) return;
+    const force = opts && opts.force;
+    const fetchName = "history:" + name;
     if (state.historyInFlight[name]) {
-      state.historyRefreshQueued[name] = true;
-      return;
+      if (force) {
+        abortFetchState(fetchName);
+        state.historyInFlight[name] = false;
+      } else {
+        state.historyRefreshQueued[name] = true;
+        return;
+      }
     }
     state.historyInFlight[name] = true;
+    const request = beginFetchState(
+      fetchName,
+      "history",
+      () => {
+        if (state.selectedKind === "chat" && state.selectedSurface === name) {
+          renderHistoryLoading(fetchName);
+        }
+      },
+      () => loadHistory(name, { force: true }),
+      { preserveSettled: true },
+    );
     try {
       const path =
         API + "/chat/" + encodeURIComponent(name) + "/messages?limit="
         + MAX_MESSAGES + "&direction=desc";
-      const data = await apiJson(path);
+      const data = await apiJson(path, { signal: request.signal });
       if (state.selectedKind === "chat" && state.selectedSurface === name) {
         renderHistory(data);
       }
     } catch (err) {
+      if (isAbortError(err)) return;
       if (state.selectedKind === "chat" && state.selectedSurface === name) {
         renderHistoryError(err);
       }
     } finally {
+      if (!finishFetchState(fetchName, request.seq)) return;
       state.historyInFlight[name] = false;
       if (state.historyRefreshQueued[name]) {
         state.historyRefreshQueued[name] = false;
@@ -1316,6 +1483,15 @@
         }
       }
     }
+  }
+
+  function renderHistoryLoading(fetchName) {
+    const list = $("message-list");
+    list.innerHTML = "";
+    list.appendChild(
+      fetchAffordance(fetchName, "div", "message-empty", "loading history..."),
+    );
+    updateStopAgentButton();
   }
 
   function renderHistory(data) {
@@ -1897,23 +2073,39 @@
 
   // ----- dashboard rollups (right rail) ----------------------------------
 
-  async function pollDashboard() {
+  async function pollDashboard(opts) {
+    const force = opts && opts.force;
     if (state.dashboardInFlight) {
-      state.dashboardRefreshQueued = true;
-      return;
+      if (force) {
+        abortFetchState("dashboard");
+        state.dashboardInFlight = false;
+      } else {
+        state.dashboardRefreshQueued = true;
+        return;
+      }
     }
     state.dashboardInFlight = true;
+    const request = beginFetchState(
+      "dashboard",
+      "dashboard",
+      renderDashboardLoading,
+      () => pollDashboard({ force: true }),
+      { preserveSettled: true },
+    );
     try {
       const params = new URLSearchParams();
       if (state.selectedProject) params.set("project", state.selectedProject);
       const query = params.toString();
       const data = await apiJson(
         API + "/dashboard" + (query ? "?" + query : ""),
+        { signal: request.signal },
       );
       renderDashboard(data);
     } catch (err) {
+      if (isAbortError(err)) return;
       renderDashboardError(err);
     } finally {
+      if (!finishFetchState("dashboard", request.seq)) return;
       state.dashboardInFlight = false;
       if (state.dashboardRefreshQueued) {
         state.dashboardRefreshQueued = false;
@@ -1935,28 +2127,104 @@
     return scopedFields.indexOf(key) !== -1;
   }
 
-  function buildCard(label, value, cls, scoped, onClick) {
-    const labelText = scoped ? label + " (filtered)" : label;
-    const attrs = { class: "rollup-card " + (cls || "") };
-    if (onClick) {
-      attrs.role = "button";
-      attrs.tabindex = "0";
-      attrs.title = "Open " + label;
+  function renderDashboardLoading() {
+    const box = $("dashboard-rollups");
+    if (!box) return;
+    box.innerHTML = "";
+    box.appendChild(
+      fetchAffordance("dashboard", "div", "rollup-empty", "loading..."),
+    );
+  }
+
+  function renderDashboardDrilldown(card) {
+    $("pane-title").textContent = "Dashboard: " + card.label;
+    $("pane-meta").textContent = card.value;
+    $("send-input").disabled = true;
+    $("send-button").disabled = true;
+    updateStopAgentButton();
+    const list = $("message-list");
+    list.innerHTML = "";
+    const rows = [
+      ["Metric", card.label],
+      ["Value", card.value],
+    ];
+    if (card.detail) rows.push(["Context", card.detail]);
+    const children = [];
+    for (const row of rows) {
+      children.push(el("div", { class: "task-detail-row" }, [
+        el("span", { class: "task-detail-label", text: row[0] }),
+        el("span", { class: "task-detail-value", text: String(row[1]) }),
+      ]));
     }
-    const card = el("div", attrs, [
+    list.appendChild(el("div", { class: "task-detail dashboard-detail" }, children));
+  }
+
+  function firstSurfaceName(data) {
+    if (data && Array.isArray(data.active_sessions)) {
+      for (const item of data.active_sessions) {
+        const name = item && item.session_name;
+        if (name && state.surfaces.some((s) => s.session_name === name)) {
+          return name;
+        }
+      }
+      const firstActive = data.active_sessions.find((item) => item.session_name);
+      if (firstActive) return firstActive.session_name;
+    }
+    return state.surfaces.length > 0 ? state.surfaces[0].session_name : null;
+  }
+
+  function firstTaskKey(statuses) {
+    for (const task of state.taskSurfaces) {
+      if (!statuses || statuses.indexOf(task.work_status) !== -1) return task.key;
+    }
+    return null;
+  }
+
+  function dashboardCardAction(card, data) {
+    return () => {
+      if (card.target === "surface") {
+        const name = firstSurfaceName(data);
+        if (name && state.surfaces.some((s) => s.session_name === name)) {
+          selectSurface(name);
+          return;
+        }
+      }
+      if (card.target === "review-task") {
+        const key = firstTaskKey(["review", "queued", "rework", "blocked"]);
+        if (key) {
+          selectTask(key);
+          return;
+        }
+      }
+      if (card.target === "task") {
+        const key = firstTaskKey(null);
+        if (key) {
+          selectTask(key);
+          return;
+        }
+      }
+      renderDashboardDrilldown(card);
+    };
+  }
+
+  // Dashboard rail cards always render as buttons with a Playwright-friendly
+  // aria-label and route through `dashboardCardAction` for drill-down. PR
+  // #2266's `selectInbox` workflow remains reachable via the inbox surface
+  // rail entry; merging both click semantics into the same card produced
+  // ambiguous routing, so we standardize on the PR #2172 button shape here.
+  function buildCard(label, value, cls, scoped, action, detail) {
+    const labelText = scoped ? label + " (filtered)" : label;
+    const button = el("button", {
+      type: "button",
+      class: "rollup-card " + (cls || ""),
+      "aria-label": "Open dashboard detail for " + labelText + ": " + value,
+    }, [
       el("div", { class: "rollup-label", text: labelText }),
       el("div", { class: "rollup-value", text: String(value) }),
     ]);
-    if (onClick) {
-      card.addEventListener("click", onClick);
-      card.addEventListener("keydown", (ev) => {
-        if (ev.key === "Enter" || ev.key === " ") {
-          ev.preventDefault();
-          onClick();
-        }
-      });
-    }
-    return card;
+    button.addEventListener("click", action);
+    if (detail) button.setAttribute("title", detail);
+    return button;
   }
 
   function renderDashboard(data) {
@@ -1986,7 +2254,13 @@
         rollups.open_inbox_count + " items",
         "rollup-attention",
         isScoped(scopedFields, "rollups.open_inbox_count"),
-        () => selectInbox(),
+        dashboardCardAction({
+          label: "inbox",
+          value: rollups.open_inbox_count + " items",
+          target: "surface",
+          detail: "Opens an active chat surface when one is visible.",
+        }, data),
+        "Open an active chat surface",
       ));
     }
     if (typeof rollups.pending_plan_reviews === "number") {
@@ -1995,7 +2269,13 @@
         rollups.pending_plan_reviews + " waiting",
         "rollup-attention",
         isScoped(scopedFields, "rollups.pending_plan_reviews"),
-        () => selectInbox({ type: "plan_review" }),
+        dashboardCardAction({
+          label: "plan reviews",
+          value: rollups.pending_plan_reviews + " waiting",
+          target: "review-task",
+          detail: "Opens a visible task waiting on review when available.",
+        }, data),
+        "Open a review task",
       ));
     }
     if (typeof rollups.alert_count === "number") {
@@ -2006,6 +2286,13 @@
         // alert_count is intentionally global per DashboardRollups
         // docstring — never appears in scoped_fields, so no tag.
         false,
+        dashboardCardAction({
+          label: "alerts",
+          value: rollups.alert_count,
+          target: "detail",
+          detail: "Shows the current alert count.",
+        }, data),
+        "Show alert count",
       ));
     }
 
@@ -2023,6 +2310,13 @@
         sweeps + " sweeps / " + msgs + " msgs",
         "rollup-working",
         false,
+        dashboardCardAction({
+          label: "activity (24h)",
+          value: sweeps + " sweeps / " + msgs + " msgs",
+          target: "surface",
+          detail: "Opens an active chat surface when one is visible.",
+        }, data),
+        "Open an active chat surface",
       ));
     }
 
@@ -2034,6 +2328,13 @@
         data.daemon_status,
         up ? "rollup-working" : "rollup-blocked",
         false,
+        dashboardCardAction({
+          label: "daemon",
+          value: data.daemon_status,
+          target: "detail",
+          detail: "Shows daemon status.",
+        }, data),
+        "Show daemon status",
       ));
     }
 
@@ -2044,6 +2345,13 @@
         data.active_sessions.length,
         "",
         isScoped(scopedFields, "active_sessions"),
+        dashboardCardAction({
+          label: "active sessions",
+          value: data.active_sessions.length,
+          target: "surface",
+          detail: "Opens the first visible active chat surface.",
+        }, data),
+        "Open active session",
       ));
     }
 
@@ -2054,6 +2362,13 @@
         rollups.tracked_count,
         "",
         isScoped(scopedFields, "rollups.tracked_count"),
+        dashboardCardAction({
+          label: "projects tracked",
+          value: rollups.tracked_count,
+          target: "task",
+          detail: "Opens a visible task when available.",
+        }, data),
+        "Open a visible task",
       ));
     }
 

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -262,6 +262,9 @@ aside#dashboard-rail {
   cursor: default;
   font-style: italic;
 }
+.surface-list li.fetch-state {
+  gap: 8px;
+}
 .surface-list li.surface-group {
   background: transparent;
   border-color: transparent;
@@ -337,6 +340,12 @@ section#message-pane {
   font-style: italic;
   padding: 24px 0;
   text-align: center;
+}
+.message-empty.fetch-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 .message {
   margin: 0 0 10px;
@@ -606,11 +615,27 @@ section#message-pane {
   padding: 0 12px 16px;
 }
 .rollup-card {
+  display: block;
+  width: 100%;
   background: var(--bg-row);
   border: 1px solid var(--border-line);
   border-radius: 6px;
   padding: 10px 12px;
   margin: 0 0 8px;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+.rollup-card:hover {
+  background: var(--bg-row-hover);
+}
+.rollup-card:focus {
+  outline: none;
+  border-color: var(--info);
+}
+.rollup-card:focus-visible {
+  box-shadow: 0 0 0 2px rgba(91, 138, 255, 0.35);
 }
 .rollup-card[role="button"] {
   cursor: pointer;
@@ -624,6 +649,11 @@ section#message-pane {
   color: var(--text-muted);
   font-style: italic;
   padding: 8px;
+}
+.rollup-empty.fetch-state {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 .rollup-label {
   font-size: 11px;
@@ -721,6 +751,29 @@ section#message-pane {
   color: var(--text-body);
   font-size: 11.5px;
   overflow-wrap: anywhere;
+}
+
+.fetch-retry {
+  align-self: flex-start;
+  padding: 5px 9px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-heading);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-style: normal;
+}
+.fetch-retry:hover {
+  background: var(--bg-row-hover);
+}
+.fetch-retry:focus {
+  outline: none;
+  border-color: var(--info);
+}
+.fetch-retry:focus-visible {
+  box-shadow: 0 0 0 2px rgba(91, 138, 255, 0.35);
 }
 
 .error-banner {

--- a/tests/playwright/tests/dashboard_rail.spec.ts
+++ b/tests/playwright/tests/dashboard_rail.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect } from "@playwright/test";
+
+const FAKE_SURFACE = {
+  session_name: "operator",
+  surface_type: "operator",
+  persona: "polly",
+  project: "pollypm",
+  window: { present: true, pane_dead: false },
+};
+
+async function stubSurfaces(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/chat/sessions", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [FAKE_SURFACE] }),
+    }),
+  );
+  await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
+  await page.route("**/api/v1/chat/operator/messages*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        session_name: "operator",
+        surface_type: "operator",
+        transcript_source: "jsonl",
+        messages: [],
+      }),
+    }),
+  );
+}
+
+async function installQuietEventSource(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    class MockEventSource {
+      url: string;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(url: string) {
+        this.url = url;
+        setTimeout(() => {
+          if (this.onopen) this.onopen(new Event("open"));
+        }, 0);
+      }
+
+      addEventListener() {}
+      close() {}
+    }
+
+    (window as any).EventSource = MockEventSource as any;
+  });
+}
+
+function dashboardPayload() {
+  return {
+    rollups: {
+      open_inbox_count: 3,
+      pending_plan_reviews: 1,
+      alert_count: 2,
+      sweep_count_24h: 5,
+      message_count_24h: 8,
+      tracked_count: 4,
+    },
+    daemon_status: "up",
+    active_sessions: [{ session_name: "operator" }],
+    recent_messages: [],
+    projects: [],
+    generated_at: "2026-05-23T00:00:00Z",
+    scoped_fields: [],
+  };
+}
+
+test.describe("dashboard rail", () => {
+  test("rollup cards are focusable buttons that drill into visible state", async ({ page }) => {
+    await installQuietEventSource(page);
+    await stubSurfaces(page);
+    await page.route("**/api/v1/dashboard", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload()),
+      }),
+    );
+
+    await page.goto("/ui/");
+
+    const expected: Array<[RegExp, string]> = [
+      [/inbox/i, "operator"],
+      [/plan reviews/i, "Dashboard: plan reviews"],
+      [/alerts/i, "Dashboard: alerts"],
+      [/activity/i, "operator"],
+      [/daemon/i, "Dashboard: daemon"],
+      [/active sessions/i, "operator"],
+      [/projects tracked/i, "Dashboard: projects tracked"],
+    ];
+
+    for (const [name, title] of expected) {
+      const card = page.getByRole("button", { name });
+      await expect(card).toBeVisible();
+      await expect(card).toHaveAttribute("aria-label", /Open dashboard detail/);
+      await card.focus();
+      await expect(card).toBeFocused();
+      await page.evaluate(() => {
+        const titleNode = document.getElementById("pane-title");
+        const listNode = document.getElementById("message-list");
+        if (titleNode) titleNode.textContent = "Reset";
+        if (listNode) listNode.textContent = "Reset";
+      });
+      await card.click();
+      await expect(page.locator("#pane-title")).toHaveText(title, {
+        timeout: 750,
+      });
+    }
+  });
+
+  test("dashboard refresh keeps painted cards while a poll is pending", async ({ page }) => {
+    await installQuietEventSource(page);
+    await stubSurfaces(page);
+
+    let dashboardRequests = 0;
+    let releaseSecond: (() => void) | null = null;
+    const secondRequestGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    await page.route("**/api/v1/dashboard", async (route) => {
+      dashboardRequests += 1;
+      if (dashboardRequests === 2) {
+        await secondRequestGate;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload()),
+      });
+    });
+
+    await page.goto("/ui/");
+    await expect.poll(() => dashboardRequests).toBe(1);
+    await expect(page.getByRole("button", { name: /inbox/i })).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as any).PollyPM.pollDashboard();
+    });
+    await expect.poll(() => dashboardRequests).toBe(2);
+    await expect(
+      page.locator("#dashboard-rollups .rollup-empty.fetch-state"),
+    ).toHaveCount(0, { timeout: 250 });
+    await expect(page.getByRole("button", { name: /inbox/i })).toBeVisible();
+
+    releaseSecond!();
+    await expect.poll(() =>
+      page.evaluate(() => (window as any).PollyPM.state.dashboardInFlight),
+    ).toBe(false);
+    await expect(page.getByRole("button", { name: /inbox/i })).toBeVisible();
+  });
+
+  test("slow dashboard load shows retry after three seconds", async ({ page }) => {
+    await page.clock.install({ time: new Date("2026-05-23T00:00:00Z") });
+    await installQuietEventSource(page);
+    await stubSurfaces(page);
+
+    let dashboardRequests = 0;
+    let releaseFirst: (() => void) | null = null;
+    const firstRequestGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    await page.route("**/api/v1/dashboard", async (route) => {
+      dashboardRequests += 1;
+      if (dashboardRequests === 1) {
+        await firstRequestGate;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload()),
+      }).catch(() => undefined);
+    });
+
+    await page.goto("/ui/");
+    await expect.poll(() => dashboardRequests).toBe(1);
+    await expect(
+      page.getByRole("button", { name: /Retry loading dashboard/i }),
+    ).toHaveCount(0, { timeout: 100 });
+
+    await page.clock.runFor(2500);
+    await expect(
+      page.getByRole("button", { name: /Retry loading dashboard/i }),
+    ).toHaveCount(0, { timeout: 100 });
+
+    await page.clock.runFor(500);
+    await expect(page.locator("#dashboard-rollups .rollup-empty")).toContainText(
+      /taking longer/i,
+      { timeout: 750 },
+    );
+    await expect(
+      page.getByRole("button", { name: /Retry loading dashboard/i }),
+    ).toBeVisible({ timeout: 750 });
+
+    await page.getByRole("button", { name: /Retry loading dashboard/i }).click();
+    await expect.poll(() => dashboardRequests).toBe(2);
+
+    releaseFirst!();
+    await expect(page.getByRole("button", { name: /inbox/i })).toBeVisible(
+      { timeout: 750 },
+    );
+  });
+});

--- a/tests/playwright/tests/dashboard_rail.spec.ts
+++ b/tests/playwright/tests/dashboard_rail.spec.ts
@@ -23,6 +23,16 @@ async function stubSurfaces(page: import("@playwright/test").Page) {
       body: JSON.stringify({ items: [] }),
     }),
   );
+  // PR #2266 added a parallel /projects fetch inside `loadSurfaces`; the
+  // dashboard rail tests need a deterministic stub so `surfacesInFlight`
+  // settles regardless of operator state on the running server.
+  await page.route(/\/api\/v1\/projects(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
   await page.route("**/api/v1/chat/operator/messages*", (route) =>
     route.fulfill({
       status: 200,
@@ -92,6 +102,15 @@ test.describe("dashboard rail", () => {
     );
 
     await page.goto("/ui/");
+    // Wait for `loadSurfaces` to settle before clicking — PR #2266 added
+    // a third (`/projects`) leg to that fetch which can outlive the
+    // dashboard render, and the "surface" target relies on
+    // `state.surfaces` being populated.
+    await page.waitForFunction(
+      () => !(window as any).PollyPM.state.surfacesInFlight,
+      undefined,
+      { timeout: 5000 },
+    );
 
     const expected: Array<[RegExp, string]> = [
       [/inbox/i, "operator"],
@@ -103,8 +122,13 @@ test.describe("dashboard rail", () => {
       [/projects tracked/i, "Dashboard: projects tracked"],
     ];
 
+    // Scope rollup-card lookups to the dashboard rail because the empty
+    // pane CTA "Open inbox" introduced by PR #2266 also matches the
+    // /inbox/i locator at the page level.
+    const rollups = page.locator("#dashboard-rollups");
+
     for (const [name, title] of expected) {
-      const card = page.getByRole("button", { name });
+      const card = rollups.getByRole("button", { name });
       await expect(card).toBeVisible();
       await expect(card).toHaveAttribute("aria-label", /Open dashboard detail/);
       await card.focus();
@@ -146,7 +170,10 @@ test.describe("dashboard rail", () => {
 
     await page.goto("/ui/");
     await expect.poll(() => dashboardRequests).toBe(1);
-    await expect(page.getByRole("button", { name: /inbox/i })).toBeVisible();
+    const inboxCard = page
+      .locator("#dashboard-rollups")
+      .getByRole("button", { name: /inbox/i });
+    await expect(inboxCard).toBeVisible();
 
     await page.evaluate(() => {
       (window as any).PollyPM.pollDashboard();
@@ -155,13 +182,13 @@ test.describe("dashboard rail", () => {
     await expect(
       page.locator("#dashboard-rollups .rollup-empty.fetch-state"),
     ).toHaveCount(0, { timeout: 250 });
-    await expect(page.getByRole("button", { name: /inbox/i })).toBeVisible();
+    await expect(inboxCard).toBeVisible();
 
     releaseSecond!();
     await expect.poll(() =>
       page.evaluate(() => (window as any).PollyPM.state.dashboardInFlight),
     ).toBe(false);
-    await expect(page.getByRole("button", { name: /inbox/i })).toBeVisible();
+    await expect(inboxCard).toBeVisible();
   });
 
   test("slow dashboard load shows retry after three seconds", async ({ page }) => {
@@ -211,8 +238,10 @@ test.describe("dashboard rail", () => {
     await expect.poll(() => dashboardRequests).toBe(2);
 
     releaseFirst!();
-    await expect(page.getByRole("button", { name: /inbox/i })).toBeVisible(
-      { timeout: 750 },
-    );
+    await expect(
+      page
+        .locator("#dashboard-rollups")
+        .getByRole("button", { name: /inbox/i }),
+    ).toBeVisible({ timeout: 750 });
   });
 });


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Make right-rail rollup cards actionable and keyboard-focusable.
- Route card clicks to the relevant dashboard/surface/task view instead of leaving static counts.
- Add bounded loading, still-loading, slow-state retry, and abort handling for dashboard, surface, and message-history fetches.
- Add Playwright coverage for rail interactions and timeout/retry UI.

Closes #2142.
Closes #2143.

## Verification
- `node --check src/pollypm/web_api/ui/app.js`
- `uv run --extra test pytest tests/web_api/test_web_ui.py -k "render_dashboard or surface_rail or ui_app_js_renderdashboard"`
- `npm install` in `tests/playwright`
- local server: `uv run pm serve --host 127.0.0.1 --port 8765`
- `npm test -- --project=chromium tests/dashboard_rail.spec.ts`
- `npm test -- --project=chromium tests/surfaces.spec.ts -g "coalesce|SSE audit event refreshes dashboard"`
- `git diff --check`

## Notes
- Desktop Chromium was exercised. Mobile browser coverage was not run in this watcher pass.
