### PR TITLE
fix(api): expose task lifecycle actions

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1050,6 +1050,14 @@ paths:
             Filter by `work_status`. Repeatable — pass `status=draft&status=queued`
             to OR multiple statuses.
         - in: query
+          name: work_status
+          schema:
+            $ref: "#/components/schemas/TaskStatus"
+          description: |
+            Alias for `status`; repeatable and ORed with any `status`
+            values. Kept because clients naturally filter by the
+            response field name.
+        - in: query
           name: assignee
           schema: { type: string }
           description: Filter by assignee (exact match).
@@ -3860,6 +3868,7 @@ components:
         current_node_id: { type: string }
         plan_version: { type: integer }
         updated_at: { type: string, format: date-time }
+        dwell_seconds: { type: integer, minimum: 0 }
 
     Transition:
       type: object
@@ -4308,9 +4317,8 @@ components:
             committed but the per-task worker session could not
             be provisioned (tmux/worktree/cap failures), and to
             surface SessionManager wire-up failures. Each entry
-            includes recovery wording (hold + resume) matching
-            the CLI's `pm task claim` stderr warning. Empty on
-            the happy path; clients can branch on
+            includes REST recovery wording (hold + resume) without
+            terminal commands. Empty on the happy path; clients can branch on
             `len(warnings) > 0` to render a banner alongside the
             now-`in_progress` task.
 

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -403,7 +403,7 @@ Fields: `project`, `task_number`, `task_id` (`{project}/{n}`),
 `relationships`, `flow_template_id`, `flow_template_version`,
 `plan_version`, `predecessor_task_id`, `transitions`, `executions`
 (optional, only on detail), `total_input_tokens`,
-`total_output_tokens`, `session_count`, timestamps.
+`total_output_tokens`, `session_count`, `dwell_seconds`, timestamps.
 
 ### TaskStatus (enum)
 

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -164,6 +164,7 @@ class TaskSummary(BaseModel):
     current_node_id: str | None = None
     plan_version: int | None = None
     updated_at: datetime | None = None
+    dwell_seconds: int | None = Field(default=None, ge=0)
 
 
 class Transition(BaseModel):
@@ -521,10 +522,9 @@ class TaskActionResult(BaseModel):
     Today the claim path uses it to surface ``last_provision_error``
     when the DB transition committed but the per-task worker session
     failed to provision — the task is ``in_progress`` with no live
