### PR TITLE
fix(heartbeat): write PG heartbeats and audit recovery cascade

### DIFF
--- a/docs/test-plan/01-task-lifecycle.md
+++ b/docs/test-plan/01-task-lifecycle.md
@@ -401,7 +401,13 @@ sleep 180  # 3 min — recovery loop interval + buffer
 1. Heartbeat tier detects missing pane within ~60s.
 2. Recovery loop (`auto_recover_no_session_alerts`) respawns `worker_pollypm`.
 3. New worker picks up `$TID` (or task gets re-queued + claimed).
-4. Audit log shows the cascade trail: `heartbeat.missing` → `recovery.spawn` → `task.reclaimed`.
+4. Audit log shows the cascade trail in `~/.pollypm/audit/<project>.jsonl`:
+   `heartbeat.missing` → `recovery.spawn` → `task.reclaimed`.
+   `heartbeat.missing` carries `target_session`, `reason`, and tmux window
+   metadata plus an empty `target_task` when no task is known;
+   `recovery.spawn` carries the replacement `target_session`, account,
+   provider, reason, and an empty `target_task`; `task.reclaimed` carries
+   `target_task`, `target_session`, and the stale-claim recovery reason.
 
 **If it doesn't recover:** the fix is in the cascade. Do NOT manually claim or dispatch. File `bug:cascade` with the missing audit events.
 

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -253,11 +253,14 @@ EVENT_ADVISOR_TICK_FIRED = "advisor.tick.fired"
 EVENT_ADVISOR_TICK_SKIPPED = "advisor.tick.skipped"
 # Recovery cascade breadcrumbs. ``heartbeat.missing`` records the
 # supervisor/heartbeat detection edge for a tracked session whose tmux
-# window or pane disappeared; ``session.spawn`` records the successful
-# relaunch edge. Operators use this pair to prove a kill->respawn
-# cascade happened without replaying message-store state.
+# window or pane disappeared; ``recovery.spawn`` records the canonical
+# recovery relaunch edge; ``session.spawn`` is the broader session
+# lifecycle synonym retained for existing consumers; ``task.reclaimed``
+# records the task layer picking work back up after a dead worker claim.
 EVENT_HEARTBEAT_MISSING = "heartbeat.missing"
+EVENT_RECOVERY_SPAWN = "recovery.spawn"
 EVENT_SESSION_SPAWN = "session.spawn"
+EVENT_TASK_RECLAIMED = "task.reclaimed"
 
 
 @dataclass(slots=True, frozen=True)
