### PR TITLE
test: isolate web API work-service state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -46,6 +47,13 @@ _POLLYPM_HOME_GUARDED_DIRS = (
 # any process by these names that appears DURING a test but persists
 # AFTER the test is an orphan the test failed to tear down.
 _POLLYPM_REAP_NAMES = ("claude", "codex")
+
+# Capture the operator home before any test fixture can monkeypatch
+# ``HOME``. The real-home pollution guard below must continue watching
+# the operator's ``~/.pollypm`` even for tests that deliberately run with
+# a sandboxed home.
+_OPERATOR_HOME = Path(os.environ.get("HOME") or os.path.expanduser("~")).expanduser()
+_OPERATOR_POLLYPM_HOME = _OPERATOR_HOME / ".pollypm"
 
 
 def pytest_configure(config):
@@ -201,6 +209,133 @@ def _resolve_backend_marker(request) -> str:
     return raw
 
 
+def _node_relpath(request) -> str:
+    """Return the current test path relative to the repo root."""
+    raw_path = getattr(request.node, "path", None)
+    if raw_path is None:
+        raw_path = getattr(request.node, "fspath", "")
+    path = Path(str(raw_path)).resolve()
+    root = Path(__file__).resolve().parents[1]
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _needs_live_state_isolation(request) -> bool:
+    """True for the issue #2177 target subset."""
+    rel = _node_relpath(request)
+    return (
+        rel.startswith("tests/web_api/")
+        or rel.startswith("tests/test_work_service")
+    )
+
+
+def _is_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _patch_module_path(module_name: str, attr: str, value: Path, monkeypatch) -> None:
+    module = sys.modules.get(module_name)
+    if module is not None and hasattr(module, attr):
+        monkeypatch.setattr(module, attr, value)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_web_api_and_work_service_live_state(
+    request,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Sandbox HOME/config and guard PG DSN resolution for #2177 tests.
+
+    The targeted web_api/work_service tests should never read the
+    operator's ``~/.pollypm`` or fall through to the default local
+    ``pollypm`` Postgres database. Production code still sees normal
+    public config/env seams; the fixture just binds those seams to a
+    pytest-owned sandbox for this subset.
+    """
+    if not _needs_live_state_isolation(request):
+        yield
+        return
+
+    sandbox_home = tmp_path / "home"
+    sandbox_pollypm = sandbox_home / ".pollypm"
+    sandbox_pollypm.mkdir(parents=True, exist_ok=True)
+    sandbox_config = sandbox_pollypm / "pollypm.toml"
+
+    monkeypatch.setenv("HOME", str(sandbox_home))
+    monkeypatch.setenv("POLLYPM_HOME", str(sandbox_pollypm))
+
+    import pollypm.config as config_mod
+
+    monkeypatch.setattr(config_mod, "GLOBAL_CONFIG_DIR", sandbox_pollypm)
+    monkeypatch.setattr(config_mod, "DEFAULT_CONFIG_PATH", sandbox_config)
+    _patch_module_path(
+        "pollypm.cli_features.web_api",
+        "DEFAULT_CONFIG_PATH",
+        sandbox_config,
+        monkeypatch,
+    )
+    _patch_module_path(
+        "pollypm.web_api.token",
+        "DEFAULT_TOKEN_PATH",
+        sandbox_pollypm / "api-token",
+        monkeypatch,
+    )
+
+    try:
+        from pollypm.storage import pg_pool
+        from tests.conftest_pg import _is_ambient_live_pg_dsn
+    except ImportError:
+        pg_pool = None  # type: ignore[assignment]
+        _is_ambient_live_pg_dsn = None  # type: ignore[assignment]
+
+    if pg_pool is not None and _is_ambient_live_pg_dsn is not None:
+        real_resolve_dsn = pg_pool.resolve_dsn
+
+        def _guarded_resolve_dsn(config=None):
+            dsn = real_resolve_dsn(config)
+            if _is_ambient_live_pg_dsn(dsn):
+                pytest.fail(
+                    "Targeted test attempted to use the ambient local "
+                    "pollypm Postgres database. Request pg_schema_pool "
+                    "or pass an explicit isolated test DSN.",
+                    pytrace=False,
+                )
+            return dsn
+
+        monkeypatch.setattr(pg_pool, "resolve_dsn", _guarded_resolve_dsn)
+
+    yield
+
+    current_home = Path(os.environ.get("HOME", ""))
+    if current_home == _OPERATOR_HOME:
+        pytest.fail(
+            "Targeted test restored HOME to the operator home; keep "
+            "web_api/work_service tests bound to tmp_path.",
+            pytrace=False,
+        )
+
+    if Path(config_mod.GLOBAL_CONFIG_DIR) == _OPERATOR_POLLYPM_HOME:
+        pytest.fail(
+            "Targeted test restored pollypm.config.GLOBAL_CONFIG_DIR to "
+            "the operator ~/.pollypm.",
+            pytrace=False,
+        )
+
+    if not _is_under(Path(config_mod.DEFAULT_CONFIG_PATH), sandbox_pollypm):
+        pytest.fail(
+            "Targeted test moved pollypm.config.DEFAULT_CONFIG_PATH outside "
+            "the pytest PollyPM sandbox.",
+            pytrace=False,
+        )
+
+
 @pytest.fixture
 def work_service(request, tmp_path):
     """Dispatch fixture returning a pg-backed work service.
@@ -247,14 +382,13 @@ def work_service(request, tmp_path):
 def _real_pollypm_home() -> Path | None:
     """Return the dev machine's ``~/.pollypm`` (or ``None`` if unset).
 
-    Uses ``os.path.expanduser`` rather than ``Path.home()`` so a test
-    that monkeypatched ``Path.home`` doesn't accidentally redirect the
-    guard at its own sandbox — we want the *real* home here.
+    Uses the import-time operator home so tests that monkeypatch
+    ``HOME`` / ``Path.home`` don't accidentally redirect the guard at
+    their own sandbox — we want the *real* home here.
     """
-    home = os.environ.get("HOME") or os.path.expanduser("~")
-    if not home or home == "~":
+    if str(_OPERATOR_HOME) in {"", "~"}:
         return None
-    candidate = Path(home) / ".pollypm"
+    candidate = _OPERATOR_POLLYPM_HOME
     return candidate if candidate.is_dir() else None
 
 

--- a/tests/conftest_pg.py
+++ b/tests/conftest_pg.py
@@ -33,11 +33,64 @@ from __future__ import annotations
 
 import importlib
 import os
+import re
 import uuid
 from pathlib import Path
 from typing import Iterator
+from urllib.parse import unquote, urlsplit
 
 import pytest
+
+
+_LOCAL_PG_FALLBACK_DSNS = (
+    "postgresql://localhost:5432/pollypm_test",
+)
+
+_LOCAL_PG_HOSTS = {"", "localhost", "127.0.0.1", "::1"}
+
+
+def _keyword_dsn_value(dsn: str, key: str) -> str | None:
+    match = re.search(rf"(?:^|\s){re.escape(key)}=('[^']*'|\"[^\"]*\"|\S+)", dsn)
+    if match is None:
+        return None
+    value = match.group(1).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value
+
+
+def _is_ambient_live_pg_dsn(dsn: str) -> bool:
+    """Return True for the operator-default local ``pollypm`` database.
+
+    Testcontainers also commonly uses a database named ``pollypm``, but
+    on a randomized forwarded port. The unsafe shape is the ambient
+    local endpoint that production defaults to: local host/socket,
+    default port, database name ``pollypm``.
+    """
+    stripped = dsn.strip()
+    if "://" in stripped:
+        try:
+            parsed = urlsplit(stripped)
+            port = parsed.port
+        except ValueError:
+            return False
+        db_name = unquote(parsed.path or "").lstrip("/").split("/", 1)[0]
+        host = (parsed.hostname or "").lower()
+        return (
+            db_name == "pollypm"
+            and host in _LOCAL_PG_HOSTS
+            and (port is None or port == 5432)
+        )
+
+    db_name = _keyword_dsn_value(stripped, "dbname")
+    if db_name != "pollypm":
+        return False
+    host = (_keyword_dsn_value(stripped, "host") or "").lower()
+    port = _keyword_dsn_value(stripped, "port")
+    return (
+        (host in _LOCAL_PG_HOSTS or host.startswith("/"))
+        and (port in {None, "", "5432"})
+    )
 
 
 def _has_docker() -> bool:
@@ -58,8 +111,8 @@ def _local_pg_with_vector() -> str | None:
     """Return a DSN to a local pg with pgvector installed, or None.
 
     Used as the fallback when Docker isn't available. Tries the env
-    DSN first, then the conventional dev DBs (``pollypm_test``,
-    ``pollypm``); returns the first one that's reachable and has the
+    DSN first, then the conventional test DB (``pollypm_test``);
+    returns the first one that's reachable and has the
     ``vector`` extension available. Returns None on missing driver or
     no reachable candidate.
     """
@@ -70,13 +123,15 @@ def _local_pg_with_vector() -> str | None:
     candidates: list[str] = []
     env = os.environ.get("POLLYPM_PG_DSN", "").strip()
     if env:
+        if _is_ambient_live_pg_dsn(env):
+            raise RuntimeError(
+                "Refusing to run pg-backed tests against the ambient "
+                "local pollypm database. Use Docker/testcontainers or "
+                "set POLLYPM_PG_DSN to an isolated test database such "
+                "as pollypm_test."
+            )
         candidates.append(env)
-    candidates.extend(
-        [
-            "postgresql://localhost:5432/pollypm_test",
-            "postgresql://localhost:5432/pollypm",
-        ]
-    )
+    candidates.extend(_LOCAL_PG_FALLBACK_DSNS)
     for dsn in candidates:
         try:
             conn = psycopg.connect(dsn, connect_timeout=2)
@@ -126,7 +181,10 @@ def _pg_container() -> Iterator[str]:
             finally:
                 container.stop()
 
-    dsn = _local_pg_with_vector()
+    try:
+        dsn = _local_pg_with_vector()
+    except RuntimeError as exc:
+        pytest.fail(str(exc), pytrace=False)
     if dsn is None:
         pytest.skip(
             "no pg container / local pg with vector ext; install Docker "

--- a/tests/test_pg_fixtures.py
+++ b/tests/test_pg_fixtures.py
@@ -23,6 +23,42 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
+# Ambient database guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://localhost:5432/pollypm",
+        "postgresql://localhost/pollypm",
+        "postgresql:///pollypm",
+        "dbname=pollypm",
+        "host=/var/run/postgresql dbname=pollypm",
+    ],
+)
+def test_pg_fixture_rejects_ambient_live_pollypm_dsn(dsn: str) -> None:
+    from tests.conftest_pg import _is_ambient_live_pg_dsn
+
+    assert _is_ambient_live_pg_dsn(dsn) is True
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://localhost:5432/pollypm_test",
+        "postgresql://localhost:15432/pollypm",
+        "postgresql://postgres.example.invalid:5432/pollypm",
+        "host=localhost dbname=pollypm_test",
+    ],
+)
+def test_pg_fixture_allows_isolated_test_dsns(dsn: str) -> None:
+    from tests.conftest_pg import _is_ambient_live_pg_dsn
+
+    assert _is_ambient_live_pg_dsn(dsn) is False
+
+
+# ---------------------------------------------------------------------------
 # pg_work_service fixture
 # ---------------------------------------------------------------------------
 

