### PR TITLE
fix(sessions): add account relaunch and failover viability

### DIFF
--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -206,17 +206,21 @@ def is_account_runtime_unavailable(value: str | None) -> bool:
 
     Mirrors the canonical list used by ``Supervisor._account_is_viable``
     (auth_broken / exhausted / provider_outage / blocked) but also
-    tolerates the hyphenated ``"auth-broken"`` form so legacy rows or
-    UI-driven writes still match.
+    tolerates capacity/auth hyphen and underscore variants so legacy rows
+    or UI-driven writes still match.
     """
     if value is None:
         return False
     return value in {
         "auth_broken",
         "auth-broken",
+        "capacity-exhausted",
+        "capacity_exhausted",
         "exhausted",
         "provider_outage",
         "blocked",
+        "signed-out",
+        "throttled",
     }
 
 

--- a/src/pollypm/capacity.py
+++ b/src/pollypm/capacity.py
@@ -133,11 +133,12 @@ def probe_capacity(
     usage, runtime = _read_account_state(config, store, account_name)
 
     # Runtime status takes precedence (captures live failures)
-    if runtime and runtime.status in FAILOVER_TRIGGERS:
+    runtime_state = _health_to_state(runtime.status) if runtime else None
+    if runtime_state in FAILOVER_TRIGGERS:
         return CapacityProbeResult(
             account_name=account_name,
             provider=account.provider,
-            state=CapacityState(runtime.status),
+            state=runtime_state,
             reason=runtime.reason,
             reset_time=runtime.available_at,
         )
@@ -351,11 +352,9 @@ def select_failover_account(
 ) -> FailoverDecision:
     """Select the best failover account when one fails.
 
