### PR TITLE
fix(ui): suspend dashboard fallback while SSE is healthy

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -18,6 +18,7 @@
   const FALLBACK_POLL_MS = 15000;
   const SSE_RETRY_MS = 30000;
   const SSE_FAILURE_LIMIT = 3;
+  const SSE_STABLE_OPEN_MS = 5000;
   const PUSH_REFRESH_DEBOUNCE_MS = 150;
   const MAX_MESSAGES = 50;
   const SESSION_ISSUED_COOKIE = "pollypm-session-issued-at";
@@ -36,6 +37,7 @@
     eventSource: null,
     fallbackTimer: null,
     pushRefreshTimer: null,
+    sseStableOpenTimer: null,
     surfacesInFlight: false,
     surfacesRefreshQueued: false,
     dashboardInFlight: false,
@@ -1028,10 +1030,49 @@
     state.fallbackTimer = null;
   }
 
-  function closeEventStream() {
-    if (!state.eventSource) return;
+  function clearSseStableOpenTimer() {
+    if (state.sseStableOpenTimer === null) return;
+    clearTimeout(state.sseStableOpenTimer);
+    state.sseStableOpenTimer = null;
+  }
+
+  function eventSourceIsOpen(source) {
+    if (!source || typeof source.readyState !== "number") return true;
+    const openState = (
+      typeof window.EventSource === "function"
+      && typeof window.EventSource.OPEN === "number"
+    ) ? window.EventSource.OPEN : 1;
+    return source.readyState === openState;
+  }
+
+  function suspendFallbackAfterStableOpen(source) {
+    clearSseStableOpenTimer();
+    state.sseStableOpenTimer = setTimeout(() => {
+      state.sseStableOpenTimer = null;
+      if (state.eventSource !== source) return;
+      if (!eventSourceIsOpen(source)) {
+        startFallbackPolling();
+        return;
+      }
+      stopFallbackPolling();
+    }, SSE_STABLE_OPEN_MS);
+  }
+
+  function resumeFallbackForUnhealthyStream() {
+    clearSseStableOpenTimer();
+    startFallbackPolling();
+  }
+
+  function closeEventStream(options) {
+    const resumeFallback = !options || options.resumeFallback !== false;
+    clearSseStableOpenTimer();
+    if (!state.eventSource) {
+      if (resumeFallback) startFallbackPolling();
+      return;
+    }
     state.eventSource.close();
     state.eventSource = null;
+    if (resumeFallback) startFallbackPolling();
   }
 
   function eventStreamUrl() {
@@ -1070,14 +1111,22 @@
       clearTimeout(state.sseRetryTimer);
       state.sseRetryTimer = null;
     }
-    closeEventStream();
+    closeEventStream({ resumeFallback: false });
+    startFallbackPolling();
 
-    const source = new window.EventSource(eventStreamUrl());
+    let source;
+    try {
+      source = new window.EventSource(eventStreamUrl());
+    } catch (err) {
+      setStatus("warn", "SSE unavailable");
+      scheduleEventStreamRetry();
+      return;
+    }
     state.eventSource = source;
     source.onopen = () => {
       if (state.eventSource !== source) return;
       state.sseFailures = 0;
-      stopFallbackPolling();
+      suspendFallbackAfterStableOpen(source);
       setStatus("ok", "online");
     };
     source.addEventListener("audit", handleSseEvent);
@@ -1085,10 +1134,10 @@
     source.onerror = () => {
       if (state.eventSource !== source) return;
       state.sseFailures += 1;
+      resumeFallbackForUnhealthyStream();
       setStatus("warn", "SSE reconnecting");
       if (state.sseFailures >= SSE_FAILURE_LIMIT) {
         closeEventStream();
-        startFallbackPolling();
         scheduleEventStreamRetry();
       }
     };
@@ -1142,7 +1191,6 @@
     wireStopAgentButton();
     setStatus("warn", "connecting…");
     loadSurfaces();
-    pollDashboard();
     startEventStream();
     setInterval(loadSurfaces, 30000);
   }

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -44,11 +44,16 @@ test.describe("surfaces", () => {
     await page.addInitScript(() => {
       const instances: any[] = [];
       class MockEventSource {
+        static CONNECTING = 0;
+        static OPEN = 1;
+        static CLOSED = 2;
+
         url: string;
-        listeners: Record<string, EventListenerOrEventListenerObject>;
+        listeners: Record<string, EventListenerOrEventListenerObject[]>;
         onopen: ((event: Event) => void) | null;
         onmessage: ((event: MessageEvent) => void) | null;
         onerror: ((event: Event) => void) | null;
+        readyState: number;
         closed: boolean;
 
         constructor(url: string) {
@@ -57,10 +62,12 @@ test.describe("surfaces", () => {
           this.onopen = null;
           this.onmessage = null;
           this.onerror = null;
+          this.readyState = MockEventSource.CONNECTING;
           this.closed = false;
           instances.push(this);
           setTimeout(() => {
             if (!this.closed && typeof this.onopen === "function") {
+              this.readyState = MockEventSource.OPEN;
               this.onopen(new Event("open"));
             }
           }, 0);
@@ -70,16 +77,79 @@ test.describe("surfaces", () => {
           type: string,
           handler: EventListenerOrEventListenerObject,
         ) {
-          this.listeners[type] = handler;
+          const handlers = this.listeners[type] || [];
+          handlers.push(handler);
+          this.listeners[type] = handlers;
+        }
+
+        removeEventListener(
+          type: string,
+          handler: EventListenerOrEventListenerObject,
+        ) {
+          const handlers = this.listeners[type] || [];
+          this.listeners[type] = handlers.filter((item) => item !== handler);
+        }
+
+        dispatch(type: string, event: Event) {
+          for (const handler of this.listeners[type] || []) {
+            if (typeof handler === "function") {
+              handler.call(this, event);
+            } else {
+              handler.handleEvent(event);
+            }
+          }
+          if (type === "message" && typeof this.onmessage === "function") {
+            this.onmessage(event as MessageEvent);
+          }
+        }
+
+        emit(type: string, data: string, lastEventId: string) {
+          const event = new MessageEvent(type, {
+            data,
+            lastEventId,
+          });
+          this.dispatch(type, event);
+        }
+
+        fail() {
+          if (this.closed) return;
+          this.readyState = MockEventSource.CONNECTING;
+          if (typeof this.onerror === "function") {
+            this.onerror(new Event("error"));
+          }
         }
 
         close() {
           this.closed = true;
+          this.readyState = MockEventSource.CLOSED;
         }
       }
 
       (window as any).__pollypmEventSources = instances;
       (window as any).EventSource = MockEventSource as any;
+    });
+  }
+
+  async function emitAuditEvent(
+    page: import("@playwright/test").Page,
+    index: number,
+  ) {
+    await page.evaluate((eventIndex) => {
+      const source = (window as any).__pollypmEventSources[0];
+      const seconds = String(eventIndex).padStart(2, "0");
+      const ts = `2026-05-23T00:00:${seconds}Z`;
+      source.emit(
+        "audit",
+        JSON.stringify({ ts, event: "message" }),
+        ts,
+      );
+    }, index);
+  }
+
+  async function failEventSource(page: import("@playwright/test").Page) {
+    await page.evaluate(() => {
+      const source = (window as any).__pollypmEventSources[0];
+      source.fail();
     });
   }
 
@@ -302,6 +372,87 @@ test.describe("surfaces", () => {
     await expect(page.locator("#message-list .message-text")).toContainText(
       "refresh",
     );
+  });
+
+  test("healthy SSE uses push refreshes without fallback dashboard ticks", async ({ page }) => {
+    await page.clock.install({ time: new Date("2026-05-23T00:00:00Z") });
+    await installHealthyEventSource(page);
+    await stubEmptySessions(page);
+    await stubEmptyTasks(page);
+
+    let dashboardRequests = 0;
+    await page.route("**/api/v1/dashboard", (route) => {
+      dashboardRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(dashboardRequests)),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.clock.runFor(1);
+    await expect.poll(() => dashboardRequests).toBe(1);
+
+    await page.clock.runFor(5001);
+    await expect
+      .poll(() =>
+        page.evaluate(() => (window as any).PollyPM.state.fallbackTimer),
+      )
+      .toBeNull();
+
+    await emitAuditEvent(page, 1);
+    await page.clock.runFor(151);
+    await expect.poll(() => dashboardRequests).toBe(2);
+
+    await page.clock.runFor(45000);
+    expect(dashboardRequests).toBe(2);
+
+    await emitAuditEvent(page, 2);
+    await page.clock.runFor(151);
+    await expect.poll(() => dashboardRequests).toBe(3);
+
+    await page.clock.runFor(30000);
+    expect(dashboardRequests).toBe(3);
+  });
+
+  test("SSE error resumes dashboard fallback polling immediately", async ({ page }) => {
+    await page.clock.install({ time: new Date("2026-05-23T00:00:00Z") });
+    await installHealthyEventSource(page);
+    await stubEmptySessions(page);
+    await stubEmptyTasks(page);
+
+    let dashboardRequests = 0;
+    await page.route("**/api/v1/dashboard", (route) => {
+      dashboardRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(dashboardRequests)),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.clock.runFor(1);
+    await expect.poll(() => dashboardRequests).toBe(1);
+
+    await page.clock.runFor(5001);
+    await expect
+      .poll(() =>
+        page.evaluate(() => (window as any).PollyPM.state.fallbackTimer),
+      )
+      .toBeNull();
+
+    await failEventSource(page);
+    await expect.poll(() => dashboardRequests).toBe(2);
+    await expect
+      .poll(() =>
+        page.evaluate(() => (window as any).PollyPM.state.fallbackTimer),
+      )
+      .not.toBeNull();
+
+    await page.clock.runFor(15000);
+    await expect.poll(() => dashboardRequests).toBe(3);
   });
 
   test("dashboard refreshes coalesce while a request is in flight", async ({ page }) => {


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Pauses the dashboard fallback poll after EventSource has stayed open for 5s.
- Resumes fallback polling immediately when the SSE stream errors or closes.
- Adds Playwright coverage for healthy SSE push-only refreshes and error fallback resume.

Fixes #2134.

## Tests
- `npx playwright test tests/surfaces.spec.ts -g "healthy SSE|SSE error" --project=chromium` (pass)
- `npx playwright test tests/surfaces.spec.ts -g "healthy SSE|SSE error"` (pass)
- `git diff --check` (pass)

Known non-regression from worker verification:
- `npx playwright test tests/surfaces.spec.ts --project=chromium` still has existing live-data rail timeouts outside the focused SSE path.