-    agent lane, and the operator needs to recover manually. This
-    mirrors the CLI's stderr warning at
-    ``src/pollypm/work/cli.py:912-929`` so the API and ``pm task
-    claim`` give the same recovery story (#2064 round-10).
+    agent lane, and the operator needs to recover manually. This gives
+    API clients the same recovery story without embedding terminal
+    commands in the HTTP response (#2064 round-10, #2219).
     """
 
     ok: bool

--- a/src/pollypm/web_api/routes/tasks.py
+++ b/src/pollypm/web_api/routes/tasks.py
@@ -79,6 +79,15 @@ def list_tasks_endpoint(
     # Query into ``?status=draft&status=queued`` (OR semantics on the
     # service side).
     status: Annotated[list[str] | None, Query(description="Filter by work_status (repeatable).")] = None,
+    work_status: Annotated[
+        list[str] | None,
+        Query(
+            description=(
+                "Alias for `status`; kept because clients naturally "
+                "filter by the response field name."
+            ),
+        ),
+    ] = None,
     assignee: Annotated[str | None, Query(description="Filter by exact assignee.")] = None,
     since: Annotated[
         str | None,
@@ -96,6 +105,7 @@ def list_tasks_endpoint(
     limit: Annotated[int, Query(ge=1, le=200, description="Page size (capped at 200).")] = 50,
     cursor: Annotated[str | None, Query(description="Opaque cursor from next_cursor.")] = None,
 ) -> TaskListResponse:
+    statuses = [*list(status or []), *list(work_status or [])] or None
     since_dt: datetime | None = None
     if since is not None:
         try:
@@ -131,7 +141,7 @@ def list_tasks_endpoint(
         items, next_cursor, warnings = list_all_tasks(
             config,
             project=project,
-            statuses=status,
+            statuses=statuses,
             assignee=assignee,
             since=since_dt,
             include_untracked=include_untracked,

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -68,6 +68,12 @@ from pollypm.work.cancel_safety import (
 
 logger = logging.getLogger(__name__)
 
+_TASK_API_UNAVAILABLE_HINT = (
+    "Retry shortly; check API server health if the failure persists."
+)
+_PM_COMMAND_RE = re.compile(r"`?pm\s+[a-z][^`\n]*`?")
+_PM_COMMAND_LINE_RE = re.compile(r"(?m)^\s*pm\s+[^\n]*$")
+
 
 # ---------------------------------------------------------------------------
 # Read-only work-service open
@@ -1177,7 +1183,7 @@ def list_project_tasks(
         )
         raise service_unavailable(
             f"Backing store unavailable for project {project_key}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -1488,8 +1494,23 @@ def get_task_detail(
         )
         raise service_unavailable(
             f"Backing store unavailable for task {project_key}/{task_number}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
+
+
+def _sanitize_task_api_text(message: str) -> str:
+    """Remove CLI-command recovery prose from work-service messages."""
+    text = str(message or "").strip()
+    if not text:
+        return ""
+    for marker in ("\n\nFix:", "\nFix:", " Fix:"):
+        if marker in text:
+            text = text.split(marker, 1)[0].rstrip()
+            break
+    text = _PM_COMMAND_LINE_RE.sub("", text)
+    text = _PM_COMMAND_RE.sub("the REST task API", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
 
 
 # ---------------------------------------------------------------------------
@@ -1556,10 +1577,8 @@ def queue_task(
                 raise APIError(
                     status_code=409,
                     code="invalid_state",
-                    message=(
-                        str(exc)
-                        or f"Task {task_id} cannot be queued from its current state."
-                    ),
+                    message=_sanitize_task_api_text(str(exc))
+                    or f"Task {task_id} cannot be queued from its current state.",
                     hint="Only draft tasks can be queued; refresh the task to see the current work_status.",
                 ) from exc
             except WorkValidationError as exc:
@@ -1573,7 +1592,8 @@ def queue_task(
                 raise APIError(
                     status_code=422,
                     code="validation_error",
-                    message=str(exc) or f"Task {task_id} failed pre-queue gates.",
+                    message=_sanitize_task_api_text(str(exc))
+                    or f"Task {task_id} failed pre-queue gates.",
                     hint="Fix the failing gate (e.g. add a description) before queueing.",
                 ) from exc
             # Re-read so the response carries the post-transition
@@ -1590,7 +1610,7 @@ def queue_task(
         )
         raise service_unavailable(
             f"Backing store unavailable while queueing {task_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -1665,7 +1685,8 @@ def claim_task(
                 raise APIError(
                     status_code=409,
                     code="invalid_state",
-                    message=str(exc) or f"Task {task_id} cannot be claimed.",
+                    message=_sanitize_task_api_text(str(exc))
+                    or f"Task {task_id} cannot be claimed.",
                     hint="Only queued+unblocked tasks can be claimed.",
                 ) from exc
             except WorkerCapExceededError as exc:
@@ -1703,7 +1724,7 @@ def claim_task(
         )
         raise service_unavailable(
             f"Backing store unavailable while claiming {task_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -1731,11 +1752,10 @@ def _collect_claim_warnings(
       claim even though the operator expects the per-task worker
       lifecycle.
 
-    Each entry uses the same "what to do" wording as the CLI warning
-    at ``src/pollypm/work/cli.py:912-929`` so the recovery story is
-    identical across surfaces. The list is empty on the happy path —
-    clients can branch on ``len(warnings) > 0`` to decide whether to
-    surface a banner.
+    Each entry uses REST recovery actions instead of CLI commands so
+    HTTP clients can display the warning without translating shell
+    syntax. The list is empty on the happy path; clients can branch on
+    ``len(warnings) > 0`` to decide whether to surface a banner.
     """
     warnings: list[str] = []
     last_provision_error = getattr(svc, "last_provision_error", None)
@@ -1769,10 +1789,10 @@ def _collect_claim_warnings(
                 f"{last_provision_error}. The DB claim is in effect, "
                 f"but no live agent lane was created. To recover: "
                 f"either continue work from an existing worker "
-                f"session for this project, or hold + resume to "
-                f"retry provisioning "
-                f"(`pm task hold {task_id} --reason 'provision "
-                f"failed'` then `pm task resume {task_id}`)."
+                f"session for this project, or call "
+                f"POST /api/v1/tasks/{task_id}/hold with a reason, "
+                f"then POST /api/v1/tasks/{task_id}/resume to retry "
+                f"provisioning."
             )
     if session_attach_error:
         warnings.append(
@@ -1781,10 +1801,9 @@ def _collect_claim_warnings(
             f"but the worker-session subsystem could not be "
             f"initialised for this request — no per-task tmux lane "
             f"was provisioned. Check tmux availability and the "
-            f"project worktree, then hold + resume the task to "
-            f"retry (`pm task hold {task_id} --reason "
-            f"'session attach failed'` then `pm task resume "
-            f"{task_id}`)."
+            f"project worktree, then call "
+            f"POST /api/v1/tasks/{task_id}/hold with a reason, "
+            f"then POST /api/v1/tasks/{task_id}/resume to retry."
         )
     return warnings
 
@@ -1871,7 +1890,8 @@ def cancel_task(
                 raise APIError(
                     status_code=409,
                     code="invalid_state",
-                    message=str(exc) or f"Task {task_id} cannot be cancelled.",
+                    message=_sanitize_task_api_text(str(exc))
+                    or f"Task {task_id} cannot be cancelled.",
                     hint="Tasks in terminal state (done/cancelled) cannot be cancelled again.",
                 ) from exc
             task = svc.get(task_id)
@@ -1895,7 +1915,7 @@ def cancel_task(
         )
         raise service_unavailable(
             f"Backing store unavailable while cancelling {task_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -1932,7 +1952,8 @@ def reopen_task(
                 raise APIError(
                     status_code=409,
                     code="invalid_state",
-                    message=str(exc) or f"Task {task_id} cannot be reopened.",
+                    message=_sanitize_task_api_text(str(exc))
+                    or f"Task {task_id} cannot be reopened.",
                     hint="Only cancelled tasks can be reopened.",
                 ) from exc
             task = svc.get(task_id)
@@ -1946,7 +1967,7 @@ def reopen_task(
         )
         raise service_unavailable(
             f"Backing store unavailable while reopening {task_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2003,7 +2024,7 @@ def reassign_task(
                 raise APIError(
                     status_code=409,
                     code="invalid_state",
-                    message=str(exc)
+                    message=_sanitize_task_api_text(str(exc))
                     or f"Task {task_id} cannot be reassigned in its "
                     f"current state.",
                     hint=(
@@ -2016,7 +2037,8 @@ def reassign_task(
                 raise APIError(
                     status_code=422,
                     code="validation_error",
-                    message=str(exc) or "Reassignment failed validation.",
+                    message=_sanitize_task_api_text(str(exc))
+                    or "Reassignment failed validation.",
                 ) from exc
             return _task_to_detail_with_plan(task, svc=svc)
     except _BACKING_STORE_ERRORS as exc:
@@ -2028,7 +2050,7 @@ def reassign_task(
         )
         raise service_unavailable(
             f"Backing store unavailable while reassigning {task_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2082,7 +2104,7 @@ def _run_lifecycle_transition(
                 raise APIError(
                     status_code=409,
                     code="invalid_state",
-                    message=str(exc)
+                    message=_sanitize_task_api_text(str(exc))
                     or f"Task {task_id} cannot transition via {verb}.",
                     hint=(
                         "Refresh the task to see the current "
@@ -2094,7 +2116,8 @@ def _run_lifecycle_transition(
                 raise APIError(
                     status_code=422,
                     code="validation_error",
-                    message=str(exc) or f"{verb} validation failed.",
+                    message=_sanitize_task_api_text(str(exc))
+                    or f"{verb} validation failed.",
                 ) from exc
             task = svc.get(task_id)
             return _task_to_detail_with_plan(task, svc=svc)
@@ -2108,7 +2131,7 @@ def _run_lifecycle_transition(
         )
         raise service_unavailable(
             f"Backing store unavailable while {verb}-ing {task_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2370,10 +2393,8 @@ def patch_task(
                     raise APIError(
                         status_code=422,
                         code="validation_error",
-                        message=(
-                            str(exc)
-                            or "labels/metadata update failed validation."
-                        ),
+                        message=_sanitize_task_api_text(str(exc))
+                        or "labels/metadata update failed validation.",
                     ) from exc
 
             # Status-only PATCH: route through the lifecycle owner
@@ -2418,16 +2439,15 @@ def patch_task(
                     raise APIError(
                         status_code=409,
                         code="invalid_state",
-                        message=(
-                            str(exc)
-                            or f"Status transition to {status!r} refused."
-                        ),
+                        message=_sanitize_task_api_text(str(exc))
+                        or f"Status transition to {status!r} refused.",
                     ) from exc
                 except WorkValidationError as exc:
                     raise APIError(
                         status_code=422,
                         code="validation_error",
-                        message=str(exc) or "status transition gate failed.",
+                        message=_sanitize_task_api_text(str(exc))
+                        or "status transition gate failed.",
                     ) from exc
 
             # Final read also serves as the existence probe for an
@@ -2448,7 +2468,7 @@ def patch_task(
         )
         raise service_unavailable(
             f"Backing store unavailable while patching {task_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2594,7 +2614,7 @@ def archive_inbox_item(
             except InvalidTransitionError as exc:
                 # The atomic UPDATE asserted the row was non-terminal;
                 # losing the race means another caller archived first.
-                message = str(exc)
+                message = _sanitize_task_api_text(str(exc))
                 raise APIError(
                     status_code=409,
                     code="invalid_state",
@@ -2629,7 +2649,7 @@ def archive_inbox_item(
         )
         raise service_unavailable(
             f"Backing store unavailable while archiving {item_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2739,7 +2759,7 @@ def snooze_inbox_item(
         )
         raise service_unavailable(
             f"Backing store unavailable while snoozing {item_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2789,7 +2809,7 @@ def mark_read_inbox_item(
         )
         raise service_unavailable(
             f"Backing store unavailable while marking-read {item_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2837,7 +2857,8 @@ def reply_inbox_item(
                 raise APIError(
                     status_code=422,
                     code="validation_error",
-                    message=str(exc) or "Reply body failed validation.",
+                    message=_sanitize_task_api_text(str(exc))
+                    or "Reply body failed validation.",
                 ) from exc
             task = svc.get(item_id)
             return _task_to_detail(task)
@@ -2848,7 +2869,7 @@ def reply_inbox_item(
         )
         raise service_unavailable(
             f"Backing store unavailable while replying to {item_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2927,7 +2948,7 @@ def promote_inbox_to_task(
         )
         raise service_unavailable(
             f"Backing store unavailable while promoting {item_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -2977,7 +2998,7 @@ def get_active_plan(
         )
         raise service_unavailable(
             f"Backing store unavailable for project {project_key}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
+            hint=_TASK_API_UNAVAILABLE_HINT,
         ) from exc
 
 
@@ -3156,6 +3177,17 @@ def _is_in_review(task) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _task_dwell_seconds(task: object) -> int | None:
+    updated_at = getattr(task, "updated_at", None)
+    if not isinstance(updated_at, datetime):
+        return None
+    if updated_at.tzinfo is None or updated_at.tzinfo.utcoffset(updated_at) is None:
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+    else:
+        now = datetime.now(updated_at.tzinfo)
+    return max(0, int((now - updated_at).total_seconds()))
+
+
 def _task_to_summary(task) -> APITaskSummary:
     return APITaskSummary(
         task_id=task.task_id,
@@ -3170,6 +3202,7 @@ def _task_to_summary(task) -> APITaskSummary:
         current_node_id=task.current_node_id,
         plan_version=getattr(task, "plan_version", None),
         updated_at=getattr(task, "updated_at", None),
+        dwell_seconds=_task_dwell_seconds(task),
     )
 
 
@@ -3245,6 +3278,7 @@ def _task_to_detail(task, *, plan: APIPlan | None = None) -> APITaskDetail:
         current_node_id=task.current_node_id,
         plan_version=getattr(task, "plan_version", None),
         updated_at=getattr(task, "updated_at", None),
+        dwell_seconds=_task_dwell_seconds(task),
         description=task.description or "",
         acceptance_criteria=task.acceptance_criteria,
         constraints=task.constraints,

--- a/src/pollypm/work/mock_service.py
+++ b/src/pollypm/work/mock_service.py
@@ -473,6 +473,7 @@ class MockWorkService:
                 exe.completed_at = _now()
         task.work_status = WorkStatus.QUEUED
         task.assignee = None
+        task.claimed_by_session = None
         task.current_node_id = None
         task.updated_at = _now()
         self._record_transition(
@@ -488,7 +489,12 @@ class MockWorkService:
         task = self._tasks.get(task_id)
         if task is None:
             raise TaskNotFoundError(f"Task '{task_id}' not found.")
-        if task.work_status not in (WorkStatus.IN_PROGRESS, WorkStatus.QUEUED):
+        if task.work_status not in (
+            WorkStatus.IN_PROGRESS,
+            WorkStatus.REWORK,
+            WorkStatus.QUEUED,
+            WorkStatus.REVIEW,
+        ):
             raise InvalidTransitionError(
                 f"Cannot hold task in '{task.work_status.value}' state."
             )

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -1210,7 +1210,8 @@ class PgWorkService:
                 )
                 cur.execute(
                     "UPDATE work_tasks SET work_status = %s, "
-                    "assignee = NULL, current_node_id = NULL, "
+                    "assignee = NULL, claimed_by_session = NULL, "
+                    "current_node_id = NULL, "
                     "updated_at = %s "
                     "WHERE project = %s AND task_number = %s",
                     (WorkStatus.QUEUED.value, now, project, task_number),

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -1272,6 +1272,7 @@ def test_reopen_cancelled_task_returns_to_clean_queue(pg_service):
 
     assert reopened.work_status is WorkStatus.QUEUED
     assert reopened.assignee is None
+    assert reopened.claimed_by_session is None
     assert reopened.current_node_id is None
 
     with pg_service._pool.connection() as conn, conn.cursor() as cur:

--- a/tests/test_tasks_writes_endpoint.py
+++ b/tests/test_tasks_writes_endpoint.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -220,6 +220,7 @@ class FakeWorkService:
             )
         task.work_status = WorkStatus.QUEUED
         task.assignee = None
+        task.claimed_by_session = None
         task.current_node_id = None
         task.updated_at = datetime.now(timezone.utc)
         return task
@@ -608,10 +609,12 @@ def test_claim_surfaces_last_provision_error_warning(
     warning = warnings[0]
     assert "tmux client missing" in warning
     assert "myproj/201" in warning
-    # Recovery wording must point at hold + resume — that is the
-    # exact same operator workflow ``pm task claim`` documents.
+    # Recovery wording must point at REST hold + resume actions.
     assert "hold" in warning.lower()
     assert "resume" in warning.lower()
+    assert "pm task" not in warning
+    assert "POST /api/v1/tasks/myproj/201/hold" in warning
+    assert "POST /api/v1/tasks/myproj/201/resume" in warning
 
 
 def test_claim_attach_session_manager_failure_captured(
@@ -669,6 +672,48 @@ def test_claim_attach_session_manager_failure_captured(
     assert "SessionManager wire-up failed" in warning
     assert "TmuxClient unreachable" in warning
     assert "myproj/202" in warning
+    assert "pm task" not in warning
+    assert "POST /api/v1/tasks/myproj/202/hold" in warning
+    assert "POST /api/v1/tasks/myproj/202/resume" in warning
+
+
+def test_claim_invalid_state_sanitizes_cli_recovery_message(
+    api_config, token_path, token, task_store, monkeypatch  # noqa: ARG001
+) -> None:
+    """REST errors should not surface CLI recovery commands."""
+    _seed(task_store, n=203, work_status=WorkStatus.QUEUED)
+
+    class _CliMessageWorkService(FakeWorkService):
+        def claim(self, task_id: str, actor: str) -> FakeTask:  # noqa: ARG002
+            raise InvalidTransitionError(
+                "Cannot claim task in 'review' state.\n\n"
+                "Fix: run `pm task hold myproj/203 --reason blocked` "
+                "then `pm task resume myproj/203`."
+            )
+
+    def _factory(**_kwargs: object) -> _CliMessageWorkService:
+        return _CliMessageWorkService(task_store)
+
+    from pollypm.web_api.app import create_app
+    from pollypm.work import factory as work_factory
+    from pollypm.work import service_factory as work_service_factory
+
+    monkeypatch.setattr(work_factory, "create_work_service", _factory)
+    monkeypatch.setattr(
+        work_service_factory, "create_work_service_with_session", _factory
+    )
+    app = create_app(config=api_config, token_path=token_path)
+    local_client = TestClient(app)
+    response = local_client.post(
+        "/api/v1/tasks/myproj/203/claim",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"actor": "alice"},
+    )
+    assert response.status_code == 409, response.text
+    message = response.json()["error"]["message"]
+    assert "Cannot claim task" in message
+    assert "Fix:" not in message
+    assert "pm task" not in message
 
 
 def test_create_work_service_with_session_captures_attach_exception(
@@ -960,6 +1005,7 @@ def test_reopen_happy_path(client, auth_headers, task_store) -> None:
     _seed(
         task_store, n=53,
         work_status=WorkStatus.CANCELLED, assignee="bob",
+        claimed_by_session="stale-session",
         current_node_id="implement",
     )
     response = client.post(
@@ -972,6 +1018,7 @@ def test_reopen_happy_path(client, auth_headers, task_store) -> None:
     assert body["ok"] is True
     assert body["task"]["work_status"] == "queued"
     assert body["task"]["assignee"] is None
+    assert body["task"]["claimed_by_session"] is None
     assert body["task"]["current_node_id"] is None
 
 
@@ -1738,6 +1785,21 @@ def test_get_task_detail_hydrates_plan_for_plan_review(
     plan = response.json()["plan"]
     assert plan is not None
     assert "caching" in plan["summary"].lower()
+
+
+def test_get_task_detail_includes_dwell_seconds(
+    client, auth_headers, task_store
+) -> None:
+    seeded = _seed(task_store, n=46, work_status=WorkStatus.QUEUED)
+    seeded.updated_at = datetime.now(timezone.utc) - timedelta(seconds=125)
+
+    response = client.get(
+        "/api/v1/tasks/myproj/46", headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    dwell_seconds = response.json()["dwell_seconds"]
+    assert isinstance(dwell_seconds, int)
+    assert dwell_seconds >= 120
 
 
 def test_action_result_plan_hydration_parity_claim(

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -675,9 +675,12 @@ def test_claim_contract_exposes_session_identity() -> None:
     contract = _load_contract()
     static_summary = contract["components"]["schemas"]["TaskSummary"]
     assert "claimed_by_session" in static_summary["properties"]
+    assert "dwell_seconds" in static_summary["properties"]
+    assert static_summary["properties"]["dwell_seconds"]["minimum"] == 0
 
     runtime_summary = TaskSummary.model_json_schema()
     assert "claimed_by_session" in runtime_summary["properties"]
+    assert "dwell_seconds" in runtime_summary["properties"]
 
     static_actor = contract["components"]["schemas"]["TaskClaimRequest"][
         "properties"

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -221,6 +221,29 @@ def test_list_tasks_status_filter_or_semantics(
     assert titles == ["Drafty", "Queued one"]
 
 
+def test_list_tasks_work_status_alias_filters(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """``?work_status=`` aliases ``?status=`` instead of no-oping."""
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        queued = make_task(svc, project="myproj", title="Queued alias")
+        make_task(svc, project="myproj", title="Draft alias")
+        svc.queue(queued.task_id, actor="tester")
+
+    response = client.get(
+        "/api/v1/tasks?work_status=queued", headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    titles = {item["title"] for item in response.json()["items"]}
+    assert "Queued alias" in titles
+    assert "Draft alias" not in titles
+    assert {item["work_status"] for item in response.json()["items"]} == {
+        "queued"
+    }
+
+
 def test_list_tasks_since_filter_rejects_bad_iso(
     api_config, client, auth_headers
 ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- add task lifecycle REST endpoints for queue/claim/done/review/approve/reject/hold/resume/block/rework/reopen/cancel/reassign/patch flows
- clear `claimed_by_session` on reopen and expose `dwell_seconds` in task summaries/details
- sanitize task API recovery/error messages so REST callers do not get CLI-only command guidance
- add `work_status` as an explicit alias for the task list `status` filter
- document the routes and update the static OpenAPI contract

Closes #2137.
Closes #2216.
Closes #2220.
Closes #2219.
Closes #2229.
Refs #2218: removes an avoidable post-claim read and adds slow-claim instrumentation, but deeper provisioning latency remains a separate perf investigation.

## Tests
- `uv run --extra dev ruff check src/pollypm/web_api/routes/tasks.py src/pollypm/web_api/service.py src/pollypm/web_api/models.py src/pollypm/work/pg_service.py src/pollypm/work/mock_service.py tests/test_tasks_writes_endpoint.py tests/web_api/test_openapi_conformance.py tests/web_api/test_tasks_list_endpoint.py`
- `HOME=$(mktemp -d /tmp/pollypm-taskapi-home.XXXXXX) uv run --extra test pytest --noconftest tests/test_tasks_writes_endpoint.py -q`
- `HOME=$(mktemp -d /tmp/pollypm-taskapi-home.XXXXXX) uv run --extra dev pytest tests/web_api/test_openapi_conformance.py tests/web_api/test_tasks_list_endpoint.py::test_list_tasks_work_status_alias_filters -q`
- `HOME=$(mktemp -d /tmp/pollypm-taskapi-home.XXXXXX) uv run --extra dev pytest tests/test_pg_work_service_full.py::test_reopen_cancelled_task_returns_to_clean_queue -q`
- `git diff --check origin/main...HEAD`
