### PR TITLE
fix(recovery): persist pause and spawn audit events

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -108,10 +108,14 @@ The current event families are:
 | `work_db.opened` | `PgWorkService.__init__` | `had_messages_table_pre_open`, `tables_created`, `project_path` |
 | `work_table.cleared` | Reserved for future wholesale work-table reset paths | reset reason and affected scope |
 | `heartbeat.tick` | audit watchdog cadence | cadence metadata |
+| `heartbeat.missing` | supervisor recovery detection | `session`, `window_name`, `tmux_session`, `failure_type`, `failure_message` |
+| `session.spawn` | supervisor recovery relaunch | `session`, `window_name`, `tmux_session`, `failure_type`, `account`, `provider` |
 | `audit.finding` | audit watchdog findings | `rule`, `message`, `recommendation`, plus rule-specific data |
 | `worker.session_reaped` | worker marker reaper | `window_name`, `marker_path`, `reason` |
 | `watchdog.escalation_dispatched` | auto-unstick dispatch path | `finding_type`, `subject`, `brief` |
 | `session.provisioned` | reviewer/role recovery provisioning | `role`, `project`, `reason` |
+| `session.pause.marker_unreadable` | pause-marker reader | `path`, `reason`, `last_readable_paused_names` |
+| `session.pause.marker_restored` | pause-marker reader | `path`, `restored_size_bytes`, `restored_mtime`, `paused_state_diff` |
 | `worker.thread_leaked` | job worker shutdown leak detector | worker/thread diagnostic metadata |
 | `socket.reaped` | cockpit socket reaper | stale socket diagnostics |
 | `daemon.reaped` | rail daemon reaper | `role`, `pid`, `age_s`, `reason` |

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -251,6 +251,13 @@ EVENT_INBOX_KIND_BACKFILLED = "inbox.kind_backfilled"
 # evidence.
 EVENT_ADVISOR_TICK_FIRED = "advisor.tick.fired"
 EVENT_ADVISOR_TICK_SKIPPED = "advisor.tick.skipped"
+# Recovery cascade breadcrumbs. ``heartbeat.missing`` records the
+# supervisor/heartbeat detection edge for a tracked session whose tmux
+# window or pane disappeared; ``session.spawn`` records the successful
+# relaunch edge. Operators use this pair to prove a kill->respawn
+# cascade happened without replaying message-store state.
+EVENT_HEARTBEAT_MISSING = "heartbeat.missing"
+EVENT_SESSION_SPAWN = "session.spawn"
 
 
 @dataclass(slots=True, frozen=True)