-    Selection priority:
-    1. Healthy non-controller same provider
-    2. Healthy non-controller different provider
-    3. Controller same provider (if not the failed one)
-    4. Controller different provider (if not the failed one)
+    Selection follows ``config.pollypm.failover_accounts`` first, then
+    the controller account, then any remaining configured accounts. The
+    first healthy account in that order wins.
     """
     if not config.pollypm.failover_enabled:
         return FailoverDecision(
@@ -384,10 +383,24 @@ def select_failover_account(
     controller = config.pollypm.controller_account
     failed_provider = failed_config.provider
 
-    # Build candidate list with priorities
+    # Build candidate list in configured failover order. The operator-facing
+    # `pm failover` output presents this as an ordered chain, so recovery must
+    # walk that same chain before falling back to controller/other accounts.
     candidates: list[FailoverCandidate] = []
+    ordered_names: list[str] = []
+    for name in config.pollypm.failover_accounts:
+        if name and name not in ordered_names:
+            ordered_names.append(name)
+    if controller and controller not in ordered_names:
+        ordered_names.append(controller)
+    for name in config.accounts:
+        if name not in ordered_names:
+            ordered_names.append(name)
 
-    for name, account in config.accounts.items():
+    for order, name in enumerate(ordered_names):
+        account = config.accounts.get(name)
+        if account is None:
+            continue
         if name == failed_account:
             continue
 
@@ -395,23 +408,14 @@ def select_failover_account(
         if capacity.state in FAILOVER_TRIGGERS:
             continue  # Skip accounts that are also failing
 
-        is_controller = (name == controller)
-        same_provider = (account.provider == failed_provider)
-
-        if not is_controller and same_provider:
-            priority = 0  # Best: non-controller, same provider
-        elif not is_controller and not same_provider:
-            priority = 1  # Good: non-controller, different provider
-        elif is_controller and same_provider:
-            priority = 2  # Acceptable: controller, same provider
-        else:
-            priority = 3  # Last resort: controller, different provider
-
         candidates.append(FailoverCandidate(
             account_name=name,
             provider=account.provider,
-            priority=priority,
-            reason=f"priority={priority}, state={capacity.state}",
+            priority=order,
+            reason=(
+                f"order={order}, state={capacity.state}, "
+                f"same_provider={account.provider == failed_provider}"
+            ),
         ))
 
     if not candidates:
@@ -422,7 +426,7 @@ def select_failover_account(
             candidates_evaluated=0,
         )
 
-    # Sort by priority (lower is better)
+    # Sort by configured/fallback order (lower is better)
     candidates.sort(key=lambda c: c.priority)
     best = candidates[0]
 
@@ -567,6 +571,13 @@ def persist_capacity_probe(
 
 def _health_to_state(health: str) -> CapacityState:
     """Convert a health string to a CapacityState enum."""
+    aliases = {
+        "auth_broken": CapacityState.AUTH_BROKEN,
+        "capacity_exhausted": CapacityState.EXHAUSTED,
+        "exhausted": CapacityState.EXHAUSTED,
+    }
+    if health in aliases:
+        return aliases[health]
     try:
         return CapacityState(health)
     except ValueError:

--- a/src/pollypm/cli_features/alerts.py
+++ b/src/pollypm/cli_features/alerts.py
@@ -233,6 +233,100 @@ def session_set_status(
     typer.echo(f"Updated {session_name} to {status}")
 
 
+def _session_restart_impl(
+    session_name: str,
+    *,
+    account: str | None,
+    force: bool,
+    json_output: bool,
+    config_path: Path,
+) -> None:
+    from pollypm import cli as cli_mod
+    from pollypm.session_leases import SessionLeaseConflictError
+
+    try:
+        result = _service(config_path).restart_session(
+            session_name,
+            account_name=account,
+            force=force,
+        )
+    except KeyError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except SessionLeaseConflictError as exc:
+        typer.echo(f"Cannot restart {session_name}: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except RuntimeError as exc:
+        typer.echo(f"Restart failed for {session_name}: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if json_output:
+        cli_mod._emit_json({"session": result})
+        return
+    typer.echo(
+        f"Restarted {result['session_name']} on "
+        f"{result['account']} [{result['provider']}]"
+    )
+
+
+@session_app.command(
+    "relaunch",
+    help=(
+        "Restart a configured session, optionally on a different account "
+        "without editing pollypm.toml."
+    ),
+)
+def session_relaunch(
+    session_name: str = typer.Argument(..., help="Configured session name."),
+    account: str | None = typer.Option(
+        None,
+        "--account",
+        help="Configured account to use for this relaunch.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Bypass an existing human lease on the session.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit structured JSON."),
+    config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
+) -> None:
+    _session_restart_impl(
+        session_name,
+        account=account,
+        force=force,
+        json_output=json_output,
+        config_path=config_path,
+    )
+
+
+@session_app.command(
+    "restart",
+    help="Alias for `pm session relaunch`.",
+)
+def session_restart(
+    session_name: str = typer.Argument(..., help="Configured session name."),
+    account: str | None = typer.Option(
+        None,
+        "--account",
+        help="Configured account to use for this restart.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Bypass an existing human lease on the session.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit structured JSON."),
+    config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
+) -> None:
+    _session_restart_impl(
+        session_name,
+        account=account,
+        force=force,
+        json_output=json_output,
+        config_path=config_path,
+    )
+
+
 @heartbeat_app.command("install")
 def heartbeat_install(
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),

--- a/src/pollypm/cli_features/workers.py
+++ b/src/pollypm/cli_features/workers.py
@@ -23,6 +23,7 @@ def _worker_start_impl(
     prompt: str | None,
     role: str,
     agent_profile: str | None,
+    account: str | None,
     config_path: Path,
 ) -> None:
     if role == "worker":
@@ -67,6 +68,11 @@ def _worker_start_impl(
     # ``plugins_builtin/task_assignment_notify/resolver.py`` so the
     # two stay in sync.
     supervisor = cli_mod._load_supervisor(config_path)
+    if account is not None and account not in supervisor.config.accounts:
+        known = ", ".join(sorted(supervisor.config.accounts)) or "<none>"
+        raise typer.BadParameter(
+            f"Unknown account: {account} (known accounts: {known})"
+        )
     existing = next(
         (
             session
@@ -75,14 +81,26 @@ def _worker_start_impl(
         ),
         None,
     )
-    session = existing or cli_mod.create_worker_session(
-        config_path,
-        project_key=project_key,
-        prompt=prompt,
-        role=role,
-        agent_profile=agent_profile,
-    )
-    cli_mod.launch_worker_session(config_path, session.name)
+    if existing is not None:
+        session = existing
+        if account is not None:
+            supervisor.restart_session(
+                session.name,
+                account,
+                failure_type="manual_relaunch",
+            )
+        else:
+            cli_mod.launch_worker_session(config_path, session.name)
+    else:
+        session = cli_mod.create_worker_session(
+            config_path,
+            project_key=project_key,
+            prompt=prompt,
+            role=role,
+            agent_profile=agent_profile,
+            account_name=account,
+        )
+        cli_mod.launch_worker_session(config_path, session.name)
     refreshed = cli_mod._load_supervisor(config_path)
     launch = next(
         item for item in refreshed.plan_launches()
@@ -286,9 +304,18 @@ def register_worker_commands(app: typer.Typer) -> None:
                 "profile if one exists."
             ),
         ),
+        account: str | None = typer.Option(
+            None,
+            "--account",
+            help=(
+                "Configured account to use. Existing role sessions are "
+                "restarted with a runtime override; new sessions are "
+                "created on this account."
+            ),
+        ),
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
-        _worker_start_impl(project_key, prompt, role, agent_profile, config_path)
+        _worker_start_impl(project_key, prompt, role, agent_profile, account, config_path)
 
     @app.command("switch-provider")
     def switch_provider(

--- a/src/pollypm/defaults/docs/reference/accounts.md
+++ b/src/pollypm/defaults/docs/reference/accounts.md
@@ -23,7 +23,7 @@ Check with `pm accounts`. Each account shows:
   failover_accounts = ["codex_backup"]
   ```
 
-When a session fails auth or hits quota, the recovery system automatically tries failover accounts (same provider first, then cross-provider).
+When a session fails auth or hits quota, the recovery system automatically tries accounts in the configured failover order, then falls back to other available accounts.
 
 ## Quota Rotation
 

--- a/src/pollypm/defaults/docs/reference/sessions.md
+++ b/src/pollypm/defaults/docs/reference/sessions.md
@@ -39,7 +39,7 @@ When the heartbeat detects a dead or stuck session:
 1. Raise an alert (warn or error severity)
 2. Check if a human holds a lease (defer if so)
 3. Rate limit (max 5 attempts per 30-minute window, hard stop at 20 total)
-4. Build candidate accounts (same provider first, then cross-provider failover)
+4. Build candidate accounts from the configured failover order
 5. Restart the session with the best available account
 6. Clear alerts on success
 

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -658,6 +658,43 @@ class PollyPMService:
         """Rebind a session to a different configured account."""
         self.load_supervisor().switch_session_account(session_name, account_name)
 
+    def restart_session(
+        self,
+        session_name: str,
+        *,
+        account_name: str | None = None,
+        force: bool = False,
+    ) -> dict[str, str]:
+        """Restart a configured session, optionally on a runtime account override.
+
+        This is the operator-facing service facade for one-session recovery.
+        It does not edit ``pollypm.toml``; an explicit ``account_name`` is
+        recorded as the session runtime's effective account by
+        :meth:`Supervisor.restart_session`.
+        """
+        supervisor = self.load_supervisor()
+        launch = supervisor.launch_by_session(session_name)
+        target_account = account_name or launch.session.account
+        account = supervisor.config.accounts.get(target_account)
+        if account is None:
+            known = ", ".join(sorted(supervisor.config.accounts)) or "<none>"
+            raise KeyError(
+                f"Unknown account: {target_account} "
+                f"(known accounts: {known})"
+            )
+        supervisor.restart_session(
+            session_name,
+            target_account,
+            failure_type="manual_relaunch",
+            force=force,
+        )
+        return {
+            "session_name": session_name,
+            "account": target_account,
+            "provider": account.provider.value,
+            "status": "restarted",
+        }
+
     def schedule_job(
         self,
         *,

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -2730,7 +2730,7 @@ class Supervisor:
             )
             remaining_threshold = max(0, 100 - int(used_threshold))
             needs_roll, probe = account_needs_proactive_rollover(
-                self.config, self.store, launch.account.name,
+                self.config, None, launch.account.name,
                 threshold_pct=remaining_threshold,
             )
         except Exception:  # noqa: BLE001
@@ -2779,10 +2779,33 @@ class Supervisor:
         )
 
     def _account_is_viable(self, account_name: str) -> bool:
-        runtime = self.store.get_account_runtime(account_name)
-        if runtime is not None and runtime.status in {"auth_broken", "exhausted", "provider_outage"}:
+        account = self.config.accounts.get(account_name)
+        if account is None:
             return False
-        account = self.config.accounts[account_name]
+        try:
+            from pollypm.capacity import FAILOVER_TRIGGERS, probe_capacity
+
+            probe = probe_capacity(self.config, None, account_name)
+            if probe.state in FAILOVER_TRIGGERS:
+                return False
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "account viability pg probe failed for %s; falling back",
+                account_name,
+                exc_info=True,
+            )
+        try:
+            from pollypm.accounts import is_account_runtime_unavailable
+
+            runtime = self.store.get_account_runtime(account_name)
+            if runtime is not None and is_account_runtime_unavailable(runtime.status):
+                return False
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "account viability legacy runtime check failed for %s",
+                account_name,
+                exc_info=True,
+            )
         if account.home is None:
             return False
         if account.provider is ProviderKind.CLAUDE:
@@ -3819,12 +3842,14 @@ class Supervisor:
             )
             return
 
-        # For auth_broken on Claude accounts, allow retrying the same account —
-        # the refresh token is long-lived and Claude Code will refresh on restart.
-        # Force failover for capacity_exhausted (genuine account limit) and
+        # Force failover for auth_broken / capacity_exhausted and
         # capacity_low (proactive rollover near the limit — staying on the
         # same account defeats the purpose).
-        allow_same = failure_type not in {"capacity_exhausted", "capacity_low"}
+        allow_same = failure_type not in {
+            "auth_broken",
+            "capacity_exhausted",
+            "capacity_low",
+        }
         candidates = self._candidate_accounts(launch, allow_same=allow_same)
         if not candidates:
             self._msg_store.upsert_alert(
@@ -3940,6 +3965,7 @@ class Supervisor:
             last_failure_type=failure_type,
             last_failure_message=f"recovering on {account_name}",
         )
+        self.invalidate_launch_cache()
         spawned = False
         try:
             self.launch_session(session_name)
@@ -3975,6 +4001,7 @@ class Supervisor:
                 retry_at=previous_runtime.retry_at if previous_runtime else None,
                 last_recovered_at=previous_runtime.last_recovered_at if previous_runtime else None,
             )
+            self.invalidate_launch_cache()
             raise
         if spawned:
             from pollypm.audit.log import (

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -138,7 +138,10 @@ class TestHealthToState:
     def test_known_states(self) -> None:
         assert _health_to_state("healthy") == CapacityState.HEALTHY
         assert _health_to_state("capacity-exhausted") == CapacityState.EXHAUSTED
+        assert _health_to_state("capacity_exhausted") == CapacityState.EXHAUSTED
+        assert _health_to_state("exhausted") == CapacityState.EXHAUSTED
         assert _health_to_state("auth-broken") == CapacityState.AUTH_BROKEN
+        assert _health_to_state("auth_broken") == CapacityState.AUTH_BROKEN
 
     def test_unknown_state(self) -> None:
         assert _health_to_state("something-weird") == CapacityState.UNKNOWN
@@ -435,6 +438,38 @@ class TestSelectFailoverAccount:
         assert decision.should_failover
         # Should prefer claude_backup (same provider, non-controller)
         assert decision.selected_account == "claude_backup"
+
+    def test_selects_first_healthy_account_in_failover_order(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        config.pollypm.failover_accounts = ["codex_main", "claude_backup"]
+        store = _store(tmp_path)
+        store.upsert_account_runtime(
+            account_name="claude_main",
+            provider="claude",
+            status="capacity-exhausted",
+            reason="rate limited",
+        )
+        store.upsert_account_usage(
+            account_name="codex_main",
+            provider="codex",
+            plan="pro",
+            health="healthy",
+            usage_summary="80% left",
+            raw_text="",
+        )
+        store.upsert_account_usage(
+            account_name="claude_backup",
+            provider="claude",
+            plan="max",
+            health="healthy",
+            usage_summary="50% left",
+            raw_text="",
+        )
+
+        decision = select_failover_account(config, store, "claude_main")
+
+        assert decision.should_failover
+        assert decision.selected_account == "codex_main"
 
     def test_selects_different_provider_when_same_unavailable(self, tmp_path: Path) -> None:
         config = _config(tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import sys
 from typer.testing import CliRunner
 
 import pollypm.cli as cli
+from pollypm.cli_features import alerts as alerts_cli
 
 
 def test_root_command_defaults_to_up(monkeypatch, tmp_path: Path) -> None:
@@ -412,7 +413,7 @@ def test_worker_start_role_architect_still_works(monkeypatch, tmp_path: Path) ->
     monkeypatch.setattr(
         cli,
         "create_worker_session",
-        lambda path, project_key, prompt=None, role="worker", agent_profile=None: (
+        lambda path, project_key, prompt=None, role="worker", agent_profile=None, account_name=None: (
             created.append((path, project_key, prompt))
             or type("Session", (), {"name": "architect_pollypm"})()
         ),
@@ -428,6 +429,93 @@ def test_worker_start_role_architect_still_works(monkeypatch, tmp_path: Path) ->
     assert result.exit_code == 0
     assert created == [(config_path, "pollypm", "Plan it")]
     assert launched == [(config_path, "architect_pollypm")]
+    assert "Managed architect architect_pollypm ready for project pollypm" in result.output
+
+
+def test_worker_start_existing_role_restarts_with_account(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("[project]\nname = \"pollypm\"\n")
+    restarted: list[tuple[str, str, str]] = []
+
+    class FakeSupervisor:
+        def __init__(self) -> None:
+            session = type(
+                "Session",
+                (),
+                {
+                    "name": "architect_pollypm",
+                    "role": "architect",
+                    "project": "pollypm",
+                    "enabled": True,
+                },
+            )()
+            self.config = type(
+                "Config",
+                (),
+                {
+                    "sessions": {"architect_pollypm": session},
+                    "accounts": {"claude_backup": object()},
+                    "project": type("Project", (), {"tmux_session": "pollypm"})(),
+                },
+            )()
+
+        def restart_session(
+            self,
+            session_name: str,
+            account_name: str,
+            *,
+            failure_type: str,
+        ) -> None:
+            restarted.append((session_name, account_name, failure_type))
+
+        def tmux_session_for_launch(self, launch) -> str:
+            return "pollypm-storage-closet"
+
+        def plan_launches(self):
+            session = type("Session", (), {"name": "architect_pollypm"})()
+            return [
+                type(
+                    "Launch",
+                    (),
+                    {"session": session, "window_name": "architect-pollypm"},
+                )()
+            ]
+
+    monkeypatch.setattr(cli, "_load_supervisor", lambda path: FakeSupervisor())
+    monkeypatch.setattr(
+        cli,
+        "create_worker_session",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("existing session should not be recreated")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "launch_worker_session",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("account override should use restart_session")
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "worker-start",
+            "pollypm",
+            "--role",
+            "architect",
+            "--account",
+            "claude_backup",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert restarted == [
+        ("architect_pollypm", "claude_backup", "manual_relaunch")
+    ]
     assert "Managed architect architect_pollypm ready for project pollypm" in result.output
 
 
@@ -488,7 +576,7 @@ def test_worker_start_role_architect_works_outside_tmux(monkeypatch, tmp_path: P
     monkeypatch.setattr(
         cli,
         "create_worker_session",
-        lambda path, project_key, prompt=None, role="worker", agent_profile=None: (
+        lambda path, project_key, prompt=None, role="worker", agent_profile=None, account_name=None: (
             created.append((path, project_key, prompt, role, agent_profile))
             or type("Session", (), {"name": "architect_pollypm"})()
         ),
@@ -518,6 +606,54 @@ def test_worker_start_role_architect_works_outside_tmux(monkeypatch, tmp_path: P
     assert created == [(config_path, "pollypm", None, "architect", None)]
     assert launched == [(config_path, "architect_pollypm")]
     assert "Managed architect architect_pollypm ready for project pollypm" in result.output
+
+
+def test_session_relaunch_cli_routes_account_to_service(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("[project]\nname = \"pollypm\"\n")
+    calls: list[tuple[Path, str, str | None, bool]] = []
+
+    class FakeService:
+        def __init__(self, config_path: Path) -> None:
+            self.config_path = config_path
+
+        def restart_session(
+            self,
+            session_name: str,
+            *,
+            account_name: str | None = None,
+            force: bool = False,
+        ) -> dict[str, str]:
+            calls.append((self.config_path, session_name, account_name, force))
+            return {
+                "session_name": session_name,
+                "account": account_name or "claude_main",
+                "provider": "claude",
+                "status": "restarted",
+            }
+
+    monkeypatch.setattr(alerts_cli, "_service", FakeService)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "session",
+            "relaunch",
+            "architect_bikepath",
+            "--account",
+            "claude_backup",
+            "--force",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        (config_path, "architect_bikepath", "claude_backup", True)
+    ]
+    assert "Restarted architect_bikepath on claude_backup [claude]" in result.output
 
 
 def test_help_lists_heartbeat_agent_commands() -> None:

--- a/tests/test_service_api.py
+++ b/tests/test_service_api.py
@@ -13,6 +13,7 @@ from pollypm.models import (
     ProjectKind,
     ProjectSettings,
     ProviderKind,
+    SessionConfig,
 )
 from pollypm.service_api import PollyPMService, render_json
 from pollypm.storage.state import StateStore
@@ -132,6 +133,64 @@ def test_service_focus_and_send_input_use_supervisor(monkeypatch, tmp_path: Path
     assert calls == [
         ("focus", "operator", None),
         ("send", "operator", "Continue"),
+    ]
+
+
+def test_service_restart_session_uses_supervisor_facade(monkeypatch, tmp_path: Path) -> None:
+    service = PollyPMService(tmp_path / "pollypm.toml")
+    calls: list[tuple[str, str, str, bool]] = []
+
+    class FakeConfig:
+        accounts = {
+            "claude_main": AccountConfig(
+                name="claude_main",
+                provider=ProviderKind.CLAUDE,
+            ),
+            "claude_backup": AccountConfig(
+                name="claude_backup",
+                provider=ProviderKind.CLAUDE,
+            ),
+        }
+
+    class FakeSupervisor:
+        config = FakeConfig()
+
+        def launch_by_session(self, session_name: str):
+            session = SessionConfig(
+                name=session_name,
+                role="architect",
+                provider=ProviderKind.CLAUDE,
+                account="claude_main",
+                cwd=tmp_path,
+            )
+            return type("Launch", (), {"session": session})()
+
+        def restart_session(
+            self,
+            session_name: str,
+            account_name: str,
+            *,
+            failure_type: str,
+            force: bool = False,
+        ) -> None:
+            calls.append((session_name, account_name, failure_type, force))
+
+    monkeypatch.setattr(service, "load_supervisor", lambda: FakeSupervisor())
+
+    result = service.restart_session(
+        "architect_demo",
+        account_name="claude_backup",
+        force=True,
+    )
+
+    assert result == {
+        "session_name": "architect_demo",
+        "account": "claude_backup",
+        "provider": "claude",
+        "status": "restarted",
+    }
+    assert calls == [
+        ("architect_demo", "claude_backup", "manual_relaunch", True)
     ]
 
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -123,6 +123,56 @@ def test_supervisor_failover_prefers_viable_backup(monkeypatch, tmp_path: Path) 
     }
 
 
+def test_supervisor_failover_skips_pg_exhausted_account(monkeypatch, tmp_path: Path) -> None:
+    from pollypm.capacity import CapacityProbeResult, CapacityState
+
+    config = _config(tmp_path)
+    backup_auth = config.accounts["codex_backup"].home / ".codex" / "auth.json"
+    backup_auth.parent.mkdir(parents=True, exist_ok=True)
+    backup_auth.write_text("{}")
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = next(
+        item for item in supervisor.plan_launches()
+        if item.session.name == "operator"
+    )
+    restarted: dict[str, str] = {}
+
+    def fake_probe_capacity(config, store, account_name: str):
+        state = (
+            CapacityState.EXHAUSTED
+            if account_name == "claude_controller"
+            else CapacityState.HEALTHY
+        )
+        return CapacityProbeResult(
+            account_name=account_name,
+            provider=config.accounts[account_name].provider,
+            state=state,
+            reason=state.value,
+        )
+
+    monkeypatch.setattr("pollypm.capacity.probe_capacity", fake_probe_capacity)
+    monkeypatch.setattr(
+        supervisor,
+        "_restart_session",
+        lambda session_name, account_name, failure_type: restarted.update(
+            {"session": session_name, "account": account_name, "failure": failure_type}
+        ),
+    )
+
+    supervisor._maybe_recover_session(
+        launch,
+        failure_type="capacity_exhausted",
+        failure_message="0% left",
+    )
+
+    assert restarted == {
+        "session": "operator",
+        "account": "codex_backup",
+        "failure": "capacity_exhausted",
+    }
+
+
 def test_ensure_layout_skips_scaffolding_global_control_root(
     monkeypatch, tmp_path: Path,
 ) -> None:
@@ -1492,8 +1542,14 @@ def test_restart_session_emits_session_spawn_audit(
         item for item in supervisor.plan_launches()
         if item.session.name == "operator"
     )
+    invalidations: list[str] = []
 
     monkeypatch.setattr(supervisor.session_service.tmux, "has_session", lambda _name: False)
+    monkeypatch.setattr(
+        supervisor,
+        "invalidate_launch_cache",
+        lambda: invalidations.append("invalidate"),
+    )
     monkeypatch.setattr(supervisor, "launch_session", lambda _name: launch)
 
     supervisor.restart_session(
@@ -1501,6 +1557,8 @@ def test_restart_session_emits_session_spawn_audit(
         "claude_controller",
         failure_type="missing_window",
     )
+
+    assert invalidations == ["invalidate"]
 
     events = read_events(
         "pollypm",


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds `pm session relaunch <session> --account <account>` plus `pm session restart` alias, routed through the service facade and supervisor restart path without editing `pollypm.toml`.
- Adds `pm worker-start --account` so existing role sessions can restart on a runtime account override and new role sessions can be created on the requested account.
- Tightens recovery account viability: skips auth/capacity-exhausted accounts across pg and legacy runtime state, honors configured failover order, and invalidates launch cache around account override relaunches.
- Updates account/session reference docs for configured failover order.

## Tests
- `python -m compileall -q src/pollypm/accounts.py src/pollypm/capacity.py src/pollypm/cli_features/alerts.py src/pollypm/cli_features/workers.py src/pollypm/service_api/v1.py src/pollypm/supervisor.py tests/test_cli.py tests/test_service_api.py tests/test_capacity.py tests/test_supervisor.py`
- `HOME=$(mktemp -d /tmp/pollypm-account-tests.XXXXXX) uv run --extra test pytest tests/test_service_api.py::test_service_restart_session_uses_supervisor_facade tests/test_cli.py::test_worker_start_existing_role_restarts_with_account tests/test_cli.py::test_session_relaunch_cli_routes_account_to_service tests/test_cli.py::test_worker_start_role_architect_still_works tests/test_cli.py::test_worker_start_role_architect_works_outside_tmux tests/test_capacity.py::TestHealthToState::test_known_states tests/test_capacity.py::TestSelectFailoverAccount::test_selects_first_healthy_account_in_failover_order tests/test_supervisor.py::test_supervisor_failover_skips_pg_exhausted_account tests/test_supervisor.py::test_restart_session_emits_session_spawn_audit -q` (9 passed)
- `HOME=$(mktemp -d /tmp/pollypm-account-tests.XXXXXX) uv run --extra test pytest tests/test_capacity.py::TestSelectFailoverAccount tests/test_supervisor.py::test_supervisor_failover_prefers_viable_backup tests/test_supervisor.py::test_supervisor_failover_skips_pg_exhausted_account tests/test_supervisor.py::test_restart_session_emits_session_spawn_audit -q` (10 passed)
- `uv run --with ruff ruff check --select F821,F841 ...` on touched source/test files
- `git diff --check origin/main...HEAD`

Full-file Ruff on all touched files is still blocked by pre-existing E402/F401 debt in `src/pollypm/accounts.py` and `tests/test_supervisor.py`; targeted undefined/local-variable checks pass.

Closes #2249
Closes #2227
