### PR TITLE
fix(chat): resolve thinking transcripts after account drift

### DIFF
--- a/src/pollypm/web_api/chat/registry.py
+++ b/src/pollypm/web_api/chat/registry.py
@@ -20,6 +20,7 @@ the database.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -165,6 +166,7 @@ def enumerate_chat_surfaces(
     *,
     work_service: Any | None = None,
     tmux_client: Any | None = None,
+    effective_accounts: Mapping[str, str] | None = None,
 ) -> list[ChatSurface]:
     """Return every chat surface (operator/architect/advisor/worker).
 
@@ -177,6 +179,11 @@ def enumerate_chat_surfaces(
     and ``pane_id``. When ``None`` we don't probe tmux — the response
     still returns the configured ``window_name`` and the caller can
     treat ``present`` as "unknown" (defaults to ``False``).
+
+    ``effective_accounts`` maps configured session names to runtime
+    accounts after failover / manual account switch. Transcript lookup
+    must follow the account that actually launched the provider
+    process, not only the static ``SessionConfig.account`` value.
 
     The returned list is ordered: operator first, then architects,
     then advisors, then workers (sorted by ``project`` then ``task_id``).
@@ -195,6 +202,7 @@ def enumerate_chat_surfaces(
         config,
         tmux_state_cache=tmux_state_cache,
         session_index_cache=session_index_cache,
+        effective_accounts=effective_accounts,
     ))
     if work_service is not None:
         surfaces.extend(enumerate_worker_surfaces(
@@ -232,6 +240,7 @@ def enumerate_config_surfaces(
     *,
     tmux_state_cache: dict[str, TmuxWindowState] | None = None,
     session_index_cache: dict[Path, list] | None = None,
+    effective_accounts: Mapping[str, str] | None = None,
 ) -> list[ChatSurface]:
     """Enumerate operator/architect/advisor surfaces from ``config.sessions``.
 
@@ -253,6 +262,7 @@ def enumerate_config_surfaces(
             tmux_session=tmux_session,
             tmux_state_cache=tmux_state_cache,
             session_index_cache=session_index_cache,
+            effective_accounts=effective_accounts,
         )
         if surface is not None:
             surfaces.append(surface)