--- a/tests/web_api/conftest.py
+++ b/tests/web_api/conftest.py
@@ -1,10 +1,11 @@
 """Shared fixtures for the Web API integration tests.
 
-Each fixture builds a tmp ``PollyPMConfig`` whose work-DB path
-points at a per-test SQLite file, registers a single project, and
-wires the bearer-auth token into a tmp file. The FastAPI app is
-constructed via :func:`pollypm.web_api.create_app` so the tests
-exercise the same code path ``pm serve`` uses at runtime.
+Each fixture builds a tmp ``PollyPMConfig`` with one tracked project,
+wires the bearer-auth token into a tmp file, and opens work-service
+state through the shared per-test Postgres schema fixture. The FastAPI
+app is constructed via :func:`pollypm.web_api.create_app` so the tests
+exercise the same code path ``pm serve`` uses at runtime without
+touching the operator's live ``~/.pollypm`` or default ``pollypm`` DB.
 """
 
 from __future__ import annotations
@@ -43,8 +44,19 @@ def workspace_root(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def api_config(tmp_path: Path, project_root: Path, workspace_root: Path) -> PollyPMConfig:
+def api_pg_pool(pg_schema_pool):
+    """Require a per-test pg schema before any app/client opens storage."""
+    return pg_schema_pool
+
+
+@pytest.fixture
+def api_config(
+    project_root: Path,
+    workspace_root: Path,
+    api_pg_pool,
+) -> PollyPMConfig:
     """A minimal :class:`PollyPMConfig` with one tracked project."""
+    del api_pg_pool
     base_dir = workspace_root / ".pollypm"
     state_db = base_dir / "state.db"
     config = PollyPMConfig(

--- a/tests/web_api/test_isolation.py
+++ b/tests/web_api/test_isolation.py
@@ -1,0 +1,50 @@
+"""Regression guards for the web_api/work_service test sandbox (#2177)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def test_web_api_tests_run_with_sandboxed_pollypm_home() -> None:
+    import pollypm.config as config_mod
+    import pollypm.web_api.token as token_mod
+
+    home = Path(os.environ["HOME"])
+    pollypm_home = home / ".pollypm"
+
+    assert home.name == "home"
+    assert pollypm_home.is_dir()
+    assert Path(config_mod.GLOBAL_CONFIG_DIR) == pollypm_home
+    assert Path(config_mod.DEFAULT_CONFIG_PATH) == pollypm_home / "pollypm.toml"
+    assert Path(token_mod.DEFAULT_TOKEN_PATH) == pollypm_home / "api-token"
+
+
+def test_web_api_work_service_writes_land_in_per_test_pg_schema(
+    api_config,
+    api_pg_pool,
+) -> None:
+    from pollypm.work.factory import create_work_service
+
+    with create_work_service(config=api_config, project_key="myproj") as svc:
+        task = svc.create(
+            title="schema isolation guard",
+            type="task",
+            project="myproj",
+            flow_template="default",
+            roles={"worker": "agent-1"},
+            created_by="pytest",
+        )
+
+    with api_pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT title
+            FROM work_tasks
+            WHERE project = %s AND task_number = %s
+            """,
+            (task.project, task.task_number),
+        )
+        row = cur.fetchone()
+
+    assert row == ("schema isolation guard",)


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Sandboxes HOME, POLLYPM_HOME, config path, and token path for the targeted web API/work-service test subset.
- Rejects ambient local pollypm Postgres DSNs and removes the live pollypm DB fallback from PG fixture discovery.
- Adds regression guards for unsafe DSN detection and web API test sandbox isolation.

Fixes #2177.

## Tests
- `uv run --extra dev ruff check tests/conftest.py tests/conftest_pg.py tests/test_pg_fixtures.py tests/web_api/conftest.py tests/web_api/test_isolation.py` (pass)
- `uv run --extra dev python -m pytest tests/test_pg_fixtures.py::test_pg_fixture_rejects_ambient_live_pollypm_dsn tests/test_pg_fixtures.py::test_pg_fixture_allows_isolated_test_dsns -q` (pass, 9 passed)
- `uv run --extra dev python -m pytest tests/web_api/test_isolation.py::test_web_api_tests_run_with_sandboxed_pollypm_home -q` (pass)
- Worker verification: narrow non-PG slice passed (38 passed), PG web API isolation smoke passed, representative web API task endpoint slice passed.

Known broader-run status from worker verification:
- `uv run --extra test ...` failed at collection because `openapi_spec_validator` is not in the test extra.
- `uv run --extra dev ...` broader subset still had 2 existing queue endpoint expectation failures and 5 existing real-home guard errors from live cockpit checkpoint writes under `/Users/sam/.pollypm`.