### PR TITLE
fix(tasks): surface untracked rows and claim races

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1036,7 +1036,12 @@ paths:
         - in: query
           name: project
           schema: { type: string }
-          description: Limit results to this project key.
+          description: |
+            Limit results to this project key. By default this still
+            respects the tracked-project scope; pass
+            `include_untracked=true` to read rows for a project key
+            that exists in the backing store but is outside the
+            tracked set.
         - in: query
           name: status
           schema:
@@ -1057,6 +1062,15 @@ paths:
             ISO-8601 lower bound on `updated_at`. Only tasks whose
             `updated_at` is strictly after this value are returned.
         - in: query
+          name: include_untracked
+          schema: { type: boolean, default: false }
+          description: |
+            Include task rows for projects outside the tracked-project
+            set. Defaults to false so existing dashboards stay scoped.
+            When false and matching rows are omitted, the response
+            includes a `warnings[]` entry with
+            `code=untracked_filtered` and `dropped_count`.
+        - in: query
           name: limit
           schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
         - in: query
@@ -1068,8 +1082,10 @@ paths:
           description: |
             Page of task summaries. The optional `warnings` array
             lists any projects whose backing store failed during this
-            request — clients should surface that to the operator
-            rather than treat a 200 with warnings as a complete read.
+            request and any tracked-scope filtering that omitted
+            matching task rows — clients should surface that to the
+            operator rather than treat a 200 with warnings as a
+            complete read.
           content:
             application/json:
               schema:
@@ -3713,15 +3729,18 @@ components:
         warnings:
           type: array
           description: |
-            Per-project partial-failure notices. Absent/empty when
-            every project read succeeded. One entry per project whose
-            backing store raised during this request (clients should
-            render the partial-failure state explicitly rather than
-            assume the body is complete).
+            Per-project partial-failure notices and tracked-scope
+            filtering notices. Absent/empty when every project read
+            succeeded and no matching rows were omitted.
           items:
             $ref: "#/components/schemas/TaskListWarning"
 
     TaskListWarning:
+      oneOf:
+        - $ref: "#/components/schemas/TaskListPartialFailureWarning"
+        - $ref: "#/components/schemas/TaskListFilteredWarning"
+
+    TaskListPartialFailureWarning:
       type: object
       required: [project, error]
       properties:
@@ -3733,6 +3752,21 @@ components:
           description: |
             Short error code (e.g. `service_unavailable`). Stable across
             releases so clients can switch on it.
+
+    TaskListFilteredWarning:
+      type: object
+      required: [code, dropped_count, reason]
+      properties:
+        code:
+          type: string
+          enum: [untracked_filtered]
+        dropped_count:
+          type: integer
+          minimum: 1
+          description: Number of matching task rows omitted by the tracked-project scope.
+        reason:
+          type: string
+          enum: [untracked_projects]
 
     ApproveRequest:
       type: object

--- a/docs/work-service-spec.md
+++ b/docs/work-service-spec.md
@@ -319,7 +319,7 @@ callers rely on, including `created_by`, `skip_gates`, and `entry_type`.
 | `get` | task_id | Task | Read a task with all fields including current flow node and execution state. |
 | `list_tasks` | work_status?, owner?, project?, assignee?, blocked?, type?, limit?, offset? | list[Task] | Query tasks with filters. |
 | `queue` | task_id, actor, skip_gates? | Task | Move from `draft` to `queued`. If `requires_human_review`, validates human has approved via inbox unless gates are explicitly skipped. |
-| `claim` | task_id, actor, skip_gates? | Task | Atomic: activate first flow node, set role-derived `assignee`, record `actor` as `claimed_by_session`, and set `work_status=in_progress`. Task must be `queued`. |
+| `claim` | task_id, actor, skip_gates? | Task | Atomic: activate first flow node, set role-derived `assignee`, record `actor` as `claimed_by_session`, append/emit `claim.won_by`, and set `work_status=in_progress`. Contended losers append/emit `claim.attempted_by_loser` with `reason=already_claimed`. Task must be `queued`. |
 | `next` | agent?, project? | Task? | Return the highest-priority queued+unblocked task, optionally filtered by project. Does not claim it. |
 | `update` | task_id, fields... | Task | Update mutable fields (title, description, priority, labels, roles). Cannot change work_status directly. |
 | `cancel` | task_id, actor, reason | Task | Move any non-terminal task to `cancelled`; operator surfaces must confirm before cancelling `in_progress` work. |
@@ -682,6 +682,9 @@ The single `claim` call:
 
 - Marks the task `assignee=worker`, records the caller as
   `claimed_by_session`, and sets `work_status=in_progress`.
+- Records claim forensics: `claim.won_by` for the winning session and
+  `claim.attempted_by_loser` with `reason=already_claimed` when another
+  claimant races an already-claimed task.
 - Activates the first flow node.
 - Creates a real git worktree at `.pollypm/worktrees/<project>-<number>`
   on branch `task/<project>-<number>`.

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -20,6 +20,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from pollypm.claim_breadcrumbs import (
+    CLAIM_ATTEMPTED_BY_LOSER,
+    CLAIM_WON_BY,
+)
+
 logger = logging.getLogger(__name__)
 
 # Rotation defaults — mirrored by :class:`pollypm.models.AuditSettings`.
@@ -57,6 +62,8 @@ SCHEMA_VERSION = 1
 EVENT_TASK_CREATED = "task.created"
 EVENT_TASK_STATUS_CHANGED = "task.status_changed"
 EVENT_TASK_CLAIMED_BY_SESSION = "task.claimed_by_session"
