### PR TITLE
Fix chat message contracts and storage session presence

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3314,6 +3314,7 @@ components:
         - subagent_result
         - system_event
         - thinking
+        - synthetic_notice
 
     ChatMessageEnvelope:
       type: object
@@ -3343,6 +3344,10 @@ components:
             `subagent_transcript` — a list of envelopes parsed from
             the raw Claude subagent JSONL referenced by `output_file`
             (allowlist-constrained, capped per envelope). See #2052.
+            `synthetic_notice` envelopes are ingestor-generated stubs
+            and carry `metadata.synthetic=true` with
+            `metadata.model="<synthetic>"`; clients should render them
+            as notice/banner content, not as assistant speech.
 
     ChatMessagesResponse:
       type: object
@@ -3362,10 +3367,6 @@ components:
             Which source the envelopes came from for this request —
             `jsonl` (archive), `capture` (live tmux), or `null` (no
             archive yet and capture unavailable).
-        transcript_path:
-          type: string
-          nullable: true
-          description: Archive path when `transcript_source=jsonl`.
         messages:
           type: array
           items:

--- a/src/pollypm/web_api/chat/envelope.py
+++ b/src/pollypm/web_api/chat/envelope.py
@@ -58,6 +58,7 @@ class MessageType(StrEnum):
     SUBAGENT_RESULT = "subagent_result"
     SYSTEM_EVENT = "system_event"
     THINKING = "thinking"
+    SYNTHETIC_NOTICE = "synthetic_notice"
 
 
 @dataclass(slots=True)

--- a/src/pollypm/web_api/chat/registry.py
+++ b/src/pollypm/web_api/chat/registry.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from pollypm.models import PollyPMConfig, SessionConfig
 from pollypm.projects import project_transcripts_dir