@@ -1004,6 +1011,8 @@ __all__ = [
     "EVENT_COCKPIT_DUPLICATE_WINDOW_KILLED",
     "EVENT_COCKPIT_PARK_SKIPPED_EXISTING",
     "EVENT_INBOX_KIND_BACKFILLED",
+    "EVENT_HEARTBEAT_MISSING",
+    "EVENT_SESSION_SPAWN",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/session_paused.py
+++ b/src/pollypm/session_paused.py
@@ -75,6 +75,7 @@ import threading
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -174,6 +175,9 @@ _MARKER_STATE_LOCK = threading.Lock()
 # can detect transitions and emit a restored event when the marker
 # becomes readable again.
 _LAST_MARKER_KIND: dict[str, str] = {}
+# Last known readable paused-name set. ``None`` means the process has
+# never seen a readable state for that marker path.
+_LAST_MARKER_NAMES: dict[str, frozenset[str] | None] = {}
 # Last monotonic timestamp at which we emitted the unreadable event
 # for a given marker path. ``None`` / missing entry means "never";
 # we deliberately avoid 0.0 because :func:`time.monotonic` can return
@@ -442,6 +446,7 @@ def _reset_skip_throttle_for_tests() -> None:
         _PAUSE_SKIP_LAST_EMITTED.clear()
     with _MARKER_STATE_LOCK:
         _LAST_MARKER_KIND.clear()
+        _LAST_MARKER_NAMES.clear()
         _LAST_UNREADABLE_EMITTED.clear()
 
 
@@ -519,6 +524,166 @@ def _marker_state_key(config: Any) -> str:
     return str(path)
 
 
+def _project_audit_context(config: Any) -> tuple[str, Path | None]:
+    """Return the audit project key and per-project path for ``config``."""
+    project_key = ""
+    project_path: Path | None = None
+    project_obj = getattr(config, "project", None)
+    if project_obj is not None:
+        project_key = str(
+            getattr(project_obj, "name", "")
+            or getattr(project_obj, "key", "")
+            or ""
+        )
+        root = getattr(project_obj, "root_dir", None)
+        if root is not None:
+            project_path = Path(root)
+    return project_key, project_path
+
+
+def _parse_audit_ts(value: str) -> datetime | None:
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _audit_event_age_seconds(ts: str) -> float | None:
+    parsed = _parse_audit_ts(ts)
+    if parsed is None:
+        return None
+    return (datetime.now(UTC) - parsed).total_seconds()
+
+
+def _latest_marker_diagnostic(config: Any, key: str) -> Any | None:
+    """Return the latest marker diagnostic for ``key`` from the audit log.
+
+    The unreadable/restored contract must survive heartbeat process
+    restarts. The canonical audit log is the durable state handoff:
+    process-local dictionaries are only a fast path for a long-lived
+    daemon.
+    """
+    try:
+        from pollypm.audit.log import read_events
+    except Exception:  # noqa: BLE001
+        logger.debug("pause marker diagnostic read import failed", exc_info=True)
+        return None
+
+    project_key, project_path = _project_audit_context(config)
+    wanted = {
+        PAUSE_MARKER_RESTORED_EVENT_TYPE,
+        PAUSE_MARKER_UNREADABLE_EVENT_TYPE,
+    }
+    rows = []
+    try:
+        for event_type in wanted:
+            rows.extend(
+                read_events(
+                    project_key,
+                    project_path=project_path,
+                    event=event_type,
+                    limit=50,
+                )
+            )
+    except Exception:  # noqa: BLE001
+        logger.debug("pause marker diagnostic read failed", exc_info=True)
+        return None
+    rows.sort(key=lambda row: getattr(row, "ts", ""))
+    for row in reversed(rows):
+        if getattr(row, "event", "") not in wanted:
+            continue
+        metadata = getattr(row, "metadata", {}) or {}
+        if metadata.get("path") == key:
+            return row
+    return None
+
+
+def _names_from_unreadable_event(row: Any) -> frozenset[str] | None:
+    metadata = getattr(row, "metadata", {}) or {}
+    raw = metadata.get("last_readable_paused_names")
+    if not isinstance(raw, list):
+        return None
+    return frozenset(str(name) for name in raw if isinstance(name, str))
+
+
+def _marker_file_metadata(config: Any) -> dict[str, Any]:
+    path = _pause_marker_path(config)
+    if path is None:
+        return {
+            "restored_size_bytes": None,
+            "restored_mtime": None,
+        }
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return {
+            "restored_size_bytes": 0,
+            "restored_mtime": None,
+        }
+    except OSError as exc:
+        return {
+            "restored_size_bytes": None,
+            "restored_mtime": None,
+            "stat_error": f"{type(exc).__name__}: {exc!s}",
+        }
+    return {
+        "restored_size_bytes": stat.st_size,
+        "restored_mtime": datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+    }
+
+
+def _unreadable_metadata(
+    key: str,
+    state: MarkerState,
+    *,
+    prior_names: frozenset[str] | None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"path": key, "reason": state.reason}
+    if prior_names is None:
+        metadata["last_readable_paused_names"] = None
+        metadata["last_readable_paused_count"] = None
+    else:
+        metadata["last_readable_paused_names"] = sorted(prior_names)
+        metadata["last_readable_paused_count"] = len(prior_names)
+    return metadata
+
+
+def _restored_metadata(
+    config: Any,
+    key: str,
+    state: MarkerState,
+    *,
+    prior_names: frozenset[str] | None,
+) -> dict[str, Any]:
+    current_names = state.names if state.kind == "ok" else frozenset()
+    previous_known = prior_names is not None
+    previous_names = prior_names or frozenset()
+    diff = {
+        "previous_names_known": previous_known,
+        "previous_state": "unreadable_fail_closed",
+        "current_state": state.kind,
+        "added_paused": sorted(current_names - previous_names)
+        if previous_known else sorted(current_names),
+        "removed_paused": sorted(previous_names - current_names)
+        if previous_known else [],
+    }
+    metadata: dict[str, Any] = {
+        "path": key,
+        "kind": state.kind,
+        "restored_at": datetime.now(UTC).isoformat(),
+        "paused_names": sorted(current_names),
+        "paused_count": len(current_names),
+        "paused_state_diff": diff,
+    }
+    metadata.update(_marker_file_metadata(config))
+    return metadata
+
+
 def _record_marker_kind_transition(config: Any, state: MarkerState) -> None:
     """Detect ``unreadable`` transitions and emit one-time diagnostics.
 
@@ -535,9 +700,16 @@ def _record_marker_kind_transition(config: Any, state: MarkerState) -> None:
     """
     key = _marker_state_key(config)
     kind = state.kind
+    prior_names: frozenset[str] | None = None
+    check_persistent_restored = False
     with _MARKER_STATE_LOCK:
         prior = _LAST_MARKER_KIND.get(key)
+        prior_names = _LAST_MARKER_NAMES.get(key)
         _LAST_MARKER_KIND[key] = kind
+        if kind == "ok":
+            _LAST_MARKER_NAMES[key] = state.names
+        elif kind == "absent":
+            _LAST_MARKER_NAMES[key] = frozenset()
         if kind == "unreadable":
             last_emit = _LAST_UNREADABLE_EMITTED.get(key)
             now = time.monotonic()
@@ -553,6 +725,7 @@ def _record_marker_kind_transition(config: Any, state: MarkerState) -> None:
             should_warn = became_unreadable
         else:
             should_emit = prior == "unreadable"
+            check_persistent_restored = prior is None
             should_warn = False
             # Successful read resets the unreadable-emit window so the
             # next failure re-emits even if it lands inside the prior
@@ -572,6 +745,17 @@ def _record_marker_kind_transition(config: Any, state: MarkerState) -> None:
         except Exception:  # noqa: BLE001
             logger.debug("pause marker stderr warn failed", exc_info=True)
     if should_emit and kind == "unreadable":
+        latest = _latest_marker_diagnostic(config, key)
+        if (
+            latest is not None
+            and getattr(latest, "event", "") == PAUSE_MARKER_UNREADABLE_EVENT_TYPE
+        ):
+            age = _audit_event_age_seconds(str(getattr(latest, "ts", "")))
+            if (
+                age is not None
+                and age < PAUSE_MARKER_UNREADABLE_THROTTLE_SECONDS
+            ):
+                return
         _emit_marker_diagnostic(
             config,
             event=PAUSE_MARKER_UNREADABLE_EVENT_TYPE,
@@ -580,9 +764,23 @@ def _record_marker_kind_transition(config: Any, state: MarkerState) -> None:
                 "recovery loops failing closed"
             ),
             status="warn",
-            metadata={"path": key, "reason": state.reason},
+            metadata=_unreadable_metadata(
+                key,
+                state,
+                prior_names=prior_names,
+            ),
         )
