### PR TITLE
refactor(schedulers): remove supervisor type backedge

### DIFF
--- a/src/pollypm/schedulers/base.py
+++ b/src/pollypm/schedulers/base.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Protocol
-
-if TYPE_CHECKING:
-    from pollypm.supervisor import Supervisor
+from typing import Any, Protocol
 
 
 @dataclass(slots=True)
@@ -19,12 +16,26 @@ class ScheduledJob:
     last_error: str | None = None
 
 
+class SchedulerHost(Protocol):
+    """Structural host surface required by scheduler backends.
+
+    ``pollypm.supervisor`` imports the scheduler facade at module load, so
+    the scheduler protocol cannot type-import ``Supervisor`` without
+    reintroducing the #1367 static import back-edge. Scheduler backends only
+    need the config/message-store surface below and an opaque object for job
+    executors, so a structural protocol keeps ownership local.
+    """
+
+    config: Any
+    msg_store: Any
+
+
 class SchedulerBackend(Protocol):
     name: str
 
     def schedule(
         self,
-        supervisor: "Supervisor",
+        supervisor: SchedulerHost,
         *,
         kind: str,
         run_at: datetime,
@@ -32,6 +43,6 @@ class SchedulerBackend(Protocol):
         interval_seconds: int | None = None,
     ) -> ScheduledJob: ...
 
-    def list_jobs(self, supervisor: "Supervisor") -> list[ScheduledJob]: ...
+    def list_jobs(self, supervisor: SchedulerHost) -> list[ScheduledJob]: ...
 
-    def run_due(self, supervisor: "Supervisor", *, now: datetime | None = None) -> list[ScheduledJob]: ...
+    def run_due(self, supervisor: SchedulerHost, *, now: datetime | None = None) -> list[ScheduledJob]: ...

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -64,7 +64,6 @@ _SUPERVISOR_IMPORT_ALLOWLIST: frozenset[str] = frozenset(
         # the rail grows (tracked under the decomposition meta-issue).
         "src/pollypm/job_runner.py",
         "src/pollypm/plugins_builtin/core_recurring/plugin.py",
-        "src/pollypm/schedulers/base.py",
         "src/pollypm/session_intelligence.py",
         "src/pollypm/workers.py",
         # TODO(#2061-followup): pre-existing direct imports in two CLI/API


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Replaces the scheduler protocol's type-only `Supervisor` import with a structural `SchedulerHost` protocol.
- Removes `src/pollypm/schedulers/base.py` from the direct-supervisor-import allowlist.
- Keeps scheduler backends dependent only on the config/msg_store host surface they actually use.

Refs #1367.

## Tests
- `uv run --extra dev ruff check src/pollypm/schedulers/base.py tests/test_import_boundary.py` (pass)
- `uv run --extra dev python -m pytest tests/test_import_boundary.py::test_supervisor_import_allowlist_matches_reality tests/test_import_boundary.py::test_supervisor_import_allowlist_has_no_stale_entries -q` (pass)
- `git diff --check` (pass)