### PR TITLE
fix(migrate): verify apply clears gate

### DIFF
--- a/src/pollypm/cli_features/migrate.py
+++ b/src/pollypm/cli_features/migrate.py
@@ -58,9 +58,7 @@ def _resolve_state_db(config_path: Path) -> Path:
     """Return the workspace-scope state.db path from the resolved config."""
     path = resolve_config_path(config_path)
     if not path.exists():
-        raise typer.BadParameter(
-            f"Config not found at {path}. Run `pm onboard` first."
-        )
+        raise typer.BadParameter(f"Config not found at {path}. Run `pm onboard` first.")
     config = load_config(path)
     return config.project.state_db
 
@@ -89,9 +87,7 @@ def register_migrate_commands(app: typer.Typer) -> None:
         ),
     ) -> None:
         if check == apply:
-            raise typer.BadParameter(
-                "Specify exactly one of --check or --apply."
-            )
+            raise typer.BadParameter("Specify exactly one of --check or --apply.")
 
         db_path = _resolve_state_db(config_path)
 
@@ -99,12 +95,20 @@ def register_migrate_commands(app: typer.Typer) -> None:
         # tool that fixes the situation the gate protects against, so
         # opening the store here must not trip the guard.
         from pollypm.store import migrations as _migrations
+
+        previous_bypass = os.environ.get("POLLYPM_SKIP_MIGRATION_GATE")
         _migrations.set_bypass(True)
 
-        if check:
-            _run_check(db_path)
-        else:
-            _run_apply(db_path, force=force)
+        try:
+            if check:
+                _run_check(db_path)
+            else:
+                _run_apply(db_path, force=force)
+        finally:
+            if previous_bypass is None:
+                _migrations.set_bypass(False)
+            else:
+                os.environ["POLLYPM_SKIP_MIGRATION_GATE"] = previous_bypass
 
 
 def _run_check(db_path: Path) -> None:
@@ -198,8 +202,7 @@ def _refuse_live_processes(live: list[tuple[str, int, Path]]) -> None:
     from pollypm.structured_message import StructuredUserMessage
 
     bullets = "\n".join(
-        f"  - {label} (pid {pid}, pidfile {pidfile})"
-        for label, pid, pidfile in live
+        f"  - {label} (pid {pid}, pidfile {pidfile})" for label, pid, pidfile in live
     )
     msg = StructuredUserMessage(
         summary="Refusing to apply migrations — live PollyPM process detected.",
@@ -234,13 +237,34 @@ def _run_apply(db_path: Path, *, force: bool = False) -> None:
         outcome = _migrations.apply(db_path)
     except _migrations.UnusableDatabaseError as exc:
         _migrations.exit_unusable_database(exc)
+    except _migrations.MigrationApplyError as exc:
+        from pollypm.structured_message import StructuredUserMessage
+
+        status = _migrations.MigrationStatus(
+            db_path=exc.db_path,
+            pending=list(exc.pending),
+        )
+        msg = StructuredUserMessage(
+            summary="Migration apply FAILED — gate still reports pending migrations.",
+            why=(
+                "PollyPM replayed the migration runners, but the follow-up "
+                "gate check still found pending schema versions. Reporting "
+                "success here would leave the next launch blocked."
+            ),
+            next_action=(
+                "Run `pm migrate --check` and inspect the pending list below; "
+                "do not bypass the migration gate until the schema records "
+                "match the installed version."
+            ),
+            details=_migrations.format_pending_summary(status),
+        )
+        typer.echo(msg.render_cli(show_details=True), err=True)
+        raise typer.Exit(code=3) from exc
     if outcome.already_up_to_date:
         typer.echo("All migrations up to date.")
     else:
         migration_word = "migration" if len(outcome.applied) == 1 else "migrations"
-        typer.echo(
-            f"Applied {len(outcome.applied)} {migration_word} to {db_path}:"
-        )
+        typer.echo(f"Applied {len(outcome.applied)} {migration_word} to {db_path}:")
         for item in outcome.applied:
             typer.echo(f"  [{item.namespace}] v{item.version}: {item.description}")
     _run_legacy_per_project_db_migration()
@@ -277,11 +301,14 @@ def _run_legacy_per_project_db_migration() -> None:
                 err=True,
             )
             continue