-    elif should_emit:
+    elif not should_emit and check_persistent_restored:
+        latest = _latest_marker_diagnostic(config, key)
+        if (
+            latest is not None
+            and getattr(latest, "event", "") == PAUSE_MARKER_UNREADABLE_EVENT_TYPE
+        ):
+            should_emit = True
+            persisted_names = _names_from_unreadable_event(latest)
+            if persisted_names is not None:
+                prior_names = persisted_names
+    if should_emit and kind != "unreadable":
         _emit_marker_diagnostic(
             config,
             event=PAUSE_MARKER_RESTORED_EVENT_TYPE,
@@ -591,7 +789,12 @@ def _record_marker_kind_transition(config: Any, state: MarkerState) -> None:
                 f"(kind={kind}); recovery loops resumed normal gating"
             ),
             status="ok",
-            metadata={"path": key, "kind": kind},
+            metadata=_restored_metadata(
+                config,
+                key,
+                state,
+                prior_names=prior_names,
+            ),
         )
 
 
@@ -633,14 +836,7 @@ def _emit_marker_diagnostic(
         )
         return
 
-    project_key = ""
-    project_path: Path | None = None
-    project_obj = getattr(config, "project", None)
-    if project_obj is not None:
-        project_key = str(getattr(project_obj, "name", "") or "")
-        root = getattr(project_obj, "root_dir", None)
-        if root is not None:
-            project_path = Path(root)
+    project_key, project_path = _project_audit_context(config)
 
     try:
         _audit_emit(

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -913,6 +913,57 @@ class Supervisor:
         launch = self._launch_by_session(session_name)
         return self._tmux_session_for_launch(launch)
 
+    def _emit_session_recovery_audit(
+        self,
+        event: str,
+        launch: SessionLaunchSpec,
+        *,
+        status: str,
+        actor: str,
+        metadata: dict[str, object],
+    ) -> None:
+        """Best-effort JSONL audit breadcrumb for recovery cascade edges."""
+        try:
+            from pollypm.audit.log import emit as _audit_emit
+        except Exception:  # noqa: BLE001
+            logger.debug("session recovery audit import failed", exc_info=True)
+            return
+
+        project_key = str(launch.session.project or "")
+        try:
+            project_path = self._project_path_for_session(project_key)
+        except Exception:  # noqa: BLE001
+            project_path = getattr(self.config.project, "root_dir", None)
+        try:
+            tmux_session = self._tmux_session_for_launch(launch)
+        except Exception:  # noqa: BLE001
+            tmux_session = ""
+        payload: dict[str, object] = {
+            "session": launch.session.name,
+            "role": launch.session.role,
+            "project": project_key,
+            "window_name": launch.window_name,
+            "tmux_session": tmux_session,
+        }
+        payload.update(metadata)
+        try:
+            _audit_emit(
+                event=event,
+                project=project_key,
+                subject=launch.session.name,
+                actor=actor,
+                status=status,
+                metadata=payload,
+                project_path=project_path,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "session recovery audit emit failed for %s/%s",
+                event,
+                launch.session.name,
+                exc_info=True,
+            )
+
     def _all_tmux_session_names(self) -> list[str]:
         names = [self.config.project.tmux_session]
         storage = self.storage_closet_session_name()
@@ -2747,6 +2798,7 @@ class Supervisor:
 
     # Failure types where the session is gone — no live interaction to protect.
     _DEAD_SESSION_FAILURES = frozenset({"missing_window", "pane_dead", "shell_returned"})
+    _AUDIT_MISSING_FAILURES = _DEAD_SESSION_FAILURES
 
     # Map detected failure types to the raw signals the RecoveryPolicy
     # expects. Keeps the policy decoupled from Supervisor's vocabulary.
@@ -3634,6 +3686,21 @@ class Supervisor:
                 },
             )
 
