### PR TITLE
fix(migrate): close gate-loop and --check NameError (#2194)

### DIFF
--- a/src/pollypm/store/migrations.py
+++ b/src/pollypm/store/migrations.py
@@ -245,7 +245,17 @@ def _table_set(db_path: Path) -> set[str]:
 
 def _default_clone_path() -> Path:
     """Location of the dry-run clone (~/.pollypm/migration-check.db)."""
-    home = Path(os.environ.get("POLLYPM_HOME", str(GLOBAL_CONFIG_DIR)))
+    # Lazy import — pollypm.config pulls in a lot of optional deps, and
+    # this helper is on the ``pm migrate --check`` hot path that must
+    # survive partial installs (#2194). Falling back to ``Path.home() /
+    # ".pollypm"`` keeps the dry-run usable even if the config module
+    # cannot be imported.
+    try:
+        from pollypm.config import GLOBAL_CONFIG_DIR
+        default_home = str(GLOBAL_CONFIG_DIR)
+    except Exception:  # noqa: BLE001
+        default_home = str(Path.home() / ".pollypm")
+    home = Path(os.environ.get("POLLYPM_HOME", default_home))
     return home / "migration-check.db"
 
 
@@ -309,19 +319,36 @@ def _apply_all(db_path: Path) -> None:
     """Replay every migration idempotently by opening the existing writers.
 
     ``StateStore.__init__`` already replays ``_MIGRATIONS`` against the
-    DB; ``SQLiteWorkService.__init__`` (via ``create_work_tables``) does
-    the same for ``_WORK_MIGRATIONS``. We also mirror the applied set
-    into the unified ``schema_migrations`` audit table so operators have
-    a single pane of glass.
+    DB. The work-domain migrations live in ``_WORK_MIGRATIONS`` and used
+    to be applied via ``SQLiteWorkService.__init__`` — but post-sqlite-
+    ripout (#1971) ``create_work_service`` returns a PG-backed service
+    that ignores ``db_path`` and never touches the workspace state.db
+    (#2194). ``inspect()`` still reads ``work_schema_version`` from the
+    sqlite state.db, so a stale ``work_schema_version`` row keeps the
+    refuse-start gate firing forever even after ``pm migrate --apply``
+    claims success. Replay the work-domain migrations directly against
+    the state.db sqlite connection so the gate-tracked table actually
+    advances.
     """
     from pollypm.storage.state import StateStore
-    from pollypm.work import create_work_service
+    from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas
+    from pollypm.work.schema import create_work_tables
 
     with StateStore(db_path) as _store:
         pass
 
-    with create_work_service(db_path=db_path) as _svc:
-        pass
+    # #2194 — apply the work-domain migrations directly to the sqlite
+    # state.db. The state.db retains the legacy ``work_*`` tables from
+    # pre-pg installs; ``inspect()`` reads ``work_schema_version`` from
+    # here, so if this step is skipped the refuse-start gate fires
+    # forever.
+    conn = sqlite3.connect(str(db_path), timeout=5.0)
+    try:
+        apply_workspace_pragmas(conn)
+        create_work_tables(conn)
+        conn.commit()
+    finally:
+        conn.close()
 
     _record_schema_migrations(db_path)
 

--- a/tests/test_migrate_gate_regression_2194.py
+++ b/tests/test_migrate_gate_regression_2194.py
@@ -1,0 +1,171 @@
+"""Regression tests for #2194 — pm migrate gate loop and --check NameError.
+
+Wave 1B finding: a returning user runs ``git pull && pm up`` and the
+migration gate fires. ``pm migrate --apply`` reports success but the
+gate still blocks the cockpit, and ``pm migrate --check`` crashes with
+``NameError: GLOBAL_CONFIG_DIR``. The user's only escape is the
+undiscoverable ``POLLYPM_SKIP_MIGRATION_GATE=1`` env var.
+
+Root causes:
+
+1. ``_default_clone_path`` referenced ``GLOBAL_CONFIG_DIR`` without
+   importing it, so ``check_against_clone`` raised ``NameError`` the
+   moment it needed the default clone path.
+
+2. ``_apply_all`` delegated work-domain migrations to
+   ``create_work_service(db_path=...)``, but post-sqlite-ripout (#1971)
+   that factory returns a PG-backed service that ignores ``db_path``.
+   The sqlite ``work_schema_version`` table never advanced, so
+   ``inspect()`` kept reporting v11 pending and the refuse-start gate
+   kept firing.
+
+These tests pin the user-facing contracts:
+
+* ``check_against_clone`` against a stale-work-schema DB succeeds
+  without raising ``NameError``.
+* ``apply`` followed by ``inspect`` reports the DB up-to-date — the
+  same probe ``require_no_pending_or_exit`` uses, so the cockpit
+  startup gate no longer fires.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pollypm.store import migrations as _migrations
+
+
+def _seed_state_db_at_work_v10(db_path: Path) -> None:
+    """Produce a full state.db whose ``work_schema_version`` stops at v10.
+
+    Steps:
+
+    1. Open a full ``StateStore`` + ``create_work_tables`` against
+       ``db_path`` so every state-domain and work-domain table exists.
+    2. Roll the ``work_schema_version`` row set back to v10 and drop
+       the v11 column from ``work_tasks``. SQLite supports DROP COLUMN
+       since 3.35 (May 2021), which is well below our floor.
+
+    This recreates the exact on-disk state an operator hits after
+    ``git pull`` on the #2145 commit: every prior migration applied,
+    only v11 outstanding.
+    """
+    # Late imports — they pull pollypm.config et al., which want a real
+    # workspace; we only want the sqlite DDL bits here.
+    from pollypm.storage.state import StateStore
+    from pollypm.work.schema import create_work_tables
+
+    with StateStore(db_path) as _store:
+        pass
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        create_work_tables(conn)
+        # Trim work_schema_version back to v10 and drop the v11 column
+        # so ``inspect()`` reports work v11 as pending.
+        conn.execute("DELETE FROM work_schema_version WHERE version > 10")
+        conn.execute("ALTER TABLE work_tasks DROP COLUMN claimed_by_session")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def stale_state_db(tmp_path: Path) -> Path:
+    db = tmp_path / "state.db"
+    _seed_state_db_at_work_v10(db)
+    return db
+
+
+def test_check_against_clone_does_not_raise_name_error(
+    stale_state_db: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``pm migrate --check`` must not crash with ``NameError`` (#2194).
+
+    The bug was in ``_default_clone_path``, which referenced
+    ``GLOBAL_CONFIG_DIR`` without importing it. ``check_against_clone``
+    invokes ``_default_clone_path`` whenever the caller does not supply
+    an explicit clone path, so any real CLI invocation hit the
+    ``NameError`` before SQLite was touched.
+
+    Pin both the helper directly (catches the import regression
+    surface-level) and the public ``check_against_clone`` call against
+    a stale-schema DB (catches the integration path the CLI uses).
+    """
+    # Point POLLYPM_HOME at a writable tmp dir so the dry-run clone
+    # doesn't pollute ~/.pollypm during testing.
+    monkeypatch.setenv("POLLYPM_HOME", str(tmp_path))
+    monkeypatch.setenv("POLLYPM_SKIP_MIGRATION_GATE", "1")
+
+    # Direct surface: the bug raised here.
+    clone_path = _migrations._default_clone_path()
+    assert clone_path.parent == tmp_path
+    assert clone_path.name == "migration-check.db"
+
+    # Integration: the CLI hits this with clone_path=None.
+    outcome = _migrations.check_against_clone(stale_state_db)
+    assert outcome.ok, f"dry-run failed: {outcome.error!r}"
+    assert any(
+        item.namespace == "work" and item.version == 11
+        for item in outcome.applied
+    ), "expected work v11 in the dry-run applied set"
+
+
+def test_apply_then_inspect_reports_up_to_date(
+    stale_state_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``pm migrate --apply`` must actually clear the gate (#2194).
+
+    The bug: ``_apply_all`` called ``create_work_service(db_path=...)``
+    but post-sqlite-ripout that factory returns a PG service that
+    ignores ``db_path``. The sqlite ``work_schema_version`` table never
+    advanced, so ``inspect()`` kept reporting v11 pending — which is
+    exactly the probe ``require_no_pending_or_exit`` (the cockpit
+    refuse-start gate) uses. Net effect: ``pm migrate --apply &&
+    pm cockpit`` loops the user back to the gate forever.
+
+    Pin the user-facing contract: after ``apply()`` returns success,
+    ``inspect()`` must report ``up_to_date=True`` and the gate must
+    silently succeed.
+    """
+    monkeypatch.setenv("POLLYPM_SKIP_MIGRATION_GATE", "1")
+
+    status_before = _migrations.inspect(stale_state_db)
+    assert not status_before.up_to_date
+    pending_versions = {
+        (p.namespace, p.version) for p in status_before.pending
+    }
+    assert ("work", 11) in pending_versions, (
+        "test setup expected work v11 pending; got "
+        f"{pending_versions!r}"
+    )
+
+    outcome = _migrations.apply(stale_state_db)
+    assert not outcome.already_up_to_date
+    applied_versions = {(p.namespace, p.version) for p in outcome.applied}
+    assert ("work", 11) in applied_versions
+
+    # The probe ``require_no_pending_or_exit`` runs — must not raise.
+    status_after = _migrations.inspect(stale_state_db)
+    assert status_after.up_to_date, (
+        f"gate would still fire after apply: pending="
+        f"{[(p.namespace, p.version) for p in status_after.pending]}"
+    )
+    _migrations.require_no_pending_or_exit(stale_state_db)
+
+    # And the v11 column actually landed on the live DB.
+    conn = sqlite3.connect(str(stale_state_db))
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(work_tasks)")}
+    finally:
+        conn.close()
+    assert "claimed_by_session" in cols, (
+        "v11 migration claims success but claimed_by_session column "
+        "was never added to work_tasks"
+    )


### PR DESCRIPTION
## Summary
Wave 1B finding (P0): a returning user runs `git pull && pm up` and is locked out of the cockpit because the migration gate fires. `pm migrate --apply` claims success but the gate still blocks the cockpit, and `pm migrate --check` crashes with `NameError: GLOBAL_CONFIG_DIR`. The only escape was the undiscoverable env var `POLLYPM_SKIP_MIGRATION_GATE=1`.

## Diagnosis
Two distinct bugs in `src/pollypm/store/migrations.py`:

1. **`--check` NameError** — `_default_clone_path` referenced `GLOBAL_CONFIG_DIR` without importing it. Any invocation that hit the default clone path (which `_run_check` always does) raised before SQLite was touched.

2. **`--apply` gate-loop** — `_apply_all` delegated work-domain migrations to `create_work_service(db_path=...)`. Post-sqlite-ripout (#1971) that factory returns a PG-backed service that **ignores `db_path`** — so the sqlite `work_schema_version` table never advanced. Meanwhile `inspect()` (used by the refuse-start gate) still reads `work_schema_version` from the sqlite `state.db`. Net effect: v11 stayed pending forever, the gate fired forever, and `pm migrate --apply` was a silent no-op for any work-domain migration.

## Fix
Minimum diff (RC stability):

- Lazy-import `GLOBAL_CONFIG_DIR` in `_default_clone_path` with a `Path.home()` fallback.
- Replay work-domain migrations in `_apply_all` directly against the sqlite `state.db` via `create_work_tables(conn)` so the gate-tracked `work_schema_version` row actually advances.

## Before / After (real `~/.pollypm/state.db`, work_schema_version stopped at v10)

**Before:**
```
$ pm migrate --check
Dry-run against clone of /Users/sam/.pollypm/state.db
1 pending migration:
  [work] v11: Add claimed_by_session to work_tasks for claim identity breadcrumbs (#2145)
NameError: name 'GLOBAL_CONFIG_DIR' is not defined
```

```python
>>> apply(db); inspect(db).pending
[PendingMigration(namespace='work', version=11, ...)]   # still pending after apply!
```

**After:**
```
$ pm migrate --check
Dry-run against clone of /Users/sam/.pollypm/state.db
1 pending migration:
  [work] v11: Add claimed_by_session to work_tasks for claim identity breadcrumbs (#2145)
No table-level changes — migrations affect columns/indexes only.
Clone retained at /Users/sam/.pollypm/migration-check.db for inspection.
Migration check OK. Run `pm migrate --apply` to upgrade the live DB.
```

```
=== Running apply... ===
  applied=[('work', 11)]
=== After apply: gate fires? ===
  Gate passed — cockpit would start.
```

## Test plan
- [x] New regression: `tests/test_migrate_gate_regression_2194.py` pins both paths
  - `check_against_clone` against stale-work-schema DB returns `ok=True` with no NameError
  - `apply` → `inspect` reports `up_to_date=True`; `require_no_pending_or_exit` passes; `claimed_by_session` column landed
- [x] `pytest tests/test_migrate_gate_regression_2194.py` → 2 passed
- [x] `pytest tests/test_upgrade.py` → 35 passed (only unrelated home-write-guard teardown error, also fails on main)
- [x] `pytest -k 'migrate or migration'` → 24 passed in the migrate-domain (1 pre-existing failure in `test_doctor.py` unrelated to this change, verified on main)
- [x] Manual end-to-end: `pm migrate --check` no longer crashes; simulated `apply` + `require_no_pending_or_exit` cycle on a real state.db copy passes the gate

Closes #2194.

Authorized claude-created PR (Sam offline 2026-05-24, 2h Codex-stall rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)