+EVENT_CLAIM_WON_BY = CLAIM_WON_BY
+EVENT_CLAIM_ATTEMPTED_BY_LOSER = CLAIM_ATTEMPTED_BY_LOSER
 EVENT_TASK_CANCEL_WARNED = "task.cancel.warned"
 EVENT_TASK_CANCEL_CONFIRMED = "task.cancel.confirmed"
 EVENT_TASK_DELETED = "task.deleted"
@@ -979,6 +986,8 @@ __all__ = [
     "EVENT_TASK_CREATED",
     "EVENT_TASK_STATUS_CHANGED",
     "EVENT_TASK_CLAIMED_BY_SESSION",
+    "EVENT_CLAIM_WON_BY",
+    "EVENT_CLAIM_ATTEMPTED_BY_LOSER",
     "EVENT_TASK_CANCEL_WARNED",
     "EVENT_TASK_CANCEL_CONFIRMED",
     "EVENT_TASK_DELETED",

--- a/src/pollypm/claim_breadcrumbs.py
+++ b/src/pollypm/claim_breadcrumbs.py
@@ -1,0 +1,77 @@
+"""Shared claim breadcrumb vocabulary and render helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+CLAIM_WON_BY = "claim.won_by"
+CLAIM_ATTEMPTED_BY_LOSER = "claim.attempted_by_loser"
+CLAIM_ALREADY_CLAIMED_REASON = "already_claimed"
+
+
+def _clean(value: object | None) -> str:
+    return str(value or "").strip()
+
+
+def _add_field(parts: list[str], name: str, value: object | None) -> None:
+    text = _clean(value)
+    if text:
+        parts.append(f"{name}={text}")
+
+
+def build_claim_breadcrumb_text(
+    *,
+    event_type: str,
+    task_id: str,
+    actor: str,
+    session: str | None,
+    reason: str | None = None,
+    assignee: str | None = None,
+    winner_session: str | None = None,
+) -> str:
+    """Render a stable, grep-friendly task context breadcrumb."""
+    parts = [event_type]
+    _add_field(parts, "task_id", task_id)
+    _add_field(parts, "actor", actor)
+    _add_field(parts, "session", session or actor)
+    _add_field(parts, "reason", reason)
+    _add_field(parts, "assignee", assignee)
+    _add_field(parts, "winner_session", winner_session)
+    return " ".join(parts)
+
+
+def build_claim_breadcrumb_metadata(
+    *,
+    task_id: str,
+    actor: str,
+    session: str | None,
+    timestamp: datetime | None = None,
+    reason: str | None = None,
+    assignee: str | None = None,
+    winner_session: str | None = None,
+) -> dict[str, Any]:
+    """Structured counterpart to the context breadcrumb text."""
+    metadata: dict[str, Any] = {
+        "task_id": task_id,
+        "actor": actor,
+        "session": session or actor,
+    }
+    if timestamp is not None:
+        metadata["timestamp"] = timestamp.isoformat()
+    if reason:
+        metadata["reason"] = reason
+    if assignee:
+        metadata["assignee"] = assignee
+    if winner_session:
+        metadata["winner_session"] = winner_session
+    return metadata
+
+
+__all__ = [
+    "CLAIM_ALREADY_CLAIMED_REASON",
+    "CLAIM_ATTEMPTED_BY_LOSER",
+    "CLAIM_WON_BY",
+    "build_claim_breadcrumb_metadata",
+    "build_claim_breadcrumb_text",
+]

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -12,7 +12,7 @@ models (``ApproveRequest``, ``RejectRequest``, etc.) ship in Phase 2.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 
 from pydantic import BaseModel, Field
 
@@ -270,7 +270,7 @@ class TaskDetail(TaskSummary):
     plan: Plan | None = None
 
 
-class TaskListWarning(BaseModel):
+class TaskListPartialFailureWarning(BaseModel):
     """Per-project partial-failure notice on the cross-project task list.
 
     Round 1 of Codex review on PR #2067 flagged that silently skipping
@@ -283,6 +283,19 @@ class TaskListWarning(BaseModel):
 
     project: str
     error: str  # short code, e.g. "service_unavailable"
+
+
+class TaskListFilteredWarning(BaseModel):
+    """Notice that the list omitted untracked task rows by design."""
+
+    code: Literal["untracked_filtered"]
+    dropped_count: int = Field(ge=1)
+    reason: Literal["untracked_projects"]
+
+
+TaskListWarning: TypeAlias = (
+    TaskListPartialFailureWarning | TaskListFilteredWarning
+)
 
 
 class TaskListResponse(BaseModel):
@@ -637,6 +650,8 @@ __all__ = [
     "TaskCancelRequest",
     "TaskClaimRequest",
     "TaskDetail",
+    "TaskListFilteredWarning",
+    "TaskListPartialFailureWarning",
     "TaskListResponse",
     "TaskListWarning",
     "TaskPatchRequest",

--- a/src/pollypm/web_api/routes/tasks.py
+++ b/src/pollypm/web_api/routes/tasks.py
@@ -32,7 +32,6 @@ from pollypm.web_api.models import (
     TaskClaimRequest,
     TaskDetail,
     TaskListResponse,
-    TaskListWarning,
     TaskPatchRequest,
     TaskReassignRequest,
     TaskReopenRequest,
@@ -71,6 +70,15 @@ def list_tasks_endpoint(
         str | None,
         Query(description="ISO-8601 lower bound on updated_at (strictly after)."),
     ] = None,
+    include_untracked: Annotated[
+        bool,
+        Query(
+            description=(
+                "Include task rows for projects outside the tracked-project "
+                "set. Defaults to false so existing dashboards stay scoped."
+            ),
+        ),
+    ] = False,
     limit: Annotated[int, Query(ge=1, le=200, description="Page size (capped at 200).")] = 50,
     cursor: Annotated[str | None, Query(description="Opaque cursor from next_cursor.")] = None,
 ) -> TaskListResponse:
@@ -112,6 +120,7 @@ def list_tasks_endpoint(
             statuses=status,
             assignee=assignee,
             since=since_dt,
+            include_untracked=include_untracked,
             limit=limit,
             cursor=cursor,
         )
@@ -131,9 +140,7 @@ def list_tasks_endpoint(
     return TaskListResponse(
         items=items,
         next_cursor=next_cursor,
-        warnings=(
-            [TaskListWarning(**w) for w in warnings] if warnings else None
-        ),
+        warnings=warnings or None,
     )
 
 

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -30,6 +30,7 @@ import psycopg_pool
 from pollypm.audit.log import AuditEvent, read_events
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.models import KnownProject
+from pollypm.work.inbox_snooze import is_snooze_active as _is_snooze_active
 from pollypm.work.inbox_view import is_inbox_task, is_inbox_task_identity
 from pollypm.web_api.errors import (
     APIError,
@@ -1033,18 +1034,17 @@ def list_all_tasks(
     statuses: list[str] | None = None,
     assignee: str | None = None,
     since: datetime | None = None,
+    include_untracked: bool = False,
     limit: int = 50,
     cursor: str | None = None,
-) -> tuple[list[APITaskSummary], str | None, list[dict[str, str]]]:
+) -> tuple[list[APITaskSummary], str | None, list[dict[str, object]]]:
     """Cross-project flat task list (spec §5.1 / Phase 6 P0).
 
-    No cross-project helper exists on the work-service yet, so we
-    iterate the registered projects, call :meth:`list_tasks` per
-    project, and concatenate. This is acceptable for v1 — workspaces
-    are small (<20 projects, low hundreds of tasks each) and the
-    per-project DB open is the same cost ``list_project_tasks`` pays.
-    A native cross-project query can replace this body without
-    changing the route signature.
+    The default scoped view iterates tracked projects, calls
+    :meth:`list_tasks` per project, and concatenates. The
+    ``include_untracked`` opt-in uses the work-service's workspace
+    list query so rows outside ``config.projects`` can be surfaced
+    without teaching the route layer about storage internals.
 
     * ``project`` — when set, restricts to a single project. The
       result is equivalent to ``list_project_tasks`` minus the 404 on
@@ -1056,6 +1056,10 @@ def list_all_tasks(
     * ``since`` — only tasks with ``updated_at > since`` are returned.
       Must be timezone-aware; the route layer rejects naive ISO
       values before they reach this helper.
+    * ``include_untracked`` — when false, restrict results to the
+      tracked-project set and surface a warning when matching rows
+      are omitted. When true, include rows for any project key stored
+      in the work-service backing store.
     * Pagination uses an opaque cursor; the cursor encodes the
       ``(updated_at_iso, task_id)`` of the last item on the previous
       page. A cursor that no longer matches any item raises
@@ -1064,23 +1068,39 @@ def list_all_tasks(
       duplicate rows / infinite loops under concurrent updates
       (PR #2067 Codex round 1, P0 #3).
 
-    Returns ``(page, next_cursor, warnings)``. ``warnings`` is a list
-    of ``{"project": <key>, "error": <code>}`` dicts — one entry per
-    project whose backing store raised during this request. An empty
-    list means every project read succeeded; the partial-failure
-    surface is explicit so a pg outage on one project can't hide
-    behind a 200 with a silently-truncated body (PR #2067 Codex round
-    1, P0 #1).
+    Returns ``(page, next_cursor, warnings)``. ``warnings`` contains
+    either per-project backing-store failures
+    (``{"project": <key>, "error": <code>}``) or the tracked-scope
+    filter warning (``{"code": "untracked_filtered", ...}``). An
+    empty list means every project read succeeded and no matching
+    rows were omitted.
     """
-    keys: Iterable[str]
-    if project is not None:
-        keys = (project,) if project in config.projects else ()
-    else:
-        keys = config.projects.keys()
-
     status_filter = set(statuses or [])
     summaries: list[APITaskSummary] = []
-    warnings: list[dict[str, str]] = []
+    warnings: list[dict[str, object]] = []
+
+    if include_untracked:
+        tasks = _list_tasks_from_workspace(config, project=project)
+        for task in tasks:
+            if not _task_matches_list_filters(
+                task,
+                status_filter=status_filter,
+                assignee=assignee,
+                since=since,
+            ):
+                continue
+            summaries.append(_task_to_summary(task))
+        return _page_task_summaries(
+            summaries, limit=limit, cursor=cursor, warnings=warnings
+        )
+
+    tracked_keys = _tracked_project_keys(config)
+    keys: Iterable[str]
+    if project is not None:
+        keys = (project,) if project in tracked_keys else ()
+    else:
+        keys = tracked_keys
+
     for key in keys:
         proj = config.projects[key]
         try:
@@ -1104,19 +1124,130 @@ def list_all_tasks(
             continue
 
         for task in tasks:
-            if status_filter:
-                value = _enum_value(getattr(task, "work_status", ""))
-                if value not in status_filter:
-                    continue
-            if assignee is not None:
-                if (getattr(task, "assignee", None) or "") != assignee:
-                    continue
-            if since is not None:
-                updated = getattr(task, "updated_at", None)
-                if updated is not None and updated <= since:
-                    continue
+            if not _task_matches_list_filters(
+                task,
+                status_filter=status_filter,
+                assignee=assignee,
+                since=since,
+            ):
+                continue
             summaries.append(_task_to_summary(task))
 
+    try:
+        dropped_count = _count_untracked_matches(
+            config,
+            tracked_keys=tracked_keys,
+            project=project,
+            status_filter=status_filter,
+            assignee=assignee,
+            since=since,
+        )
+    except _BACKING_STORE_ERRORS as exc:
+        logger.warning(
+            "list_all_tasks: could not inspect untracked task rows; "
+            "surfacing workspace warning: %s",
+            exc,
+            exc_info=True,
+        )
+        warnings.append(
+            {"project": "__workspace__", "error": "service_unavailable"}
+        )
+        dropped_count = 0
+    if dropped_count:
+        warnings.append(
+            {
+                "code": "untracked_filtered",
+                "dropped_count": dropped_count,
+                "reason": "untracked_projects",
+            }
+        )
+
+    return _page_task_summaries(
+        summaries, limit=limit, cursor=cursor, warnings=warnings
+    )
+
+
+def _tracked_project_keys(config: PollyPMConfig) -> tuple[str, ...]:
+    return tuple(
+        key
+        for key, proj in config.projects.items()
+        if getattr(proj, "tracked", True)
+    )
+
+
+def _list_tasks_from_workspace(config: PollyPMConfig, *, project: str | None):
+    workspace_root = (
+        getattr(config.project, "workspace_root", None)
+        or getattr(config.project, "root_dir", None)
+        or Path.cwd()
+    )
+    with _open_work_service_readonly(
+        config=config,
+        project_key="__workspace__",
+        project_path=Path(workspace_root),
+    ) as svc:
+        return svc.list_tasks(project=project)
+
+
+def _task_matches_list_filters(
+    task,
+    *,
+    status_filter: set[str],
+    assignee: str | None,
+    since: datetime | None,
+) -> bool:
+    if status_filter:
+        value = _enum_value(getattr(task, "work_status", ""))
+        if value not in status_filter:
+            return False
+    if assignee is not None:
+        if (getattr(task, "assignee", None) or "") != assignee:
+            return False
+    if since is not None:
+        updated = getattr(task, "updated_at", None)
+        if updated is not None and updated <= since:
+            return False
+    return True
+
+
+def _count_untracked_matches(
+    config: PollyPMConfig,
+    *,
+    tracked_keys: Iterable[str],
+    project: str | None,
+    status_filter: set[str],
+    assignee: str | None,
+    since: datetime | None,
+) -> int:
+    tracked = set(tracked_keys)
+    if project is not None and project in tracked:
+        return 0
+    tasks = _list_tasks_from_workspace(config, project=project)
+    dropped = 0
+    for task in tasks:
+        task_project = str(getattr(task, "project", ""))
+        if project is None:
+            if task_project in tracked:
+                continue
+        elif task_project != project:
+            continue
+        if _task_matches_list_filters(
+            task,
+            status_filter=status_filter,
+            assignee=assignee,
+            since=since,
+        ):
+            dropped += 1
+    return dropped
+
+
+def _page_task_summaries(
+    summaries: list[APITaskSummary],
+    *,
+    limit: int,
+    cursor: str | None,
+    warnings: list[dict[str, object]],
+) -> tuple[list[APITaskSummary], str | None, list[dict[str, object]]]:
     # Newest-first ordering is the most useful default for cross-
     # project list views (cockpit "what changed recently?"). Tasks
     # without ``updated_at`` sort to the end via the epoch fallback so
@@ -2934,11 +3065,10 @@ def _collect_inbox_items(
 #
 # The POST /inbox/{id}/snooze endpoint persists an ``entry_type='snooze'``
 # row whose text starts with ``until_iso=<ISO>; snoozed until <ISO>``.
-# The wake-time parser + "still snoozed?" predicate live in
+# The "still snoozed?" predicate lives in
 # ``pollypm.work.inbox_snooze`` so cockpit can adopt them WITHOUT
-# duplicating regex logic (Codex round-2 ask on PR #2060). The
-# module-private aliases here keep the existing import sites + tests
-# working unchanged.
+# duplicating regex logic (Codex round-2 ask on PR #2060). The import
+# alias keeps the existing call sites + tests working unchanged.
 #
 # ``_active_snoozed_ids`` calls ``svc.latest_snoozes_bulk(...)``
 # (single SQL on pg) instead of the original per-task
@@ -2946,12 +3076,6 @@ def _collect_inbox_items(
 # inbox-list path is user-facing and a 50-task page was paying N
 # round-trips to the work-service per request.
 # ---------------------------------------------------------------------------
-
-from pollypm.work.inbox_snooze import (
-    is_snooze_active as _is_snooze_active,
-    parse_snooze_until as _parse_snooze_until,
-)
-
 
 def _task_key(task_id: str) -> tuple[str, int]:
     """Split ``project/n`` into a ``(project, number)`` tuple.

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -26,6 +26,10 @@ from pollypm.audit.log import (
     EVENT_TASK_CANCEL_CONFIRMED,
     EVENT_TASK_CANCEL_WARNED,
 )
+from pollypm.claim_breadcrumbs import (
+    CLAIM_ATTEMPTED_BY_LOSER,
+    CLAIM_WON_BY,
+)
 from pollypm.work.cancel_safety import (
     emit_cancel_safety_event,
     in_progress_assignee,
@@ -342,6 +346,10 @@ def _resolve_actor_for_task(
 _INTERNAL_CONTEXT_ENTRY_TYPES = frozenset({
     "sweeper_ping",
 })
+_CLAIM_CONTEXT_ENTRY_TYPES = frozenset({
+    CLAIM_ATTEMPTED_BY_LOSER,
+    CLAIM_WON_BY,
+})
 
 
 def _is_sweeper_internal(entry) -> bool:
@@ -371,6 +379,16 @@ def _filter_visible_context(entries, *, show_internal: bool):
     if show_internal:
         return list(entries)
     return [e for e in entries if not _is_sweeper_internal(e)]
+
+
+def _format_claim_history_line(entries) -> str | None:
+    claim_entries = [
+        e for e in entries
+        if getattr(e, "entry_type", None) in _CLAIM_CONTEXT_ENTRY_TYPES
+    ]
+    if not claim_entries:
+        return None
+    return "Claim history: " + " | ".join(str(e.text) for e in claim_entries)
 
 
 def _print_task(task, as_json: bool = False, show_internal: bool = False) -> None:
@@ -1633,9 +1651,12 @@ def task_context(
         entries = _run(
             svc.get_context, task_id, limit=limit, entry_type=entry_type,
         )
-        # ``get_context`` returns DESC (most-recent first); reverse to
-        # render chronologically so readers can follow the conversation.
-        entries = list(reversed(entries))
+        # ``get_context`` returns DESC (most-recent first). Sort by the
+        # entry timestamp so post-commit audit breadcrumbs still render
+        # in the order the claim attempts happened.
+        entries = sorted(
+            entries, key=lambda e: str(getattr(e, "timestamp", "") or ""),
+        )
         visible = _filter_visible_context(
             entries, show_internal=show_internal,
         )
@@ -1671,14 +1692,26 @@ def task_context(
                 typer.echo(f"No context entries on {task_id}.")
             return
 
+        claim_history = _format_claim_history_line(visible)
+        if claim_history is not None:
+            typer.echo(claim_history)
+
+        actor_width = max(
+            14, *(len(str(getattr(e, "actor", "") or "")) for e in visible),
+        )
+        type_width = max(
+            14,
+            *(len(str(getattr(e, "entry_type", "") or "")) for e in visible),
+        )
         typer.echo(
-            f"{'Timestamp':<26} {'Actor':<14} {'Type':<14} Text"
+            f"{'Timestamp':<26} {'Actor':<{actor_width}} "
+            f"{'Type':<{type_width}} Text"
         )
         typer.echo("-" * 80)
         for e in visible:
             typer.echo(
-                f"{str(e.timestamp):<26} {e.actor:<14} "
-                f"{e.entry_type:<14} {e.text}"
+                f"{str(e.timestamp):<26} {e.actor:<{actor_width}} "
+                f"{e.entry_type:<{type_width}} {e.text}"
             )
         if hidden_count:
             typer.echo(

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -42,6 +42,13 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from pollypm.claim_breadcrumbs import (
+    CLAIM_ALREADY_CLAIMED_REASON,
+    CLAIM_ATTEMPTED_BY_LOSER,
+    CLAIM_WON_BY,
+    build_claim_breadcrumb_metadata,
+    build_claim_breadcrumb_text,
+)
 from pollypm.inbox.kind import InboxItemKind, coerce_kind as _coerce_inbox_kind
 from pollypm.work.models import (
     ActorType,
@@ -80,6 +87,11 @@ if TYPE_CHECKING:
     from pollypm.work.sync import SyncManager
 
 logger = logging.getLogger(__name__)
+
+_CLAIM_CONTESTED_STATUSES = frozenset({
+    WorkStatus.IN_PROGRESS,
+    WorkStatus.REVIEW,
+})
 
 # Per-process dedup for the ``work_db.opened`` audit row (#1808). The
 # event is a doctor / heartbeat diagnostic stamped at first open of a
@@ -1394,6 +1406,135 @@ class PgWorkService:
                 exc_info=True,
             )
 
+    def _insert_claim_breadcrumb_locked(
+        self,
+        cur,
+        *,
+        event_type: str,
+        project: str,
+        task_number: int,
+        actor: str,
+        session: str | None,
+        timestamp: datetime,
+        reason: str | None = None,
+        assignee: str | None = None,
+        winner_session: str | None = None,
+    ) -> None:
+        task_id = f"{project}/{task_number}"
+        text = build_claim_breadcrumb_text(
+            event_type=event_type,
+            task_id=task_id,
+            actor=actor,
+            session=session,
+            reason=reason,
+            assignee=assignee,
+            winner_session=winner_session,
+        )
+        cur.execute(
+            "INSERT INTO work_context_entries "
+            "(task_project, task_number, actor, text, created_at, "
+            "entry_type) VALUES (%s, %s, %s, %s, %s, %s)",
+            (
+                project,
+                task_number,
+                actor,
+                text,
+                timestamp,
+                event_type,
+            ),
+        )
+
+    def _emit_claim_breadcrumb_audit(
+        self,
+        *,
+        event_type: str,
+        project: str,
+        task_number: int,
+        actor: str,
+        session: str | None,
+        timestamp: datetime,
+        reason: str | None = None,
+        assignee: str | None = None,
+        winner_session: str | None = None,
+    ) -> None:
+        task_id = f"{project}/{task_number}"
+        try:
+            from pollypm.audit import emit as _audit_emit
+
+            _audit_emit(
+                event=event_type,
+                project=project,
+                subject=task_id,
+                actor=actor or "",
+                metadata=build_claim_breadcrumb_metadata(
+                    task_id=task_id,
+                    actor=actor,
+                    session=session,
+                    timestamp=timestamp,
+                    reason=reason,
+                    assignee=assignee,
+                    winner_session=winner_session,
+                ),
+                project_path=self._project_path,
+            )
+        except Exception:  # noqa: BLE001 — audit must never break claim
+            logger.debug(
+                "claim breadcrumb audit emit failed for %s",
+                task_id,
+                exc_info=True,
+            )
+
+    def _record_claim_breadcrumb(
+        self,
+        *,
+        event_type: str,
+        project: str,
+        task_number: int,
+        actor: str,
+        session: str | None,
+        timestamp: datetime,
+        reason: str | None = None,
+        assignee: str | None = None,
+        winner_session: str | None = None,
+    ) -> None:
+        """Record a claim forensic breadcrumb without changing claim outcome."""
+        task_id = f"{project}/{task_number}"
+        try:
+            with self._pool.connection() as conn:
+                conn.autocommit = False
+                with conn.cursor() as cur:
+                    self._insert_claim_breadcrumb_locked(
+                        cur,
+                        event_type=event_type,
+                        project=project,
+                        task_number=task_number,
+                        actor=actor,
+                        session=session,
+                        timestamp=timestamp,
+                        reason=reason,
+                        assignee=assignee,
+                        winner_session=winner_session,
+                    )
+                conn.commit()
+        except Exception:  # noqa: BLE001 — forensics must not change claim
+            logger.warning(
+                "claim breadcrumb context insert failed for %s",
+                task_id,
+                exc_info=True,
+            )
+
+        self._emit_claim_breadcrumb_audit(
+            event_type=event_type,
+            project=project,
+            task_number=task_number,
+            actor=actor,
+            session=session,
+            timestamp=timestamp,
+            reason=reason,
+            assignee=assignee,
+            winner_session=winner_session,
+        )
+
     def _sync_transition(
         self, task: Task, old_status: str, new_status: str
     ) -> None:
@@ -1866,25 +2007,72 @@ class PgWorkService:
                 )
 
                 if locked_task.work_status != WorkStatus.QUEUED:
-                    if locked_task.work_status == WorkStatus.IN_PROGRESS:
-                        claimant = locked_task.assignee or "another actor"
-                        raise InvalidTransitionError(
+                    if locked_task.work_status in _CLAIM_CONTESTED_STATUSES:
+                        claimant = (
+                            locked_task.claimed_by_session
+                            or locked_task.assignee
+                            or "another actor"
+                        )
+                        timestamp = _now_iso()
+                        error = InvalidTransitionError(
                             f"Task {task_id} is already claimed by "
                             f"'{claimant}'.\n"
                             f"\n"
-                            f"Why: the task is in 'in_progress' and "
+                            f"Why: the task is in "
+                            f"'{locked_task.work_status.value}' and "
                             f"assigned. A second claim would orphan "
-                            f"the first worker's session.\n"
+                            f"the first claimant's session.\n"
                             f"\n"
                             f"Fix: use `pm task get {task_id}` to see "
                             f"the current state. If the existing claim "
-                            f"is stale (worker session dead), hold and "
+                            f"is stale (claimant session dead), hold and "
                             f"resume:\n"
                             f"    pm task hold {task_id} --reason 'stale claim'\n"
                             f"    pm task resume {task_id}\n"
                             f"Otherwise, find an unclaimed task with "
                             f"`pm task next`."
                         )
+                        try:
+                            self._insert_claim_breadcrumb_locked(
+                                cur,
+                                event_type=CLAIM_ATTEMPTED_BY_LOSER,
+                                project=project,
+                                task_number=task_number,
+                                actor=actor,
+                                session=actor,
+                                timestamp=timestamp,
+                                reason=CLAIM_ALREADY_CLAIMED_REASON,
+                                assignee=locked_task.assignee,
+                                winner_session=locked_task.claimed_by_session,
+                            )
+                            conn.commit()
+                        except Exception:  # noqa: BLE001
+                            try:
+                                conn.rollback()
+                            except Exception:  # noqa: BLE001
+                                logger.debug(
+                                    "claim loser rollback failed for %s",
+                                    task_id,
+                                    exc_info=True,
+                                )
+                            logger.warning(
+                                "claim loser breadcrumb insert failed for %s",
+                                task_id,
+                                exc_info=True,
+                            )
+                        else:
+                            self._emit_claim_breadcrumb_audit(
+                                event_type=CLAIM_ATTEMPTED_BY_LOSER,
+                                project=project,
+                                task_number=task_number,
+                                actor=actor,
+                                session=actor,
+                                timestamp=timestamp,
+                                reason=CLAIM_ALREADY_CLAIMED_REASON,
+                                assignee=locked_task.assignee,
+                                winner_session=locked_task.claimed_by_session,
+                            )
+                        raise error
                     raise InvalidTransitionError(
                         f"Cannot claim task in "
                         f"'{locked_task.work_status.value}' state.\n"
@@ -2096,6 +2284,15 @@ class PgWorkService:
                 project=project,
                 task_number=task_number,
                 actor=actor,
+                assignee=assignee,
+            )
+            self._record_claim_breadcrumb(
+                event_type=CLAIM_WON_BY,
+                project=project,
+                task_number=task_number,
+                actor=actor,
+                session=actor,
+                timestamp=now,
                 assignee=assignee,
             )
         return result

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -582,7 +582,9 @@ def test_concurrent_reassign_serializes_breadcrumbs(pg_service):
     assert final.assignee == destinations[1]
 
 
-def test_concurrent_claim_serializes_one_winner_one_loser(pg_service):
+def test_concurrent_claim_serializes_one_winner_one_loser(
+    pg_service, monkeypatch,
+):
     """Spec §P-9 + concurrency safety (#2064 round-8 blocker #1).
 
     The new ``POST /tasks/{p}/{n}/claim`` route advertises an atomic
@@ -626,8 +628,22 @@ def test_concurrent_claim_serializes_one_winner_one_loser(pg_service):
     """
     import threading
 
+    from pollypm.claim_breadcrumbs import (
+        CLAIM_ALREADY_CLAIMED_REASON,
+        CLAIM_ATTEMPTED_BY_LOSER,
+        CLAIM_WON_BY,
+    )
     from pollypm.work.models import WorkStatus
     from pollypm.work.service_support import InvalidTransitionError
+
+    event_lock = threading.Lock()
+    emitted: list[dict] = []
+
+    def fake_emit(**kw):
+        with event_lock:
+            emitted.append(kw)
+
+    monkeypatch.setattr("pollypm.audit.emit", fake_emit)
 
     task = _make_draft(
         pg_service, roles={"worker": "alice", "reviewer": "bob"}
@@ -823,6 +839,44 @@ def test_concurrent_claim_serializes_one_winner_one_loser(pg_service):
         f"{execution_count}. Loser inserted a duplicate visit row "
         f"from its stale pre-transaction snapshot."
     )
+
+    entries = pg_service.get_context(task.task_id)
+    claim_entries = {
+        entry.entry_type: entry
+        for entry in entries
+        if entry.entry_type in {CLAIM_WON_BY, CLAIM_ATTEMPTED_BY_LOSER}
+    }
+    assert set(claim_entries) == {CLAIM_WON_BY, CLAIM_ATTEMPTED_BY_LOSER}
+    won = claim_entries[CLAIM_WON_BY]
+    assert won.actor == "winner"
+    assert f"task_id={task.task_id}" in won.text
+    assert "actor=winner" in won.text
+    assert "session=winner" in won.text
+    assert "assignee=alice" in won.text
+
+    lost = claim_entries[CLAIM_ATTEMPTED_BY_LOSER]
+    assert lost.actor == "loser"
+    assert f"task_id={task.task_id}" in lost.text
+    assert "actor=loser" in lost.text
+    assert "session=loser" in lost.text
+    assert f"reason={CLAIM_ALREADY_CLAIMED_REASON}" in lost.text
+    assert "winner_session=winner" in lost.text
+    assert "assignee=alice" in lost.text
+
+    claim_events = [
+        event for event in emitted
+        if event.get("event") in {CLAIM_WON_BY, CLAIM_ATTEMPTED_BY_LOSER}
+    ]
+    assert {event["event"] for event in claim_events} == {
+        CLAIM_WON_BY,
+        CLAIM_ATTEMPTED_BY_LOSER,
+    }
+    events_by_type = {event["event"]: event for event in claim_events}
+    assert events_by_type[CLAIM_WON_BY]["metadata"]["session"] == "winner"
+    loser_metadata = events_by_type[CLAIM_ATTEMPTED_BY_LOSER]["metadata"]
+    assert loser_metadata["session"] == "loser"
+    assert loser_metadata["reason"] == CLAIM_ALREADY_CLAIMED_REASON
+    assert loser_metadata["winner_session"] == "winner"
 
 
 def test_concurrent_role_update_does_not_leak_into_claim(pg_service):

--- a/tests/test_task_claim_context_cli.py
+++ b/tests/test_task_claim_context_cli.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from typer.testing import CliRunner
+
+from pollypm.claim_breadcrumbs import (
+    CLAIM_ALREADY_CLAIMED_REASON,
+    CLAIM_ATTEMPTED_BY_LOSER,
+    CLAIM_WON_BY,
+)
+from pollypm.work import cli as work_cli
+from pollypm.work.models import ContextEntry
+
+
+class _ContextService:
+    def __init__(self, entries: list[ContextEntry]) -> None:
+        self._entries = entries
+
+    def get_context(
+        self,
+        task_id: str,
+        limit: int | None = None,
+        entry_type: str | None = None,
+    ) -> list[ContextEntry]:
+        assert task_id == "demo/1"
+        entries = [
+            entry for entry in self._entries
+            if entry_type is None or entry.entry_type == entry_type
+        ]
+        if limit is not None:
+            return entries[:limit]
+        return entries
+
+
+def test_task_context_renders_claim_history_breadcrumbs(monkeypatch) -> None:
+    entries = [
+        ContextEntry(
+            actor="loser",
+            timestamp=datetime(2026, 5, 24, 12, 0, 1, tzinfo=UTC),
+            text=(
+                f"{CLAIM_ATTEMPTED_BY_LOSER} task_id=demo/1 actor=loser "
+                f"session=loser reason={CLAIM_ALREADY_CLAIMED_REASON} "
+                "assignee=worker winner_session=winner"
+            ),
+            entry_type=CLAIM_ATTEMPTED_BY_LOSER,
+        ),
+        ContextEntry(
+            actor="winner",
+            timestamp=datetime(2026, 5, 24, 12, 0, 0, tzinfo=UTC),
+            text=(
+                f"{CLAIM_WON_BY} task_id=demo/1 actor=winner "
+                "session=winner assignee=worker"
+            ),
+            entry_type=CLAIM_WON_BY,
+        ),
+    ]
+    monkeypatch.setattr(
+        work_cli, "_svc", lambda **_kw: _ContextService(entries),
+    )
+
+    result = CliRunner().invoke(work_cli.task_app, ["context", "demo/1"])
+
+    assert result.exit_code == 0, result.output
+    assert "Claim history:" in result.output
+    assert "Timestamp" in result.output
+    assert "Actor" in result.output
+    assert "Type" in result.output
+    assert CLAIM_WON_BY in result.output
+    assert CLAIM_ATTEMPTED_BY_LOSER in result.output
+    assert result.output.index(CLAIM_WON_BY) < result.output.index(
+        CLAIM_ATTEMPTED_BY_LOSER
+    )
+    assert "actor=winner" in result.output
+    assert "actor=loser" in result.output
+    assert f"reason={CLAIM_ALREADY_CLAIMED_REASON}" in result.output
+    assert "winner_session=winner" in result.output

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -126,6 +126,31 @@ def test_chat_message_type_enum_matches_runtime() -> None:
     )
 
 
+def test_task_status_enum_matches_runtime_work_status() -> None:
+    """``TaskStatus`` must mirror the work-service status enum.
+
+    Live PG may not currently contain every lifecycle state, but the
+    OpenAPI contract has to describe values the runtime can emit.
+    Tightening the schema to today's sampled rows would make generated
+    clients reject valid review/rework/on-hold transitions.
+    """
+    from pollypm.work.models import WorkStatus
+
+    contract = _load_contract()
+    yaml_enum = set(contract["components"]["schemas"]["TaskStatus"]["enum"])
+    runtime_enum = {member.value for member in WorkStatus}
+    missing_in_yaml = runtime_enum - yaml_enum
+    extra_in_yaml = yaml_enum - runtime_enum
+    assert not missing_in_yaml, (
+        f"TaskStatus enum is missing runtime values: {missing_in_yaml}. "
+        "Update docs/api/openapi.yaml to include them."
+    )
+    assert not extra_in_yaml, (
+        f"TaskStatus enum has values the runtime cannot emit: {extra_in_yaml}. "
+        "Remove them from docs/api/openapi.yaml."
+    )
+
+
 def test_static_yaml_does_not_advertise_idempotency_on_inbox_writes() -> None:
     """Static contract must match the implementation: no Idempotency-Key
     on inbox-write paths.

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -57,6 +57,23 @@ def _seed_two_projects(api_config, workspace_root):
     return second_root
 
 
+def _seed_untracked_project(api_config, workspace_root, key: str = "paused"):
+    """Register an untracked project that still has work rows in PG."""
+    from pollypm.models import KnownProject, ProjectKind
+
+    project_root = workspace_root / key
+    project_root.mkdir()
+    (project_root / ".pollypm").mkdir()
+    api_config.projects[key] = KnownProject(
+        key=key,
+        path=project_root,
+        name=key.title(),
+        tracked=False,
+        kind=ProjectKind.GIT,
+    )
+    return project_root
+
+
 def test_list_tasks_returns_all_projects(
     api_config, client, auth_headers, project_root, workspace_root
 ) -> None:
@@ -99,6 +116,84 @@ def test_list_tasks_project_filter(
     assert response.status_code == 200
     titles = [item["title"] for item in response.json()["items"]]
     assert titles == ["Theirs"]
+
+
+def test_list_tasks_warns_when_tracked_scope_drops_untracked_rows(
+    api_config, client, auth_headers, project_root, workspace_root
+) -> None:
+    """Default list scope is tracked projects, but the truncation is explicit."""
+    _seed_untracked_project(api_config, workspace_root)
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        make_task(svc, project="myproj", title="Visible")
+        make_task(svc, project="paused", title="Hidden")
+
+    response = client.get("/api/v1/tasks", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [item["title"] for item in body["items"]] == ["Visible"]
+    assert body["warnings"] == [
+        {
+            "code": "untracked_filtered",
+            "dropped_count": 1,
+            "reason": "untracked_projects",
+        }
+    ]
+
+
+def test_list_tasks_include_untracked_returns_hidden_rows(
+    api_config, client, auth_headers, project_root, workspace_root
+) -> None:
+    """``include_untracked=true`` opts into rows outside the tracked set."""
+    _seed_untracked_project(api_config, workspace_root)
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        make_task(svc, project="myproj", title="Visible")
+        make_task(svc, project="paused", title="Hidden")
+
+    response = client.get(
+        "/api/v1/tasks?include_untracked=true", headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    titles = sorted(item["title"] for item in body["items"])
+    assert titles == ["Hidden", "Visible"]
+    assert body.get("warnings") is None
+
+
+def test_list_tasks_project_filter_warns_for_unregistered_pg_rows(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """A project key absent from config is a no-match unless explicitly included."""
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        make_task(svc, project="orphan", title="Orphan row")
+
+    response = client.get(
+        "/api/v1/tasks?project=orphan", headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["items"] == []
+    assert body["warnings"] == [
+        {
+            "code": "untracked_filtered",
+            "dropped_count": 1,
+            "reason": "untracked_projects",
+        }
+    ]
+
+    included = client.get(
+        "/api/v1/tasks?project=orphan&include_untracked=true",
+        headers=auth_headers,
+    )
+    assert included.status_code == 200, included.text
+    included_body = included.json()
+    assert [item["title"] for item in included_body["items"]] == ["Orphan row"]
+    assert included_body.get("warnings") is None
 
 
 def test_list_tasks_status_filter_or_semantics(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add `include_untracked` to `GET /api/v1/tasks` and emit `untracked_filtered` warnings when the tracked scope omits matching task rows.
- Pin `TaskStatus` in OpenAPI to the runtime `WorkStatus` enum so live-data samples do not narrow valid lifecycle states.
- Record claim race breadcrumbs (`claim.won_by`, `claim.attempted_by_loser`) in context/audit output and show a `Claim history:` line in `pm task context`.

## Test plan
- `uv run pytest tests/web_api/test_tasks_list_endpoint.py tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31 tests/web_api/test_openapi_conformance.py::test_implementation_serves_phase_1_paths tests/web_api/test_openapi_conformance.py::test_task_status_enum_matches_runtime_work_status tests/test_task_claim_context_cli.py tests/test_pg_work_service_full.py::test_concurrent_claim_serializes_one_winner_one_loser tests/test_pg_work_service_full.py::test_claim_records_session_identity_separately tests/test_error_messages.py::TestClaimAlreadyClaimed::test_claim_on_in_progress_identifies_claimant_and_offers_recovery -q`
- `uv run ruff check src/pollypm/claim_breadcrumbs.py src/pollypm/audit/log.py src/pollypm/web_api/models.py src/pollypm/web_api/service.py src/pollypm/web_api/routes/tasks.py src/pollypm/work/cli.py src/pollypm/work/pg_service.py tests/test_pg_work_service_full.py tests/test_task_claim_context_cli.py tests/web_api/test_tasks_list_endpoint.py tests/web_api/test_openapi_conformance.py`

Refs #2165, #2167, #2146.