+        if failure_type in self._AUDIT_MISSING_FAILURES:
+            from pollypm.audit.log import EVENT_HEARTBEAT_MISSING
+
+            self._emit_session_recovery_audit(
+                EVENT_HEARTBEAT_MISSING,
+                launch,
+                status="warn",
+                actor="heartbeat",
+                metadata={
+                    "failure_type": failure_type,
+                    "failure_message": failure_message,
+                    "loop": "supervisor.maybe_recover_session",
+                },
+            )
+
         lease = self._get_lease(launch.session.name)
         if lease is not None and lease.owner != "pollypm":
             if failure_type in self._DEAD_SESSION_FAILURES:
@@ -3822,14 +3889,17 @@ class Supervisor:
             last_failure_type=failure_type,
             last_failure_message=f"recovering on {account_name}",
         )
+        spawned = False
         try:
             self.launch_session(session_name)
+            spawned = True
         except RuntimeError as exc:
             # Retry once if window name collision
             if "already exists" in str(exc).lower() or "duplicate" in str(exc).lower():
                 time.sleep(0.5)
                 try:
                     self.launch_session(session_name)
+                    spawned = True
                 except Exception:
                     # #1355: previously silent. This is the second of two
                     # launch attempts during account-recovery. If both
@@ -3855,6 +3925,21 @@ class Supervisor:
                 last_recovered_at=previous_runtime.last_recovered_at if previous_runtime else None,
             )
             raise
+        if spawned:
+            from pollypm.audit.log import EVENT_SESSION_SPAWN
+
+            self._emit_session_recovery_audit(
+                EVENT_SESSION_SPAWN,
+                launch,
+                status="ok",
+                actor="supervisor",
+                metadata={
+                    "failure_type": failure_type,
+                    "account": account_name,
+                    "provider": account.provider.value,
+                    "reason": "recovery_restart",
+                },
+            )
         # Inject recovery prompt so the agent knows what it was doing.
         # For role-scoped agents (reviewer / heartbeat) prepend an
         # identity reminder so a recovery that lands inside a noisy

