### PR TITLE
fix(chat): surface thinking envelopes for stale archives

### DIFF
--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -636,6 +636,20 @@ def _load_envelopes(
     # branch above) — try capture, fall back to whatever JSONL we have
     # (better stale data than no data, per spec §4.8 which prefers
     # empty over erroring).
+    if include_thinking and archive is not None and archive.exists():
+        # tmux capture can only see rendered pane text; Anthropic
+        # thinking blocks live exclusively in the normalized JSONL.
+        # When the caller explicitly opts in and the archive has any
+        # thinking envelope, prefer that archive over stale capture so
+        # the request can actually satisfy ``include_thinking=true``.
+        envelopes = parse_events_jsonl(
+            archive,
+            actor_fallback=actor_fallback,
+            include_thinking=True,
+        )
+        if any(env.type == MessageType.THINKING for env in envelopes):
+            return envelopes, "jsonl", archive
+
     captured = _capture_for_surface(surface, actor_fallback=actor_fallback)
     if captured:
         return captured, "capture", None

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -774,6 +774,120 @@ def test_messages_endpoint_emits_thinking_envelopes_when_include_thinking_true(
     assert thinking_msg["metadata"]["signature"] == "opaque"
 
 
+def test_messages_endpoint_include_thinking_reaches_ingested_surface_archive(
+    client, auth_headers, config, project_root, monkeypatch,
+):
+    """A real surface + ingested Claude transcript can return thinking.
+
+    Regression for #2160: ``source=auto`` used to choose stale tmux
+    capture before reading the archive, so ``include_thinking=true``
+    returned zero thinking envelopes even when the raw Claude JSONL had
+    an Anthropic ``thinking`` block. This drives the real ingestor,
+    real surface registry, and real REST route; only tmux is faked.
+    """
+    import json as _json
+
+    from pollypm.transcript_ingest import sync_transcripts_once
+    from pollypm.tmux.client import TmuxWindow
+    from pollypm.web_api.chat.transcripts import _parse_cache_clear
+
+    account_home = project_root / ".pollypm/homes/claude_main"
+    config.accounts["claude_main"] = AccountConfig(
+        name="claude_main",
+        provider=ProviderKind.CLAUDE,
+        home=account_home,
+    )
+    config.pollypm.controller_account = "claude_main"
+    config.sessions["operator"] = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CLAUDE,
+        account="claude_main",
+        cwd=project_root,
+        project="myproj",
+        window_name="operator",
+    )
+
+    raw_path = (
+        account_home
+        / ".claude/projects/demo/session-rest-thinking.jsonl"
+    )
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(_json.dumps({
+        "type": "assistant",
+        "sessionId": "session-rest-thinking",
+        "timestamp": "2026-05-21T10:00:00Z",
+        "cwd": str(project_root),
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-4-7",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "Route-level thought.",
+                    "signature": "sig-route",
+                },
+                {"type": "text", "text": "Visible reply."},
+            ],
+        },
+    }) + "\n")
+    sync_transcripts_once(config)
+    archive = (
+        project_root
+        / ".pollypm/transcripts/session-rest-thinking/events.jsonl"
+    )
+    assert archive.exists()
+    _parse_cache_clear()
+
+    class _LiveTmuxClient:
+        def list_windows(self, target, timeout=None):  # noqa: ARG002
+            return [TmuxWindow(
+                session=target,
+                index=0,
+                name="operator",
+                active=True,
+                pane_id="%2160",
+                pane_current_command="claude",
+                pane_current_path=str(project_root),
+                pane_dead=False,
+            )]
+
+        def capture_pane(self, target, lines=3000):  # noqa: ARG002
+            return "live capture without hidden thinking"
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_tmux_client",
+        lambda: _LiveTmuxClient(),
+    )
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "is_archive_stale",
+        lambda path, **kw: True,
+    )
+
+    default_response = client.get(
+        "/api/v1/chat/operator/messages?direction=asc",
+        headers=auth_headers,
+    )
+    assert default_response.status_code == 200, default_response.text
+    default_body = default_response.json()
+    assert default_body["transcript_source"] == "capture"
+    assert [m["type"] for m in default_body["messages"]] == ["text"]
+
+    thinking_response = client.get(
+        "/api/v1/chat/operator/messages?include_thinking=true&direction=asc",
+        headers=auth_headers,
+    )
+    assert thinking_response.status_code == 200, thinking_response.text
+    body = thinking_response.json()
+    assert body["transcript_source"] == "jsonl"
+    assert [m["type"] for m in body["messages"]] == ["thinking", "text"]
+    assert body["messages"][0]["text"] == "Route-level thought."
+    assert body["messages"][0]["metadata"]["signature"] == "sig-route"
+    assert body["messages"][1]["text"] == "Visible reply."
+
+
 def test_messages_endpoint_no_subagent_inlining_by_default(
     client, auth_headers, patch_registry, patch_parser, tmp_path,
 ):


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Makes `include_thinking=true` prefer a stale JSONL archive when that archive contains thinking envelopes, since tmux capture cannot include hidden Anthropic thinking blocks.
- Preserves default `include_thinking=false` stale-capture behavior.
- Adds a REST regression that ingests a synthetic Claude transcript, registers the surface, and verifies thinking is reachable from the messages endpoint.

Fixes #2160.

## Tests
- New regression only: pass (`1 passed`)
- Focused endpoint/parser/ingest/registry slice: pass (`54 passed`)
- `ruff check` on changed files: pass
- `git diff --check`: pass

Known non-regression from worker verification:
- Broader targeted suite hit existing perf-ratio sensitivity in `tests/test_chat_transcripts.py::test_parse_tail_perf_beats_full_parse_on_10k_archive`; absolute tail time stayed under 5 ms, but the 50x ratio threshold was not met on that run.