### PR TITLE
feat(api): add project plan decisions

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -598,6 +598,80 @@ paths:
         "409":
           $ref: "#/components/responses/Conflict"
 
+  /projects/{key}/plan/approve:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    post:
+      tags: [Plans]
+      operationId: approveProjectPlan
+      summary: Approve the active project plan review
+      description: |
+        Finds the active `plan_project` task parked at
+        `work_status=review` and `current_node_id=user_approval`,
+        then routes through the work-service `approve` transition.
+        The lifecycle service owns actor validation, node advancement,
+        decision persistence, and follow-up assignment.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlanApproveRequest"
+      responses:
+        "200":
+          description: Plan approved; response carries the post-transition task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /projects/{key}/plan/reject:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    post:
+      tags: [Plans]
+      operationId: rejectProjectPlan
+      summary: Reject the active project plan review
+      description: |
+        Finds the active `plan_project` task parked at
+        `work_status=review` and `current_node_id=user_approval`,
+        then routes through the work-service `reject` transition.
+        Rejection requires a reason and sends the task to its
+        configured reject node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlanRejectRequest"
+      responses:
+        "200":
+          description: Plan rejected; response carries the post-transition task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
   /projects/{key}/chat:
     parameters:
       - $ref: "#/components/parameters/ProjectKey"
@@ -4451,6 +4525,34 @@ components:
           type: string
           description: Architect critic notes; nullable.
         created_at: { type: string, format: date-time }
+
+    PlanApproveRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+          minLength: 1
+          default: user
+          description: Human/operator actor approving the plan review.
+        note:
+          type: string
+          description: Optional approval note recorded on the review decision.
+
+    PlanRejectRequest:
+      type: object
+      additionalProperties: false
+      required: [reason]
+      properties:
+        actor:
+          type: string
+          minLength: 1
+          default: user
+          description: Human/operator actor rejecting the plan review.
+        reason:
+          type: string
+          minLength: 1
+          description: Required rejection reason recorded on the review decision.
 
     # ---- Inbox ------------------------------------------------------
     InboxItemType:

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -252,6 +252,38 @@ class Plan(BaseModel):
     created_at: datetime
 
 
+class PlanApproveRequest(BaseModel):
+    """Body for ``POST /projects/{key}/plan/approve``."""
+
+    model_config = {"extra": "forbid"}
+
+    actor: str = Field(
+        default="user",
+        min_length=1,
+        description="Human/operator actor approving the plan review.",
+    )
+    note: str | None = Field(
+        default=None,
+        description="Optional approval note recorded on the review decision.",
+    )
+
+
+class PlanRejectRequest(BaseModel):
+    """Body for ``POST /projects/{key}/plan/reject``."""
+
+    model_config = {"extra": "forbid"}
+
+    actor: str = Field(
+        default="user",
+        min_length=1,
+        description="Human/operator actor rejecting the plan review.",
+    )
+    reason: str = Field(
+        min_length=1,
+        description="Required rejection reason recorded on the review decision.",
+    )
+
+
 class TaskDetail(TaskSummary):
     description: str
     acceptance_criteria: str | None = None