--- a/tests/test_session_paused_marker_wiring.py
+++ b/tests/test_session_paused_marker_wiring.py
@@ -478,6 +478,40 @@ def test_is_paused_unreadable_emits_audit_event_once(
     assert "payload" not in row
 
 
+def test_is_paused_unreadable_throttle_survives_process_restart(
+    config_with_base_dir: _FakeConfig,
+) -> None:
+    """A one-shot heartbeat process must not reset the 5 min throttle."""
+    from pollypm.session_paused import (
+        PAUSE_MARKER_UNREADABLE_EVENT_TYPE,
+        _reset_skip_throttle_for_tests,
+        is_paused,
+    )
+
+    marker = config_with_base_dir.project.base_dir / "paused-sessions.json"
+    marker.write_text("{not json}")
+    assert is_paused(config_with_base_dir, "operator") is True
+
+    # Simulate the next heartbeat invocation in a fresh process: the
+    # in-memory transition/throttle dictionaries are gone, but the
+    # canonical audit log remains.
+    _reset_skip_throttle_for_tests()
+    assert is_paused(config_with_base_dir, "operator") is True
+
+    audit_path = config_with_base_dir.project.base_dir / "audit.jsonl"
+    rows = [
+        json.loads(line)
+        for line in audit_path.read_text().splitlines()
+        if line.strip()
+    ]
+    unreadable_rows = [
+        row
+        for row in rows
+        if row.get("event") == PAUSE_MARKER_UNREADABLE_EVENT_TYPE
+    ]
+    assert len(unreadable_rows) == 1, rows
+
+
 def test_is_paused_unreadable_to_readable_emits_restored(
     config_with_base_dir: _FakeConfig,
 ) -> None:
@@ -524,6 +558,77 @@ def test_is_paused_unreadable_to_readable_emits_restored(
     assert restored["status"] == "ok"
     assert restored["actor"] == "system"
     assert restored["metadata"]["kind"] in {"ok", "absent"}
+
+
+def test_marker_restored_survives_process_restart(
+    config_with_base_dir: _FakeConfig,
+) -> None:
+    """Restored detection must use the durable audit log, not memory."""
+    from pollypm.session_paused import (
+        PAUSE_MARKER_RESTORED_EVENT_TYPE,
+        _reset_skip_throttle_for_tests,
+        is_paused,
+    )
+
+    marker = config_with_base_dir.project.base_dir / "paused-sessions.json"
+    marker.write_text("{not json}")
+    assert is_paused(config_with_base_dir, "operator") is True
+
+    _reset_skip_throttle_for_tests()
+    _write_marker(config_with_base_dir, ["operator"])
+    assert is_paused(config_with_base_dir, "operator") is True
+
+    audit_path = config_with_base_dir.project.base_dir / "audit.jsonl"
+    rows = [
+        json.loads(line)
+        for line in audit_path.read_text().splitlines()
+        if line.strip()
+    ]
+    restored_rows = [
+        row
+        for row in rows
+        if row.get("event") == PAUSE_MARKER_RESTORED_EVENT_TYPE
+    ]
+    assert len(restored_rows) == 1, rows
+    metadata = restored_rows[0]["metadata"]
+    assert metadata["restored_size_bytes"] > 0
+    assert metadata["restored_at"]
+    assert metadata["restored_mtime"]
+    assert metadata["paused_names"] == ["operator"]
+    assert metadata["paused_count"] == 1
+    assert metadata["paused_state_diff"]["current_state"] == "ok"
+
+
+def test_marker_restored_metadata_includes_session_diff(
+    config_with_base_dir: _FakeConfig,
+) -> None:
+    from pollypm.session_paused import (
+        PAUSE_MARKER_RESTORED_EVENT_TYPE,
+        is_paused,
+    )
+
+    marker = _write_marker(config_with_base_dir, ["operator"])
+    assert is_paused(config_with_base_dir, "operator") is True
+    marker.write_text("{not json}")
+    assert is_paused(config_with_base_dir, "operator") is True
+    _write_marker(config_with_base_dir, ["reviewer"])
+    assert is_paused(config_with_base_dir, "reviewer") is True
+
+    audit_path = config_with_base_dir.project.base_dir / "audit.jsonl"
+    rows = [
+        json.loads(line)
+        for line in audit_path.read_text().splitlines()
+        if line.strip()
+    ]
+    restored = next(
+        row
+        for row in rows
+        if row.get("event") == PAUSE_MARKER_RESTORED_EVENT_TYPE
+    )
+    diff = restored["metadata"]["paused_state_diff"]
+    assert diff["previous_names_known"] is True
+    assert diff["added_paused"] == ["reviewer"]
+    assert diff["removed_paused"] == ["operator"]
 
 
 def test_skip_if_paused_returns_false_for_unpaused_session(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1428,6 +1428,88 @@ def test_recovery_waits_on_non_pollypm_lease(tmp_path: Path) -> None:
     assert "lease owner human" in alerts[0].message
 
 
+def test_missing_window_recovery_emits_heartbeat_missing_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.audit.log import EVENT_HEARTBEAT_MISSING, read_events
+
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = next(
+        item for item in supervisor.plan_launches()
+        if item.session.name == "operator"
+    )
+
+    monkeypatch.setattr(supervisor, "_policy_recommendation", lambda *_: None)
+    monkeypatch.setattr(
+        supervisor,
+        "_record_recovery_attempt",
+        lambda *_args, **_kwargs: (False, 1),
+    )
+
+    supervisor.maybe_recover_session(
+        launch,
+        failure_type="missing_window",
+        failure_message="Expected tmux window is missing",
+    )
+
+    events = read_events(
+        "pollypm",
+        project_path=tmp_path,
+        event=EVENT_HEARTBEAT_MISSING,
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event.subject == "operator"
+    assert event.actor == "heartbeat"
+    assert event.status == "warn"
+    assert event.metadata["session"] == "operator"
+    assert event.metadata["failure_type"] == "missing_window"
+    assert event.metadata["window_name"] == "pm-operator"
+
+
+def test_restart_session_emits_session_spawn_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.audit.log import EVENT_SESSION_SPAWN, read_events
+
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = next(
+        item for item in supervisor.plan_launches()
+        if item.session.name == "operator"
+    )
+
+    monkeypatch.setattr(supervisor.session_service.tmux, "has_session", lambda _name: False)
+    monkeypatch.setattr(supervisor, "launch_session", lambda _name: launch)
+
+    supervisor.restart_session(
+        "operator",
+        "claude_controller",
+        failure_type="missing_window",
+    )
+
+    events = read_events(
+        "pollypm",
+        project_path=tmp_path,
+        event=EVENT_SESSION_SPAWN,
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event.subject == "operator"
+    assert event.actor == "supervisor"
+    assert event.status == "ok"
+    assert event.metadata["session"] == "operator"
+    assert event.metadata["failure_type"] == "missing_window"
+    assert event.metadata["account"] == "claude_controller"
+
+
 def test_stalled_worker_gets_heartbeat_nudge_after_five_identical_cycles(monkeypatch, tmp_path: Path) -> None:
     config = _config(tmp_path)
     # #1004: pin workspace_root so the work-db resolver lands inside


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Persist pause-marker unreadable/restored diagnostics through the canonical audit log so throttling and restored detection survive one-shot heartbeat process restarts.
- Add restored metadata with repaired marker size, timestamp, paused names, and paused-state diff.
- Emit canonical `heartbeat.missing` and `session.spawn` JSONL audit breadcrumbs from the supervisor recovery cascade.
- Document the new/now-emitted audit event families.

Fixes #2186.
Fixes #2188.
Fixes #2189.

## Verification
- `uv run --extra test pytest -q tests/test_session_paused_marker_wiring.py tests/test_supervisor.py::test_missing_window_recovery_emits_heartbeat_missing_audit tests/test_supervisor.py::test_restart_session_emits_session_spawn_audit`
- `uv run --extra dev ruff check --ignore E402,F401 src/pollypm/session_paused.py src/pollypm/supervisor.py src/pollypm/audit/log.py tests/test_session_paused_marker_wiring.py tests/test_supervisor.py`

Note: a plain `ruff check` on the touched legacy supervisor files still reports pre-existing E402/F401 import-order/unused-import findings unrelated to this change.