### PR TITLE
fix(serve): supervise pm serve with launchd

### DIFF
--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -87,6 +87,26 @@ is down, and vice versa.
   of truth, no cache invalidation problem, and the audit log
   guarantees ordering even with concurrent writers.
 
+### macOS launchd supervision
+
+Daily-driver installs should run `pm serve` under the user LaunchAgent
+`com.pollypm.serve`:
+
+- `pm serve install` renders the plist into `~/Library/LaunchAgents/`
+  and loads it with `launchctl`.
+- `pm serve stop` writes `~/.pollypm/.serve-quiesced` and unloads the
+  LaunchAgent for intentional operator shutdown.
+- `pm serve start` removes the quiesce marker, refreshes the plist, and
+  loads the LaunchAgent again.
+- `pm serve uninstall` unloads the LaunchAgent and removes the plist.
+
+The plist uses `KeepAlive=true`, `RunAtLoad=true`, and
+`ThrottleInterval=10` so launchd restarts the API after crashes,
+SIGKILL, OOM, or host login without depending on PollyPM's own
+heartbeat tiers. Each `pm serve` startup records its PID in the
+workspace base directory and emits `daemon.serve.respawn` when the PID
+changed from a prior launch.
+
 ### Why FastAPI?
 
 FastAPI is recommended because:

--- a/scripts/com.pollypm.serve.plist.template
+++ b/scripts/com.pollypm.serve.plist.template
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{{LABEL}}</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{PM_BINARY}}</string>
+    <string>serve</string>
+  </array>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>{{HOME}}/.pollypm/logs/serve.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>{{HOME}}/.pollypm/logs/serve.log</string>
+
+  <key>WorkingDirectory</key>
+  <string>{{HOME}}</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>{{HOME}}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+</dict>
+</plist>

