### PR TITLE
Avoid blocking task cancel prompts in non-TTY pipes

### DIFF
--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import json
 import re
+import select
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -78,6 +80,36 @@ _PROJECT_OPTION = typer.Option(None, "--project", "-p", help="Project filter.")
 _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON.")
 
 _TASK_NOT_FOUND_RE = re.compile(r"Task '([^']+)' not found\.")
+
+
+def _non_tty_confirmation(prompt: str) -> tuple[bool | None, bool]:
+    stream = sys.stdin
+    is_tty = getattr(stream, "isatty", lambda: False)
+    if is_tty():
+        return None, False
+    try:
+        stream.fileno()
+        ready, _, _ = select.select([stream], [], [], 0)
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None, False
+    if not ready:
+        return None, True
+    typer.echo(f"{prompt} [y/N]: ", nl=False)
+    answer = stream.readline()
+    if not answer:
+        return None, True
+    return answer.strip().lower() in {"y", "yes"}, True
+
+
+def _confirm_active_cancel(prompt: str) -> bool | None:
+    piped_answer, handled_non_tty = _non_tty_confirmation(prompt)
+    if piped_answer is not None:
+        return piped_answer
+    if handled_non_tty:
+        return None
+    return typer.confirm(prompt, default=False)
+
+
 _INVALID_TASK_ID_RE = re.compile(r"Invalid task_id '([^']+)'\.")
 _REQUIRED_ROLE_RE = re.compile(
     r"Required role '([^']+)' not provided\. Flow '([^']+)' requires: \[(.*)\]"
@@ -1188,11 +1220,19 @@ def task_cancel(
             surface="cli",
             force=False,
         )
-        if not typer.confirm(
+        prompt = (
             f"Worker {active_assignee} currently working this task. "
-            "Cancel anyway?",
-            default=False,
-        ):
+            "Cancel anyway?"
+        )
+        confirmed = _confirm_active_cancel(prompt)
+        if confirmed is None:
+            typer.echo(
+                "Refusing to cancel in_progress task non-interactively. "
+                "Pass --force to confirm in scripts.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        if not confirmed:
             typer.echo("Aborted; task was not cancelled.", err=True)
             raise typer.Exit(code=1)
     task = _run(svc.cancel, task_id, actor, reason)

--- a/tests/test_task_cancel_reopen_cli.py
+++ b/tests/test_task_cancel_reopen_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 from typer.testing import CliRunner
@@ -67,6 +68,52 @@ def test_cancel_in_progress_decline_does_not_cancel(monkeypatch) -> None:
     assert task.work_status is WorkStatus.IN_PROGRESS
     assert "Worker worker currently working this task" in result.output
     assert [event["event"] for event in events] == ["task.cancel.warned"]
+
+
+def test_cancel_in_progress_noninteractive_without_input_exits_2(
+    monkeypatch,
+) -> None:
+    task = _Task("demo/4", WorkStatus.IN_PROGRESS, assignee="worker")
+    service = _Service(task)
+    events: list[dict] = []
+    monkeypatch.setattr(work_cli, "_svc", lambda **_kw: service)
+    monkeypatch.setattr("pollypm.audit.emit", lambda **kw: events.append(kw))
+    monkeypatch.setattr(work_cli, "_confirm_active_cancel", lambda _prompt: None)
+
+    result = CliRunner().invoke(
+        work_cli.task_app,
+        ["cancel", "demo/4", "--reason", "oops"],
+    )
+
+    assert result.exit_code == 2
+    assert service.cancel_calls == []
+    assert task.work_status is WorkStatus.IN_PROGRESS
+    assert "Refusing to cancel in_progress task non-interactively" in result.output
+    assert "--force" in result.output
+    assert [event["event"] for event in events] == ["task.cancel.warned"]
+
+
+def test_cancel_confirmation_reads_piped_yes(monkeypatch) -> None:
+    read_fd, write_fd = os.pipe()
+    with os.fdopen(write_fd, "w", encoding="utf-8") as writer:
+        writer.write("y\n")
+    reader = os.fdopen(read_fd, "r", encoding="utf-8")
+    monkeypatch.setattr(work_cli.sys, "stdin", reader)
+    try:
+        assert work_cli._confirm_active_cancel("Cancel?") is True
+    finally:
+        reader.close()
+
+
+def test_cancel_confirmation_empty_pipe_returns_no_decision(monkeypatch) -> None:
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    reader = os.fdopen(read_fd, "r", encoding="utf-8")
+    monkeypatch.setattr(work_cli.sys, "stdin", reader)
+    try:
+        assert work_cli._confirm_active_cancel("Cancel?") is None
+    finally:
+        reader.close()
 
 
 def test_cancel_in_progress_force_skips_prompt(monkeypatch) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a non-TTY cancel-confirmation path that reads ready piped input without blocking.
- Return a clear exit-2 failure with `--force` guidance when an in-progress cancel needs confirmation but no noninteractive answer is available.
- Preserve `--force` behavior and existing interactive decline behavior.

Refs #2182

## Tests
- `uv run --extra dev pytest --noconftest tests/test_task_cancel_reopen_cli.py -q`
- `python -m compileall -q src/pollypm/work/cli.py tests/test_task_cancel_reopen_cli.py`
- `git diff --check`