+from pollypm.session_health import storage_session_name
 from pollypm.work.session_manager import task_window_name
 from pollypm.web_api.chat.transcripts import (
     build_session_index,
@@ -242,6 +243,7 @@ def enumerate_config_surfaces(
     request even when multiple surfaces share it.
     """
     surfaces: list[ChatSurface] = []
+    tmux_session = storage_session_name(config.project.tmux_session)
     for session_name, session in (config.sessions or {}).items():
         if not session.enabled:
             continue
@@ -264,7 +266,7 @@ def enumerate_config_surfaces(
             window_state = tmux_state_cache[window_name]
         else:
             window_state = TmuxWindowState(
-                tmux_session=config.project.tmux_session,
+                tmux_session=tmux_session,
                 window_name=window_name,
                 present=False,
             )
@@ -313,6 +315,7 @@ def enumerate_worker_surfaces(
         )
         return []
     surfaces: list[ChatSurface] = []
+    tmux_session = storage_session_name(config.project.tmux_session)
     for record in records or []:
         project = getattr(record, "task_project", "") or ""
         task_number = getattr(record, "task_number", 0)
@@ -337,7 +340,7 @@ def enumerate_worker_surfaces(
             window_state = tmux_state_cache[window_name]
         else:
             window_state = TmuxWindowState(
-                tmux_session=config.project.tmux_session,
+                tmux_session=tmux_session,
                 window_name=window_name,
                 present=False,
                 pane_id=getattr(record, "pane_id", None),
@@ -447,7 +450,8 @@ def _build_tmux_state_cache(
     list_windows = getattr(tmux_client, "list_windows", None)
     if not callable(list_windows):
         return cache
-    target = config.project.tmux_session
+    base = getattr(config.project, "tmux_session", "") or ""
+    target = storage_session_name(base)
     try:
         try:
             windows = list_windows(target, timeout=_TMUX_DISCOVERY_TIMEOUT_SECONDS)

--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -127,21 +127,14 @@ def build_session_index(transcripts_root: Path) -> list[_SessionIndexEntry]:
     """
     if not transcripts_root.exists():
         return []
+    signature = _session_index_signature(transcripts_root)
+    cached = _SESSION_INDEX_CACHE.get(transcripts_root)
+    if cached is not None and cached[0] == signature:
+        return list(cached[1])
+
     entries: list[_SessionIndexEntry] = []
-    for child in transcripts_root.iterdir():
-        if not child.is_dir():
-            continue
-        if child.name in {"tasks", ".ingestion-state.lock"}:
-            # ``tasks/`` holds per-task raw-provider-JSONL archives
-            # written by SessionManager._archive_jsonl; not normalized.
-            continue
-        events_path = child / "events.jsonl"
-        if not events_path.exists():
-            continue
-        try:
-            mtime = events_path.stat().st_mtime
-        except OSError:
-            continue
+    for child_name, mtime, _size in signature:
+        events_path = transcripts_root / child_name / "events.jsonl"
         fingerprint = _read_first_event_fingerprint(events_path)
         if fingerprint is None:
             # Empty / malformed — skip so we never serve an
@@ -153,13 +146,40 @@ def build_session_index(transcripts_root: Path) -> list[_SessionIndexEntry]:
         # session_id if the dir name diverges.
         entries.append(_SessionIndexEntry(
             path=events_path,
-            session_id=child.name or session_id,
+            session_id=child_name or session_id,
             cwd=cwd,
             account_name=account_name,
             provider=provider,
             mtime=mtime,
         ))
+    _SESSION_INDEX_CACHE[transcripts_root] = (signature, entries)
+    while len(_SESSION_INDEX_CACHE) > _SESSION_INDEX_CACHE_MAX:
+        _SESSION_INDEX_CACHE.pop(next(iter(_SESSION_INDEX_CACHE)))
     return entries
+
+
+def _session_index_signature(
+    transcripts_root: Path,
+) -> tuple[tuple[str, float, int], ...]:
+    """Cheap invalidation signature for normalized transcript archives."""
+    entries: list[tuple[str, float, int]] = []
+    try:
+        children = list(transcripts_root.iterdir())
+    except OSError:
+        return ()
+    for child in children:
+        if not child.is_dir():
+            continue
+        if child.name in {"tasks", ".ingestion-state.lock"}:
+            continue
+        events_path = child / "events.jsonl"
+        try:
+            stat = events_path.stat()
+        except OSError:
+            continue
+        entries.append((child.name, stat.st_mtime, stat.st_size))
+    entries.sort()
+    return tuple(entries)
 
 
 def lookup_transcript_path(
@@ -315,9 +335,16 @@ _PARSE_CACHE: dict[
 _PARSE_CACHE_MAX = 100
 
 
+_SESSION_INDEX_CACHE: dict[
+    Path, tuple[tuple[tuple[str, float, int], ...], list[_SessionIndexEntry]]
+] = {}
+_SESSION_INDEX_CACHE_MAX = 100
+
+
 def _parse_cache_clear() -> None:
     """Drop every cached parse result. Test-only helper."""
     _PARSE_CACHE.clear()
+    _SESSION_INDEX_CACHE.clear()
 
 
 def parse_events_jsonl(
@@ -795,6 +822,21 @@ def _envelope_assistant_turn(
     actor_fallback: str,
 ) -> MessageEnvelope:
     text = str(payload.get("text") or "")
+    model = str(event.get("model_name") or "")
+    if model == "<synthetic>":
+        return MessageEnvelope(
+            id=msg_id,
+            ts=timestamp,
+            role=MessageRole.SYSTEM,
+            actor="system",
+            type=MessageType.SYNTHETIC_NOTICE,
+            text=text,
+            metadata={
+                "provider": event.get("provider", ""),
+                "model": model,
+                "synthetic": True,
+            },
+        )
     return MessageEnvelope(
         id=msg_id,
         ts=timestamp,
@@ -804,7 +846,7 @@ def _envelope_assistant_turn(
         text=text,
         metadata={
             "provider": event.get("provider", ""),
-            "model": event.get("model_name") or "",
+            "model": model,
         },
     )
 

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -40,6 +40,8 @@ from pollypm.web_api.chat import (
     STALE_THRESHOLD_SECONDS,
     ChatSurface,
     MessageEnvelope,
+    MessageRole,
+    MessageType,
     SurfaceType,
     capture_envelopes,
     enumerate_chat_surfaces,
@@ -162,9 +164,9 @@ class ChatMessageEnvelope(BaseModel):
 
     id: str
     ts: str
-    role: str
+    role: MessageRole
     actor: str
-    type: str
+    type: MessageType
     text: str
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -176,7 +178,6 @@ class ChatMessagesResponse(BaseModel):
     surface_type: str
     persona: str | None = None
     transcript_source: str | None = None
-    transcript_path: str | None = None
     messages: list[ChatMessageEnvelope]
     has_more: bool = False
     next_cursor: str | None = None
@@ -1066,7 +1067,7 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
     ):
         tail_hint = limit + 1
 
-    envelopes, transcript_source, transcript_path = _load_envelopes(
+    envelopes, transcript_source, _transcript_path = _load_envelopes(
         surface,
         source=source,
         tail_hint=tail_hint,
@@ -1099,7 +1100,6 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
         surface_type=str(surface.surface_type),
         persona=surface.persona,
         transcript_source=transcript_source,
-        transcript_path=str(transcript_path) if transcript_path else None,
         messages=rows,
         has_more=has_more,
         next_cursor=next_cursor,

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -432,7 +432,7 @@ def test_messages_endpoint_returns_envelopes_for_known_session(
     assert body["surface_type"] == "operator"
     assert body["persona"] == "Polly"
     assert body["transcript_source"] == "jsonl"
-    assert body["transcript_path"] == str(archive)
+    assert "transcript_path" not in body
     assert [m["id"] for m in body["messages"]] == ["msg_1", "msg_2"]
     assert body["has_more"] is False
     assert body["next_cursor"] is None
@@ -472,7 +472,7 @@ def test_messages_endpoint_empty_when_no_transcript_yet(
     body = response.json()
     assert body["messages"] == []
     assert body["transcript_source"] is None
-    assert body["transcript_path"] is None
+    assert "transcript_path" not in body
 
 
 # ---------------------------------------------------------------------------
@@ -844,7 +844,7 @@ def test_messages_endpoint_source_capture_uses_tmux_fallback(
         headers=auth_headers,
     ).json()
     assert body["transcript_source"] == "capture"
-    assert body["transcript_path"] is None
+    assert "transcript_path" not in body
     assert [m["id"] for m in body["messages"]] == ["cap_1", "cap_2"]
 
 
@@ -1610,7 +1610,7 @@ def test_messages_endpoint_jsonl_uses_real_parser_no_typeerror(
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["transcript_source"] == "jsonl"
-    assert body["transcript_path"] == str(archive)
+    assert "transcript_path" not in body
     assert len(body["messages"]) == 1
     assert body["messages"][0]["text"] == "hello from real parser"
     assert body["messages"][0]["type"] == "text"

--- a/tests/test_chat_registry.py
+++ b/tests/test_chat_registry.py
@@ -80,7 +80,7 @@ def _build_config(
             logs_dir=project_root / ".pollypm/logs",
             snapshots_dir=project_root / ".pollypm/snapshots",
             state_db=project_root / ".pollypm/state.db",
-            tmux_session="storage-closet",
+            tmux_session="pollypm",
         ),
         pollypm=PollyPMSettings(controller_account="claude_main"),
         accounts={
@@ -426,7 +426,7 @@ def test_tmux_client_populates_window_present_and_pane_id(tmp_path: Path) -> Non
     })
     tmux = _StubTmuxClient([
         TmuxWindow(
-            session="storage-closet",
+            session="pollypm-storage-closet",
             index=1,
             name="pm-operator",
             active=True,
@@ -439,8 +439,8 @@ def test_tmux_client_populates_window_present_and_pane_id(tmp_path: Path) -> Non
     surfaces = enumerate_chat_surfaces(config, tmux_client=tmux)
     assert surfaces[0].window.present is True
     assert surfaces[0].window.pane_id == "%17"
-    assert surfaces[0].window.tmux_session == "storage-closet"
-    assert tmux.list_calls == ["storage-closet"]
+    assert surfaces[0].window.tmux_session == "pollypm-storage-closet"
+    assert tmux.list_calls == ["pollypm-storage-closet"]
 
 
 def test_window_present_false_when_tmux_returns_no_window(tmp_path: Path) -> None:
@@ -486,7 +486,7 @@ def test_pane_dead_propagates_from_tmux(tmp_path: Path) -> None:
     })
     tmux = _StubTmuxClient([
         TmuxWindow(
-            session="storage-closet",
+            session="pollypm-storage-closet",
             index=1,
             name="pm-operator",
             active=False,
@@ -573,7 +573,7 @@ def test_two_surfaces_sharing_cwd_resolve_to_correct_transcripts(
             logs_dir=project_root / ".pollypm/logs",
             snapshots_dir=project_root / ".pollypm/snapshots",
             state_db=project_root / ".pollypm/state.db",
-            tmux_session="storage-closet",
+            tmux_session="pollypm",
         ),
         pollypm=PollyPMSettings(controller_account="claude_main"),
         accounts=accounts,

--- a/tests/test_chat_transcripts.py
+++ b/tests/test_chat_transcripts.py
@@ -121,6 +121,23 @@ def test_parses_claude_assistant_turn_with_actor_fallback(tmp_path: Path) -> Non
     assert envelopes[0].metadata["model"] == "claude-opus-4-7"
 
 
+def test_synthetic_assistant_turn_becomes_typed_notice(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    event = _claude_event("assistant_turn", text="limit reset")
+    event["model_name"] = "<synthetic>"
+    _write_events(events_path, [event])
+
+    envelopes = parse_events_jsonl(events_path, actor_fallback="Polly")
+
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env.type == MessageType.SYNTHETIC_NOTICE
+    assert env.role == MessageRole.SYSTEM
+    assert env.actor == "system"
+    assert env.metadata["model"] == "<synthetic>"
+    assert env.metadata["synthetic"] is True
+
+
 def test_skips_user_turn_with_empty_text(tmp_path: Path) -> None:
     # Spec: ingestor only emits user_turn when text is truthy, but we
     # still test the parser is tolerant of an empty-string payload.
@@ -1375,6 +1392,37 @@ def test_build_session_index_skips_unreadable_events(tmp_path: Path) -> None:
     )
     index = build_session_index(transcripts)
     assert {entry.session_id for entry in index} == {"session-ok"}
+
+
+def test_build_session_index_reuses_fingerprint_cache(
+    tmp_path: Path, monkeypatch
+) -> None:
+    transcripts_module._parse_cache_clear()
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    session_dir = transcripts / "session-a"
+    session_dir.mkdir(parents=True)
+    event = _claude_event("user_turn", text="hi")
+    event["cwd"] = str(tmp_path / "x")
+    (session_dir / "events.jsonl").write_text(json.dumps(event) + "\n")
+
+    calls = {"count": 0}
+    real = transcripts_module._read_first_event_fingerprint
+
+    def counting(path: Path):  # type: ignore[no-untyped-def]
+        calls["count"] += 1
+        return real(path)
+
+    monkeypatch.setattr(
+        transcripts_module, "_read_first_event_fingerprint", counting,
+    )
+
+    first = build_session_index(transcripts)
+    second = build_session_index(transcripts)
+
+    assert [entry.session_id for entry in first] == ["session-a"]
+    assert [entry.session_id for entry in second] == ["session-a"]
+    assert calls["count"] == 1
 
 
 def test_lookup_returns_none_without_cwd(tmp_path: Path) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add `synthetic_notice` as the typed envelope for normalized synthetic assistant turns and document the metadata contract.
- Use `MessageRole` and `MessageType` enums on the public chat message response model.
- Stop exposing internal transcript filesystem paths from `/api/v1/chat/{session_id}/messages` responses.
- Probe the storage tmux session name from the configured base session so `/chat/sessions` presence matches the actual storage window.
- Cache the normalized transcript session index by directory fingerprint to reduce repeated surface/message lookup overhead.

Closes #2158.
Closes #2159.
Closes #2162.
Closes #2164.
Closes #2166.
Closes #2168.

## Verification
- `uv run --extra dev ruff check src/pollypm/web_api/chat/envelope.py src/pollypm/web_api/chat/transcripts.py src/pollypm/web_api/chat/registry.py src/pollypm/web_api/routes/chat_messages.py tests/test_chat_messages_endpoint.py tests/test_chat_registry.py tests/test_chat_transcripts.py`
- `uv run --extra test pytest tests/test_chat_transcripts.py::test_synthetic_assistant_turn_becomes_typed_notice tests/test_chat_transcripts.py::test_build_session_index_reuses_fingerprint_cache tests/test_chat_registry.py::test_tmux_client_populates_window_present_and_pane_id tests/test_chat_registry.py::test_window_present_false_when_tmux_returns_no_window tests/test_chat_messages_endpoint.py::test_messages_endpoint_returns_envelopes_for_known_session tests/test_chat_messages_endpoint.py::test_messages_endpoint_empty_when_no_transcript_yet tests/test_chat_messages_endpoint.py::test_messages_endpoint_source_auto_prefers_jsonl tests/test_chat_messages_endpoint.py::test_messages_endpoint_jsonl_uses_real_parser_no_typeerror -q`
- `uv run --extra test pytest tests/web_api/test_openapi_conformance.py -q`
- `git diff --check`

## Investigation Notes
- Live origin/main check showed `/api/v1/chat/sessions` returning `tmux_session: pollypm` and `present: false` while the actual storage session is `pollypm-storage-closet`.
- The transcript index cache targets the repeated fixed lookup work on chat session/message requests. I did not claim a full p95 performance budget pass here; this removes one measured fixed-cost source and leaves broader dashboard/chat perf to the perf harness.