@@ -310,6 +320,7 @@ def find_chat_surface(
     *,
     work_service: Any | None = None,
     tmux_client: Any | None = None,
+    effective_accounts: Mapping[str, str] | None = None,
 ) -> ChatSurface | None:
     """Resolve one chat surface without enumerating the whole workspace.
 
@@ -332,6 +343,7 @@ def find_chat_surface(
             tmux_session=storage_session_name(config.project.tmux_session),
             tmux_state_cache=tmux_state_cache,
             session_index_cache=session_index_cache,
+            effective_accounts=effective_accounts,
         )
 
     parsed = parse_task_window_name(session_name)
@@ -377,6 +389,7 @@ def _config_surface(
     tmux_session: str,
     tmux_state_cache: dict[str, TmuxWindowState] | None,
     session_index_cache: dict[Path, list] | None,
+    effective_accounts: Mapping[str, str] | None = None,
 ) -> ChatSurface | None:
     if not session.enabled:
         return None
@@ -388,12 +401,26 @@ def _config_surface(
     persona = _persona_for_session(config, session, surface_type)
     cwd = session.cwd if isinstance(session.cwd, Path) else Path(session.cwd or ".")
     index = _build_session_index(project_root, session_index_cache)
-    transcript_path = lookup_transcript_path(
+    account_candidates = _account_candidates_for_transcript_lookup(
+        config,
+        session_name,
+        session,
+        effective_accounts=effective_accounts,
+    )
+    transcript_path = _lookup_transcript_path_for_accounts(
         index,
         cwd=str(cwd),
-        account_name=session.account,
         provider=str(session.provider),
+        account_candidates=account_candidates,
     )
+    if transcript_path is None and surface_type == SurfaceType.OPERATOR:
+        transcript_path = _lookup_transcript_path_for_accounts(
+            index,
+            cwd=str(project_root),
+            provider=str(session.provider),
+            account_candidates=account_candidates,
+            prefer_newest=True,
+        )
     window_name = session.window_name or session_name
     if tmux_state_cache and window_name in tmux_state_cache:
         window_state = tmux_state_cache[window_name]
@@ -414,6 +441,73 @@ def _config_surface(
         provider=str(session.provider),
         auth_token_present=bool(session.auth_token),
     )
+
+
+def _account_candidates_for_transcript_lookup(
+    config: PollyPMConfig,
+    session_name: str,
+    session: SessionConfig,
+    *,
+    effective_accounts: Mapping[str, str] | None = None,
+) -> list[str | None]:
+    candidates: list[str | None] = []
+
+    def add(account_name: object) -> None:
+        candidate = str(account_name) if account_name else None
+        if candidate not in candidates:
+            candidates.append(candidate)
+
+    if effective_accounts is not None:
+        add(effective_accounts.get(session_name))
+    add(getattr(session, "account", None))
+
+    session_provider = str(getattr(session, "provider", "") or "")
+    settings = getattr(config, "pollypm", None)
+    failover_accounts = getattr(settings, "failover_accounts", None) or []
+    accounts = getattr(config, "accounts", None) or {}
+    for account_name in failover_accounts:
+        account = accounts.get(account_name)
+        if account is None:
+            continue
+        if str(getattr(account, "provider", "") or "") != session_provider:
+            continue
+        add(account_name)
+
+    return candidates or [None]
+
+
+def _lookup_transcript_path_for_accounts(
+    index: list,
+    *,
+    cwd: str | None,
+    provider: str | None,
+    account_candidates: list[str | None],
+    prefer_newest: bool = False,
+) -> Path | None:
+    matches: list[Path] = []
+    for account_name in account_candidates:
+        candidate = lookup_transcript_path(
+            index,
+            cwd=cwd,
+            account_name=account_name,
+            provider=provider,
+        )
+        if candidate is None:
+            continue
+        if not prefer_newest:
+            return candidate
+        matches.append(candidate)
+    if not matches:
+        return None
+    matches.sort(key=_path_mtime, reverse=True)
+    return matches[0]
+
+
+def _path_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
 
 
 def _worker_surface(

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -360,6 +360,28 @@ def _build_work_service_stub_strict(
     return _WorkerSessionStub(records)
 
 
+def _build_effective_account_map(config: Any) -> dict[str, str]:
+    """Return session runtime account overrides for transcript lookup."""
+    settings = getattr(config, "pollypm", None)
+    if not (
+        getattr(settings, "failover_enabled", False)
+        or getattr(settings, "failover_accounts", None)
+    ):
+        return {}
+    try:
+        from pollypm.web_api.service import list_session_effective_accounts
+    except Exception:  # noqa: BLE001
+        return {}
+    try:
+        return list_session_effective_accounts(config)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "chat_messages: session effective-account lookup failed",
+            exc_info=True,
+        )
+        return {}
+
+
 class _WorkerSessionStub:
     """Minimal stand-in exposing ``list_worker_sessions`` for the registry.
 
@@ -452,11 +474,16 @@ def _find_surface(
                     "Retry shortly; check `pm sessions` / pg pool health."
                 ),
             ) from exc
+    effective_accounts = _build_effective_account_map(config)
+    enumerate_kwargs: dict[str, Any] = {}
+    if effective_accounts:
+        enumerate_kwargs["effective_accounts"] = effective_accounts
     surface = find_chat_surface(
         config,
         session_name,
         work_service=work_service,
         tmux_client=tmux_client,
+        **enumerate_kwargs,
     )
     if surface is not None and surface.session_name == session_name:
         return surface
@@ -467,6 +494,7 @@ def _find_surface(
         config,
         work_service=work_service,
         tmux_client=tmux_client,
+        **enumerate_kwargs,
     )
     for candidate in surfaces:
         if candidate.session_name == session_name:
