### PR TITLE
perf(api): bound dashboard and chat hot paths

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -893,6 +893,127 @@ def _walk_log_chain(live: Path) -> Iterable[Path]:
         yield archive
 
 
+_TAIL_READ_CHUNK_BYTES = 128 * 1024
+
+
+def _audit_obj_matches(
+    obj: dict[str, Any],
+    *,
+    project: str,
+    since: str | None,
+    event: str | None,
+) -> bool:
+    """Apply the read_events filters to a decoded audit object."""
+    if event is not None and obj.get("event") != event:
+        return False
+    if since is not None:
+        ts = str(obj.get("ts", ""))
+        if ts <= since:
+            return False
+    # Skip cross-project rows that snuck into a per-project file
+    # (shouldn't happen, but defensive — the per-project log only ever
+    # receives writes from one project's mutation hooks).
+    return not (obj.get("project") and obj.get("project") != project)
+
+
+def _decode_audit_line(raw: bytes | str) -> dict[str, Any] | None:
+    if isinstance(raw, bytes):
+        line = raw.decode("utf-8", errors="ignore").strip()
+    else:
+        line = raw.strip()
+    if not line:
+        return None
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def _iter_live_log_lines_reverse(path: Path) -> Iterable[dict[str, Any]]:
+    """Yield decoded live-jsonl rows newest-first using bounded tail reads.
+
+    The project detail endpoint asks for the last 25 audit rows. Reading
+    a multi-megabyte audit log from the head just to slice ``[-25:]`` is
+    proportional to total project history, not the requested page size.
+    This iterator snapshots the file size, walks backward in chunks, and
+    yields complete JSONL rows from newest to oldest. A concurrently
+    appended partial tail line is treated the same way as the forward
+    reader treats malformed lines: skipped, never fatal.
+    """
+    try:
+        file_size = path.stat().st_size
+    except OSError as exc:
+        logger.warning("audit.read: stat failed for %s: %s", path, exc)
+        return
+    if file_size <= 0:
+        return
+
+    carry = b""
+    offset = file_size
+    try:
+        with path.open("rb") as fh:
+            while offset > 0:
+                read_size = min(_TAIL_READ_CHUNK_BYTES, offset)
+                offset -= read_size
+                fh.seek(offset)
+                data = fh.read(read_size) + carry
+                lines = data.splitlines()
+                if offset > 0:
+                    if lines:
+                        carry = lines[0]
+                        lines = lines[1:]
+                    else:
+                        carry = data
+                        continue
+                else:
+                    carry = b""
+                for raw in reversed(lines):
+                    obj = _decode_audit_line(raw)
+                    if obj is not None:
+                        yield obj
+    except OSError as exc:
+        logger.warning("audit.read: tail read failed for %s: %s", path, exc)
+
+
+def _iter_log_lines_reverse(path: Path) -> Iterable[dict[str, Any]]:
+    """Yield decoded rows newest-first for live or rotated audit files."""
+    if path.suffix == ".gz":
+        # Gzip streams are not efficiently seekable. This only runs when
+        # the live tail did not satisfy the requested limit, so it is a
+        # cold/rotation fallback rather than the hot path.
+        rows = list(_iter_log_lines(path))
+        for obj in reversed(rows):
+            yield obj
+        return
+    yield from _iter_live_log_lines_reverse(path)
+
+
+def _read_events_limited_tail(
+    live: Path,
+    project: str,
+    *,
+    limit: int,
+    event: str | None,
+) -> list[AuditEvent]:
+    """Read the newest ``limit`` matching rows without scanning history."""
+    if limit <= 0:
+        return []
+    events: list[AuditEvent] = []
+    for path in _walk_log_chain(live):
+        for obj in _iter_log_lines_reverse(path):
+            if not _audit_obj_matches(
+                obj, project=project, since=None, event=event
+            ):
+                continue
+            events.append(AuditEvent.from_dict(obj))
+            if len(events) >= limit:
+                events.sort(key=lambda e: e.ts)
+                return events
+    events.sort(key=lambda e: e.ts)
+    return events
+
+
 def read_events(
     project: str,
     *,
@@ -930,15 +1051,21 @@ def read_events(
       (post-filter, in chronological order).
 
     Returns a list (not a generator) because typical callers want
-    to count / slice / re-iterate. Audit logs are bounded — even a
-    chatty project lands in the low thousands per day — so loading
-    fully into memory is fine.
+    to count / slice / re-iterate. Limited tail reads skip the
+    full-history scan when no ``since`` filter is present; other
+    shapes keep the chronological full scan so rotated logs and
+    dedupe windows remain authoritative.
     """
     per_project = project_log_path(project_path)
     if per_project is not None and per_project.exists():
         live = per_project
     else:
         live = central_log_path(project)
+
+    if limit is not None and limit >= 0 and since is None:
+        return _read_events_limited_tail(
+            live, project, limit=limit, event=event
+        )
 
     # ``_walk_log_chain`` yields live first then archives newest-first.
     # Each file is a chronological run of records (older-first within
@@ -951,17 +1078,9 @@ def read_events(
     for path in _walk_log_chain(live):
         bucket: list[AuditEvent] = []
         for obj in _iter_log_lines(path):
-            if event is not None and obj.get("event") != event:
-                continue
-            if since is not None:
-                ts = str(obj.get("ts", ""))
-                if ts <= since:
-                    continue
-            # Skip cross-project rows that snuck into a per-project
-            # file (shouldn't happen, but defensive — the per-project
-            # log only ever receives writes from one project's
-            # mutation hooks).
-            if obj.get("project") and obj.get("project") != project:
+            if not _audit_obj_matches(
+                obj, project=project, since=since, event=event
+            ):
                 continue
             bucket.append(AuditEvent.from_dict(obj))
         per_file.append(bucket)

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -13,6 +13,10 @@ from pollypm.config import PollyPMConfig, load_config
 
 logger = logging.getLogger(__name__)
 
+# Test seam for ``load_dashboard``. Kept lazy in production so importing
+# dashboard_data does not eagerly open the sqlite state module.
+StateStore = None
+
 
 # ANSI CSI/OSC escapes plus C0 control chars that can survive in a
 # tmux pane snapshot. ``readyring`` and friends in the cockpit Now
@@ -778,7 +782,11 @@ def load_dashboard(config_path: Path) -> tuple[PollyPMConfig, DashboardData]:
     if is_pg_backend(config):
         data = gather(config, None)
         return config, data
-    from pollypm.storage.state import StateStore
+    global StateStore
+    if StateStore is None:
+        from pollypm.storage.state import StateStore as _StateStore
+
+        StateStore = _StateStore
 
     store = StateStore(config.project.state_db)
     try:
@@ -800,7 +808,10 @@ def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
     use_pg = is_pg_backend(config)
     if use_pg:
         from pollypm.storage.pg_alerts import open_alerts as pg_open_alerts
-        from pollypm.storage.pg_heartbeats import latest_heartbeat as pg_latest_heartbeat
+        from pollypm.storage.pg_heartbeats import (
+            latest_heartbeat as pg_latest_heartbeat,
+            latest_heartbeats_bulk as pg_latest_heartbeats_bulk,
+        )
         from pollypm.storage.pg_sessions import (
             list_session_runtimes as pg_list_session_runtimes,
             recent_events as pg_recent_events,
@@ -818,6 +829,22 @@ def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
         all_runtimes = []
     runtime_map = {rt.session_name: rt for rt in all_runtimes}
     launches = plan_launches_readonly(config, store)
+    heartbeat_map: dict[str, object] = {}
+    heartbeat_bulk_loaded = False
+    if use_pg and launches:
+        try:
+            heartbeat_map = pg_latest_heartbeats_bulk(
+                [launch.session.name for launch in launches],
+                config=config,
+            )
+            heartbeat_bulk_loaded = True
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "dashboard_data.gather: bulk heartbeat lookup failed; "
+                "falling back to per-session reads",
+                exc_info=True,
+            )
+            heartbeat_map = {}
 
     active: list[SessionActivity] = []
     for launch in launches:
@@ -828,7 +855,9 @@ def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
 
         # Get last snapshot path for description
         if use_pg:
-            hb = pg_latest_heartbeat(launch.session.name)
+            hb = heartbeat_map.get(launch.session.name)
+            if hb is None and not heartbeat_bulk_loaded:
+                hb = pg_latest_heartbeat(launch.session.name, config=config)
         elif store is not None:
             hb = store.latest_heartbeat(launch.session.name)  # type: ignore[attr-defined]
         else:

--- a/src/pollypm/web_api/chat/__init__.py
+++ b/src/pollypm/web_api/chat/__init__.py
@@ -37,6 +37,7 @@ from pollypm.web_api.chat.registry import (
     enumerate_chat_surfaces,
     enumerate_config_surfaces,
     enumerate_worker_surfaces,
+    find_chat_surface,
 )
 from pollypm.web_api.chat.tmux_capture import (
     capture_envelopes,
@@ -62,6 +63,7 @@ __all__ = [
     "enumerate_chat_surfaces",
     "enumerate_config_surfaces",
     "enumerate_worker_surfaces",
+    "find_chat_surface",
     "is_archive_stale",
     "parse_events_jsonl",
     "parse_events_jsonl_tail",

--- a/src/pollypm/web_api/chat/registry.py
+++ b/src/pollypm/web_api/chat/registry.py
@@ -28,6 +28,7 @@ from typing import Any
 from pollypm.models import PollyPMConfig, SessionConfig
 from pollypm.projects import project_transcripts_dir
 from pollypm.session_health import storage_session_name
+from pollypm.work.task_state import parse_task_window_name
 from pollypm.work.session_manager import task_window_name
 from pollypm.web_api.chat.transcripts import (
     build_session_index,
@@ -245,42 +246,16 @@ def enumerate_config_surfaces(
     surfaces: list[ChatSurface] = []
     tmux_session = storage_session_name(config.project.tmux_session)
     for session_name, session in (config.sessions or {}).items():
-        if not session.enabled:
-            continue
-        surface_type = _classify_session(session)
-        if surface_type is None:
-            continue
-        project_key = _project_key_for_session(config, session, surface_type)
-        project_root = _project_root_for_key(config, project_key)
-        persona = _persona_for_session(config, session, surface_type)
-        cwd = session.cwd if isinstance(session.cwd, Path) else Path(session.cwd or ".")
-        index = _build_session_index(project_root, session_index_cache)
-        transcript_path = lookup_transcript_path(
-            index,
-            cwd=str(cwd),
-            account_name=session.account,
-            provider=str(session.provider),
+        surface = _config_surface(
+            config,
+            session_name,
+            session,
+            tmux_session=tmux_session,
+            tmux_state_cache=tmux_state_cache,
+            session_index_cache=session_index_cache,
         )
-        window_name = session.window_name or session_name
-        if tmux_state_cache and window_name in tmux_state_cache:
-            window_state = tmux_state_cache[window_name]
-        else:
-            window_state = TmuxWindowState(
-                tmux_session=tmux_session,
-                window_name=window_name,
-                present=False,
-            )
-        surfaces.append(ChatSurface(
-            session_name=session_name,
-            surface_type=surface_type,
-            persona=persona,
-            project=project_key if surface_type != SurfaceType.OPERATOR else None,
-            window=window_state,
-            transcript_path=transcript_path,
-            cwd=cwd,
-            provider=str(session.provider),
-            auth_token_present=bool(session.auth_token),
-        ))
+        if surface is not None:
+            surfaces.append(surface)
     return surfaces
 
 
@@ -317,53 +292,179 @@ def enumerate_worker_surfaces(
     surfaces: list[ChatSurface] = []
     tmux_session = storage_session_name(config.project.tmux_session)
     for record in records or []:
-        project = getattr(record, "task_project", "") or ""
-        task_number = getattr(record, "task_number", 0)
-        if not project or not task_number:
-            continue
-        session_name = task_window_name(project, task_number)
-        project_root = _project_root_for_key(config, project)
-        worktree_path = (
-            Path(record.worktree_path) if record.worktree_path else None
+        surface = _worker_surface(
+            config,
+            record,
+            tmux_session=tmux_session,
+            tmux_state_cache=tmux_state_cache,
+            session_index_cache=session_index_cache,
         )
-        cwd_for_lookup = str(worktree_path) if worktree_path else None
-        provider_value = getattr(record, "provider", "") or ""
-        index = _build_session_index(project_root, session_index_cache)
-        transcript_path = lookup_transcript_path(
-            index,
-            cwd=cwd_for_lookup,
-            account_name=None,  # WorkerSessionRecord doesn't carry account
-            provider=provider_value or None,
-        )
-        window_name = session_name
-        if tmux_state_cache and window_name in tmux_state_cache:
-            window_state = tmux_state_cache[window_name]
-        else:
-            window_state = TmuxWindowState(
-                tmux_session=tmux_session,
-                window_name=window_name,
-                present=False,
-                pane_id=getattr(record, "pane_id", None),
-            )
-        surfaces.append(ChatSurface(
-            session_name=session_name,
-            surface_type=SurfaceType.WORKER,
-            persona=None,
-            project=project,
-            window=window_state,
-            transcript_path=transcript_path,
-            task_id=int(task_number),
-            cwd=worktree_path,
-            provider=provider_value,
-            auth_token_present=False,
-            worktree_path=worktree_path,
-        ))
+        if surface is not None:
+            surfaces.append(surface)
     return surfaces
+
+
+def find_chat_surface(
+    config: PollyPMConfig,
+    session_name: str,
+    *,
+    work_service: Any | None = None,
+    tmux_client: Any | None = None,
+) -> ChatSurface | None:
+    """Resolve one chat surface without enumerating the whole workspace.
+
+    ``GET /chat/{name}/messages`` is a single-session hot path. The
+    broad discovery helper intentionally scans all configured sessions
+    and worker rows so the sidebar can render everything, but doing that
+    before every transcript read makes message latency proportional to
+    workspace size. This resolver builds the same ``ChatSurface`` shape
+    for only the requested session.
+    """
+    tmux_state_cache = _build_tmux_state_cache(config, tmux_client)
+    session_index_cache: dict[Path, list] = {}
+
+    session = (config.sessions or {}).get(session_name)
+    if session is not None:
+        return _config_surface(
+            config,
+            session_name,
+            session,
+            tmux_session=storage_session_name(config.project.tmux_session),
+            tmux_state_cache=tmux_state_cache,
+            session_index_cache=session_index_cache,
+        )
+
+    parsed = parse_task_window_name(session_name)
+    if parsed is None or work_service is None:
+        return None
+    project, task_number = parsed
+    list_fn = getattr(work_service, "list_worker_sessions", None)
+    if not callable(list_fn):
+        return None
+    try:
+        try:
+            records = list_fn(project=project, active_only=True)
+        except TypeError:
+            records = list_fn(active_only=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("chat.registry: list_worker_sessions failed: %s", exc)
+        return None
+    for record in records or []:
+        if (
+            getattr(record, "task_project", "") == project
+            and int(getattr(record, "task_number", 0) or 0) == task_number
+        ):
+            return _worker_surface(
+                config,
+                record,
+                tmux_session=storage_session_name(config.project.tmux_session),
+                tmux_state_cache=tmux_state_cache,
+                session_index_cache=session_index_cache,
+            )
+    return None
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _config_surface(
+    config: PollyPMConfig,
+    session_name: str,
+    session: SessionConfig,
+    *,
+    tmux_session: str,
+    tmux_state_cache: dict[str, TmuxWindowState] | None,
+    session_index_cache: dict[Path, list] | None,
+) -> ChatSurface | None:
+    if not session.enabled:
+        return None
+    surface_type = _classify_session(session)
+    if surface_type is None:
+        return None
+    project_key = _project_key_for_session(config, session, surface_type)
+    project_root = _project_root_for_key(config, project_key)
+    persona = _persona_for_session(config, session, surface_type)
+    cwd = session.cwd if isinstance(session.cwd, Path) else Path(session.cwd or ".")
+    index = _build_session_index(project_root, session_index_cache)
+    transcript_path = lookup_transcript_path(
+        index,
+        cwd=str(cwd),
+        account_name=session.account,
+        provider=str(session.provider),
+    )
+    window_name = session.window_name or session_name
+    if tmux_state_cache and window_name in tmux_state_cache:
+        window_state = tmux_state_cache[window_name]
+    else:
+        window_state = TmuxWindowState(
+            tmux_session=tmux_session,
+            window_name=window_name,
+            present=False,
+        )
+    return ChatSurface(
+        session_name=session_name,
+        surface_type=surface_type,
+        persona=persona,
+        project=project_key if surface_type != SurfaceType.OPERATOR else None,
+        window=window_state,
+        transcript_path=transcript_path,
+        cwd=cwd,
+        provider=str(session.provider),
+        auth_token_present=bool(session.auth_token),
+    )
+
+
+def _worker_surface(
+    config: PollyPMConfig,
+    record: Any,
+    *,
+    tmux_session: str,
+    tmux_state_cache: dict[str, TmuxWindowState] | None,
+    session_index_cache: dict[Path, list] | None,
+) -> ChatSurface | None:
+    project = getattr(record, "task_project", "") or ""
+    task_number = getattr(record, "task_number", 0)
+    if not project or not task_number:
+        return None
+    session_name = task_window_name(project, task_number)
+    project_root = _project_root_for_key(config, project)
+    worktree_path = (
+        Path(record.worktree_path) if record.worktree_path else None
+    )
+    cwd_for_lookup = str(worktree_path) if worktree_path else None
+    provider_value = getattr(record, "provider", "") or ""
+    index = _build_session_index(project_root, session_index_cache)
+    transcript_path = lookup_transcript_path(
+        index,
+        cwd=cwd_for_lookup,
+        account_name=None,  # WorkerSessionRecord doesn't carry account
+        provider=provider_value or None,
+    )
+    window_name = session_name
+    if tmux_state_cache and window_name in tmux_state_cache:
+        window_state = tmux_state_cache[window_name]
+    else:
+        window_state = TmuxWindowState(
+            tmux_session=tmux_session,
+            window_name=window_name,
+            present=False,
+            pane_id=getattr(record, "pane_id", None),
+        )
+    return ChatSurface(
+        session_name=session_name,
+        surface_type=SurfaceType.WORKER,
+        persona=None,
+        project=project,
+        window=window_state,
+        transcript_path=transcript_path,
+        task_id=int(task_number),
+        cwd=worktree_path,
+        provider=provider_value,
+        auth_token_present=False,
+        worktree_path=worktree_path,
+    )
 
 
 def _classify_session(session: SessionConfig) -> SurfaceType | None:
@@ -502,4 +603,5 @@ __all__ = [
     "enumerate_chat_surfaces",
     "enumerate_config_surfaces",
     "enumerate_worker_surfaces",
+    "find_chat_surface",
 ]

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -45,6 +45,7 @@ from pollypm.web_api.chat import (
     SurfaceType,
     capture_envelopes,
     enumerate_chat_surfaces,
+    find_chat_surface,
     is_archive_stale,
     parse_events_jsonl,
     parse_events_jsonl_tail,
@@ -319,7 +320,9 @@ def _build_work_service_stub(config: Any) -> Any | None:
     return _WorkerSessionStub(records)
 
 
-def _build_work_service_stub_strict(config: Any) -> Any | None:
+def _build_work_service_stub_strict(
+    config: Any, *, project: str | None = None
+) -> Any | None:
     """Strict variant: surfaces facade outages instead of swallowing them.
 
     Consumes the public
@@ -349,7 +352,7 @@ def _build_work_service_stub_strict(config: Any) -> Any | None:
             "list_active_worker_sessions_strict import failed"
         ) from exc
     try:
-        records = list_active_worker_sessions_strict(config)
+        records = list_active_worker_sessions_strict(config, project=project)
     except WorkServiceFacadeUnavailable as exc:
         raise _WorkerFacadeUnavailable(str(exc)) from exc
     if not records:
@@ -372,9 +375,17 @@ class _WorkerSessionStub:
         self._records = list(records)
 
     def list_worker_sessions(
-        self, *, active_only: bool = True,  # noqa: ARG002 — registry-API compat
+        self,
+        *,
+        active_only: bool = True,  # noqa: ARG002 — registry-API compat
+        project: str | None = None,
     ) -> list[Any]:
-        return list(self._records)
+        if project is None:
+            return list(self._records)
+        return [
+            record for record in self._records
+            if getattr(record, "task_project", None) == project
+        ]
 
 
 def _build_tmux_client() -> TmuxClient | None:
@@ -418,9 +429,20 @@ def _find_surface(
         include_workers = _is_worker_session(session_name)
     tmux_client = _build_tmux_client()
     work_service: Any | None = None
+    worker_project: str | None = None
     if include_workers:
+        parsed = parse_task_window_name(session_name)
+        worker_project = parsed[0] if parsed is not None else None
         try:
-            work_service = _build_work_service_stub_strict(config)
+            try:
+                work_service = _build_work_service_stub_strict(
+                    config, project=worker_project
+                )
+            except TypeError:
+                # Older tests / adapters predate the project-scoped
+                # keyword. Fall back to the original strict call shape;
+                # the registry still filters the returned records.
+                work_service = _build_work_service_stub_strict(config)
         except _WorkerFacadeUnavailable as exc:
             raise service_unavailable(
                 f"work-service unavailable; cannot resolve worker session "
@@ -430,14 +452,25 @@ def _find_surface(
                     "Retry shortly; check `pm sessions` / pg pool health."
                 ),
             ) from exc
+    surface = find_chat_surface(
+        config,
+        session_name,
+        work_service=work_service,
+        tmux_client=tmux_client,
+    )
+    if surface is not None and surface.session_name == session_name:
+        return surface
+    # Compatibility fallback for tests and unusual callers that patch the
+    # broad enumerator directly. The normal configured-session hot path
+    # returns above and never pays this workspace-wide scan.
     surfaces = enumerate_chat_surfaces(
         config,
         work_service=work_service,
         tmux_client=tmux_client,
     )
-    for surface in surfaces:
-        if surface.session_name == session_name:
-            return surface
+    for candidate in surfaces:
+        if candidate.session_name == session_name:
+            return candidate
     raise _session_unknown(session_name)
 
 

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -157,7 +157,9 @@ class WorkServiceFacadeUnavailable(RuntimeError):
     """
 
 
-def list_active_worker_sessions_strict(config: PollyPMConfig) -> list[Any]:
+def list_active_worker_sessions_strict(
+    config: PollyPMConfig, *, project: str | None = None
+) -> list[Any]:
     """Strict variant of :func:`list_active_worker_sessions`.
 
     Same return shape, but raises :class:`WorkServiceFacadeUnavailable`
@@ -189,13 +191,18 @@ def list_active_worker_sessions_strict(config: PollyPMConfig) -> list[Any]:
             list_fn = getattr(svc, "list_worker_sessions", None)
             if not callable(list_fn):
                 return []
-            records = list_fn(active_only=True)
+            try:
+                records = list_fn(project=project, active_only=True)
+            except TypeError:
+                records = list_fn(active_only=True)
             return list(records or [])
     except Exception as exc:  # noqa: BLE001
         raise WorkServiceFacadeUnavailable(str(exc)) from exc
 
 
-def list_active_worker_sessions(config: PollyPMConfig) -> list[Any]:
+def list_active_worker_sessions(
+    config: PollyPMConfig, *, project: str | None = None
+) -> list[Any]:
     """Return active ``WorkerSessionRecord``s for chat surface discovery.
 
     Public facade so the chat-messages route doesn't need to reach
@@ -230,7 +237,10 @@ def list_active_worker_sessions(config: PollyPMConfig) -> list[Any]:
             if not callable(list_fn):
                 return []
             try:
-                records = list_fn(active_only=True)
+                try:
+                    records = list_fn(project=project, active_only=True)
+                except TypeError:
+                    records = list_fn(active_only=True)
             except Exception:  # noqa: BLE001
                 logger.debug(
                     "list_active_worker_sessions: list_worker_sessions failed",
@@ -255,15 +265,24 @@ def list_projects(config: PollyPMConfig, *, tracked_only: bool = False) -> list[
     """Return every registered project as an :class:`APIProject`.
 
     Counts and flags are computed against the work-service so the
-    response matches what the cockpit dashboard renders. We open one
-    work-service per project to keep the implementation simple — the
-    factory is cheap and the cockpit does the same.
+    response matches what the cockpit dashboard renders. On the pg
+    backend, collapse the historical per-project fanout into one bulk
+    task read so dashboard/project-list polls do not open and query the
+    work service once per registered project.
     """
     out: list[APIProject] = []
+    snapshots = _project_task_snapshots(config)
     for key, project in config.projects.items():
         if tracked_only and not project.tracked:
             continue
-        out.append(_project_to_api(config, key, project))
+        if snapshots is not None:
+            out.append(
+                _project_to_api_from_tasks(
+                    config, key, project, snapshots.get(key, [])
+                )
+            )
+        else:
+            out.append(_project_to_api(config, key, project))
     return out
 
 
@@ -280,10 +299,10 @@ def project_drilldown(config: PollyPMConfig, key: str) -> APIProjectDrilldown | 
     One round-trip is enough to render the cockpit's drilldown per
     spec §8 (``GET /api/v1/projects/{key}``).
     """
-    base = get_project(config, key)
-    if base is None:
+    project = config.projects.get(key)
+    if project is None:
         return None
-    project_path = config.projects[key].path
+    project_path = project.path
 
     recent: list[APIProjectActivityEntry] = []
     try:
@@ -310,17 +329,38 @@ def project_drilldown(config: PollyPMConfig, key: str) -> APIProjectDrilldown | 
 
     top_tasks: list[APITaskSummary] = []
     plan: APIPlan | None = None
+    counts: dict[str, int] = {}
+    pending_plan_review = False
+    open_inbox_count = 0
     try:
         with _open_work_service_readonly(
             config=config, project_key=key, project_path=project_path
         ) as svc:
+            try:
+                counts = svc.state_counts(project=key) or {}
+            except Exception:  # noqa: BLE001
+                counts = {}
+            try:
+                review_tasks = svc.list_tasks(project=key, work_status="review")
+            except Exception:  # noqa: BLE001
+                review_tasks = []
+            pending_plan_review = any(_is_plan_task(t) for t in review_tasks)
+            open_inbox_count = _count_open_inbox_with_service(svc, key)
             tasks = svc.list_tasks(project=key, limit=10)
             for task in tasks:
                 top_tasks.append(_task_to_summary(task))
-            plan = _active_plan_for_project(svc, key)
+            plan = _active_plan_from_review_tasks(svc, review_tasks)
     except Exception as exc:  # noqa: BLE001
         logger.debug("drilldown: work-service open failed for %s: %s", key, exc)
 
+    base = _project_to_api_from_metrics(
+        config,
+        key,
+        project,
+        counts=counts,
+        pending_plan_review=pending_plan_review,
+        open_inbox_count=open_inbox_count,
+    )
     return APIProjectDrilldown(
         **base.model_dump(),
         recent_activity=recent,
@@ -830,12 +870,132 @@ def init_project_guide_for_role(
     }
 
 
+_TERMINAL_STATUS_VALUES = frozenset({"done", "cancelled"})
+
+
+def _status_value(task: object) -> str:
+    status = getattr(task, "work_status", None)
+    return str(getattr(status, "value", status) or "")
+
+
+def _zero_counts() -> dict[str, int]:
+    try:
+        from pollypm.work.models import WorkStatus
+
+        return {status.value: 0 for status in WorkStatus}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _counts_from_tasks(tasks: list[object]) -> dict[str, int]:
+    counts = _zero_counts()
+    for task in tasks:
+        status = _status_value(task)
+        if not status:
+            continue
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def _open_inbox_count_from_tasks(tasks: list[object]) -> int:
+    count = 0
+    for task in tasks:
+        if getattr(task, "flow_template_id", "") != "chat":
+            continue
+        if _status_value(task) not in _TERMINAL_STATUS_VALUES:
+            count += 1
+    return count
+
+
+def _project_task_snapshots(
+    config: PollyPMConfig,
+) -> dict[str, list[object]] | None:
+    """Return pg task rows grouped by registered project, or ``None``.
+
+    This is an optimization only. If the pg aggregate path is unavailable
+    the callers fall back to the existing per-project service reads.
+    """
+    try:
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
+        if not is_pg_backend(config):
+            return None
+        from pollypm.cockpit_pg_aggregates import (
+            _all_tasks_grouped_uncached,
+            all_tasks_for_project,
+        )
+
+        # API responses should reflect the latest committed task state.
+        # Use the same one-query pg aggregate as the cockpit, but bypass
+        # the cockpit's short TTL cache so concurrent agents do not see
+        # deliberately stale project badges/counts through REST.
+        grouped = _all_tasks_grouped_uncached(config)
+        if grouped is None:
+            return None
+        return {
+            key: all_tasks_for_project(grouped, config, key)
+            for key in config.projects
+        }
+    except Exception:  # noqa: BLE001
+        logger.debug("project task snapshot aggregate unavailable", exc_info=True)
+        return None
+
+
+def _project_to_api_from_tasks(
+    config: PollyPMConfig,
+    key: str,
+    project: KnownProject,
+    tasks: list[object],
+) -> APIProject:
+    counts = _counts_from_tasks(tasks)
+    pending_plan_review = any(
+        _status_value(task) == "review" and _is_plan_task(task)
+        for task in tasks
+    )
+    open_inbox_count = _open_inbox_count_from_tasks(tasks)
+    return _project_to_api_from_metrics(
+        config,
+        key,
+        project,
+        counts=counts,
+        pending_plan_review=pending_plan_review,
+        open_inbox_count=open_inbox_count,
+    )
+
+
+def _project_to_api_from_metrics(
+    config: PollyPMConfig,  # noqa: ARG001 — kept for callsite symmetry
+    key: str,
+    project: KnownProject,
+    *,
+    counts: dict[str, int],
+    pending_plan_review: bool,
+    open_inbox_count: int,
+) -> APIProject:
+    glyph = _glyph_for_project(
+        project, counts, pending_plan_review, open_inbox_count
+    )
+    if not project.tracked:
+        glyph = "paused"
+    return APIProject(
+        key=key,
+        name=project.display_label(),
+        path=str(project.path),
+        tracked=project.tracked,
+        kind=project.kind.value if hasattr(project.kind, "value") else str(project.kind),
+        persona_name=project.persona_name,
+        state=None,
+        glyph=glyph,
+        task_counts=counts,
+        open_inbox_count=open_inbox_count,
+        pending_plan_review=pending_plan_review,
+    )
+
+
 def _project_to_api(config: PollyPMConfig, key: str, project: KnownProject) -> APIProject:
     counts: dict[str, int] = {}
     pending_plan_review = False
     open_inbox_count = 0
-    glyph = "unknown"
-    state_label: str | None = None
 
     try:
         with _open_work_service_readonly(
@@ -857,22 +1017,13 @@ def _project_to_api(config: PollyPMConfig, key: str, project: KnownProject) -> A
     except Exception as exc:  # noqa: BLE001
         logger.debug("project inbox count failed for %s: %s", key, exc)
 
-    glyph = _glyph_for_project(project, counts, pending_plan_review, open_inbox_count)
-    if not project.tracked:
-        glyph = "paused"
-
-    return APIProject(
-        key=key,
-        name=project.display_label(),
-        path=str(project.path),
-        tracked=project.tracked,
-        kind=project.kind.value if hasattr(project.kind, "value") else str(project.kind),
-        persona_name=project.persona_name,
-        state=state_label,
-        glyph=glyph,
-        task_counts=counts,
-        open_inbox_count=open_inbox_count,
+    return _project_to_api_from_metrics(
+        config,
+        key,
+        project,
+        counts=counts,
         pending_plan_review=pending_plan_review,
+        open_inbox_count=open_inbox_count,
     )
 
 
@@ -937,18 +1088,21 @@ def _count_open_inbox(config: PollyPMConfig, project_key: str) -> int:
         with _open_work_service_readonly(
             config=config, project_key=project_key, project_path=project.path
         ) as svc:
-            tasks = svc.list_tasks(project=project_key)
+            return _count_open_inbox_with_service(svc, project_key)
     except Exception:  # noqa: BLE001
         return 0
-    count = 0
-    for task in tasks:
-        if getattr(task, "flow_template_id", "") != "chat":
-            continue
-        status = getattr(task, "work_status", None)
-        status_value = getattr(status, "value", str(status)) if status else ""
-        if status_value not in {"done", "cancelled"}:
-            count += 1
-    return count
+
+
+def _count_open_inbox_with_service(svc: object, project_key: str) -> int:
+    try:
+        list_nonterminal = getattr(svc, "list_nonterminal_tasks", None)
+        if callable(list_nonterminal):
+            tasks = list_nonterminal(project=project_key)
+        else:
+            tasks = svc.list_tasks(project=project_key)  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001
+        return 0
+    return _open_inbox_count_from_tasks(list(tasks or []))
 
 
 # ---------------------------------------------------------------------------
@@ -2607,6 +2761,10 @@ def _active_plan_for_project(svc, project_key: str) -> APIPlan | None:
         review_tasks = svc.list_tasks(project=project_key, work_status="review")
     except Exception:  # noqa: BLE001
         review_tasks = []
+    return _active_plan_from_review_tasks(svc, review_tasks)
+
+
+def _active_plan_from_review_tasks(svc, review_tasks: list[object]) -> APIPlan | None:
     candidates = [t for t in review_tasks if _is_plan_task(t)]
     if not candidates:
         return None

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -175,11 +175,12 @@ def list_active_worker_sessions_strict(
     ``[]`` — there can't be any per-task workers without a project,
     so the caller treats that as a legitimate empty registry.
     """
-    project = getattr(config, "project", None)
-    if project is None:
+    project_filter = project
+    project_settings = getattr(config, "project", None)
+    if project_settings is None:
         return []
-    project_key = getattr(project, "name", "")
-    project_path = getattr(project, "root_dir", None)
+    project_key = getattr(project_settings, "name", "")
+    project_path = getattr(project_settings, "root_dir", None)
     if not project_key or project_path is None:
         return []
     try:
@@ -192,7 +193,12 @@ def list_active_worker_sessions_strict(
             if not callable(list_fn):
                 return []
             try:
-                records = list_fn(project=project, active_only=True)
+                if project_filter is None:
+                    records = list_fn(active_only=True)
+                else:
+                    records = list_fn(
+                        project=project_filter, active_only=True
+                    )
             except TypeError:
                 records = list_fn(active_only=True)
             return list(records or [])
@@ -220,11 +226,12 @@ def list_active_worker_sessions(
     module at import time (and the consumer only needs duck-typed
     attribute access).
     """
-    project = getattr(config, "project", None)
-    if project is None:
+    project_filter = project
+    project_settings = getattr(config, "project", None)
+    if project_settings is None:
         return []
-    project_key = getattr(project, "name", "")
-    project_path = getattr(project, "root_dir", None)
+    project_key = getattr(project_settings, "name", "")
+    project_path = getattr(project_settings, "root_dir", None)
     if not project_key or project_path is None:
         return []
     try:
@@ -238,7 +245,12 @@ def list_active_worker_sessions(
                 return []
             try:
                 try:
-                    records = list_fn(project=project, active_only=True)
+                    if project_filter is None:
+                        records = list_fn(active_only=True)
+                    else:
+                        records = list_fn(
+                            project=project_filter, active_only=True
+                        )
                 except TypeError:
                     records = list_fn(active_only=True)
             except Exception:  # noqa: BLE001

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -644,6 +644,52 @@ def test_read_events_walks_gz_archives_after_rotation(
     assert archived_match.metadata.get("root_cause_hash") == "abc123"
 
 
+def test_read_events_limit_uses_live_tail_without_full_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Project detail asks for the last 25 audit rows.
+
+    That path must stay proportional to the requested page size, not to
+    the full audit history. When the live log has enough rows, the
+    limited reader should tail the JSONL directly and never invoke the
+    forward full-file iterator.
+    """
+    import pollypm.audit.log as log_mod
+
+    project_root = tmp_path / "tailfast"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    rows = []
+    for i in range(200):
+        rows.append(json.dumps({
+            "schema": SCHEMA_VERSION,
+            "ts": f"2026-05-20T00:{i // 60:02d}:{i % 60:02d}+00:00",
+            "project": "tailfast",
+            "event": "task.status_changed",
+            "subject": f"tailfast/{i}",
+            "actor": "test",
+            "status": "ok",
+            "metadata": {},
+        }))
+    audit_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    def fail_forward_scan(_path):
+        raise AssertionError("limited read should not scan from file head")
+
+    monkeypatch.setattr(log_mod, "_iter_log_lines", fail_forward_scan)
+
+    events = log_mod.read_events("tailfast", project_path=project_root, limit=5)
+
+    assert [event.subject for event in events] == [
+        "tailfast/195",
+        "tailfast/196",
+        "tailfast/197",
+        "tailfast/198",
+        "tailfast/199",
+    ]
+
+
 def test_read_events_chains_live_and_gz_in_chronological_order(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -14,6 +14,7 @@ skipped — these tests are self-contained.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,7 @@ from pollypm.models import (
     RuntimeKind,
     SessionConfig,
 )
+from pollypm.projects import project_transcripts_dir
 from pollypm.web_api import create_app, ensure_token
 from pollypm.web_api.auth import SESSION_COOKIE_NAME
 from pollypm.web_api.chat.envelope import (
@@ -216,8 +218,16 @@ def patch_registry(monkeypatch: pytest.MonkeyPatch):
     def install(surfaces: list[ChatSurface]) -> None:
         def fake(config, work_service=None, tmux_client=None):
             return list(surfaces)
+        def fake_find(config, session_name, work_service=None, tmux_client=None):
+            for surface in surfaces:
+                if surface.session_name == session_name:
+                    return surface
+            return None
         monkeypatch.setattr(
             chat_messages_routes, "enumerate_chat_surfaces", fake,
+        )
+        monkeypatch.setattr(
+            chat_messages_routes, "find_chat_surface", fake_find,
         )
         # Also stub the work-service stub factory so we never try to
         # open Postgres during these tests. (The route uses the
@@ -228,6 +238,11 @@ def patch_registry(monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(
             chat_messages_routes,
             "_build_work_service_stub",
+            lambda _config, **_kw: None,
+        )
+        monkeypatch.setattr(
+            chat_messages_routes,
+            "_build_work_service_stub_strict",
             lambda _config, **_kw: None,
         )
         # Stop the route from constructing a real TmuxClient (spawning
@@ -436,6 +451,78 @@ def test_messages_endpoint_returns_envelopes_for_known_session(
     assert [m["id"] for m in body["messages"]] == ["msg_1", "msg_2"]
     assert body["has_more"] is False
     assert body["next_cursor"] is None
+
+
+def test_messages_endpoint_resolves_one_config_surface_without_full_enumeration(
+    client,
+    auth_headers,
+    config,
+    workspace,
+    project_root,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The message hot path must not build the whole session sidebar.
+
+    A single configured session can be resolved from ``config.sessions``
+    and that project's transcript index. Regressing to
+    ``enumerate_chat_surfaces`` would rescan every project transcript
+    root and reopen the worker facade before every message fetch.
+    """
+    transcript_dir = project_transcripts_dir(project_root) / "provider-session"
+    transcript_dir.mkdir(parents=True)
+    archive = transcript_dir / "events.jsonl"
+    archive.write_text(
+        json.dumps({
+            "timestamp": "2026-05-21T10:00:00Z",
+            "event_type": "assistant_turn",
+            "session_id": "provider-session",
+            "account_name": "codex_primary",
+            "provider": "codex",
+            "project_key": "myproj",
+            "source_path": "/tmp/raw.jsonl",
+            "source_offset": 0,
+            "cwd": str(workspace),
+            "model_name": "gpt-5",
+            "payload": {"text": "direct lookup"},
+        }) + "\n",
+        encoding="utf-8",
+    )
+    config.sessions["operator"] = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=workspace,
+        project="myproj",
+        window_name="operator",
+    )
+    monkeypatch.setattr(chat_messages_routes, "_build_tmux_client", lambda: None)
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_work_service_stub_strict",
+        lambda *_args, **_kwargs: pytest.fail(
+            "non-worker lookup should not open work-service"
+        ),
+    )
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "enumerate_chat_surfaces",
+        lambda *_args, **_kwargs: pytest.fail(
+            "message lookup should not enumerate every surface"
+        ),
+    )
+
+    response = client.get(
+        "/api/v1/chat/operator/messages?source=jsonl&direction=asc",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["session_name"] == "operator"
+    assert [message["text"] for message in body["messages"]] == [
+        "direct lookup",
+    ]
 
 
 def test_messages_endpoint_404s_unknown_session(

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -50,6 +50,7 @@ from pollypm.web_api.chat.registry import (
     TmuxWindowState,
 )
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
+from pollypm.web_api import service as web_api_service
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +189,45 @@ def _all_four_surfaces(tp: Path | None = None) -> list[ChatSurface]:
         _surface("task-myproj-7", SurfaceType.WORKER, persona=None,
                  project="myproj", task_id=7, transcript_path=tp),
     ]
+
+
+def test_worker_session_facade_forwards_project_filter(
+    config: PollyPMConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeWorkService:
+        def list_worker_sessions(
+            self, *, project: str | None = None, active_only: bool = True
+        ) -> list[object]:
+            seen["project"] = project
+            seen["active_only"] = active_only
+            return []
+
+    class FakeWorkServiceContext:
+        def __enter__(self) -> FakeWorkService:
+            return FakeWorkService()
+
+        def __exit__(self, *exc: object) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        web_api_service,
+        "_open_work_service_readonly",
+        lambda **_kwargs: FakeWorkServiceContext(),
+    )
+
+    assert web_api_service.list_active_worker_sessions_strict(
+        config, project="myproj"
+    ) == []
+    assert seen == {"project": "myproj", "active_only": True}
+
+    seen.clear()
+    assert web_api_service.list_active_worker_sessions(
+        config, project="other"
+    ) == []
+    assert seen == {"project": "other", "active_only": True}
 
 
 def _env(

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -281,6 +281,62 @@ def _api_project(
     )
 
 
+def test_list_projects_uses_pg_bulk_task_snapshot(
+    config: PollyPMConfig, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dashboard project rows should not open the work service per project."""
+    from types import SimpleNamespace
+
+    from pollypm.web_api import service as api_service
+
+    grouped = {
+        "myproj": [
+            SimpleNamespace(
+                project="myproj",
+                task_id="myproj/1",
+                work_status="review",
+                flow_template_id="plan_review",
+                labels=[],
+            ),
+            SimpleNamespace(
+                project="myproj",
+                task_id="myproj/2",
+                work_status="queued",
+                flow_template_id="chat",
+                labels=[],
+            ),
+        ],
+        "otherproj": [],
+    }
+
+    monkeypatch.setattr(
+        "pollypm.storage._backend_dispatch.is_pg_backend",
+        lambda _config: True,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates._all_tasks_grouped_uncached",
+        lambda _config: grouped,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.all_tasks_for_project",
+        lambda rows, _config, key: list(rows.get(key, [])),
+    )
+    monkeypatch.setattr(
+        api_service,
+        "_open_work_service_readonly",
+        lambda **_kw: pytest.fail(
+            "pg project list should use one bulk task snapshot"
+        ),
+    )
+
+    items = api_service.list_projects(config)
+
+    by_key = {item.key: item for item in items}
+    assert by_key["myproj"].pending_plan_review is True
+    assert by_key["myproj"].open_inbox_count == 1
+    assert by_key["myproj"].task_counts["review"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Happy paths
 # ---------------------------------------------------------------------------

--- a/tests/test_polly_dashboard_ui.py
+++ b/tests/test_polly_dashboard_ui.py
@@ -7,6 +7,8 @@ import threading
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from pollypm.cockpit_ui import PollyDashboardApp
 from pollypm.dashboard_data import (
     AccountQuotaUsage,
@@ -322,6 +324,90 @@ def test_dashboard_gather_includes_cached_llm_quota_usage(
     assert usage.email == "claude@swh.me"
     assert usage.used_pct == 79
     assert usage.limit_label == "weekly limit"
+
+
+def test_dashboard_gather_uses_bulk_heartbeat_lookup(monkeypatch) -> None:
+    from pollypm.dashboard_data import gather
+
+    config = SimpleNamespace(
+        projects={
+            "myproj": SimpleNamespace(display_label=lambda: "My Project"),
+        },
+        accounts={},
+    )
+    launches = [
+        SimpleNamespace(
+            session=SimpleNamespace(
+                name="operator",
+                role="operator",
+                project="myproj",
+            )
+        ),
+        SimpleNamespace(
+            session=SimpleNamespace(
+                name="architect_myproj",
+                role="architect",
+                project="myproj",
+            )
+        ),
+    ]
+    bulk_calls: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "pollypm.storage._backend_dispatch.is_pg_backend",
+        lambda _config: True,
+    )
+    monkeypatch.setattr(
+        "pollypm.service_api.plan_launches_readonly",
+        lambda _config, _store: launches,
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_sessions.list_session_runtimes",
+        lambda: [
+            SimpleNamespace(
+                session_name="operator",
+                status="healthy",
+                updated_at="2026-05-24T00:00:00+00:00",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_heartbeats.latest_heartbeats_bulk",
+        lambda names, **_kw: bulk_calls.append(list(names)) or {
+            "operator": SimpleNamespace(snapshot_path=""),
+        },
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_heartbeats.latest_heartbeat",
+        lambda *_args, **_kw: pytest.fail(
+            "dashboard gather should not issue per-session heartbeat reads"
+        ),
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_sessions.recent_events", lambda *, limit: []
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_token_usage.daily_token_usage",
+        lambda *, days: [],
+    )
+    monkeypatch.setattr("pollypm.storage.pg_alerts.open_alerts", lambda: [])
+    monkeypatch.setattr("pollypm.dashboard_data._recent_commits", lambda *_a, **_kw: [])
+    monkeypatch.setattr("pollypm.dashboard_data._completed_issues", lambda *_a, **_kw: [])
+    monkeypatch.setattr("pollypm.dashboard_data._recent_inbox_messages", lambda *_a, **_kw: [])
+    monkeypatch.setattr("pollypm.dashboard_data._count_dashboard_inbox_items", lambda _config: 0)
+    monkeypatch.setattr("pollypm.dashboard_data._account_quota_usage", lambda *_a, **_kw: [])
+    monkeypatch.setattr(
+        "pollypm.dashboard_data._user_waiting_task_ids_across_projects",
+        lambda _config: frozenset(),
+    )
+
+    data = gather(config, None)
+
+    assert bulk_calls == [["operator", "architect_myproj"]]
+    assert [session.name for session in data.active_sessions] == [
+        "operator",
+        "architect_myproj",
+    ]
 
 
 def test_polly_dashboard_i_key_routes_to_inbox(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Bound `read_events(..., limit=N)` to reverse tail reads so project detail recent activity no longer scans full audit history.
- Resolve a single `/api/v1/chat/{name}/messages` surface without enumerating every configured/worker surface first.
- Collapse API project/dashboard rollups onto bulk task/heartbeat reads where possible and reuse one work-service handle inside project drilldown.

## Perf Evidence
- Audit tail fixture, 50k JSONL rows, 30 warm samples: `origin/main` p50 415.5ms / p95 484.9ms / max 486.0ms; this branch p50 0.65ms / p95 0.98ms / max 0.99ms.
- Chat surface lookup fixture, 200 configured sessions, 30 warm samples: `origin/main` p50 73.3ms / p95 86.6ms / max 87.0ms; this branch p50 0.33ms / p95 0.62ms / max 0.65ms.
- Project list fanout fixture, 100 projects with 1ms service-open cost, 20 warm samples: `origin/main` p50 1475.2ms / p95 1544.5ms / max 1549.6ms; this branch p50 1.38ms / p95 1.41ms / max 1.43ms.

## Tests
- `python -m py_compile src/pollypm/audit/log.py src/pollypm/web_api/chat/registry.py src/pollypm/web_api/routes/chat_messages.py src/pollypm/web_api/service.py src/pollypm/dashboard_data.py`
- `uv run --with pytest python -m pytest --noconftest tests/test_chat_messages_endpoint.py tests/test_dashboard_endpoint.py tests/test_polly_dashboard_ui.py tests/test_audit_log.py -q`
- `git diff --check origin/main...HEAD`

Closes #2236
Closes #2164
Closes #2193
Closes #2195
Closes #2207
Refs #2140