@@ -772,7 +804,9 @@ __all__ = [
     "InboxReplyRequest",
     "InboxSnoozeRequest",
     "Plan",
+    "PlanApproveRequest",
     "PlanJudgmentCall",
+    "PlanRejectRequest",
     "Project",
     "ProjectActivityEntry",
     "ProjectDrilldown",

--- a/src/pollypm/web_api/routes/projects.py
+++ b/src/pollypm/web_api/routes/projects.py
@@ -27,19 +27,24 @@ from pollypm.web_api.errors import not_found
 from pollypm.web_api.models import (
     ActionResult,
     Plan,
+    PlanApproveRequest,
+    PlanRejectRequest,
     Project,
     ProjectDrilldown,
     ProjectListResponse,
+    TaskActionResult,
     TaskListResponse,
 )
 from pollypm.web_api.routes._deps import ConfigDep
 from pollypm.web_api.service import (
     archive_project,
+    approve_active_plan,
     get_active_plan,
     init_project_guide_for_role,
     list_project_tasks,
     list_projects,
     project_drilldown,
+    reject_active_plan,
     set_project_tracked,
 )
 
@@ -187,6 +192,73 @@ def get_project_plan_endpoint(
             hint="Plans appear here once a task reaches the user_approval node.",
         )
     return plan
+
+
+@router.post(
+    "/projects/{key}/plan/approve",
+    response_model=TaskActionResult,
+    summary="Approve the active project plan review",
+    operation_id="approveProjectPlan",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project or active plan review not found."},
+        "409": {"description": "Active plan is not currently reviewable."},
+        "422": {"description": "Actor or review gates rejected the decision."},
+        "503": {"description": "Backing store unavailable."},
+    },
+)
+def approve_project_plan_endpoint(
+    key: str,
+    config: ConfigDep,
+    body: PlanApproveRequest | None = None,
+) -> TaskActionResult:
+    if key not in config.projects:
+        raise not_found(f"Project not registered: {key}")
+    decision = body or PlanApproveRequest()
+    task = approve_active_plan(
+        config,
+        key,
+        actor=decision.actor,
+        note=decision.note,
+    )
+    return TaskActionResult(
+        ok=True,
+        message=f"approved plan {task.task_id}",
+        task=task,
+    )
+
+
+@router.post(
+    "/projects/{key}/plan/reject",
+    response_model=TaskActionResult,
+    summary="Reject the active project plan review",
+    operation_id="rejectProjectPlan",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project or active plan review not found."},
+        "409": {"description": "Active plan is not currently reviewable."},
+        "422": {"description": "Body validation or review gates rejected the decision."},
+        "503": {"description": "Backing store unavailable."},
+    },
+)
+def reject_project_plan_endpoint(
+    key: str,
+    body: PlanRejectRequest,
+    config: ConfigDep,
+) -> TaskActionResult:
+    if key not in config.projects:
+        raise not_found(f"Project not registered: {key}")
+    task = reject_active_plan(
+        config,
+        key,
+        actor=body.actor,
+        reason=body.reason,
+    )
+    return TaskActionResult(
+        ok=True,
+        message=f"rejected plan {task.task_id}",
+        task=task,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -1144,18 +1144,7 @@ def _has_pending_plan_review(svc, project_key: str) -> bool:
     Phase 1 only needs a boolean, so we read tasks-in-review and check
     whether their flow template is plan-shaped.
     """
-    try:
-        tasks = svc.list_tasks(project=project_key, work_status="review")
-    except Exception:  # noqa: BLE001
-        return False
-    for task in tasks:
-        flow_id = getattr(task, "flow_template_id", "") or ""
-        if "plan" in flow_id.lower():
-            return True
-        labels = getattr(task, "labels", []) or []
-        if any("plan" in lbl.lower() for lbl in labels):
-            return True
-    return False
+    return _active_plan_task_for_project(svc, project_key) is not None
 
 
 def _count_open_inbox(config: PollyPMConfig, project_key: str) -> int:
@@ -3107,7 +3096,8 @@ def get_active_plan(
         with _open_work_service_readonly(
             config=config, project_key=project_key, project_path=project.path
         ) as svc:
-            plan = _active_plan_for_project(svc, project_key)
+            task = _active_plan_task_for_project(svc, project_key)
+            plan = _build_plan(svc, task) if task is not None else None
             if plan is None:
                 return None
             if version is not None and plan.version != version:
@@ -3128,21 +3118,152 @@ def get_active_plan(
         ) from exc
 
 
-def _active_plan_for_project(svc, project_key: str) -> APIPlan | None:
+def _active_plan_task_for_project(svc, project_key: str):
     try:
         review_tasks = svc.list_tasks(project=project_key, work_status="review")
     except Exception:  # noqa: BLE001
         review_tasks = []
-    return _active_plan_from_review_tasks(svc, review_tasks)
+    return _active_plan_task_from_review_tasks(review_tasks)
+
+
+def _active_plan_task_from_review_tasks(review_tasks: list[object]):
+    candidates = [
+        t for t in review_tasks
+        if _is_plan_task(t)
+        and (getattr(t, "current_node_id", "") or "") == "user_approval"
+    ]
+    if not candidates:
+        return None
+    # Newest plan_version wins; updated_at breaks ties so repeated
+    # review tasks in the same project do not return a stale decision.
+    def _plan_sort_key(task) -> tuple[int, str]:
+        updated = getattr(task, "updated_at", None)
+        updated_key = (
+            updated.isoformat()
+            if hasattr(updated, "isoformat")
+            else str(updated or "")
+        )
+        return (getattr(task, "plan_version", 1) or 1, updated_key)
+
+    candidates.sort(key=_plan_sort_key, reverse=True)
+    return candidates[0]
 
 
 def _active_plan_from_review_tasks(svc, review_tasks: list[object]) -> APIPlan | None:
-    candidates = [t for t in review_tasks if _is_plan_task(t)]
-    if not candidates:
-        return None
-    # Newest plan_version wins.
-    candidates.sort(key=lambda t: getattr(t, "plan_version", 1) or 1, reverse=True)
-    return _build_plan(svc, candidates[0])
+    task = _active_plan_task_from_review_tasks(review_tasks)
+    return _build_plan(svc, task) if task is not None else None
+
+
+def _active_plan_for_project(svc, project_key: str) -> APIPlan | None:
+    task = _active_plan_task_for_project(svc, project_key)
+    return _build_plan(svc, task) if task is not None else None
+
+
+def approve_active_plan(
+    config: PollyPMConfig,
+    project_key: str,
+    *,
+    actor: str = "user",
+    note: str | None = None,
+) -> APITaskDetail:
+    """Approve the active plan-review task for ``project_key``."""
+    return _decide_active_plan(
+        config,
+        project_key,
+        actor=actor,
+        decision="approve",
+        reason=note,
+    )
+
+
+def reject_active_plan(
+    config: PollyPMConfig,
+    project_key: str,
+    *,
+    actor: str = "user",
+    reason: str,
+) -> APITaskDetail:
+    """Reject the active plan-review task for ``project_key``."""
+    return _decide_active_plan(
+        config,
+        project_key,
+        actor=actor,
+        decision="reject",
+        reason=reason,
+    )
+
+
+def _decide_active_plan(
+    config: PollyPMConfig,
+    project_key: str,
+    *,
+    actor: str,
+    decision: str,
+    reason: str | None,
+) -> APITaskDetail:
+    from pollypm.work.factory import create_work_service
+    from pollypm.work.service_support import (
+        InvalidTransitionError,
+        TaskNotFoundError,
+        ValidationError as WorkValidationError,
+    )
+
+    project = config.projects.get(project_key)
+    if project is None:
+        raise not_found(f"Project not registered: {project_key}")
+
+    try:
+        with create_work_service(
+            config=config, project_key=project_key, project_path=project.path
+        ) as svc:
+            task = _active_plan_task_for_project(svc, project_key)
+            if task is None:
+                raise not_found(
+                    "No plan in review for this project",
+                    hint=(
+                        "Plans can be approved or rejected only while a "
+                        "plan_project task is parked at the user_approval node."
+                    ),
+                )
+            try:
+                if decision == "approve":
+                    updated = svc.approve(task.task_id, actor, reason)
+                else:
+                    updated = svc.reject(task.task_id, actor, reason or "")
+            except TaskNotFoundError as exc:
+                raise not_found(f"Task not found: {task.task_id}") from exc
+            except InvalidTransitionError as exc:
+                raise APIError(
+                    status_code=409,
+                    code="invalid_state",
+                    message=str(exc) or f"Plan {task.task_id} is not reviewable.",
+                    hint=(
+                        "Refresh the project plan; only an active "
+                        "user_approval review can be decided."
+                    ),
+                ) from exc
+            except WorkValidationError as exc:
+                raise APIError(
+                    status_code=422,
+                    code="validation_error",
+                    message=str(exc) or f"Plan decision rejected for {task.task_id}.",
+                    hint=(
+                        "Use an authorized human actor such as `user`, "
+                        "and include a rejection reason when rejecting."
+                    ),
+                ) from exc
+            return _task_to_detail_with_plan(updated, svc=svc)
+    except _BACKING_STORE_ERRORS as exc:
+        logger.warning(
+            "plan decision: backing store error for %s: %s",
+            project_key,
+            exc,
+            exc_info=True,
+        )
+        raise service_unavailable(
+            f"Backing store unavailable for project {project_key}",
+            hint="Retry shortly; check `pm doctor` if the failure persists.",
+        ) from exc
 
 
 def _build_plan(svc, task) -> APIPlan:

--- a/tests/web_api/test_endpoints.py
+++ b/tests/web_api/test_endpoints.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import inspect
 import sqlite3
+from datetime import UTC, datetime
 
 import pytest
 
@@ -261,6 +262,138 @@ def test_get_project_plan_404_when_no_plan(client, auth_headers) -> None:
     body = response.json()
     assert body["error"]["code"] == "not_found"
     assert "hint" in body["error"]
+
+
+_PLAN_BODY = (
+    "# Project plan\n\n"
+    "## Summary\n"
+    "Ship the operator plan review surface.\n\n"
+    "## Judgment calls\n"
+    "- Keep approval in the work-service lifecycle\n\n"
+    "## Critic synthesis\n"
+    "No unresolved blockers.\n"
+)
+
+
+def _seed_active_plan_review(api_config, project_root):
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        task = make_task(
+            svc,
+            project="myproj",
+            title="Plan myproj",
+            description=_PLAN_BODY,
+            flow_template="plan_project",
+            roles={"architect": "architect"},
+            labels=["plan_review"],
+        )
+        now = datetime.now(UTC).isoformat()
+        if hasattr(svc, "_pool"):
+            with svc._pool.connection() as conn, conn.cursor() as cur:  # noqa: SLF001
+                cur.execute(
+                    """
+                    UPDATE work_tasks
+                    SET work_status = 'review',
+                        current_node_id = 'user_approval',
+                        assignee = 'human',
+                        updated_at = %s
+                    WHERE project = %s AND task_number = %s
+                    """,
+                    (now, task.project, task.task_number),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO work_node_executions
+                        (task_project, task_number, node_id, visit, status, started_at)
+                    VALUES (%s, %s, 'user_approval', 1, 'active', %s)
+                    """,
+                    (task.project, task.task_number, now),
+                )
+                conn.commit()
+        else:
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """
+                    UPDATE work_tasks
+                    SET work_status = 'review',
+                        current_node_id = 'user_approval',
+                        assignee = 'human',
+                        updated_at = ?
+                    WHERE project = ? AND task_number = ?
+                    """,
+                    (now, task.project, task.task_number),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO work_node_executions
+                        (task_project, task_number, node_id, visit, status, started_at)
+                    VALUES (?, ?, 'user_approval', 1, 'active', ?)
+                    """,
+                    (task.project, task.task_number, now),
+                )
+    return task
+
+
+def test_get_project_plan_returns_user_approval_plan(
+    api_config, client, auth_headers, project_root
+) -> None:
+    task = _seed_active_plan_review(api_config, project_root)
+
+    response = client.get("/api/v1/projects/myproj/plan", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["task_id"] == task.task_id
+    assert "operator plan review" in body["summary"]
+    assert body["judgment_calls"] == [
+        {"point": "Keep approval in the work-service lifecycle"}
+    ]
+
+
+def test_approve_project_plan_decides_active_review(
+    api_config, client, auth_headers, project_root
+) -> None:
+    task = _seed_active_plan_review(api_config, project_root)
+
+    response = client.post(
+        "/api/v1/projects/myproj/plan/approve",
+        headers=auth_headers,
+        json={"actor": "user", "note": "ship it"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["message"] == f"approved plan {task.task_id}"
+    assert body["task"]["task_id"] == task.task_id
+    assert body["task"]["work_status"] == "in_progress"
+    assert body["task"]["current_node_id"] == "emit"
+
+
+def test_reject_project_plan_requires_reason_and_bounces_to_rework(
+    api_config, client, auth_headers, project_root
+) -> None:
+    task = _seed_active_plan_review(api_config, project_root)
+
+    missing_reason = client.post(
+        "/api/v1/projects/myproj/plan/reject",
+        headers=auth_headers,
+        json={"actor": "user"},
+    )
+    assert missing_reason.status_code == 422
+
+    response = client.post(
+        "/api/v1/projects/myproj/plan/reject",
+        headers=auth_headers,
+        json={"actor": "user", "reason": "Needs a narrower scope"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["message"] == f"rejected plan {task.task_id}"
+    assert body["task"]["task_id"] == task.task_id
+    assert body["task"]["work_status"] == "rework"
+    assert body["task"]["current_node_id"] == "synthesize"
 
 
 def test_list_inbox_empty_state(client, auth_headers) -> None:

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -32,6 +32,8 @@ PHASE_1_PATHS: set[tuple[str, str]] = {
     ("GET", "/projects/{key}"),
     ("GET", "/projects/{key}/tasks"),
     ("GET", "/projects/{key}/plan"),
+    ("POST", "/projects/{key}/plan/approve"),
+    ("POST", "/projects/{key}/plan/reject"),
     ("GET", "/tasks/{project}/{n}"),
     ("GET", "/inbox"),
     ("GET", "/inbox/{id}"),


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds `POST /api/v1/projects/{key}/plan/approve` and `/reject`.
- Finds the active `plan_project` review at `current_node_id=user_approval` and delegates the decision to the existing work-service `approve`/`reject` lifecycle methods.
- Updates OpenAPI docs and conformance coverage for the new decision routes.

Fixes #2211.

## Tests
- `uv run --extra dev ruff check src/pollypm/web_api/models.py src/pollypm/web_api/routes/projects.py src/pollypm/web_api/service.py tests/web_api/test_endpoints.py tests/web_api/test_openapi_conformance.py` (pass)
- `uv run --extra dev python -m pytest tests/web_api/test_endpoints.py::test_get_project_plan_returns_user_approval_plan tests/web_api/test_endpoints.py::test_approve_project_plan_decides_active_review tests/web_api/test_endpoints.py::test_reject_project_plan_requires_reason_and_bounces_to_rework tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31 tests/web_api/test_openapi_conformance.py::test_contract_lists_phase_1_paths tests/web_api/test_openapi_conformance.py::test_implementation_serves_phase_1_paths -q` (pass, 6 passed)
- `git diff --check` (pass)