@@ -1033,10 +1061,15 @@ def list_chat_sessions_endpoint(config: ConfigDep) -> ChatSessionsResponse:
     """
     tmux_client = _build_tmux_client()
     work_service = _build_work_service_stub(config)
+    effective_accounts = _build_effective_account_map(config)
+    enumerate_kwargs: dict[str, Any] = {}
+    if effective_accounts:
+        enumerate_kwargs["effective_accounts"] = effective_accounts
     surfaces = enumerate_chat_surfaces(
         config,
         work_service=work_service,
         tmux_client=tmux_client,
+        **enumerate_kwargs,
     )
     return ChatSessionsResponse(
         sessions=[_surface_to_wire(surface) for surface in surfaces],

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -268,6 +268,37 @@ def list_active_worker_sessions(
         return []
 
 
+def list_session_effective_accounts(config: PollyPMConfig) -> dict[str, str]:
+    """Return runtime account overrides for configured chat sessions.
+
+    Control sessions can fail over or be manually switched to a
+    different account than ``SessionConfig.account``. The transcript
+    ingestor records the account that actually produced each JSONL
+    line, so chat-surface discovery needs this runtime account map to
+    resolve the correct archive. Fail soft: if runtime state is
+    unavailable, callers fall back to static config and still return
+    the rest of the surface list.
+    """
+    del config  # The pg session-runtime facade reads the configured pool.
+    try:
+        from pollypm.storage.pg_sessions import list_session_runtimes
+
+        rows = list_session_runtimes()
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "list_session_effective_accounts: session-runtime read failed",
+            exc_info=True,
+        )
+        return {}
+    effective: dict[str, str] = {}
+    for row in rows or []:
+        session_name = getattr(row, "session_name", None)
+        account = getattr(row, "effective_account", None)
+        if session_name and account:
+            effective[str(session_name)] = str(account)
+    return effective
+
+
 # ---------------------------------------------------------------------------
 # Project helpers
 # ---------------------------------------------------------------------------
@@ -3730,6 +3761,7 @@ __all__ = [
     "list_inbox",
     "list_project_tasks",
     "list_projects",
+    "list_session_effective_accounts",
     "load_api_config",
     "mark_read_inbox_item",
     "patch_task",

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -1141,6 +1141,134 @@ def test_messages_endpoint_include_thinking_reaches_ingested_surface_archive(
     assert body["messages"][1]["text"] == "Visible reply."
 
 
+def test_messages_endpoint_include_thinking_uses_effective_account_archive(
+    client, auth_headers, config, workspace, project_root, monkeypatch,
+):
+    """Failover-account transcripts remain registered REST surfaces."""
+    import json as _json
+
+    from pollypm.web_api.chat.transcripts import _parse_cache_clear
+
+    config.accounts["claude_primary"] = AccountConfig(
+        name="claude_primary",
+        provider=ProviderKind.CLAUDE,
+        home=project_root / ".pollypm/homes/claude_primary",
+    )
+    config.accounts["claude_backup"] = AccountConfig(
+        name="claude_backup",
+        provider=ProviderKind.CLAUDE,
+        home=project_root / ".pollypm/homes/claude_backup",
+    )
+    config.pollypm.failover_enabled = True
+    config.pollypm.failover_accounts = ["claude_backup"]
+    config.sessions["operator"] = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CLAUDE,
+        account="claude_primary",
+        cwd=workspace,
+        project="myproj",
+        window_name="operator",
+    )
+
+    transcripts = project_root / ".pollypm/transcripts"
+
+    def event(
+        session_id: str,
+        *,
+        account_name: str,
+        event_type: str,
+        timestamp: str,
+        text: str,
+    ) -> dict[str, Any]:
+        payload = (
+            {"text": text, "signature": "sig-effective"}
+            if event_type == "thinking"
+            else {"text": text}
+        )
+        return {
+            "timestamp": timestamp,
+            "event_type": event_type,
+            "session_id": session_id,
+            "account_name": account_name,
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": "/tmp/raw.jsonl",
+            "source_offset": 0,
+            "cwd": str(project_root),
+            "model_name": "claude-opus-4-7",
+            "payload": payload,
+        }
+
+    primary_archive = transcripts / "session-primary/events.jsonl"
+    primary_archive.parent.mkdir(parents=True)
+    primary_archive.write_text(_json.dumps(event(
+        "session-primary",
+        account_name="claude_primary",
+        event_type="assistant_turn",
+        timestamp="2026-05-21T09:00:00Z",
+        text="Primary account text.",
+    )) + "\n")
+
+    backup_archive = transcripts / "session-backup/events.jsonl"
+    backup_archive.parent.mkdir(parents=True)
+    backup_archive.write_text(
+        _json.dumps(event(
+            "session-backup",
+            account_name="claude_backup",
+            event_type="thinking",
+            timestamp="2026-05-21T10:00:00Z",
+            text="Failover thought.",
+        ))
+        + "\n"
+        + _json.dumps(event(
+            "session-backup",
+            account_name="claude_backup",
+            event_type="assistant_turn",
+            timestamp="2026-05-21T10:00:01Z",
+            text="Failover visible reply.",
+        ))
+        + "\n"
+    )
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_tmux_client",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_effective_account_map",
+        lambda _config: {"operator": "claude_backup"},
+    )
+    _parse_cache_clear()
+
+    sessions_response = client.get(
+        "/api/v1/chat/sessions",
+        headers=auth_headers,
+    )
+    assert sessions_response.status_code == 200, sessions_response.text
+    operator = next(
+        s for s in sessions_response.json()["sessions"]
+        if s["session_name"] == "operator"
+    )
+    assert operator["transcript"]["source"] == "jsonl"
+    assert operator["transcript"]["path"] == str(backup_archive)
+
+    response = client.get(
+        "/api/v1/chat/operator/messages?include_thinking=true&limit=200",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["transcript_source"] == "jsonl"
+    types = [m["type"] for m in body["messages"]]
+    assert "thinking" in types
+    thinking = next(m for m in body["messages"] if m["type"] == "thinking")
+    assert thinking["text"] == "Failover thought."
+    assert thinking["metadata"]["signature"] == "sig-effective"
+
+
 def test_messages_endpoint_no_subagent_inlining_by_default(
     client, auth_headers, patch_registry, patch_parser, tmp_path,
 ):

--- a/tests/test_chat_registry.py
+++ b/tests/test_chat_registry.py
@@ -641,6 +641,113 @@ def test_two_surfaces_sharing_cwd_resolve_to_correct_transcripts(
     assert by_name["operator"].transcript_path != by_name["architect_pollypm"].transcript_path
 
 
+def test_surface_transcript_path_uses_runtime_effective_account(
+    tmp_path: Path,
+) -> None:
+    """Failover-account archives should remain attached to the session."""
+    project_root = tmp_path / "repo"
+    config = _build_config(tmp_path, sessions={
+        "operator": _session(
+            "operator",
+            role="operator-pm",
+            account="claude_main",
+            cwd=project_root,
+        ),
+    })
+    config.accounts["claude_backup"] = AccountConfig(
+        name="claude_backup",
+        provider=ProviderKind.CLAUDE,
+        home=project_root / ".pollypm/homes/claude_backup",
+    )
+
+    transcripts = project_root / ".pollypm" / "transcripts"
+    primary_dir = transcripts / "session-primary"
+    backup_dir = transcripts / "session-backup"
+    primary_dir.mkdir(parents=True)
+    backup_dir.mkdir(parents=True)
+
+    def write_event(path: Path, session_id: str, account_name: str) -> None:
+        event = {
+            "timestamp": "2026-05-21T20:00:00Z",
+            "event_type": "assistant_turn",
+            "session_id": session_id,
+            "account_name": account_name,
+            "provider": "claude",
+            "project_key": "pollypm",
+            "source_path": "/tmp/raw",
+            "source_offset": 0,
+            "cwd": str(project_root),
+            "payload": {"text": account_name},
+        }
+        path.write_text(json.dumps(event) + "\n")
+
+    write_event(primary_dir / "events.jsonl", "session-primary", "claude_main")
+    write_event(backup_dir / "events.jsonl", "session-backup", "claude_backup")
+
+    surfaces = enumerate_chat_surfaces(
+        config,
+        effective_accounts={"operator": "claude_backup"},
+    )
+
+    assert surfaces[0].session_name == "operator"
+    assert surfaces[0].transcript_path == backup_dir / "events.jsonl"
+
+
+def test_operator_transcript_falls_back_to_project_root_failover_archive(
+    tmp_path: Path,
+) -> None:
+    """Workspace-root operators can still see project-root failover JSONL."""
+    project_root = tmp_path / "repo"
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    config = _build_config(tmp_path, sessions={
+        "operator": _session(
+            "operator",
+            role="operator-pm",
+            account="claude_main",
+            cwd=workspace_root,
+        ),
+    })
+    config.pollypm.failover_accounts = ["claude_backup"]
+    config.accounts["claude_backup"] = AccountConfig(
+        name="claude_backup",
+        provider=ProviderKind.CLAUDE,
+        home=project_root / ".pollypm/homes/claude_backup",
+    )
+
+    transcripts = project_root / ".pollypm" / "transcripts"
+    primary_dir = transcripts / "session-primary"
+    backup_dir = transcripts / "session-backup"
+    primary_dir.mkdir(parents=True)
+    backup_dir.mkdir(parents=True)
+
+    def write_event(path: Path, session_id: str, account_name: str) -> None:
+        event = {
+            "timestamp": "2026-05-21T20:00:00Z",
+            "event_type": "assistant_turn",
+            "session_id": session_id,
+            "account_name": account_name,
+            "provider": "claude",
+            "project_key": "pollypm",
+            "source_path": "/tmp/raw",
+            "source_offset": 0,
+            "cwd": str(project_root),
+            "payload": {"text": account_name},
+        }
+        path.write_text(json.dumps(event) + "\n")
+
+    write_event(primary_dir / "events.jsonl", "session-primary", "claude_main")
+    write_event(backup_dir / "events.jsonl", "session-backup", "claude_backup")
+    import os as _os
+    _os.utime(primary_dir / "events.jsonl", (1_700_000_000, 1_700_000_000))
+    _os.utime(backup_dir / "events.jsonl", (1_700_000_100, 1_700_000_100))
+
+    surfaces = enumerate_chat_surfaces(config)
+
+    assert surfaces[0].session_name == "operator"
+    assert surfaces[0].transcript_path == backup_dir / "events.jsonl"
+
+
 # ---------------------------------------------------------------------------
 # auth_token_present surfacing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Resolves configured chat transcripts across runtime effective accounts, static accounts, and same-provider failover accounts so failover JSONL archives remain attached to their REST surface.
- Adds operator fallback from workspace cwd to project-root cwd when normalized provider transcripts record the concrete project root.
- Retargeted onto `main`; the prior #2160 tail-read claim is intentionally dropped because #2261 already merged that fix.

## Tests
- `python -m py_compile src/pollypm/web_api/chat/registry.py src/pollypm/web_api/routes/chat_messages.py src/pollypm/web_api/service.py tests/test_chat_registry.py tests/test_chat_messages_endpoint.py`
- `uv run --with ruff ruff check src/pollypm/web_api/chat/registry.py src/pollypm/web_api/routes/chat_messages.py src/pollypm/web_api/service.py tests/test_chat_registry.py tests/test_chat_messages_endpoint.py`
- `HOME=$(mktemp -d /tmp/pollypm-pr2258b.XXXXXX) uv run --extra test pytest --noconftest tests/test_chat_registry.py tests/test_chat_messages_endpoint.py::test_messages_endpoint_include_thinking_uses_effective_account_archive tests/test_chat_messages_endpoint.py::test_messages_endpoint_include_thinking_surfaces_under_default_curl -q` (36 passed)
- `HOME=$(mktemp -d /tmp/pollypm-pr2258c.XXXXXX) uv run --extra test pytest tests/test_chat_messages_endpoint.py -q` (49 passed)
- `git diff --check origin/main...HEAD`

Closes #2250