-        copied_summary = ", ".join(
-            f"{table}={count}"
-            for table, count in report.rows_copied.items()
-            if count
-        ) or "no rows"
+        copied_summary = (
+            ", ".join(
+                f"{table}={count}"
+                for table, count in report.rows_copied.items()
+                if count
+            )
+            or "no rows"
+        )
         archive = (
             f" → archived {report.archived_to.name}"
             if report.archived_to is not None

--- a/src/pollypm/store/migrations.py
+++ b/src/pollypm/store/migrations.py
@@ -54,6 +54,19 @@ class UnusableDatabaseError(RuntimeError):
         super().__init__(f"{db_path}: {detail}")
 
 
+class MigrationApplyError(RuntimeError):
+    """Raised when an apply run finishes but pending migrations remain."""
+
+    def __init__(self, db_path: Path, pending: list["PendingMigration"]) -> None:
+        self.db_path = db_path
+        self.pending = list(pending)
+        count = len(self.pending)
+        plural = "s" if count != 1 else ""
+        super().__init__(
+            f"{db_path}: migration apply left {count} pending migration{plural}"
+        )
+
+
 @dataclass(frozen=True)
 class PendingMigration:
     """One migration that has not yet been applied to a target DB."""
@@ -128,6 +141,7 @@ def _readonly_connect(db_path: Path) -> sqlite3.Connection | None:
     # #1674: percent-encode so URI metacharacters in the workspace path
     # don't get parsed as fragment/query.
     from pollypm.storage.sqlite_pragmas import readonly_uri
+
     uri = readonly_uri(db_path)
     try:
         return sqlite3.connect(uri, uri=True, timeout=1.0)
@@ -159,9 +173,7 @@ def _ensure_readable_sqlite(conn: sqlite3.Connection, db_path: Path) -> None:
 def _applied_version(conn: sqlite3.Connection, table: str) -> int:
     """Return ``MAX(version)`` from a schema-tracking table, 0 if missing."""
     try:
-        row = conn.execute(
-            f"SELECT COALESCE(MAX(version), 0) FROM {table}"
-        ).fetchone()
+        row = conn.execute(f"SELECT COALESCE(MAX(version), 0) FROM {table}").fetchone()
     except sqlite3.Error:
         return 0
     return int(row[0]) if row and row[0] is not None else 0
@@ -187,9 +199,7 @@ def inspect(db_path: Path) -> MigrationStatus:
         # Missing DB — all migrations are pending.
         pending = [
             PendingMigration(NAMESPACE_STATE, v, d) for v, d in state_declared
-        ] + [
-            PendingMigration(NAMESPACE_WORK, v, d) for v, d in work_declared
-        ]
+        ] + [PendingMigration(NAMESPACE_WORK, v, d) for v, d in work_declared]
         return MigrationStatus(
             db_path=db_path,
             applied={NAMESPACE_STATE: 0, NAMESPACE_WORK: 0},
@@ -215,7 +225,10 @@ def inspect(db_path: Path) -> MigrationStatus:
             pending.append(PendingMigration(NAMESPACE_WORK, version, desc))
 
     return MigrationStatus(
-        db_path=db_path, applied=applied, latest=latest, pending=pending,
+        db_path=db_path,
+        applied=applied,
+        latest=latest,
+        pending=pending,
     )
 
 
@@ -245,6 +258,8 @@ def _table_set(db_path: Path) -> set[str]:
 
 def _default_clone_path() -> Path:
     """Location of the dry-run clone (~/.pollypm/migration-check.db)."""
+    from pollypm.config import GLOBAL_CONFIG_DIR
+
     home = Path(os.environ.get("POLLYPM_HOME", str(GLOBAL_CONFIG_DIR)))
     return home / "migration-check.db"
 
@@ -263,7 +278,10 @@ def check_against_clone(
     status = inspect(db_path)
     if not status.pending:
         return CheckOutcome(
-            ok=True, applied=[], tables_changed=[], clone_path=None,
+            ok=True,
+            applied=[],
+            tables_changed=[],
+            clone_path=None,
         )
 
     clone = clone_path or _default_clone_path()
@@ -279,6 +297,9 @@ def check_against_clone(
 
     try:
         _apply_all(clone)
+        status_after = inspect(clone)
+        if status_after.pending:
+            raise MigrationApplyError(clone, list(status_after.pending))
     except Exception as exc:  # noqa: BLE001
         # Roll back by removing the clone — there is no live connection
         # to issue a SQL rollback against (StateStore opens its own).
@@ -309,21 +330,33 @@ def _apply_all(db_path: Path) -> None:
     """Replay every migration idempotently by opening the existing writers.
 
     ``StateStore.__init__`` already replays ``_MIGRATIONS`` against the
-    DB; ``SQLiteWorkService.__init__`` (via ``create_work_tables``) does
-    the same for ``_WORK_MIGRATIONS``. We also mirror the applied set
-    into the unified ``schema_migrations`` audit table so operators have
-    a single pane of glass.
+    DB. Work-service production traffic is now pg-only, so the public
+    ``create_work_service(db_path=...)`` compatibility argument no longer
+    opens this SQLite file. The migration gate still protects the legacy
+    SQLite ``state.db`` records, so replay the work schema runner directly.
+    We also mirror the applied set into the unified ``schema_migrations``
+    audit table so operators have a single pane of glass.
     """
     from pollypm.storage.state import StateStore
-    from pollypm.work import create_work_service
 
     with StateStore(db_path) as _store:
         pass
 
-    with create_work_service(db_path=db_path) as _svc:
-        pass
-
+    _apply_work_schema_migrations(db_path)
     _record_schema_migrations(db_path)
+
+
+def _apply_work_schema_migrations(db_path: Path) -> None:
+    """Replay legacy SQLite work-service migrations against ``db_path``."""
+    from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas
+    from pollypm.work.schema import create_work_tables
+
+    conn = sqlite3.connect(str(db_path), timeout=5.0)
+    apply_workspace_pragmas(conn)
+    try:
+        create_work_tables(conn)
+    finally:
+        conn.close()
 
 
 def _record_schema_migrations(db_path: Path) -> None:
@@ -393,6 +426,9 @@ def apply(db_path: Path) -> ApplyOutcome:
         return ApplyOutcome(applied=[], already_up_to_date=True)
 
     _apply_all(db_path)
+    status_after = inspect(db_path)
+    if status_after.pending:
+        raise MigrationApplyError(db_path, list(status_after.pending))
     return ApplyOutcome(applied=list(status_before.pending), already_up_to_date=False)
 
 
@@ -412,10 +448,12 @@ def format_unusable_database_message(error: UnusableDatabaseError) -> str:
     """Render a friendly corruption/recovery message for CLI surfaces."""
     from pollypm.structured_message import StructuredUserMessage
 
-    details = "\n".join([
-        f"DB: {error.db_path}",
-        f"SQLite error: {error.detail}",
-    ])
+    details = "\n".join(
+        [
+            f"DB: {error.db_path}",
+            f"SQLite error: {error.detail}",
+        ]
+    )
     msg = StructuredUserMessage(
         summary="Cannot use state.db — the file is not a valid SQLite database.",
         why=(
@@ -501,11 +539,13 @@ def _format_refuse_start_message(status: MigrationStatus) -> str:
         f"  [{item.namespace}] v{item.version}: {item.description}"
         for item in status.pending
     ]
-    details = "\n".join([
-        f"DB: {status.db_path}",
-        f"{count} pending migration{plural}:",
-        *pending_lines,
-    ])
+    details = "\n".join(
+        [
+            f"DB: {status.db_path}",
+            f"{count} pending migration{plural}:",
+            *pending_lines,
+        ]
+    )
     msg = StructuredUserMessage(
         summary=f"Cannot start — {count} pending schema migration{plural} on state.db.",
         why=(
@@ -572,7 +612,7 @@ def check_pending(db_path: Path | None = None) -> tuple[bool, str]:
     """
     if db_path is None:
         try:
-            from pollypm.config import DEFAULT_CONFIG_PATH, GLOBAL_CONFIG_DIR, load_config
+            from pollypm.config import DEFAULT_CONFIG_PATH, load_config
         except ImportError:
             return (True, "skipped: config module unavailable")
         if not DEFAULT_CONFIG_PATH.is_file():

--- a/tests/test_migration_gate.py
+++ b/tests/test_migration_gate.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+from pollypm.cli_features.migrate import register_migrate_commands
+from pollypm.storage.state import StateStore
+from pollypm.store import migrations
+
+
+def _state_db_with_only_state_schema(tmp_path: Path) -> Path:
+    db_path = tmp_path / "state.db"
+    with StateStore(db_path):
+        pass
+    assert any(
+        item.namespace == migrations.NAMESPACE_WORK
+        for item in migrations.inspect(db_path).pending
+    )
+    return db_path
+
+
+def _write_config(tmp_path: Path, db_path: Path) -> Path:
+    config_path = tmp_path / "pollypm.toml"
+    base_dir = tmp_path / ".pollypm"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "PollyPM"',
+                f'base_dir = "{base_dir}"',
+                f'logs_dir = "{base_dir / "logs"}"',
+                f'snapshots_dir = "{base_dir / "snapshots"}"',
+                f'state_db = "{db_path}"',
+                f'workspace_root = "{tmp_path}"',
+                "",
+                "[pollypm]",
+                'controller_account = ""',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_apply_replays_sqlite_work_migrations_and_clears_gate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("POLLYPM_SKIP_MIGRATION_GATE", raising=False)
+    db_path = _state_db_with_only_state_schema(tmp_path)
+
+    outcome = migrations.apply(db_path)
+
+    assert any(item.namespace == migrations.NAMESPACE_WORK for item in outcome.applied)
+    assert migrations.inspect(db_path).pending == []
+    migrations.require_no_pending_or_exit(db_path)
+
+
+def test_check_against_clone_uses_default_clone_path_without_name_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from pollypm import config as config_mod
+
+    db_path = _state_db_with_only_state_schema(tmp_path)
+    fake_global = tmp_path / "global"
+    monkeypatch.setattr(config_mod, "GLOBAL_CONFIG_DIR", fake_global)
+    monkeypatch.delenv("POLLYPM_HOME", raising=False)
+
+    outcome = migrations.check_against_clone(db_path)
+
+    assert outcome.ok is True
+    assert outcome.clone_path == fake_global / "migration-check.db"
+    assert outcome.clone_path.is_file()
+    assert migrations.inspect(outcome.clone_path).pending == []
+    assert any(
+        item.namespace == migrations.NAMESPACE_WORK
+        for item in migrations.inspect(db_path).pending
+    )
+
+
+def test_migrate_apply_force_clears_gate_and_restores_bypass(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("POLLYPM_SKIP_MIGRATION_GATE", raising=False)
+    db_path = _state_db_with_only_state_schema(tmp_path)
+    config_path = _write_config(tmp_path, db_path)
+    app = typer.Typer()
+    register_migrate_commands(app)
+
+    result = CliRunner().invoke(
+        app,
+        ["--apply", "--force", "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Applied" in result.output
+    assert migrations.inspect(db_path).pending == []
+    assert "POLLYPM_SKIP_MIGRATION_GATE" not in os.environ
+    migrations.require_no_pending_or_exit(db_path)


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Replays legacy SQLite work-schema migrations directly during `pm migrate --apply` instead of routing through pg-only work-service construction.
- Verifies apply/check leave no pending migrations, and reports a typed apply failure if the gate would still block the next launch.
- Fixes the `_default_clone_path()` `GLOBAL_CONFIG_DIR` NameError and restores the migration-gate bypass env after the migrate command exits.

Fixes #2194.

## Tests
- `uv run --extra test pytest tests/test_migration_gate.py -q` (pass, 3 passed)
- `uv run --extra dev ruff check src/pollypm/store/migrations.py src/pollypm/cli_features/migrate.py tests/test_migration_gate.py` (pass)
- `git diff --check` (pass)

Worker broader-run note:
- Adjacent suites `tests/test_work_schema.py tests/test_upgrade.py tests/test_no_raw_pollypm_path_joins.py` still hit unrelated baseline failures: existing raw `.pollypm` path offenders and the real-home write guard during upgrade/work-schema tests.