### PR TITLE
Fix sessions health docs command

### DIFF
--- a/docs/test-plan/00-pre-flight-baseline.md
+++ b/docs/test-plan/00-pre-flight-baseline.md
@@ -127,10 +127,10 @@ pm doctor
 
 ---
 
-## 0.5 `pm sessions health`
+## 0.5 `pm sessions --health`
 
 ```bash
-pm sessions health
+pm sessions --health
 ```
 
 **Expected:** lists active sessions; no `stuck` or `stale` heartbeats from before this session started.

--- a/docs/test-plan/01-task-lifecycle.md
+++ b/docs/test-plan/01-task-lifecycle.md
@@ -373,7 +373,7 @@ After 2 minutes (recovery cascade detection window), the operator should see:
 - TUI: a clear "stuck" indicator on that task, with the reason (no heartbeat from actor).
 - Web UI: same, surfaced in dashboard alerts.
 
-If it's silent or requires drilling into `pm sessions health` to discover, that's a magic-gap. File `magic-gap:stuck-task-surfacing`.
+If it's silent or requires drilling into `pm sessions --health` to discover, that's a magic-gap. File `magic-gap:stuck-task-surfacing`.
 
 ---
 

--- a/docs/test-plan/06-performance-budgets.md
+++ b/docs/test-plan/06-performance-budgets.md
@@ -354,7 +354,7 @@ Every 30 minutes record:
 - `/api/v1/dashboard` p95 from 10 samples
 - Browser heap
 - `pm doctor`
-- `pm sessions health`
+- `pm sessions --health`
 
 **Pass:** no monotonic resource growth, no new stale-heartbeat cluster, no connection-pool exhaustion, no progressive UI slowdown.
 

--- a/docs/test-plan/07-quick-smoke.md
+++ b/docs/test-plan/07-quick-smoke.md
@@ -39,7 +39,7 @@ When you have 5 minutes (e.g., post-merge sanity, mid-incident):
 2. **Web UI load + 3 clicks** (2 min) — open `/ui/`, click 3 surfaces, verify each <1s.
 3. **Send-receive round-trip** (2 min) — Web → tmux (<1s), tmux → Web (<5s).
 
-Skip task cycle, doctor, sessions health. The crunch version catches outright breakage but not subtle drift.
+Skip task cycle, doctor, `pm sessions --health`. The crunch version catches outright breakage but not subtle drift.
 
 Use the full 15-min version any time before declaring main shippable for the day.
 
@@ -138,7 +138,7 @@ pm doctor
 ### Sessions health (1 min)
 
 ```bash
-pm sessions health
+pm sessions --health
 ```
 
 - ☐ Lists active sessions.

--- a/docs/test-plan/journal-template.md
+++ b/docs/test-plan/journal-template.md
@@ -37,7 +37,7 @@ The journal is the durable record of a test pass — what was tested, what faile
 - pytest: <X passed / Y failed — list failures or "only known">
 - Playwright: <X passed / Y failed — list failures or "all pass">
 - pm doctor: <clean / N alerts>
-- pm sessions health: <clean / N stale>
+- pm sessions --health: <clean / N stale>
 - Baseline verdict: <green / yellow / red>
 
 If baseline is red, stop here and either fix or document why proceeding anyway.


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Replace stale `pm sessions health` references with `pm sessions --health` in the test-plan docs.
- Update the pre-flight baseline, task-lifecycle, performance-budget, quick-smoke, and journal-template docs.

Closes #2148.

## Verification
- `rg -n 'pm sessions health' docs README.md scripts tests src` returned no matches.
- `rg -n 'pm sessions --health' docs/test-plan`
- `git diff --check`
