### PR TITLE
fix(cockpit): clear activity badge and rail focus

### DIFF
--- a/src/pollypm/activity_projector_registry.py
+++ b/src/pollypm/activity_projector_registry.py
@@ -39,9 +39,11 @@ logger = logging.getLogger(__name__)
 # ``Any`` to avoid pulling the projector class — which lives in the
 # plugin tree — into the core seam.
 ActivityProjectorFactory = Callable[[Any], Any]
+ActivitySeenMarker = Callable[[Any], None]
 
 
 _factory: ActivityProjectorFactory | None = None
+_seen_marker: ActivitySeenMarker | None = None
 
 
 def register_activity_projector_factory(
@@ -54,13 +56,37 @@ def register_activity_projector_factory(
     optional plugin tree. Pass ``factory=None`` to clear (used by tests
     that want to simulate the plugin being absent).
     """
-    global _factory
+    global _factory, _seen_marker
     _factory = factory
+    if factory is None:
+        _seen_marker = None
 
 
 def get_activity_projector_factory() -> ActivityProjectorFactory | None:
     """Return the registered factory, or ``None`` when no provider is installed."""
     return _factory
+
+
+def register_activity_seen_marker(marker: ActivitySeenMarker | None) -> None:
+    """Install (or clear) the plugin-owned "mark activity seen" hook."""
+    global _seen_marker
+    _seen_marker = marker
+
+
+def mark_activity_seen(config: Any) -> None:
+    """Advance the activity-feed read cursor when a cockpit view opens it.
+
+    The cursor file is plugin-owned, so core cockpit code calls this seam
+    instead of importing from ``pollypm.plugins_builtin.activity_feed``.
+    With the plugin disabled this is a no-op.
+    """
+    if _seen_marker is None:
+        logger.debug(
+            "activity_projector_registry: no seen marker registered; "
+            "activity badge cursor unchanged",
+        )
+        return
+    _seen_marker(config)
 
 
 def build_activity_projector(config: Any) -> Any | None:
@@ -87,7 +113,10 @@ def build_activity_projector(config: Any) -> Any | None:
 
 __all__ = [
     "ActivityProjectorFactory",
+    "ActivitySeenMarker",
     "build_activity_projector",
     "get_activity_projector_factory",
+    "mark_activity_seen",
     "register_activity_projector_factory",
+    "register_activity_seen_marker",
 ]

--- a/src/pollypm/cockpit_activity.py
+++ b/src/pollypm/cockpit_activity.py
@@ -397,6 +397,7 @@ class PollyActivityFeedApp(App[None]):
         # ``call_from_thread``. Follow-mode ticks + manual refresh
         # also go off-thread (see ``_refresh`` / ``_follow_tick``).
         self._paint_loading_skeleton()
+        self._schedule_seen_marker()
         self._schedule_initial_load()
         # Alert toast surface removed in #956 — alerts already appear
         # as activity rows in the table below.
@@ -441,6 +442,26 @@ class PollyActivityFeedApp(App[None]):
             project=self._filter_project,
             limit=self.INITIAL_LIMIT,
         )
+
+    def _schedule_seen_marker(self) -> None:
+        """Advance the rail badge cursor without delaying first paint."""
+        try:
+            self.run_worker(
+                self._mark_seen_sync,
+                thread=True,
+                exclusive=True,
+                group="activity_feed_seen",
+            )
+        except Exception:  # noqa: BLE001
+            self._mark_seen_sync()
+
+    def _mark_seen_sync(self) -> None:
+        try:
+            from pollypm.activity_projector_registry import mark_activity_seen
+
+            mark_activity_seen(self._load_config())
+        except Exception:  # noqa: BLE001
+            pass
 
     # ------------------------------------------------------------------
     # Cold-boot + steady-state refresh (#1649). The activity feed

--- a/src/pollypm/cockpit_palette.py
+++ b/src/pollypm/cockpit_palette.py
@@ -547,6 +547,7 @@ _GLOBAL_HELP_BINDINGS: list[tuple[str, str]] = [
     ("?", "this help"),
     ("ctrl+q", "quit"),
     ("ctrl+w", "detach"),
+    ("ctrl+h", "return focus to the cockpit rail"),
     # PM Chat / live agent panes are raw Claude Code subprocesses that
     # consume Tab themselves (Shift-Tab cycles permission modes inside
     # Claude). The cockpit cannot intercept them, so document the tmux
@@ -678,6 +679,8 @@ def _right_pane_help_section_for_cockpit(
         desc = getattr(binding, "description", "") or ""
         if not key_field:
             continue
+        if getattr(binding, "show", True) is False:
+            continue
         norm_keys = {key.strip() for key in key_field.split(",")}
         if norm_keys & {"question_mark", "colon", "ctrl+k"}:
             continue
@@ -709,6 +712,8 @@ def _collect_keybindings_for_screen(
         key_field = getattr(binding, "key", "") or ""
         desc = getattr(binding, "description", "") or ""
         if not key_field:
+            continue
+        if getattr(binding, "show", True) is False:
             continue
         norm_keys = {key.strip() for key in key_field.split(",")}
         if norm_keys & {"question_mark", "colon", "ctrl+k"}:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -597,6 +597,7 @@ class PollyCockpitApp(App[None]):
         # the rail's cursor stops moving — the user has to Tab back
         # to the nav before navigation responds again.
         Binding("right", "focus_inbox_pane_nav", "Inbox pane", show=False, priority=True),
+        Binding("ctrl+h", "focus_rail", "Rail", priority=True),
         Binding("j,down", "cursor_down", "Down", show=False, priority=True),
         Binding("k,up", "cursor_up", "Up", show=False, priority=True),
         Binding("g,home", "cursor_first", "First", show=False, priority=True),
@@ -615,7 +616,7 @@ class PollyCockpitApp(App[None]):
             show=False, priority=True,
         ),
         Binding("Q,ctrl+q", "request_quit", "Quit", priority=True),
-        Binding("escape", "back_to_home", "Back to Home", show=False, priority=True),
+        Binding("escape", "back_to_home", "Back to rail/home", priority=True),
         Binding("w,W,ctrl+w", "detach", "Detach", priority=True),
     ]
 
@@ -667,6 +668,7 @@ class PollyCockpitApp(App[None]):
         "cursor_first",          # g, home
         "cursor_last",           # G, end
         "focus_inbox_pane_nav",  # right
+        "focus_rail",            # ctrl+h
         "forward_tab_to_right",  # tab
         "forward_action_button_1",
         "forward_action_button_2",
@@ -701,6 +703,7 @@ class PollyCockpitApp(App[None]):
         "cursor_first",          # g, home
         "cursor_last",           # G, end
         "focus_inbox_pane_nav",  # right
+        "focus_rail",            # ctrl+h
         "forward_tab_to_right",  # tab
         "forward_action_button_1",
         "forward_action_button_2",
@@ -730,6 +733,7 @@ class PollyCockpitApp(App[None]):
         "cursor_up",             # k, up
         "cursor_first",          # g, home
         "cursor_last",           # G, end
+        "focus_rail",            # ctrl+h
         "forward_action_button_1",
         "forward_action_button_2",
         "forward_action_button_3",
@@ -1448,6 +1452,11 @@ class PollyCockpitApp(App[None]):
         focus_method = getattr(self.router, "focus_rail_pane", None)
         if callable(focus_method):
             focus_method()
+
+    def action_focus_rail(self) -> None:
+        """Explicitly return keyboard ownership to the cockpit rail."""
+        self._set_inbox_pane_nav_active(False)
+        self._focus_rail_pane()
 
     def _right_pane_has_live_session(self) -> bool:
         try:
@@ -3069,6 +3078,9 @@ class PollyCockpitApp(App[None]):
         else:
             request = NavigationCommand(seq, key)
 
+        if self._is_activity_route_key(key):
+            self._mark_activity_seen_sync()
+
         try:
             result = asyncio.run(controller.resolve_and_apply(request))
         except Exception as exc:  # noqa: BLE001
@@ -3082,6 +3094,19 @@ class PollyCockpitApp(App[None]):
             self._post_route_error(key, f"Routing to {key} timed out — try again.", seq)
         elif result.state == "failed":
             self._post_route_error(key, f"Error: {result.error or result.message}", seq)
+
+    @staticmethod
+    def _is_activity_route_key(key: str) -> bool:
+        return key == "activity" or key.startswith("activity:")
+
+    def _mark_activity_seen_sync(self) -> None:
+        """Advance the activity badge cursor off the UI thread."""
+        try:
+            from pollypm.activity_projector_registry import mark_activity_seen
+
+            mark_activity_seen(load_config(self.config_path))
+        except Exception:  # noqa: BLE001
+            logger.debug("activity seen marker failed", exc_info=True)
 
     def _post_route_success(
         self, key: str, resolved: str, seq: int = 0,
@@ -3240,9 +3265,9 @@ class PollyCockpitApp(App[None]):
         a no-op (Esc still routes to Home everywhere).
         """
         if self._inbox_pane_owns_nav():
-            if self._send_key_to_inbox_pane("q"):
-                return
+            self._send_key_to_inbox_pane("q")
             self._set_inbox_pane_nav_active(False)
+            self._focus_rail_pane()
             return
         if self._on_project_surface():
             self._send_key_to_right_pane("q")
@@ -3383,9 +3408,9 @@ class PollyCockpitApp(App[None]):
             self._send_key_to_inbox_pane("escape")
             return
         if self._inbox_pane_owns_nav():
-            if self._send_key_to_inbox_pane("escape"):
-                return
+            self._send_key_to_inbox_pane("escape")
             self._set_inbox_pane_nav_active(False)
+            self._focus_rail_pane()
             return
         if self._right_pane_has_live_session():
             return_key = self._mounted_return_key()
@@ -3756,7 +3781,7 @@ class PollySettingsPaneApp(App[None]):
         Binding("c", "add_claude_account", "Add Claude", show=False),
         Binding("o", "add_codex_account", "Add Codex", show=False),
         Binding("x", "remove_account", "Remove account", show=False),
-        Binding("t", "toggle_project_tracked", "Toggle project", show=False),
+        Binding("t", "toggle_project_tracked", "Pause / Resume project"),
         Binding("m", "make_controller", "Controller", show=False),
         Binding("s", "reassign_account_sessions", "Reassign sessions", show=False),
         Binding("v", "toggle_failover", "Failover", show=False),

--- a/src/pollypm/plugins_builtin/activity_feed/plugin.py
+++ b/src/pollypm/plugins_builtin/activity_feed/plugin.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from pollypm.activity_projector_registry import (
     register_activity_projector_factory,
+    register_activity_seen_marker,
 )
 from pollypm.plugin_api.v1 import (
     Capability,
@@ -41,7 +42,6 @@ from pollypm.plugins_builtin.activity_feed.handlers.event_projector import (
     FeedEntry,
 )
 from pollypm.plugins_builtin.activity_feed.projector_factory import (
-    _collect_work_db_paths,
     build_projector,
 )
 
@@ -86,6 +86,35 @@ def _save_last_seen_id(config: Any, value: int) -> None:
         logger.debug("activity_feed: failed to persist last-seen cursor", exc_info=True)
 
 
+def _numeric_feed_entry_id(entry_id: str) -> int | None:
+    """Return the integer id for feed ids that carry the shared numeric tail."""
+    for prefix in ("msg:", "evt:"):
+        if entry_id.startswith(prefix):
+            try:
+                return int(entry_id.split(":", 1)[1])
+            except ValueError:
+                return None
+    return None
+
+
+def mark_latest_activity_seen(config: Any) -> None:
+    """Advance the activity badge cursor to the newest visible feed entry."""
+    projector = build_projector(config)
+    if projector is None:
+        return
+    try:
+        entries = projector.project(limit=1)
+    except Exception:  # noqa: BLE001
+        logger.debug("activity_feed: failed to project latest seen entry", exc_info=True)
+        return
+    if not entries:
+        return
+    newest_id = _numeric_feed_entry_id(str(getattr(entries[0], "id", "") or ""))
+    if newest_id is None:
+        return
+    _save_last_seen_id(config, newest_id)
+
+
 def _badge_provider_factory(config: Any):
     """Return a ``badge_provider`` closure for rail registration.
 
@@ -127,27 +156,7 @@ def _handler_factory(config: Any):
             except Exception:  # noqa: BLE001
                 logger.exception("activity_feed: route_selected raised")
         # Update the last-seen cursor so the badge resets.
-        projector = build_projector(config)
-        if projector is not None:
-            try:
-                entries = projector.project(limit=1)
-            except Exception:  # noqa: BLE001
-                entries = []
-            if entries:
-                newest = entries[0].id
-                # Feed entries from the unified ``messages`` table carry
-                # an ``msg:<id>`` prefix (#342). Accept that in addition
-                # to the legacy ``evt:<id>`` shape some projectors may
-                # still hand back.
-                for prefix in ("msg:", "evt:"):
-                    if newest.startswith(prefix):
-                        try:
-                            _save_last_seen_id(
-                                config, int(newest.split(":", 1)[1]),
-                            )
-                        except ValueError:
-                            pass
-                        break
+        mark_latest_activity_seen(config)
         return PanelSpec(widget=None, focus_hint="activity")
 
     return _handler
@@ -171,6 +180,7 @@ def _initialize(api: Any) -> None:
     # callers get ``None`` and render an empty feed (their existing
     # graceful-degrade path).
     register_activity_projector_factory(build_projector)
+    register_activity_seen_marker(mark_latest_activity_seen)
 
     config = api.config
     state_db = None
@@ -217,4 +227,5 @@ __all__ = [
     "build_projector",
     "EventProjector",
     "FeedEntry",
+    "mark_latest_activity_seen",
 ]

--- a/tests/test_activity_feed_ui.py
+++ b/tests/test_activity_feed_ui.py
@@ -24,8 +24,9 @@ targeted as the agent brief demands.
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -119,6 +120,26 @@ def activity_app(activity_env):
         pytest.skip("minimal pollypm.toml fixture not supported by loader")
     from pollypm.cockpit_ui import PollyActivityFeedApp
     return PollyActivityFeedApp(activity_env["config_path"])
+
+
+def test_activity_feed_mark_latest_seen_persists_numeric_cursor(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """#2200/#2233: opening Activity advances the unread badge cursor."""
+    from pollypm.plugins_builtin.activity_feed import plugin as plugin_mod
+
+    config = SimpleNamespace(project=SimpleNamespace(state_db=tmp_path / "state.db"))
+
+    class _Projector:
+        def project(self, *, limit: int):
+            assert limit == 1
+            return [SimpleNamespace(id="evt:42")]
+
+    monkeypatch.setattr(plugin_mod, "build_projector", lambda _config: _Projector())
+
+    plugin_mod.mark_latest_activity_seen(config)
+
+    assert plugin_mod._load_last_seen_id(config) == 42
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -2947,11 +2947,41 @@ def test_cockpit_ui_bindings_expose_activity_and_pin_legend() -> None:
     bindings = {binding.key: binding.description for binding in PollyCockpitApp.BINDINGS}
 
     assert bindings["t"] == "Activity"
+    assert bindings["ctrl+h"] == "Rail"
+    assert bindings["escape"] == "Back to rail/home"
     # #1088 — pin moved from ``p`` to ``P``; lowercase ``p`` now forwards
     # to the project dashboard's ``p plan`` so the bottom hint matches
     # the actual behaviour.
     assert bindings["P"] == "Pin Project"
     assert bindings["p"] == "Plan"
+
+
+def test_cockpit_help_hides_hidden_rail_forwards_and_shows_context() -> None:
+    """#2203: ``?`` should avoid hidden rail-forwards and include pane help."""
+    from pollypm.cockpit_palette import _collect_keybindings_for_screen
+
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    app.selected_key = "dashboard"
+
+    sections = _collect_keybindings_for_screen(app)
+    screen_rows = dict(next(rows for title, rows in sections if title == "This screen"))
+
+    assert "i" not in screen_rows
+    assert screen_rows["I"] == "Inbox"
+    assert screen_rows["ctrl+h"] == "Rail"
+    assert screen_rows["Esc"] == "Back to rail/home"
+
+    project_app = PollyCockpitApp.__new__(PollyCockpitApp)
+    project_app.selected_key = "project:demo:dashboard"
+    project_sections = dict(_collect_keybindings_for_screen(project_app))
+    project_rows = dict(project_sections["Right pane: Project dashboard"])
+    assert project_rows["c"] == "Chat PM"
+
+    settings_app = PollyCockpitApp.__new__(PollyCockpitApp)
+    settings_app.selected_key = "settings"
+    settings_sections = dict(_collect_keybindings_for_screen(settings_app))
+    settings_rows = dict(settings_sections["Right pane: Settings"])
+    assert settings_rows["t"] == "Pause / Resume project"
 
 
 def test_cockpit_new_worker_non_project_selection_updates_hint() -> None:
@@ -6871,12 +6901,19 @@ def test_cockpit_escape_and_q_from_active_inbox_nav_return_to_inbox_pane() -> No
     )
     app._right_pane_has_live_session = lambda: False  # type: ignore[method-assign]
     app._navigate_home = lambda: navigated.append("home") or True  # type: ignore[method-assign]
+    focused: list[str] = []
+    app._focus_rail_pane = lambda: focused.append("rail")  # type: ignore[method-assign]
 
     app.action_back_to_home()
+    assert router.active is False
+
+    router.active = True
     app.action_forward_project_home()
 
     assert forwarded == ["escape", "q"]
     assert navigated == []
+    assert focused == ["rail", "rail"]
+    assert router.active is False
 
 
 def test_cockpit_jk_from_inbox_forwards_to_inbox_pane() -> None:
@@ -7536,6 +7573,68 @@ def test_schedule_route_static_key_skips_refresh_rows_synchronously() -> None:
         "cold path past the 2s budget tracked by issue #1208"
     )
     assert ("dispatch", "inbox") in events
+
+
+@pytest.mark.parametrize("key", ["activity", "activity:demo"])
+def test_route_selected_worker_marks_activity_seen_before_apply(key: str) -> None:
+    """#2200/#2233: opening Activity clears the plugin-owned unread cursor."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+
+    class _Controller:
+        current_request_id = 7
+
+        async def resolve_and_apply(self, request):
+            return SimpleNamespace(
+                state="applied",
+                window_result=request.key,
+                destination_key=request.key,
+            )
+
+    marked: list[str] = []
+    successes: list[tuple[str, str, int]] = []
+    errors: list[tuple[str, str, int]] = []
+    controller = _Controller()
+
+    app._ensure_navigation_controller = lambda: controller  # type: ignore[method-assign]
+    app._mark_activity_seen_sync = lambda: marked.append(key)  # type: ignore[method-assign]
+    app._post_route_success = (  # type: ignore[method-assign]
+        lambda route_key, resolved, seq=0: successes.append((route_key, resolved, seq))
+    )
+    app._post_route_error = (  # type: ignore[method-assign]
+        lambda route_key, message, seq=0: errors.append((route_key, message, seq))
+    )
+    app._route_click_seq = 7
+
+    app._route_selected_worker(key, 7)
+
+    assert marked == [key]
+    assert successes == [(key, key, 7)]
+    assert errors == []
+
+
+def test_route_selected_worker_does_not_mark_non_activity_seen() -> None:
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+
+    class _Controller:
+        current_request_id = 3
+
+        async def resolve_and_apply(self, request):
+            return SimpleNamespace(
+                state="applied",
+                window_result=request.key,
+                destination_key=request.key,
+            )
+
+    marked: list[str] = []
+    app._ensure_navigation_controller = lambda: _Controller()  # type: ignore[method-assign]
+    app._mark_activity_seen_sync = lambda: marked.append("seen")  # type: ignore[method-assign]
+    app._post_route_success = lambda *args, **kwargs: None  # type: ignore[method-assign]
+    app._post_route_error = lambda *args, **kwargs: None  # type: ignore[method-assign]
+    app._route_click_seq = 3
+
+    app._route_selected_worker("inbox", 3)
+
+    assert marked == []
 
 
 def test_async_click_surfaces_timeout_on_slow_route() -> None:

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -869,6 +869,7 @@ def test_tier1_healer_registry_includes_existing_self_heal_rules() -> None:
 
 def test_tier1_healer_role_session_missing_idempotent(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Registry healer must be safe to call repeatedly. We mock the
     cli helpers so the test doesn't actually shell out."""
@@ -913,11 +914,13 @@ def test_tier1_healer_role_session_missing_idempotent(
         subject="demo/42",
         metadata={"role": "advisor", "expected_window": "advisor-demo"},
     )
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("[project]\nname = 'Demo'\n")
     counters_a = _self_heal_role_session_missing(
-        finding, project_key="demo", project_path=None,
+        finding, project_key="demo", project_path=None, config_path=config_path,
     )
     counters_b = _self_heal_role_session_missing(
-        finding, project_key="demo", project_path=None,
+        finding, project_key="demo", project_path=None, config_path=config_path,
     )
     assert counters_a["worker_lane_spawned"] == 1
     assert counters_b["worker_lane_spawned"] == 1


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds a plugin-owned activity-seen marker seam and calls it when Activity opens in cockpit/TUI, clearing the unread badge without blocking first paint.
- Cleans cockpit help output so hidden duplicate rail forwards stay hidden, `ctrl+h`/Esc are visible, and settings/project pane help exposes the relevant pause/resume/chat bindings.
- Adds explicit `ctrl+h` rail focus and makes Inbox `Esc`/`q` release pane navigation back to the rail.
- Locks the role-session-missing healer path with hermetic regression coverage.

## Tests
- `python -m compileall -q src/pollypm/activity_projector_registry.py src/pollypm/plugins_builtin/activity_feed/plugin.py src/pollypm/cockpit_activity.py src/pollypm/cockpit_palette.py src/pollypm/cockpit_ui.py tests/test_activity_feed_ui.py tests/test_cockpit.py tests/test_heartbeat_cascade_foundation.py`
- `HOME=$(mktemp -d /tmp/pollypm-cockpit-tests.XXXXXX) uv run --extra test pytest tests/test_cockpit.py -k "bindings_expose_activity or help_hides_hidden or active_inbox_nav_return or marks_activity_seen or non_activity_seen or static_key_skips" -q` (7 passed)
- `HOME=$(mktemp -d /tmp/pollypm-cockpit-tests.XXXXXX) uv run --extra test pytest tests/test_activity_feed_ui.py -q` (27 passed)
- `HOME=$(mktemp -d /tmp/pollypm-cockpit-tests.XXXXXX) uv run --extra test pytest tests/test_heartbeat_cascade_foundation.py -k "role_session_missing" -q` (10 passed)
- `HOME=$(mktemp -d /tmp/pollypm-cockpit-tests.XXXXXX) uv run --extra test pytest tests/test_cockpit_glyph_help.py tests/test_cockpit_palette_boundary.py tests/test_cockpit_interaction_contract.py -q` (31 passed)
- `uv run --with ruff ruff check src/pollypm/activity_projector_registry.py src/pollypm/plugins_builtin/activity_feed/plugin.py src/pollypm/cockpit_palette.py --select F821,F841,E402,F401`
- `git diff --check origin/main...HEAD`

Full-file Ruff on `cockpit_ui.py`/large cockpit tests remains noisy from pre-existing import-order/unused-import debt, so this PR limits Ruff to touched activity/palette files and undefined/local-variable checks where useful.

Closes #2200
Closes #2233
Closes #2203
Closes #2237
Refs #2196
Refs #2225