--- a/src/pollypm/audit/__init__.py
+++ b/src/pollypm/audit/__init__.py
@@ -81,6 +81,7 @@ from pollypm.audit.bug_reporter import (
 )
 from pollypm.audit.log import (
     AuditEvent,
+    EVENT_DAEMON_SERVE_RESPAWN,
     central_log_path,
     emit,
     project_log_path,
@@ -108,6 +109,7 @@ __all__ = [
     "EVENT_BUG_REPORT_DEDUPED",
     "EVENT_BUG_REPORT_FAILED",
     "EVENT_BUG_REPORT_FILED",
+    "EVENT_DAEMON_SERVE_RESPAWN",
     "EVENT_HEARTBEAT_TICK",
     "Finding",
     "SELF_REPORT_LABEL",

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -113,6 +113,10 @@ EVENT_DAEMON_REAPED = "daemon.reaped"
 # problem (OOM, leak, crash-loop) that needs investigation, not just
 # trust in the supervisor.
 EVENT_DAEMON_REVIVED = "daemon.revived"
+# #2185 — emitted by ``pm serve`` startup when a prior serve PID file
+# exists and differs from the current process. This is the launchd
+# KeepAlive breadcrumb for serve respawns/crash recoveries.
+EVENT_DAEMON_SERVE_RESPAWN = "daemon.serve.respawn"
 # #1398 — plan task evolution. ``plan.version_incremented`` fires when
 # a plan task is refined in place (same task_id, version bump);
 # ``plan.successor_created`` fires when a replan creates a new task
@@ -1012,6 +1016,7 @@ __all__ = [
     "EVENT_WATCHDOG_PROJECT_TRACKED_MODE_REPAIRED",
     "EVENT_DAEMON_REAPED",
     "EVENT_DAEMON_REVIVED",
+    "EVENT_DAEMON_SERVE_RESPAWN",
     "EVENT_WATCHDOG_OPERATOR_TIER4_DISPATCHED",
     "EVENT_TIER4_PROMOTED",
     "EVENT_TIER4_ACTION",

--- a/src/pollypm/cli_features/web_api.py
+++ b/src/pollypm/cli_features/web_api.py
@@ -177,8 +177,28 @@ def _print_token_location_only(token_path_hint: str) -> None:
 def register_web_api_commands(app: typer.Typer) -> None:
     """Mount the ``pm serve`` and ``pm api`` commands on the root app."""
 
-    @app.command(name="serve", help=_SERVE_HELP)
+    serve_app = typer.Typer(
+        help=_SERVE_HELP,
+        invoke_without_command=True,
+        no_args_is_help=False,
+    )
+
+    def _warn_launchctl_failure(
+        action: str,
+        result: subprocess.CompletedProcess[str] | None,
+    ) -> None:
+        if result is None or result.returncode == 0:
+            return
+        stderr = (result.stderr or "").strip()
+        detail = f": {stderr}" if stderr else ""
+        typer.echo(
+            f"Warning: launchctl {action} exited {result.returncode}{detail}",
+            err=True,
+        )
+
+    @serve_app.callback()
     def serve_command(
+        ctx: typer.Context,
         port: int = typer.Option(8765, "--port", "-p", help="TCP port to bind."),
         host: str | None = typer.Option(
             None,
@@ -225,6 +245,9 @@ def register_web_api_commands(app: typer.Typer) -> None:
             help="Override the bearer-token file location (defaults to ~/.pollypm/api-token).",
         ),
     ) -> None:
+        if ctx.invoked_subcommand is not None:
+            return
+
         from pollypm.web_api import create_app, ensure_token
 
         # Bind selection (spec doc decision a-default):
@@ -318,6 +341,17 @@ def register_web_api_commands(app: typer.Typer) -> None:
             )
 
         config = load_config(config_path)
+        try:
+            from pollypm.serve_launchd import record_serve_startup
+
+            base_dir = Path(getattr(config.project, "base_dir", config_path.parent))
+            record_serve_startup(base_dir=base_dir)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "pm serve: startup PID/audit bookkeeping failed",
+                exc_info=True,
+            )
+
         token, generated = ensure_token(token_path)
         if generated:
             _print_token_once(token, generated=generated)
@@ -352,6 +386,57 @@ def register_web_api_commands(app: typer.Typer) -> None:
         typer.echo(f"[pm serve] http://{host}:{port}/api/v1/", err=True)
         uvicorn.run(app_instance, host=host, port=port, log_level="info")
 
+    @serve_app.command(
+        "install",
+        help="Install and load the macOS launchd agent for pm serve.",
+    )
+    def serve_install() -> None:
+        from pollypm.serve_launchd import install_launch_agent
+
+        result = install_launch_agent()
+        typer.echo(f"Installed {result.plist_path}")
+        _warn_launchctl_failure("load", result.launchctl_result)
+        typer.echo("Loaded com.pollypm.serve via launchctl.")
+
+    @serve_app.command(
+        "uninstall",
+        help="Unload and remove the macOS launchd agent for pm serve.",
+    )
+    def serve_uninstall() -> None:
+        from pollypm.serve_launchd import uninstall_launch_agent
+
+        result = uninstall_launch_agent()
+        if result.removed:
+            typer.echo(f"Removed {result.plist_path}")
+            _warn_launchctl_failure("unload", result.launchctl_result)
+        else:
+            typer.echo(f"No LaunchAgent plist found at {result.plist_path}")
+
+    @serve_app.command(
+        "stop",
+        help="Quiesce and unload the macOS launchd agent for pm serve.",
+    )
+    def serve_stop() -> None:
+        from pollypm.serve_launchd import quiesced_marker_path, stop_launch_agent
+
+        result = stop_launch_agent()
+        typer.echo(f"Wrote quiesce marker {quiesced_marker_path()}")
+        _warn_launchctl_failure("unload", result.launchctl_result)
+        typer.echo("Unloaded com.pollypm.serve via launchctl.")
+
+    @serve_app.command(
+        "start",
+        help="Clear quiesce marker and load the macOS launchd agent for pm serve.",
+    )
+    def serve_start() -> None:
+        from pollypm.serve_launchd import quiesced_marker_path, start_launch_agent
+
+        result = start_launch_agent()
+        typer.echo(f"Removed quiesce marker {quiesced_marker_path()}")
+        typer.echo(f"Installed {result.plist_path}")
+        _warn_launchctl_failure("load", result.launchctl_result)
+        typer.echo("Loaded com.pollypm.serve via launchctl.")
+
     @api_app.command(name="regen-token", help="Rotate the API bearer token.")
     def regen_token_command(
         token_path: Path | None = typer.Option(
@@ -370,6 +455,7 @@ def register_web_api_commands(app: typer.Typer) -> None:
         # Print to stdout so a script can capture it (`pm api regen-token > token`).
         typer.echo(token)
 
+    app.add_typer(serve_app, name="serve", help=_SERVE_HELP)
     app.add_typer(api_app, name="api", help=_API_HELP)
 
 

--- a/src/pollypm/serve_launchd.py
+++ b/src/pollypm/serve_launchd.py
@@ -1,0 +1,408 @@
+"""macOS launchd supervision helpers for ``pm serve``.
+
+The CLI exposes these as ``pm serve install/start/stop/uninstall``.
+This module keeps the macOS-specific launchctl calls out of the Web API
+startup path and gives tests injection points for plist directories,
+binary paths, and subprocess runners.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+from xml.sax.saxutils import escape
+
+from pollypm.audit.log import EVENT_DAEMON_SERVE_RESPAWN
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LABEL = "com.pollypm.serve"
+DEFAULT_THROTTLE_INTERVAL_SECONDS = 10
+QUIESCED_MARKER_NAME = ".serve-quiesced"
+SERVE_PID_FILENAME = "serve.pid"
+TEMPLATE_FILENAME = "com.pollypm.serve.plist.template"
+DEFAULT_PLIST_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{{LABEL}}</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{PM_BINARY}}</string>
+    <string>serve</string>
+  </array>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>{{HOME}}/.pollypm/logs/serve.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>{{HOME}}/.pollypm/logs/serve.log</string>
+
+  <key>WorkingDirectory</key>
+  <string>{{HOME}}</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>{{HOME}}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+</dict>
+</plist>
+"""
+
+LaunchctlRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+AuditEmitter = Callable[..., None]
+
+
+@dataclass(frozen=True)
+class LaunchdActionResult:
+    """Result of a plist action and its optional launchctl invocation."""
+
+    plist_path: Path
+    launchctl_result: subprocess.CompletedProcess[str] | None = None
+    removed: bool = False
+
+
+def pollypm_home(*, home: Path | None = None) -> Path:
+    """Return the user-level PollyPM home for launchd-managed serve state."""
+
+    return (home or Path.home()) / ".pollypm"
+
+
+def logs_dir(*, home: Path | None = None) -> Path:
+    return pollypm_home(home=home) / "logs"
+
+
+def quiesced_marker_path(*, home: Path | None = None) -> Path:
+    return pollypm_home(home=home) / QUIESCED_MARKER_NAME
+
+
+def serve_pid_path(base_dir: Path) -> Path:
+    return Path(base_dir) / SERVE_PID_FILENAME
+
+
+def plist_path_for_label(
+    label: str = DEFAULT_LABEL,
+    *,
+    plist_dir: Path | None = None,
+    home: Path | None = None,
+) -> Path:
+    """Resolve ``~/Library/LaunchAgents/<label>.plist``.
+
+    ``plist_dir`` and ``home`` are injectable so tests never need to
+    touch the user's real LaunchAgents directory.
+    """
+
+    base = plist_dir or ((home or Path.home()) / "Library" / "LaunchAgents")
+    return base / f"{label}.plist"
+
+
+def default_template_path() -> Path:
+    """Return the source-tree plist template path."""
+
+    return Path(__file__).resolve().parents[2] / "scripts" / TEMPLATE_FILENAME
+
+
+def resolve_pm_binary(pm_binary: Path | str | None = None) -> Path:
+    """Resolve the absolute ``pm`` executable path for launchd.
+
+    launchd does not run through the user's interactive shell, so the
+    plist must contain an absolute executable path. Prefer the explicit
+    test/CLI override, then the current PATH, then ``sys.argv[0]`` if it
+    names a resolvable command.
+    """
+
+    if pm_binary is not None:
+        return Path(pm_binary).expanduser().resolve()
+
+    found = shutil.which("pm")
+    if found:
+        return Path(found).resolve()
+
+    argv0 = Path(sys.argv[0]).expanduser()
+    if argv0.is_absolute() or len(argv0.parts) > 1:
+        return argv0.resolve()
+
+    found_argv0 = shutil.which(sys.argv[0])
+    if found_argv0:
+        return Path(found_argv0).resolve()
+
+    raise RuntimeError(
+        "Could not resolve the pm executable path. Ensure `pm` is on PATH "
+        "or pass an explicit pm_binary."
+    )
+
+
+def render_plist(
+    *,
+    home: Path | None = None,
+    label: str = DEFAULT_LABEL,
+    pm_binary: Path | str | None = None,
+    template_path: Path | None = None,
+) -> str:
+    """Render the launchd plist template with HOME and pm binary path."""
+
+    resolved_home = (home or Path.home()).expanduser().resolve()
+    resolved_binary = resolve_pm_binary(pm_binary)
+    resolved_template_path = template_path or default_template_path()
+    try:
+        template = resolved_template_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        template = DEFAULT_PLIST_TEMPLATE
+    return (
+        template.replace("{{LABEL}}", escape(label))
+        .replace("{{HOME}}", escape(str(resolved_home)))
+        .replace("{{PM_BINARY}}", escape(str(resolved_binary)))
+    )
+
+
+def write_plist(
+    *,
+    home: Path | None = None,
+    label: str = DEFAULT_LABEL,
+    plist_dir: Path | None = None,
+    pm_binary: Path | str | None = None,
+    template_path: Path | None = None,
+) -> Path:
+    """Write the rendered LaunchAgent plist and ensure its log dir exists."""
+
+    logs_dir(home=home).mkdir(parents=True, exist_ok=True)
+    plist_path = plist_path_for_label(label, plist_dir=plist_dir, home=home)
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_path.write_text(
+        render_plist(
+            home=home,
+            label=label,
+            pm_binary=pm_binary,
+            template_path=template_path,
+        ),
+        encoding="utf-8",
+    )
+    return plist_path
+
+
+def _default_launchctl_runner(
+    argv: list[str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10.0,
+    )
+
+
+def _run_launchctl(
+    action: str,
+    plist_path: Path,
+    *,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> subprocess.CompletedProcess[str]:
+    runner = launchctl_runner or _default_launchctl_runner
+    return runner(["launchctl", action, str(plist_path)])
+
+
+def load_launch_agent(
+    plist_path: Path,
+    *,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return _run_launchctl("load", plist_path, launchctl_runner=launchctl_runner)
+
+
+def unload_launch_agent(
+    plist_path: Path,
+    *,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return _run_launchctl("unload", plist_path, launchctl_runner=launchctl_runner)
+
+
+def install_launch_agent(
+    *,
+    home: Path | None = None,
+    label: str = DEFAULT_LABEL,
+    plist_dir: Path | None = None,
+    pm_binary: Path | str | None = None,
+    template_path: Path | None = None,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> LaunchdActionResult:
+    """Render the plist to LaunchAgents and load it via launchctl."""
+
+    plist_path = write_plist(
+        home=home,
+        label=label,
+        plist_dir=plist_dir,
+        pm_binary=pm_binary,
+        template_path=template_path,
+    )
+    result = load_launch_agent(plist_path, launchctl_runner=launchctl_runner)
+    return LaunchdActionResult(plist_path=plist_path, launchctl_result=result)
+
+
+def uninstall_launch_agent(
+    *,
+    home: Path | None = None,
+    label: str = DEFAULT_LABEL,
+    plist_dir: Path | None = None,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> LaunchdActionResult:
+    """Unload and remove the serve LaunchAgent plist if present."""
+
+    plist_path = plist_path_for_label(label, plist_dir=plist_dir, home=home)
+    result: subprocess.CompletedProcess[str] | None = None
+    if plist_path.exists():
+        result = unload_launch_agent(plist_path, launchctl_runner=launchctl_runner)
+        plist_path.unlink(missing_ok=True)
+        return LaunchdActionResult(
+            plist_path=plist_path,
+            launchctl_result=result,
+            removed=True,
+        )
+    return LaunchdActionResult(plist_path=plist_path, launchctl_result=None)
+
+
+def start_launch_agent(
+    *,
+    home: Path | None = None,
+    label: str = DEFAULT_LABEL,
+    plist_dir: Path | None = None,
+    pm_binary: Path | str | None = None,
+    template_path: Path | None = None,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> LaunchdActionResult:
+    """Clear the quiesced marker, render the plist, and load launchd."""
+
+    marker = quiesced_marker_path(home=home)
+    marker.unlink(missing_ok=True)
+    return install_launch_agent(
+        home=home,
+        label=label,
+        plist_dir=plist_dir,
+        pm_binary=pm_binary,
+        template_path=template_path,
+        launchctl_runner=launchctl_runner,
+    )
+
+
+def stop_launch_agent(
+    *,
+    home: Path | None = None,
+    label: str = DEFAULT_LABEL,
+    plist_dir: Path | None = None,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> LaunchdActionResult:
+    """Write the quiesced marker and unload the LaunchAgent."""
+
+    marker = quiesced_marker_path(home=home)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("quiesced\n", encoding="utf-8")
+    plist_path = plist_path_for_label(label, plist_dir=plist_dir, home=home)
+    result = unload_launch_agent(plist_path, launchctl_runner=launchctl_runner)
+    return LaunchdActionResult(plist_path=plist_path, launchctl_result=result)
+
+
+def _read_pid(path: Path) -> int | None:
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+        pid = int(raw)
+    except (OSError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def _default_audit_emit(**kwargs: Any) -> None:
+    from pollypm.audit.log import emit
+
+    emit(**kwargs)
+
+
+def record_serve_startup(
+    *,
+    base_dir: Path,
+    current_pid: int | None = None,
+    audit_emit: AuditEmitter | None = None,
+) -> None:
+    """Record the current ``pm serve`` PID and audit a PID change.
+
+    The audit event is emitted when a prior PID file exists, parses as a
+    positive integer, and differs from this process. The write is
+    best-effort so serve startup does not fail because a diagnostic PID
+    file or audit tail is unavailable.
+    """
+
+    pid = int(current_pid or os.getpid())
+    path = serve_pid_path(base_dir)
+    previous_pid = _read_pid(path) if path.exists() else None
+    if previous_pid is not None and previous_pid != pid:
+        try:
+            emitter = audit_emit or _default_audit_emit
+            emitter(
+                event=EVENT_DAEMON_SERVE_RESPAWN,
+                project="_workspace",
+                subject=f"serve/{pid}",
+                actor="system",
+                status="warn",
+                metadata={
+                    "role": "serve",
+                    "previous_pid": previous_pid,
+                    "pid": pid,
+                    "pid_file": str(path),
+                },
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "daemon.serve.respawn audit emit failed "
+                "(previous_pid=%s, pid=%s)",
+                previous_pid,
+                pid,
+                exc_info=True,
+            )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{pid}\n", encoding="utf-8")
+    except OSError:
+        logger.warning("pm serve: failed to write PID file %s", path, exc_info=True)
+
+
+__all__ = [
+    "DEFAULT_LABEL",
+    "DEFAULT_THROTTLE_INTERVAL_SECONDS",
+    "EVENT_DAEMON_SERVE_RESPAWN",
+    "LaunchdActionResult",
+    "install_launch_agent",
+    "load_launch_agent",
+    "logs_dir",
+    "plist_path_for_label",
+    "pollypm_home",
+    "quiesced_marker_path",
+    "record_serve_startup",
+    "render_plist",
+    "resolve_pm_binary",
+    "serve_pid_path",
+    "start_launch_agent",
+    "stop_launch_agent",
+    "uninstall_launch_agent",
+    "unload_launch_agent",
+    "write_plist",
+]

--- a/tests/test_serve_launchd.py
+++ b/tests/test_serve_launchd.py
@@ -1,0 +1,256 @@
+"""Tests for :mod:`pollypm.serve_launchd`.
+
+The launchctl boundary is always faked here; these tests never load or
+unload a real launchd service.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import typer
+from typer.testing import CliRunner
+
+from pollypm.cli_features.web_api import register_web_api_commands
+from pollypm.serve_launchd import (
+    DEFAULT_LABEL,
+    EVENT_DAEMON_SERVE_RESPAWN,
+    LaunchdActionResult,
+    install_launch_agent,
+    plist_path_for_label,
+    quiesced_marker_path,
+    record_serve_startup,
+    render_plist,
+    serve_pid_path,
+    start_launch_agent,
+    stop_launch_agent,
+    uninstall_launch_agent,
+)
+
+
+class LaunchctlSpy:
+    def __init__(self, returncode: int = 0, stderr: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self.returncode = returncode
+        self.stderr = stderr
+
+    def __call__(self, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        self.calls.append(argv)
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=self.returncode,
+            stdout="",
+            stderr=self.stderr,
+        )
+
+
+def test_rendered_plist_matches_approved_launchd_shape(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    pm_binary = tmp_path / "bin" / "pm"
+    rendered = render_plist(home=home, pm_binary=pm_binary)
+    parsed = plistlib.loads(rendered.encode("utf-8"))
+
+    assert parsed["Label"] == DEFAULT_LABEL
+    assert parsed["ProgramArguments"] == [str(pm_binary), "serve"]
+    assert parsed["KeepAlive"] is True
+    assert parsed["RunAtLoad"] is True
+    assert parsed["ThrottleInterval"] == 10
+    assert parsed["StandardOutPath"] == str(home / ".pollypm" / "logs" / "serve.log")
+    assert parsed["StandardErrorPath"] == parsed["StandardOutPath"]
+
+
+def test_install_writes_launchagent_and_calls_launchctl_load(tmp_path: Path) -> None:
+    spy = LaunchctlSpy()
+    home = tmp_path / "home"
+    plist_dir = tmp_path / "LaunchAgents"
+    pm_binary = tmp_path / "pm"
+
+    result = install_launch_agent(
+        home=home,
+        plist_dir=plist_dir,
+        pm_binary=pm_binary,
+        launchctl_runner=spy,
+    )
+
+    assert result.plist_path == plist_dir / f"{DEFAULT_LABEL}.plist"
+    assert result.plist_path.exists()
+    assert (home / ".pollypm" / "logs").is_dir()
+    assert spy.calls == [["launchctl", "load", str(result.plist_path)]]
+
+
+def test_uninstall_unloads_then_removes_existing_plist(tmp_path: Path) -> None:
+    spy = LaunchctlSpy()
+    home = tmp_path / "home"
+    plist_dir = tmp_path / "LaunchAgents"
+    pm_binary = tmp_path / "pm"
+    installed = install_launch_agent(
+        home=home,
+        plist_dir=plist_dir,
+        pm_binary=pm_binary,
+        launchctl_runner=spy,
+    )
+    spy.calls.clear()
+
+    result = uninstall_launch_agent(
+        home=home,
+        plist_dir=plist_dir,
+        launchctl_runner=spy,
+    )
+
+    assert result.removed is True
+    assert result.plist_path == installed.plist_path
+    assert not installed.plist_path.exists()
+    assert spy.calls == [["launchctl", "unload", str(installed.plist_path)]]
+
+
+def test_stop_writes_quiesced_marker_and_unloads(tmp_path: Path) -> None:
+    spy = LaunchctlSpy()
+    home = tmp_path / "home"
+    plist_dir = tmp_path / "LaunchAgents"
+    expected_plist = plist_path_for_label(plist_dir=plist_dir)
+
+    result = stop_launch_agent(
+        home=home,
+        plist_dir=plist_dir,
+        launchctl_runner=spy,
+    )
+
+    assert quiesced_marker_path(home=home).read_text(encoding="utf-8") == "quiesced\n"
+    assert result.plist_path == expected_plist
+    assert spy.calls == [["launchctl", "unload", str(expected_plist)]]
+
+
+def test_start_removes_quiesced_marker_writes_plist_and_loads(tmp_path: Path) -> None:
+    spy = LaunchctlSpy()
+    home = tmp_path / "home"
+    plist_dir = tmp_path / "LaunchAgents"
+    pm_binary = tmp_path / "pm"
+    marker = quiesced_marker_path(home=home)
+    marker.parent.mkdir(parents=True)
+    marker.write_text("quiesced\n", encoding="utf-8")
+
+    result = start_launch_agent(
+        home=home,
+        plist_dir=plist_dir,
+        pm_binary=pm_binary,
+        launchctl_runner=spy,
+    )
+
+    assert not marker.exists()
+    assert result.plist_path.exists()
+    assert spy.calls == [["launchctl", "load", str(result.plist_path)]]
+
+
+def test_record_serve_startup_emits_respawn_when_pid_changes(tmp_path: Path) -> None:
+    base_dir = tmp_path / ".pollypm"
+    base_dir.mkdir()
+    serve_pid_path(base_dir).write_text("111\n", encoding="utf-8")
+    emitted: list[dict[str, Any]] = []
+
+    record_serve_startup(
+        base_dir=base_dir,
+        current_pid=222,
+        audit_emit=lambda **kwargs: emitted.append(kwargs),
+    )
+
+    assert serve_pid_path(base_dir).read_text(encoding="utf-8") == "222\n"
+    assert emitted == [
+        {
+            "event": EVENT_DAEMON_SERVE_RESPAWN,
+            "project": "_workspace",
+            "subject": "serve/222",
+            "actor": "system",
+            "status": "warn",
+            "metadata": {
+                "role": "serve",
+                "previous_pid": 111,
+                "pid": 222,
+                "pid_file": str(serve_pid_path(base_dir)),
+            },
+        }
+    ]
+
+
+def test_record_serve_startup_skips_audit_when_pid_is_same(tmp_path: Path) -> None:
+    base_dir = tmp_path / ".pollypm"
+    base_dir.mkdir()
+    serve_pid_path(base_dir).write_text("333\n", encoding="utf-8")
+    emitted: list[dict[str, Any]] = []
+
+    record_serve_startup(
+        base_dir=base_dir,
+        current_pid=333,
+        audit_emit=lambda **kwargs: emitted.append(kwargs),
+    )
+
+    assert emitted == []
+    assert serve_pid_path(base_dir).read_text(encoding="utf-8") == "333\n"
+
+
+def test_pm_serve_install_subcommand_does_not_start_server(monkeypatch) -> None:
+    root = typer.Typer()
+    register_web_api_commands(root)
+
+    def _explode_load_config(_path):
+        raise AssertionError("serve callback should not run for serve install")
+
+    def _fake_install() -> LaunchdActionResult:
+        return LaunchdActionResult(
+            plist_path=Path("/tmp/com.pollypm.serve.plist"),
+            launchctl_result=subprocess.CompletedProcess(
+                args=["launchctl", "load", "/tmp/com.pollypm.serve.plist"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+        )
+
+    monkeypatch.setattr("pollypm.cli_features.web_api.load_config", _explode_load_config)
+    monkeypatch.setattr("pollypm.serve_launchd.install_launch_agent", _fake_install)
+
+    result = CliRunner().invoke(root, ["serve", "install"])
+
+    assert result.exit_code == 0, result.output
+    assert "Installed /tmp/com.pollypm.serve.plist" in result.output
+
+
+def test_pm_serve_startup_records_pid_from_config_base_dir(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    root = typer.Typer()
+    register_web_api_commands(root)
+    base_dir = tmp_path / ".pollypm"
+    config = SimpleNamespace(project=SimpleNamespace(base_dir=base_dir))
+    recorded: list[Path] = []
+
+    monkeypatch.setattr("pollypm.cli_features.web_api.load_config", lambda _path: config)
+    monkeypatch.setattr(
+        "pollypm.cli_features.web_api.detect_tailscale_ip",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "pollypm.serve_launchd.record_serve_startup",
+        lambda *, base_dir: recorded.append(base_dir),
+    )
+    monkeypatch.setattr(
+        "pollypm.web_api.ensure_token",
+        lambda _path: ("test-token", False),
+    )
+    monkeypatch.setattr("pollypm.web_api.create_app", lambda **_kwargs: object())
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda *_args, **_kwargs: None)
+
+    result = CliRunner().invoke(
+        root,
+        ["serve", "--token-path", str(tmp_path / "api-token")],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert recorded == [base_dir]


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- add a macOS LaunchAgent template and `pm serve install/start/stop/uninstall` commands for OS-level `pm serve` supervision
- write a quiesce marker on intentional stop and remove it on start
- record serve PID changes on startup and emit `daemon.serve.respawn` for crash/launchd recovery visibility
- document the launchd supervision workflow in the Web API spec

Closes #2185.
Closes #2224.

## Tests
- `uv run --extra dev python -m ruff check src/pollypm/serve_launchd.py src/pollypm/cli_features/web_api.py src/pollypm/audit/log.py tests/test_serve_launchd.py`
- `uv run --extra test python -m pytest tests/test_serve_launchd.py -q`
- `git diff --check origin/main...HEAD`