@@ -1012,7 +1015,9 @@ __all__ = [
     "EVENT_COCKPIT_PARK_SKIPPED_EXISTING",
     "EVENT_INBOX_KIND_BACKFILLED",
     "EVENT_HEARTBEAT_MISSING",
+    "EVENT_RECOVERY_SPAWN",
     "EVENT_SESSION_SPAWN",
+    "EVENT_TASK_RECLAIMED",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/heartbeats/api.py
+++ b/src/pollypm/heartbeats/api.py
@@ -158,7 +158,7 @@ class SupervisorHeartbeatAPI:
     def record_observation(self, context: HeartbeatSessionContext) -> None:
         if not context.window_present or context.snapshot_path is None:
             return
-        self.supervisor.store.record_heartbeat(
+        self.supervisor.record_heartbeat(
             session_name=context.session_name,
             tmux_window=context.window_name,
             pane_id=context.pane_id or "",
@@ -248,7 +248,10 @@ class SupervisorHeartbeatAPI:
         )
 
     def recent_snapshot_hashes(self, session_name: str, *, limit: int = 3) -> list[str]:
-        return [item.snapshot_hash for item in self.supervisor.store.recent_heartbeats(session_name, limit=limit)]
+        return [
+            item.snapshot_hash
+            for item in self.supervisor.recent_heartbeats(session_name, limit=limit)
+        ]
 
     def recover_session(self, session_name: str, *, failure_type: str, message: str) -> None:
         launch = self.supervisor.launch_by_session(session_name)
@@ -373,7 +376,7 @@ class SupervisorHeartbeatAPI:
                 else:
                     snapshot_path = str(raw_snapshot_path)
                     current_snapshot_hash = snapshot_hash(pane_text)
-            previous = self.supervisor.store.latest_heartbeat(launch.session.name)
+            previous = self.supervisor.latest_heartbeat(launch.session.name)
             contexts.append(
                 HeartbeatSessionContext(
                     session_name=launch.session.name,

--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -1455,6 +1455,53 @@ def _tmux_window_alive_for_task(
     return False
 
 
+def _emit_task_reclaimed_audit(
+    services: Any,
+    *,
+    project: Any,
+    task: Any,
+    reason: str,
+) -> None:
+    """Best-effort audit breadcrumb for reclaiming work from a dead session."""
+    project_key = getattr(project, "key", None)
+    task_number = getattr(task, "task_number", None)
+    task_id = getattr(task, "task_id", None)
+    if not project_key or task_number is None or not task_id:
+        return
+    try:
+        from pollypm.audit.log import EVENT_TASK_RECLAIMED, emit as audit_emit
+        from pollypm.work.session_manager import task_window_name
+    except Exception:  # noqa: BLE001
+        logger.debug("task_auto_claim: audit import failed", exc_info=True)
+        return
+    project_path = getattr(project, "path", None) or getattr(
+        services, "project_root", None,
+    )
+    target_session = task_window_name(str(project_key), int(task_number))
+    try:
+        audit_emit(
+            event=EVENT_TASK_RECLAIMED,
+            project=str(project_key),
+            subject=str(task_id),
+            actor="auto_claim_sweep",
+            status="ok",
+            project_path=Path(project_path) if project_path is not None else None,
+            metadata={
+                "target_task": str(task_id),
+                "target_session": target_session,
+                "task_number": int(task_number),
+                "reason": reason,
+                "source": "task_assignment.sweep",
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "task_auto_claim: task.reclaimed audit failed for %s",
+            task_id,
+            exc_info=True,
+        )
+
+
 def _consecutive_abandonments_at_active_node(task: Any) -> int:
     """Return the count of consecutive ``ABANDONED`` executions at the
     task's current node, walking backwards from the most recent visit.
@@ -1726,6 +1773,12 @@ def _recover_dead_claims(
             continue
         by_outcome["auto_claim_recovered"] = (
             by_outcome.get("auto_claim_recovered", 0) + 1
+        )
+        _emit_task_reclaimed_audit(
+            services,
+            project=project,
+            task=task,
+            reason="worker session missing; stale claim released",
         )
         # Record an event so the activity log shows the auto-recovery.
         msg_store = getattr(services, "msg_store", None)

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -524,7 +524,7 @@ class PollyPMService:
         supervisor = self.load_supervisor()
         supervisor.require_session(session_name)
         launch = supervisor.launch_by_session(session_name)
-        supervisor.store.record_heartbeat(
+        supervisor.record_heartbeat(
             session_name=session_name,
             tmux_window=str(payload.get("tmux_window", launch.window_name)),
             pane_id=str(payload.get("pane_id", "")),
@@ -545,7 +545,7 @@ class PollyPMService:
             subject="heartbeat",
             payload={"message": "Recorded heartbeat snapshot"},
         )
-        record = supervisor.store.latest_heartbeat(session_name)
+        record = supervisor.latest_heartbeat(session_name)
         if record is None:
             raise RuntimeError(f"Heartbeat for {session_name} was not recorded")
         return record

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -548,6 +548,47 @@ class Supervisor:
         """Public read for the latest event of (scope, subject)."""
         return self._last_event_at(session_name, event_type)
 
+    # --- Cluster C heartbeat facade (#2136) -------------------------- #
+    # Health readers already use ``pollypm.storage.pg_heartbeats``. Keep
+    # supervisor/heartbeat writers on the same facade so ``pm sessions
+    # --health`` observes the rows the sweep records.
+
+    def record_heartbeat(
+        self,
+        *,
+        session_name: str,
+        tmux_window: str,
+        pane_id: str,
+        pane_command: str,
+        pane_dead: bool,
+        log_bytes: int,
+        snapshot_path: str,
+        snapshot_hash: str,
+    ) -> None:
+        from pollypm.storage.pg_heartbeats import record_heartbeat
+
+        record_heartbeat(
+            session_name=session_name,
+            tmux_window=tmux_window,
+            pane_id=pane_id,
+            pane_command=pane_command,
+            pane_dead=pane_dead,
+            log_bytes=log_bytes,
+            snapshot_path=snapshot_path,
+            snapshot_hash=snapshot_hash,
+            config=self.config,
+        )
+
+    def latest_heartbeat(self, session_name: str):
+        from pollypm.storage.pg_heartbeats import latest_heartbeat
+
+        return latest_heartbeat(session_name, config=self.config)
+
+    def recent_heartbeats(self, session_name: str, limit: int = 3):
+        from pollypm.storage.pg_heartbeats import recent_heartbeats
+
+        return recent_heartbeats(session_name, limit=limit, config=self.config)
+
     # --- Cluster D (leases) dispatch helpers -------------------------- #
     # Leases go through ``pollypm.storage.pg_leases``.
 
@@ -946,6 +987,14 @@ class Supervisor:
             "tmux_session": tmux_session,
         }
         payload.update(metadata)
+        payload.setdefault("target_session", launch.session.name)
+        payload.setdefault("target_task", "")
+        payload.setdefault(
+            "reason",
+            payload.get("failure_message")
+            or payload.get("failure_type")
+            or event,
+        )
         try:
             _audit_emit(
                 event=event,
@@ -2019,10 +2068,10 @@ class Supervisor:
                 log_bytes = launch.log_path.stat().st_size
             except (FileNotFoundError, OSError):
                 log_bytes = 0
-            previous = self.store.latest_heartbeat(session_key)
+            previous = self.latest_heartbeat(session_key)
             current_snapshot_hash = snapshot_hash(snapshot_content)
 
-            self.store.record_heartbeat(
+            self.record_heartbeat(
                 session_name=session_key,
                 tmux_window=window.name,
                 pane_id=window.pane_id,
@@ -3698,6 +3747,8 @@ class Supervisor:
                     "failure_type": failure_type,
                     "failure_message": failure_message,
                     "loop": "supervisor.maybe_recover_session",
+                    "target_session": launch.session.name,
+                    "reason": failure_message or failure_type,
                 },
             )
 
@@ -3926,20 +3977,26 @@ class Supervisor:
             )
             raise
         if spawned:
-            from pollypm.audit.log import EVENT_SESSION_SPAWN
-
-            self._emit_session_recovery_audit(
+            from pollypm.audit.log import (
+                EVENT_RECOVERY_SPAWN,
                 EVENT_SESSION_SPAWN,
-                launch,
-                status="ok",
-                actor="supervisor",
-                metadata={
-                    "failure_type": failure_type,
-                    "account": account_name,
-                    "provider": account.provider.value,
-                    "reason": "recovery_restart",
-                },
             )
+
+            recovery_metadata = {
+                "failure_type": failure_type,
+                "account": account_name,
+                "provider": account.provider.value,
+                "reason": "recovery_restart",
+                "target_session": session_name,
+            }
+            for event_type in (EVENT_RECOVERY_SPAWN, EVENT_SESSION_SPAWN):
+                self._emit_session_recovery_audit(
+                    event_type,
+                    launch,
+                    status="ok",
+                    actor="supervisor",
+                    metadata=recovery_metadata,
+                )
         # Inject recovery prompt so the agent knows what it was doing.
         # For role-scoped agents (reviewer / heartbeat) prepend an
         # identity reminder so a recovery that lands inside a noisy

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -637,6 +637,23 @@ def test_supervisor_heartbeat_api_records_snapshot_learnings_into_memory(tmp_pat
     assert len(checkpoints) == 1
 
 
+def test_supervisor_heartbeat_api_records_observation_via_supervisor_facade() -> None:
+    calls: list[dict[str, object]] = []
+    supervisor = SimpleNamespace(
+        record_heartbeat=lambda **kwargs: calls.append(kwargs),
+    )
+    api = SupervisorHeartbeatAPI.__new__(SupervisorHeartbeatAPI)
+    api.supervisor = supervisor
+
+    api.record_observation(_context(session_name="operator", window_name="pm-operator"))
+
+    assert len(calls) == 1
+    assert calls[0]["session_name"] == "operator"
+    assert calls[0]["tmux_window"] == "pm-operator"
+    assert calls[0]["pane_id"] == "%1"
+    assert calls[0]["snapshot_hash"] == "hash-1"
+
+
 def test_supervisor_heartbeat_api_deduplicates_snapshot_learnings(tmp_path: Path, monkeypatch) -> None:
     supervisor = Supervisor(_config(tmp_path))
     supervisor.ensure_layout()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1469,13 +1469,20 @@ def test_missing_window_recovery_emits_heartbeat_missing_audit(
     assert event.metadata["session"] == "operator"
     assert event.metadata["failure_type"] == "missing_window"
     assert event.metadata["window_name"] == "pm-operator"
+    assert event.metadata["target_session"] == "operator"
+    assert event.metadata["target_task"] == ""
+    assert event.metadata["reason"] == "Expected tmux window is missing"
 
 
 def test_restart_session_emits_session_spawn_audit(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    from pollypm.audit.log import EVENT_SESSION_SPAWN, read_events
+    from pollypm.audit.log import (
+        EVENT_RECOVERY_SPAWN,
+        EVENT_SESSION_SPAWN,
+        read_events,
+    )
 
     monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
     config = _config(tmp_path)
@@ -1508,6 +1515,56 @@ def test_restart_session_emits_session_spawn_audit(
     assert event.metadata["session"] == "operator"
     assert event.metadata["failure_type"] == "missing_window"
     assert event.metadata["account"] == "claude_controller"
+    assert event.metadata["target_session"] == "operator"
+    assert event.metadata["target_task"] == ""
+
+    recovery_events = read_events(
+        "pollypm",
+        project_path=tmp_path,
+        event=EVENT_RECOVERY_SPAWN,
+    )
+    assert len(recovery_events) == 1
+    recovery_event = recovery_events[0]
+    assert recovery_event.subject == "operator"
+    assert recovery_event.actor == "supervisor"
+    assert recovery_event.status == "ok"
+    assert recovery_event.metadata["target_session"] == "operator"
+    assert recovery_event.metadata["target_task"] == ""
+    assert recovery_event.metadata["reason"] == "recovery_restart"
+    assert recovery_event.metadata["failure_type"] == "missing_window"
+
+
+def test_supervisor_record_heartbeat_routes_through_pg_facade(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    calls: list[dict[str, object]] = []
+
+    def fake_record_heartbeat(**kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "pollypm.storage.pg_heartbeats.record_heartbeat",
+        fake_record_heartbeat,
+    )
+
+    supervisor.record_heartbeat(
+        session_name="operator",
+        tmux_window="pm-operator",
+        pane_id="%1",
+        pane_command="claude",
+        pane_dead=False,
+        log_bytes=123,
+        snapshot_path=str(tmp_path / "snapshot.txt"),
+        snapshot_hash="hash-1",
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["session_name"] == "operator"
+    assert calls[0]["tmux_window"] == "pm-operator"
+    assert calls[0]["config"] is config
 
 
 def test_stalled_worker_gets_heartbeat_nudge_after_five_identical_cycles(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_task_assignment_recovery_audit.py
+++ b/tests/test_task_assignment_recovery_audit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from pollypm.audit.log import EVENT_TASK_RECLAIMED, read_events
+from pollypm.plugins_builtin.task_assignment_notify.handlers.sweep import (
+    _recover_dead_claims,
+)
+from pollypm.work.models import WorkStatus
+
+
+class _FakeTmux:
+    def list_windows(self, _session_name: str) -> list[object]:
+        return []
+
+
+class _FakeSessionService:
+    tmux = _FakeTmux()
+
+    def storage_closet_session_name(self) -> str:
+        return "pollypm-storage-closet"
+
+
+class _FakeWork:
+    def __init__(self, task: SimpleNamespace) -> None:
+        self.task = task
+        self.released: list[tuple[str, str, str]] = []
+
+    def list_tasks(self, *, project: str, work_status: str) -> list[SimpleNamespace]:
+        if project == self.task.project and work_status == WorkStatus.IN_PROGRESS.value:
+            return [self.task]
+        return []
+
+    def release_stale_claim(self, task_id: str, actor: str, *, reason: str) -> None:
+        self.released.append((task_id, actor, reason))
+
+
+def test_recover_dead_claims_emits_task_reclaimed_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    task = SimpleNamespace(
+        project="demo",
+        task_number=7,
+        task_id="demo/7",
+        roles={"worker": "claude"},
+        current_node_id="build",
+        executions=[],
+    )
+    work = _FakeWork(task)
+    services = SimpleNamespace(
+        session_service=_FakeSessionService(),
+        msg_store=SimpleNamespace(append_event=lambda **_kwargs: None),
+        project_root=tmp_path,
+    )
+    project = SimpleNamespace(key="demo", path=project_path)
+    totals = {"by_outcome": {}}
+
+    _recover_dead_claims(services, work, project, totals)
+
+    assert work.released == [
+        ("demo/7", "auto_claim_sweep", "worker session missing"),
+    ]
+    assert totals["by_outcome"]["auto_claim_recovered"] == 1
+
+    events = read_events("demo", project_path=project_path, event=EVENT_TASK_RECLAIMED)
+    assert len(events) == 1
+    event = events[0]
+    assert event.subject == "demo/7"
+    assert event.actor == "auto_claim_sweep"
+    assert event.status == "ok"
+    assert event.metadata["target_task"] == "demo/7"
+    assert event.metadata["target_session"] == "task-demo-7"
+    assert event.metadata["reason"] == "worker session missing; stale claim released"


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Routes supervisor and heartbeat API heartbeat writes through the `pg_heartbeats` facade so `pm sessions --health` can read the rows the heartbeat tick records.
- Adds canonical `recovery.spawn` and `task.reclaimed` audit breadcrumbs while retaining the existing `session.spawn` lifecycle event.
- Documents the §1.5.1 cascade event trail and required metadata fields.

Fixes #2136.
Fixes #2139.

## Tests
- `uv run --extra dev python -m pytest tests/test_supervisor.py::test_missing_window_recovery_emits_heartbeat_missing_audit tests/test_supervisor.py::test_restart_session_emits_session_spawn_audit tests/test_supervisor.py::test_supervisor_record_heartbeat_routes_through_pg_facade tests/test_heartbeat_plugin_api.py::test_supervisor_heartbeat_api_records_observation_via_supervisor_facade tests/test_task_assignment_recovery_audit.py -q` (pass, 5 passed)
- `uv run --extra dev python -m py_compile src/pollypm/audit/log.py src/pollypm/supervisor.py src/pollypm/heartbeats/api.py src/pollypm/service_api/v1.py src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py tests/test_supervisor.py tests/test_heartbeat_plugin_api.py tests/test_task_assignment_recovery_audit.py` (pass)
- `uv run --extra dev ruff check tests/test_task_assignment_recovery_audit.py` (pass)
- `git diff --check` (pass)

Note: full-file `ruff check` on legacy supervisor/test files still reports pre-existing E402/F841/F401 issues unrelated to this patch.