### PR TITLE
fix(sessions): fail closed on unreadable pause markers

### DIFF
--- a/src/pollypm/heartbeats/api.py
+++ b/src/pollypm/heartbeats/api.py
@@ -259,6 +259,20 @@ class SupervisorHeartbeatAPI:
 
     def send_session_message(self, session_name: str, text: str, *, owner: str = "heartbeat") -> None:
         try:
+            from pollypm.session_paused import skip_if_paused
+
+            if skip_if_paused(
+                self.supervisor.config,
+                session_name,
+                store=self.supervisor.msg_store,
+                loop="heartbeat.api.send_session_message",
+                reason=f"owner={owner}",
+            ):
+                return
+        except Exception:  # noqa: BLE001
+            # Pause-marker audit/read failures must not crash the sweep.
+            pass
+        try:
             self.supervisor.send_input(session_name, text, owner=owner)
         except Exception:  # noqa: BLE001
             # Session may be dead or missing — don't crash the sweep.

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -713,6 +713,30 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         )
         api.send_session_message(context.session_name, text, owner=owner)
 
+    def _skip_if_session_paused(
+        self,
+        api,
+        context: HeartbeatSessionContext,
+    ) -> bool:
+        supervisor = getattr(api, "supervisor", None)
+        config = getattr(supervisor, "config", None)
+        if config is None:
+            return False
+        store = (
+            getattr(supervisor, "msg_store", None)
+            or getattr(supervisor, "_msg_store", None)
+            or getattr(supervisor, "store", None)
+        )
+        from pollypm.session_paused import skip_if_paused
+
+        return skip_if_paused(
+            config,
+            context.session_name,
+            store=store,
+            loop="heartbeat.local.process_session",
+            reason=f"role={context.role}",
+        )
+
     def _process_unmanaged_windows(self, api) -> None:
         current_alert_types: set[str] = set()
         existing_alert_types = {
@@ -766,6 +790,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 return
         except (AttributeError, Exception):  # noqa: BLE001
             pass  # API may not have supervisor (e.g., tests)
+        if self._skip_if_session_paused(api, context):
+            return
         mechanical_only = context.role == "heartbeat-supervisor"
         if not context.window_present:
             _emit_routed_alert(

--- a/src/pollypm/session_paused.py
+++ b/src/pollypm/session_paused.py
@@ -5,8 +5,8 @@ This module owns the on-disk pause-marker contract end-to-end:
 * The filename constant (``_PAUSE_MARKER_FILENAME``) and the
   config-derived path helper (``_pause_marker_path``).
 * The read helpers (``load_paused_state`` / ``load_paused_names`` /
-  ``is_paused``) consumed by the supervisor / recovery loops AND the
-  sessions-admin GET surface.
+  ``pause_status_from_state`` / ``is_paused``) consumed by the
+  supervisor / recovery loops AND the sessions-admin GET surface.
 * The write helpers (``save_paused_names`` / ``pause_marker_lock``)
   consumed by ``POST /api/v1/sessions/{name}/pause`` and ``resume``.
 
@@ -20,16 +20,19 @@ exactly the drift risk the shared helper is supposed to remove").
 Recovery wiring status (#2068)
 ------------------------------
 
-PR ``feat/sessions-pause-marker-wire-loops-1-3`` wires the marker into
-loops 1–3:
+The marker is consumed through ``skip_if_paused`` at the narrow loop
+chokepoints wired so far:
 
 * :func:`pollypm.recovery.no_session_spawn.auto_recover_no_session_alerts`
-  (loop 1) and :meth:`pollypm.supervisor.Supervisor.maybe_recover_session`
-  (loops 2 + 3) BOTH consult ``is_paused`` / ``skip_if_paused`` and
-  yield with an audit event when the marker is set.
+  and :meth:`pollypm.supervisor.Supervisor.maybe_recover_session`.
+* :meth:`pollypm.supervisor.Supervisor.restart_session` and
+  ``create_session_window`` / ``launch_session``.
+* ``LocalHeartbeatBackend`` per-session processing and heartbeat API
+  session-message sends.
+* ``task_assignment_notify.notify`` assignment dispatch.
 
-Remaining dispatch / cockpit / heartbeat loops still treat the marker
-as informational and are tracked as the next slice under #2068.
+Direct/manual cockpit and chat sends remain explicit operator actions
+unless they route through one of those daemon-loop chokepoints.
 
 Marker states
 -------------
@@ -51,10 +54,11 @@ state emits a throttled ``session.pause.marker_unreadable`` audit
 event and a one-time stderr warning so the operator can repair the
 marker; the transition back out emits ``session.pause.marker_restored``.
 
-For the read-only sessions-admin GET surface we keep the legacy
-"best-effort empty set" behaviour via :func:`load_paused_names` so a
-stale marker on disk does not 500 the dashboard; the GET path surfaces
-``paused`` purely as a presentational signal.
+For the read-only sessions-admin GET surface, callers use
+:func:`load_paused_state` plus :func:`pause_status_from_state` so a stale
+marker on disk does not 500 the dashboard but still fails closed in the
+payload: every row reports ``paused=True`` with
+``paused_reason="marker_unreadable"``.
 
 Audit-event spam (PR #2081 round 2 — Codex finding 1)
 -----------------------------------------------------
@@ -129,6 +133,7 @@ PAUSE_SKIP_EVENT_TYPE = "session.pause.skip"
 # :data:`PAUSE_MARKER_RESTORED_EVENT_TYPE` and reset the throttle.
 PAUSE_MARKER_UNREADABLE_EVENT_TYPE = "session.pause.marker_unreadable"
 PAUSE_MARKER_RESTORED_EVENT_TYPE = "session.pause.marker_restored"
+UNREADABLE_PAUSED_REASON = "marker_unreadable"
 
 
 # --- Marker state ---------------------------------------------------
@@ -269,11 +274,10 @@ def load_paused_state(config: Any) -> MarkerState:
 def load_paused_names(config: Any) -> set[str]:
     """Read the pause marker; empty set on missing / malformed file.
 
-    Best-effort variant retained for the read-only dashboard surface
-    (``GET /api/v1/sessions`` via ``SessionInfo.paused``) and for
-    tests that still want the legacy ``set[str]`` shape. The route
-    pause/resume endpoints now go through :func:`load_paused_state`
-    for their read-modify-write paths.
+    Best-effort variant retained for legacy/tests that still want the
+    ``set[str]`` shape. The sessions-admin GET surface and the route
+    pause/resume endpoints now go through :func:`load_paused_state` so
+    unreadable markers do not fail open.
 
     An unreadable marker collapses to an empty set HERE — recovery
     callers must use :func:`load_paused_state` / :func:`is_paused`
@@ -285,6 +289,26 @@ def load_paused_names(config: Any) -> set[str]:
     if state.kind == "ok":
         return set(state.names)
     return set()
+
+
+def pause_status_from_state(
+    state: MarkerState,
+    session_name: str,
+) -> tuple[bool, str | None]:
+    """Return wire-facing pause status for ``session_name``.
+
+    This is the shared read-side projection used by UI/API callers that
+    already loaded the discriminated marker state. It keeps the
+    fail-closed unreadable-marker semantics in one place without
+    re-reading or reparsing the marker for every row.
+    """
+    if not session_name:
+        return False, None
+    if state.kind == "unreadable":
+        return True, UNREADABLE_PAUSED_REASON
+    if state.kind == "ok":
+        return session_name in state.names, None
+    return False, None
 
 
 def is_paused(config: Any, session_name: str) -> bool:
@@ -303,13 +327,11 @@ def is_paused(config: Any, session_name: str) -> bool:
     """
     if not session_name:
         return False
-    state = load_paused_state(config)
-    if state.kind == "absent":
-        return False
-    if state.kind == "ok":
-        return session_name in state.names
-    # ``unreadable`` — fail closed: every session is treated as paused.
-    return True
+    paused, _reason = pause_status_from_state(
+        load_paused_state(config),
+        session_name,
+    )
+    return paused
 
 
 def save_paused_names(config: Any, names: set[str] | list[str]) -> None:
@@ -862,9 +884,11 @@ __all__ = [
     "PAUSE_MARKER_UNREADABLE_THROTTLE_SECONDS",
     "PAUSE_SKIP_EVENT_TYPE",
     "PAUSE_SKIP_THROTTLE_SECONDS",
+    "UNREADABLE_PAUSED_REASON",
     "is_paused",
     "load_paused_names",
     "load_paused_state",
+    "pause_status_from_state",
     "pause_marker_lock",
     "save_paused_names",
     "skip_if_paused",

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -3698,12 +3698,8 @@ class Supervisor:
         # this guard stops the relaunch / failover apply from firing —
         # leaving the policy classification + recommendation in place
         # so an operator can still see what would have happened.
-        from pollypm.session_paused import skip_if_paused
-
-        if skip_if_paused(
-            self.config,
+        if self._skip_if_session_paused(
             launch.session.name,
-            store=self._msg_store,
             loop="supervisor.maybe_recover_session",
             reason=f"failure_type={failure_type}",
         ):
@@ -3917,6 +3913,16 @@ class Supervisor:
         updates runtime/alert state.
         """
         launch = self._launch_by_session(session_name)
+        if self._skip_if_session_paused(
+            session_name,
+            loop="supervisor.restart_session",
+            reason=f"failure_type={failure_type}",
+        ):
+            logger.info(
+                "restart_session: skipped %s — pause marker present",
+                session_name,
+            )
+            return
         self._assert_lease_available(
             session_name,
             owner="pollypm",
@@ -4145,6 +4151,24 @@ class Supervisor:
     def _require_session(self, session_name: str) -> None:
         return self.require_session(session_name)
 
+    def _skip_if_session_paused(
+        self,
+        session_name: str,
+        *,
+        loop: str,
+        reason: str = "",
+    ) -> bool:
+        """Return True when the sessions-admin pause marker suppresses work."""
+        from pollypm.session_paused import skip_if_paused
+
+        return skip_if_paused(
+            self.config,
+            session_name,
+            store=getattr(self, "_msg_store", None),
+            loop=loop,
+            reason=reason,
+        )
+
     def launch_session(
         self,
         session_name: str,
@@ -4166,6 +4190,16 @@ class Supervisor:
         address.  If the window already exists, *target* is ``None``.
         """
         launch = self._launch_by_session(session_name)
+        if self._skip_if_session_paused(
+            session_name,
+            loop="supervisor.create_session_window",
+            reason="launch_session",
+        ):
+            logger.info(
+                "create_session_window: skipped %s — pause marker present",
+                session_name,
+            )
+            return launch, None
         tmux_session = self._tmux_session_for_launch(launch)
         window_map = self._window_map()
         # #1096 — scope existence-check to the launch's tmux_session.

--- a/src/pollypm/task_assignment_notify.py
+++ b/src/pollypm/task_assignment_notify.py
@@ -203,6 +203,30 @@ def _notify_record_delivery(
             )
 
 
+def _notify_skip_if_paused(
+    *,
+    services: _RuntimeServices,
+    target_name: str,
+    event: TaskAssignmentEvent,
+) -> bool:
+    """Return True when a session pause marker suppresses assignment send."""
+    config = getattr(services, "config", None)
+    if config is None:
+        return False
+    from pollypm.session_paused import skip_if_paused
+
+    return skip_if_paused(
+        config,
+        target_name,
+        store=services.msg_store or services.state_store,
+        loop="task_assignment_notify.notify",
+        reason=(
+            f"task_id={event.task_id} "
+            f"actor={event.actor_type.value}:{event.actor_name}"
+        ),
+    )
+
+
 def notify(
     event: TaskAssignmentEvent,
     *,
@@ -248,6 +272,14 @@ def notify(
         }
 
     target_name = getattr(handle, "name", "")
+    if _notify_skip_if_paused(
+        services=services, target_name=target_name, event=event,
+    ):
+        return {
+            "outcome": "skipped_paused",
+            "task_id": event.task_id,
+            "session": target_name,
+        }
 
     # #279: key the dedupe on ``(session, task, execution_version)``.
     execution_version = int(getattr(event, "execution_version", 0) or 0)

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -23,12 +23,10 @@ Endpoints
   field on ``GET /api/v1/sessions`` rows; the ``status`` field is
   unaffected (Codex PR #2061 round 2 — pause must NEVER mask the
   real runtime-health classification). **Partial enforcement**:
-  the recovery loops
-  (:func:`pollypm.recovery.no_session_spawn.auto_recover_no_session_alerts`,
-  :meth:`pollypm.supervisor.Supervisor.maybe_recover_session`) HONOR
-  this marker and yield with an audit event. The remaining dispatch
-  / cockpit / heartbeat loops do NOT yet consume it — tracked under
-  #2068. Idempotent.
+  recovery/relaunch, heartbeat per-session, heartbeat send, and
+  task-assignment dispatch chokepoints honor this marker and yield
+  with an audit event. Some direct/manual cockpit and chat sends
+  remain explicit operator actions. Idempotent.
 - ``POST   /api/v1/sessions/{name}/resume``    — remove the marker.
   Idempotent.
 
@@ -67,14 +65,12 @@ Design notes
   ``?async`` to Phase 2.5.
 
 * **Pause / resume — partial enforcement.** The pause marker is
-  HONORED by the recovery loops (``no_session_spawn.auto_recover``
-  + ``Supervisor.maybe_recover_session`` — covering the auto-spawn
-  loop and both the policy-driven and health-sweep recovery paths)
-  as of PR ``feat/sessions-pause-marker-wire-loops-1-3``. Those
-  loops emit a ``session.pause.skip`` audit event and yield without
-  acting. The remaining dispatch / cockpit / heartbeat loops still
-  treat the marker as informational; closing those gaps is tracked
-  under #2068. The marker is exposed as a *separate* ``paused:
+  HONORED by the recovery/relaunch, heartbeat per-session, heartbeat
+  send, and task-assignment dispatch chokepoints wired under #2068.
+  Those loops emit a ``session.pause.skip`` audit event and yield
+  without acting. Direct/manual cockpit and chat sends remain explicit
+  operator actions unless they route through those loop chokepoints.
+  The marker is exposed as a *separate* ``paused:
   bool`` field on the ``SessionInfo`` row rather than as a value of
   ``status`` (Codex PR #2061 round 2). Folding it into ``status``
   was incoherent: a paused-but-missing session would report
@@ -130,13 +126,13 @@ from pollypm.session_health import (
     storage_session_name as _shared_storage_session_name,
 )
 from pollypm.session_paused import (
-    load_paused_names as _load_paused_names,
-)
-from pollypm.session_paused import (
     load_paused_state as _load_paused_state,
 )
 from pollypm.session_paused import (
     pause_marker_lock as _pause_marker_lock,
+)
+from pollypm.session_paused import (
+    pause_status_from_state as _pause_status_from_state,
 )
 from pollypm.session_paused import (
     save_paused_names as _save_paused_names,
@@ -189,12 +185,11 @@ class SessionInfo(BaseModel):
     # Operator-intent marker (Codex PR #2061 round 2). Remains a
     # separate boolean from ``status`` so a paused-but-missing or
     # paused-but-stale session still reports its true runtime health.
-    # Partial enforcement today: the recovery loops
-    # (``no_session_spawn.auto_recover_no_session_alerts`` and
-    # ``Supervisor.maybe_recover_session``) honor this marker and skip
-    # respawn when set. The dispatch / cockpit / heartbeat loops do
-    # NOT yet consume it — that wiring is tracked under #2068.
     paused: bool = False
+    # Only set when the marker itself is unreadable. Intentional pause
+    # does not carry a reason; clean running rows are null/absent
+    # depending on the client serializer.
+    paused_reason: Literal["marker_unreadable"] | None = None
 
 
 class SessionsListResponse(BaseModel):
@@ -425,22 +420,22 @@ def _storage_session_name(config: Any) -> str:
 # :mod:`pollypm.session_paused` (Codex PR #2081 round 1 blocker 2 — the
 # read-side recovery loops and the write-side route MUST share these,
 # or a rename / shape change would silently desync them). Imported as
-# ``_load_paused_names`` / ``_save_paused_names`` / ``_pause_marker_lock``
-# at the top of this module.
+# ``_load_paused_state`` / ``_pause_status_from_state`` /
+# ``_save_paused_names`` / ``_pause_marker_lock`` at the top of this
+# module.
 
 
 # Operator-facing message appended to pause/resume responses. The
-# marker is now PARTIALLY enforced — the recovery loops
-# (no_session_spawn + Supervisor.maybe_recover_session) honour it, but
-# the dispatch / cockpit / heartbeat loops still treat it as
-# informational. Spelling out which side is which keeps an operator
-# from over- OR under-trusting the call: pausing is not a full daemon
-# quiesce yet, but it is no longer a pure tag either.
+# marker is PARTIALLY enforced through the daemon-loop chokepoints
+# wired under #2068. Spelling out the remaining manual-action caveat
+# keeps an operator from over- OR under-trusting the call: pausing is
+# not a full daemon quiesce for every direct send path, but it is no
+# longer a pure tag either.
 _PAUSE_PARTIAL_ENFORCEMENT_NOTE = (
-    "pause marker is HONORED by recovery loops "
-    "(no_session_spawn, Supervisor.maybe_recover_session) but the "
-    "dispatch / cockpit / heartbeat loops do NOT yet consume it — "
-    "tracked under #2068. The marker is visible via "
+    "pause marker is HONORED by recovery/relaunch, heartbeat "
+    "per-session processing, and task-assignment dispatch paths wired "
+    "under #2068. Some direct/manual cockpit and chat send surfaces are "
+    "not yet treated as daemon-loop dispatch. The marker is visible via "
     "GET /api/v1/sessions on the separate `paused` field."
 )
 
@@ -457,6 +452,7 @@ def _build_session_info(
     storage_session: str,
     windows: dict[str, Any],
     paused: bool,
+    paused_reason: str | None = None,
 ) -> SessionInfo:
     """Construct a :class:`SessionInfo` row for one configured session.
 
@@ -495,6 +491,7 @@ def _build_session_info(
         auth_token_present=auth_token_present,
         enabled=bool(getattr(session, "enabled", True)),
         paused=paused,
+        paused_reason=paused_reason,  # type: ignore[arg-type]
     )
 
 
@@ -844,28 +841,36 @@ def list_sessions_endpoint(config: ConfigDep) -> SessionsListResponse:
     Returns one row per configured (and enabled) session. ``status``
     is the pure runtime-health classification (``healthy`` / ``stale``
     / ``missing`` / ``unknown``) and follows the same thresholds the
-    CLI uses. ``paused`` is a separate informational boolean drawn
-    from the pause marker (see :func:`_load_paused_names`) and does
-    NOT influence ``status`` — see :func:`_classify_status` for why.
+    CLI uses. ``paused`` is a separate operator-intent / fail-closed
+    boolean drawn from the pause marker and does NOT influence
+    ``status`` — see :func:`_classify_status` for why. If the marker
+    exists but cannot be read, the endpoint still returns 200 and
+    marks every row ``paused=True`` with
+    ``paused_reason="marker_unreadable"``.
     """
     storage_session = _storage_session_name(config)
     windows = _list_storage_closet_windows(storage_session)
-    paused = _load_paused_names(config)
+    pause_state = _load_paused_state(config)
     raw_sessions = getattr(config, "sessions", None) or {}
     sessions = sorted(
         (s for s in raw_sessions.values() if getattr(s, "enabled", True)),
         key=lambda s: s.name,
     )
-    rows = [
-        _build_session_info(
-            config=config,
-            session=session,
-            storage_session=storage_session,
-            windows=windows,
-            paused=session.name in paused,
+    rows = []
+    for session in sessions:
+        paused, paused_reason = _pause_status_from_state(
+            pause_state, session.name,
         )
-        for session in sessions
-    ]
+        rows.append(
+            _build_session_info(
+                config=config,
+                session=session,
+                storage_session=storage_session,
+                windows=windows,
+                paused=paused,
+                paused_reason=paused_reason,
+            )
+        )
     return SessionsListResponse(sessions=rows)
 
 
@@ -968,13 +973,15 @@ def get_session_endpoint(name: str, config: ConfigDep) -> SessionDetail:
     session = _find_session(config, name)
     storage_session = _storage_session_name(config)
     windows = _list_storage_closet_windows(storage_session)
-    paused = name in _load_paused_names(config)
+    pause_state = _load_paused_state(config)
+    paused, paused_reason = _pause_status_from_state(pause_state, name)
     info = _build_session_info(
         config=config,
         session=session,
         storage_session=storage_session,
         windows=windows,
         paused=paused,
+        paused_reason=paused_reason,
     )
     window_name = session.window_name or session.name
     window = windows.get(window_name)
@@ -1205,8 +1212,8 @@ def interrupt_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
     "/sessions/{name}/pause",
     response_model=ActionResult,
     summary=(
-        "Tag a session as paused (recovery loops honor the marker; "
-        "dispatch/cockpit/heartbeat loops do not yet — #2068)"
+        "Tag a session as paused (daemon loop chokepoints honor the marker; "
+        "some manual send surfaces remain explicit actions — #2068)"
     ),
     operation_id="pauseSession",
     responses={
@@ -1230,13 +1237,11 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
     """POST /api/v1/sessions/{name}/pause — write the pause marker.
 
     **Partial enforcement.** The pause marker is HONORED by the
-    recovery loops
-    (:func:`pollypm.recovery.no_session_spawn.auto_recover_no_session_alerts`
-    and :meth:`pollypm.supervisor.Supervisor.maybe_recover_session`,
-    covering loop 1 + loops 2/3 via the shared apply path); those
-    loops emit a ``session.pause.skip`` audit event and yield. The
-    remaining dispatch / cockpit / heartbeat loops do NOT yet
-    consume the marker — closing those gaps is tracked under #2068.
+    recovery/relaunch, heartbeat per-session, heartbeat send, and
+    task-assignment dispatch chokepoints wired under #2068; those
+    loops emit a ``session.pause.skip`` audit event and yield. Some
+    direct/manual cockpit and chat send surfaces remain explicit
+    operator actions.
     The response ``message`` spells this out so operators know which
     loops they have quiesced and which still act.
 
@@ -1312,7 +1317,7 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
     response_model=ActionResult,
     summary=(
         "Clear the pause marker (recovery loops resume immediately; "
-        "dispatch/cockpit/heartbeat loops were never paused — #2068)"
+        "wired daemon-loop chokepoints resume immediately — #2068)"
     ),
     operation_id="resumeSession",
     responses={
@@ -1336,9 +1341,9 @@ def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
 
     Idempotent inverse of :func:`pause_session_endpoint`. The same
     partial-enforcement caveat applies: clearing the marker lifts
-    the yield in the recovery loops immediately, but the remaining
-    dispatch / cockpit / heartbeat loops were never honouring it in
-    the first place (tracked under #2068).
+    the yield in the wired daemon-loop chokepoints immediately. Some
+    direct/manual cockpit and chat send surfaces remain explicit
+    operator actions.
     """
     _find_session(config, name)  # 404 if unknown
     try:

--- a/tests/test_session_paused_marker_wiring.py
+++ b/tests/test_session_paused_marker_wiring.py
@@ -1,6 +1,6 @@
-"""Issue #2068 — sessions-admin pause marker wired into recovery loops.
+"""Issue #2068 — sessions-admin pause marker wired into daemon loops.
 
-Covers the **partial** wiring in PR ``feat/sessions-pause-marker-wire-loops-1-3``:
+Covers the partial wiring now present:
 
 1. ``pollypm.session_paused`` reader contract (``is_paused`` /
    ``load_paused_names`` / ``skip_if_paused``).
@@ -9,9 +9,11 @@ Covers the **partial** wiring in PR ``feat/sessions-pause-marker-wire-loops-1-3`
 3. ``pollypm.supervisor.Supervisor.maybe_recover_session`` honours the
    marker — no policy-recommendation / restart side effects when the
    session is paused.
+4. Direct supervisor relaunch/window creation and heartbeat
+   per-session processing honour the same shared helper.
 
-Remaining loops (core_recurring / cockpit_rail / heartbeats) are
-tracked under #2068 as follow-ups and are NOT exercised here.
+Remaining direct/manual cockpit and chat sends are explicit operator
+actions unless routed through those daemon-loop chokepoints.
 """
 
 from __future__ import annotations
@@ -129,10 +131,9 @@ def test_load_paused_names_handles_malformed_json(
     config_with_base_dir: _FakeConfig,
 ) -> None:
     """``load_paused_names`` keeps its best-effort empty-set degrade for
-    the GET surface — the read-side helper must not raise on a corrupt
-    marker. Recovery callers go through :func:`is_paused` /
-    :func:`load_paused_state` instead, which fail CLOSED (covered
-    below)."""
+    legacy set-shaped callers. Recovery/API callers go through
+    :func:`is_paused` / :func:`load_paused_state` instead, which fail
+    CLOSED (covered below)."""
     from pollypm.session_paused import (
         _reset_skip_throttle_for_tests, load_paused_names,
     )
@@ -141,8 +142,8 @@ def test_load_paused_names_handles_malformed_json(
     (config_with_base_dir.project.base_dir / "paused-sessions.json").write_text(
         "{not json}"
     )
-    # The route-side load remains empty so the GET dashboard does not
-    # 500; the safety story sits on ``is_paused`` (see below).
+    # The legacy set-shaped load remains empty; fail-closed callers use
+    # ``load_paused_state`` / ``is_paused`` instead.
     assert load_paused_names(config_with_base_dir) == set()
 
 
@@ -1177,3 +1178,140 @@ def test_supervisor_maybe_recover_session_proceeds_when_not_paused(
         )
     # Confirms the apply path was entered (append_event called).
     assert reached_policy
+
+
+def test_supervisor_restart_session_skips_paused_session(
+    config_with_base_dir: _FakeConfig,
+) -> None:
+    """Direct relaunch facade yields before lease / tmux side effects."""
+    from pollypm.supervisor import Supervisor
+
+    _write_marker(config_with_base_dir, ["operator"])
+
+    @dataclass
+    class _FakeSession:
+        name: str
+
+    @dataclass
+    class _FakeLaunch:
+        session: _FakeSession
+        window_name: str = "operator"
+
+    launch = _FakeLaunch(session=_FakeSession(name="operator"))
+    store = _FakeStore()
+    sup = Supervisor.__new__(Supervisor)
+    sup.config = config_with_base_dir
+    sup._msg_store = store
+    sup._launch_by_session = lambda _name: launch  # type: ignore[method-assign]
+    sup._assert_lease_available = (  # type: ignore[method-assign]
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("lease check should not run when paused")
+        )
+    )
+
+    sup.restart_session(
+        "operator", "claude_primary", failure_type="missing_window",
+    )
+
+    assert len(store.kw_events) == 1
+    event = store.kw_events[0]
+    assert event["sender"] == "session.pause.skip"
+    assert event["payload"]["loop"] == "supervisor.restart_session"
+
+
+def test_supervisor_launch_session_skips_unreadable_marker(
+    config_with_base_dir: _FakeConfig,
+) -> None:
+    """Unreadable marker suppresses launch/window creation fail-closed."""
+    from pollypm.supervisor import Supervisor
+
+    marker = config_with_base_dir.project.base_dir / "paused-sessions.json"
+    marker.write_text("{not json}")
+
+    @dataclass
+    class _FakeSession:
+        name: str
+
+    @dataclass
+    class _FakeLaunch:
+        session: _FakeSession
+        window_name: str = "operator"
+
+    launch = _FakeLaunch(session=_FakeSession(name="operator"))
+    store = _FakeStore()
+    sup = Supervisor.__new__(Supervisor)
+    sup.config = config_with_base_dir
+    sup._msg_store = store
+    sup._launch_by_session = lambda _name: launch  # type: ignore[method-assign]
+    sup._window_map = lambda: (_ for _ in ()).throw(  # type: ignore[method-assign]
+        AssertionError("window creation should not inspect tmux when paused")
+    )
+
+    result = sup.launch_session("operator")
+
+    assert result is launch
+    assert len(store.kw_events) == 1
+    event = store.kw_events[0]
+    assert event["sender"] == "session.pause.skip"
+    assert event["payload"]["loop"] == "supervisor.create_session_window"
+
+
+def test_heartbeat_process_session_skips_paused_session(
+    config_with_base_dir: _FakeConfig,
+) -> None:
+    """Heartbeat per-session processing yields before observations/recovery."""
+    from pollypm.heartbeats.base import HeartbeatSessionContext
+    from pollypm.heartbeats.local import LocalHeartbeatBackend
+
+    _write_marker(config_with_base_dir, ["operator"])
+    store = _FakeStore()
+
+    class _Supervisor:
+        config = config_with_base_dir
+        msg_store = store
+
+        def get_session_runtime(self, _session_name: str) -> None:
+            return None
+
+    class _Api:
+        supervisor = _Supervisor()
+
+        def record_observation(self, _context) -> None:  # noqa: ANN001
+            raise AssertionError("heartbeat observation should be skipped")
+
+        def recover_session(
+            self,
+            *_args,
+            **_kwargs,
+        ) -> None:
+            raise AssertionError("heartbeat recovery should be skipped")
+
+    context = HeartbeatSessionContext(
+        session_name="operator",
+        role="operator-pm",
+        project_key="demo",
+        provider="claude",
+        account_name="claude_primary",
+        cwd=str(config_with_base_dir.project.root_dir),
+        tmux_session="pollypm-storage-closet",
+        window_name="operator",
+        source_path="",
+        source_bytes=0,
+        transcript_delta="",
+        pane_text="",
+        snapshot_path=None,
+        snapshot_hash="",
+        pane_id=None,
+        pane_command=None,
+        pane_dead=False,
+        window_present=True,
+        previous_log_bytes=None,
+        previous_snapshot_hash=None,
+    )
+
+    LocalHeartbeatBackend()._process_session(_Api(), context)
+
+    assert len(store.kw_events) == 1
+    event = store.kw_events[0]
+    assert event["sender"] == "session.pause.skip"
+    assert event["payload"]["loop"] == "heartbeat.local.process_session"

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -1502,6 +1502,7 @@ def test_pause_happy_path_then_visible_in_list(
     listing = client.get("/api/v1/sessions", headers=auth_headers).json()
     by_name = {s["name"]: s for s in listing["sessions"]}
     assert by_name["operator"]["paused"] is True
+    assert by_name["operator"].get("paused_reason") is None
     # status must be a real health value, not the legacy "paused" string.
     assert by_name["operator"]["status"] in {"healthy", "stale"}
     assert by_name["operator"]["status"] != "paused"
@@ -1575,7 +1576,64 @@ def test_status_unpaused_session_reports_paused_false(
     listing = client.get("/api/v1/sessions", headers=auth_headers).json()
     row = next(s for s in listing["sessions"] if s["name"] == "operator")
     assert row["paused"] is False
+    assert row.get("paused_reason") is None
     assert row["status"] != "paused"
+
+
+def test_list_sessions_unreadable_marker_returns_200_fail_closed(
+    client,
+    auth_headers,
+    config: PollyPMConfig,
+    patch_heartbeat,
+    patch_tmux_windows,
+    isolate_audit_home: Path,
+):
+    """#2187: unreadable marker makes every listed session paused."""
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator", "advisor_myproj"])
+    marker = config.project.base_dir / "paused-sessions.json"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("{not json}")
+
+    response = client.get("/api/v1/sessions", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    rows = response.json()["sessions"]
+    assert {row["name"] for row in rows} == {"advisor_myproj", "operator"}
+    for row in rows:
+        assert row["paused"] is True
+        assert row["paused_reason"] == "marker_unreadable"
+        assert row["status"] != "paused"
+
+
+def test_list_sessions_restored_marker_clears_unreadable_reason(
+    client,
+    auth_headers,
+    config: PollyPMConfig,
+    patch_heartbeat,
+    patch_tmux_windows,
+    isolate_audit_home: Path,
+):
+    """Once the marker is readable, intentional pause has no reason."""
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_tmux_windows(["operator", "advisor_myproj"])
+    marker = config.project.base_dir / "paused-sessions.json"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("{not json}")
+    first = client.get("/api/v1/sessions", headers=auth_headers)
+    assert first.status_code == 200
+    assert all(
+        row["paused_reason"] == "marker_unreadable"
+        for row in first.json()["sessions"]
+    )
+
+    marker.write_text('[\n  "operator"\n]\n')
+    response = client.get("/api/v1/sessions", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    by_name = {s["name"]: s for s in response.json()["sessions"]}
+    assert by_name["operator"]["paused"] is True
+    assert by_name["operator"].get("paused_reason") is None
+    assert by_name["advisor_myproj"]["paused"] is False
+    assert by_name["advisor_myproj"].get("paused_reason") is None
 
 
 def test_pause_is_idempotent(
@@ -1602,15 +1660,11 @@ def test_pause_response_labels_marker_partial_enforcement(
 ):
     """PR #2081: pause response must spell out PARTIAL enforcement.
 
-    PR ``feat/sessions-pause-marker-wire-loops-1-3`` wired the marker
-    into the recovery loops (``no_session_spawn``,
-    ``Supervisor.maybe_recover_session``), but the remaining dispatch /
-    cockpit / heartbeat loops still don't consume it (tracked under
-    #2068). The response body must surface BOTH sides — which loops
-    honor the marker and which don't — so an operator knows exactly
-    what they have quiesced. "Informational only" used to be the
-    contract; now the correct word is "honored by recovery loops",
-    plus a NOT-yet caveat for the rest.
+    The marker is now honored by the daemon-loop chokepoints wired
+    under #2068. The response body still needs to surface BOTH sides:
+    which loops honor the marker and which direct/manual actions remain
+    explicit operator actions, so an operator knows exactly what they
+    have quiesced.
     """
     patch_heartbeat({})
     patch_tmux_windows(["operator"])
@@ -1624,8 +1678,8 @@ def test_pause_response_labels_marker_partial_enforcement(
     # marker (else operators still think it's a pure tag).
     assert "honored" in msg or "honor" in msg, msg
     assert "recovery" in msg, msg
-    # Remaining-gaps side: must keep flagging what DOES NOT yet
-    # consume the marker so operators don't over-trust pause.
+    # Remaining-gaps side: must keep flagging what is NOT yet covered
+    # so operators don't over-trust pause.
     assert "do not" in msg or "does not" in msg or "not yet" in msg, msg
     # #2068 is the follow-up ticket — must be referenced so the gap is
     # discoverable from the response without grepping docs.

--- a/tests/test_task_assignment_notify_helpers.py
+++ b/tests/test_task_assignment_notify_helpers.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -363,6 +364,43 @@ class TestNotifyDedupe:
         )
         assert outcome["outcome"] == "sent"
         assert len(svc.sent) == 2
+
+    def test_paused_session_skips_assignment_send(self, tmp_path, state_store):
+        from pollypm.session_paused import _reset_skip_throttle_for_tests
+
+        _reset_skip_throttle_for_tests()
+        base_dir = tmp_path / ".pollypm"
+        base_dir.mkdir()
+        (base_dir / "paused-sessions.json").write_text('["worker-demo"]\n')
+
+        config = SimpleNamespace(
+            project=SimpleNamespace(
+                name="demo",
+                root_dir=tmp_path,
+                base_dir=base_dir,
+            )
+        )
+
+        svc = FakeSessionService(handles=[FakeHandle("worker-demo")])
+        services = _RuntimeServices(
+            session_service=svc,
+            state_store=state_store,
+            work_service=None,
+            project_root=Path("."),
+            config=config,
+        )
+
+        outcome = notify(_event(), services=services)
+
+        assert outcome["outcome"] == "skipped_paused"
+        assert outcome["session"] == "worker-demo"
+        assert svc.sent == []
+        events = state_store.recent_events(5)
+        assert any(
+            event.event_type == "session.pause.skip"
+            and event.session_name == "worker-demo"
+            for event in events
+        )
 
 
 class TestNotifyEscalation:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- make `GET /api/v1/sessions` fail closed on unreadable/corrupt pause markers by returning `paused=true` and `paused_reason=marker_unreadable`
- route sessions-admin list/detail through shared marker state projection instead of best-effort `load_paused_names`
- extend shared pause guard coverage to supervisor restart/window creation, heartbeat local processing, heartbeat API sends, and task assignment dispatch
- keep marker unreadable/restored diagnostics durable through the canonical audit log

Closes #2187.
Closes #2226.
Closes #2228.
Refs #2068: extends pause consumption to additional daemon-loop chokepoints; direct/manual cockpit/chat sends remain residual.

## Tests
- `python -m compileall -q src/pollypm/session_paused.py src/pollypm/web_api/routes/sessions_admin.py src/pollypm/supervisor.py src/pollypm/heartbeats/local.py src/pollypm/heartbeats/api.py src/pollypm/task_assignment_notify.py tests/test_sessions_admin_endpoint.py tests/test_session_paused_marker_wiring.py tests/test_task_assignment_notify_helpers.py`
- `HOME=$(mktemp -d /tmp/pollypm-pause-home.XXXXXX) uv run --with pytest pytest -q tests/test_sessions_admin_endpoint.py tests/test_session_paused_marker_wiring.py tests/test_task_assignment_notify_helpers.py`
- `git diff --check origin/main...HEAD`

Note: a full-file `ruff check` over `supervisor.py` / `heartbeats/local.py` still reports pre-existing E402/import-order findings unrelated to this change; compileall and focused tests passed.
