### PR TITLE
Dedupe watchdog operator dispatches for queue stalls

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -236,6 +236,14 @@ RULE_REJECTION_LOOP = "rejection_loop"
 RULE_STATE_DB_MISSING = "state_db_missing"
 RULE_QUEUE_WITHOUT_MOTION = "queue_without_motion"
 
+# #2138 — the pollypm meta-project is the control plane itself. Its
+# queued work can legitimately pause while the operator/codebase is in
+# flux, and routing that through queue_without_motion produced noisy
+# operator-dispatched loops rather than an actionable project finding.
+QUEUE_WITHOUT_MOTION_SUPPRESSED_PROJECTS: frozenset[str] = frozenset({
+    "pollypm",
+})
+
 # #1546 — tier classifications for the heartbeat cascade. Every Finding
 # carries a ``tier`` so the dispatcher can route without re-reading the
 # rule body:
@@ -2553,6 +2561,9 @@ def _queue_without_motion_probe(ctx: ProbeContext) -> list[Finding]:
     Evidence carries the affected task IDs and the most-recent activity
     timestamp so the prompt builder can hand structured signal upward.
     """
+    if ctx.project_key in QUEUE_WITHOUT_MOTION_SUPPRESSED_PROJECTS:
+        return []
+
     cutoff = ctx.now - timedelta(
         seconds=ctx.config.queue_motion_threshold_seconds,
     )

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -1857,7 +1857,13 @@ _TIER1_HEALERS: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 
-def _operator_dedup_key(rule: str, project: str, subject: str) -> str:
+def _operator_dedup_key(
+    rule: str,
+    project: str,
+    subject: str,
+    *,
+    finding_key: str = "",
+) -> str:
     """Stable dedup key for tier-3 inbox rows.
 
     Hash-folded so the inbox's ``--dedup-key`` collapses repeated
@@ -1865,6 +1871,8 @@ def _operator_dedup_key(rule: str, project: str, subject: str) -> str:
     Mirrors :func:`pollypm.audit.watchdog.watchdog_alert_session_name`
     in spirit but lives on the inbox side.
     """
+    if finding_key:
+        return f"watchdog-operator:{rule}:{project}:{finding_key}"
     safe_subject = (subject or "").replace("/", "_").replace(" ", "_") or "_"
     return f"watchdog-operator:{rule}:{project}:{safe_subject}"
 
@@ -1928,7 +1936,10 @@ def _maybe_dispatch_to_operator(
         body = finding.message or finding.rule
 
     dedup_key = _operator_dedup_key(
-        finding.rule, finding.project, finding.subject,
+        finding.rule,
+        finding.project,
+        finding.subject,
+        finding_key=dedup_hash,
     )
     subject_text = (
         finding.message

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -3453,7 +3453,7 @@ def test_cadence_dispatch_throttles_samblog_burst_by_root_cause(
 def test_cadence_operator_dispatch_throttles_burst_by_root_cause(
     now: datetime, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Same #2015 collapse for the tier-3 (operator inbox) leg."""
+    """Same-condition tier-3 findings throttle; changed evidence dispatches."""
     from pollypm.audit.watchdog import RULE_QUEUE_WITHOUT_MOTION
     from pollypm.plugins_builtin.core_recurring import audit_watchdog as aw
 
@@ -3487,6 +3487,24 @@ def test_cadence_operator_dispatch_throttles_burst_by_root_cause(
     assert outcomes[0] == "dispatched"
     assert outcomes[1:] == ["throttled", "throttled", "throttled"], outcomes
     assert len(created) == 1
+    first_dedup_key = created[0]["dedup_key"]
+
+    changed_condition = Finding(
+        rule=RULE_QUEUE_WITHOUT_MOTION,
+        tier="3",
+        project="proj",
+        subject="proj-e",
+        evidence={
+            "queued_subjects": ["proj/1", "proj/2", "proj/9"],
+            "queued_last_updated": "2026-05-19T13:30:00+00:00",
+        },
+    )
+    assert aw._maybe_dispatch_to_operator(
+        changed_condition, project_path=None, now=now,
+    ) == "dispatched"
+    assert len(created) == 2
+    assert created[0]["dedup_key"] == first_dedup_key
+    assert created[1]["dedup_key"] != first_dedup_key
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -571,6 +571,23 @@ def test_queue_without_motion_fires_when_no_recent_activity(
     assert f.evidence["threshold_seconds"] == 600
 
 
+def test_queue_without_motion_silent_for_pollypm_meta_project(
+    now: datetime,
+) -> None:
+    cfg = WatchdogConfig(queue_motion_threshold_seconds=600)
+    queued = _StubTask(
+        project="pollypm",
+        task_number=2138,
+        work_status_str="queued",
+        executions=[],
+        updated_at=now - timedelta(hours=2),
+    )
+    findings = scan_events(
+        [], now=now, config=cfg, open_tasks=[queued], project="pollypm",
+    )
+    assert not any(f.rule == RULE_QUEUE_WITHOUT_MOTION for f in findings)
+
+
 def test_queue_without_motion_silent_when_recent_activity(
     now: datetime,
 ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Suppress `queue_without_motion` findings for the `pollypm` control-plane project.
- Use the watchdog dispatch dedup hash as the operator inbox dedup key so repeated same-condition tier-3 findings reuse the same dispatch identity.
- Add regression coverage for meta-project suppression and same-condition operator dispatch throttling.

Refs #2138

## Tests
- `uv run --extra dev pytest --noconftest tests/test_audit_watchdog.py::test_cadence_dispatch_throttles_samblog_burst_by_root_cause tests/test_audit_watchdog.py::test_cadence_operator_dispatch_throttles_burst_by_root_cause tests/test_heartbeat_cascade_foundation.py::test_queue_without_motion_silent_for_pollypm_meta_project tests/test_heartbeat_cascade_foundation.py::test_queue_without_motion_fires_when_no_recent_activity tests/test_heartbeat_cascade_foundation.py::test_queue_without_motion_silent_when_recent_activity -q`
- `python -m compileall -q src/pollypm/audit/watchdog.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py`
- `git diff --check origin/main...HEAD`

## Notes
- Worker also ran the broader changed-file test group and observed an unrelated pre-existing failure in `test_integration_state_db_missing_routes_to_tier1_healer` (`Unknown project: demo`); the focused watchdog regressions above pass after rebase.
