### PR TITLE
fix(chat): actually surface thinking envelopes in /messages response

### DIFF
--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -1072,12 +1072,24 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
     # (strict ``source=jsonl`` wants the full parse so OSError
     # propagates cleanly). The pad of ``+1`` lets the route's
     # ``has_more`` detection still fire on the boundary.
+    #
+    # Issue #2160: also skip the tail when ``include_thinking=true``.
+    # Anthropic extended-thinking blocks usually land near the head of
+    # a long conversation (model-side reasoning at the start), not the
+    # tail. A ``?include_thinking=true&limit=200`` request against a
+    # multi-thousand-line archive would otherwise tail-read only the
+    # last ~200 envelopes and miss every earlier thinking block —
+    # which is exactly the user-facing failure mode #2160 reported
+    # (39/39 sessions returned zero thinking envelopes). The flag is
+    # explicit opt-in, so trading the tail-read optimization for
+    # actually-surfaced thinking is the right call.
     tail_hint: int | None = None
     if (
         source == "auto"
         and direction == "desc"
         and since_id is None
         and limit <= TAIL_READ_LIMIT_THRESHOLD
+        and not include_thinking
     ):
         tail_hint = limit + 1
 

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -774,6 +774,132 @@ def test_messages_endpoint_emits_thinking_envelopes_when_include_thinking_true(
     assert thinking_msg["metadata"]["signature"] == "opaque"
 
 
+def test_messages_endpoint_include_thinking_surfaces_under_default_curl(
+    client, auth_headers, patch_registry, tmp_path,
+):
+    """Regression for #2160: the user-facing default curl
+
+        GET /api/v1/chat/<name>/messages?include_thinking=true&limit=200
+
+    must return at least one ``type:thinking`` envelope when the
+    archive contains any, even when the archive is large enough that
+    the route's tail-read optimization (issue #2070) would otherwise
+    activate.
+
+    Wave 4A verified that #2208's stale-archive fix did not reach the
+    user-facing path: 39/39 sessions returned zero thinking under the
+    default curl. Root cause: when ``limit <= 200`` + ``direction=desc``
+    + ``source=auto``, the route set ``tail_hint = limit + 1`` and
+    used :func:`parse_events_jsonl_tail`, which reads only the last
+    ~``chunk_size`` bytes of the file. Thinking events written earlier
+    in a long conversation were silently dropped from the response.
+
+    This test exercises the exact user-facing shape (default
+    direction=desc, ``limit=200``) against a multi-thousand-line
+    archive whose thinking block falls outside the tail-read window
+    but inside the desc-200 page by timestamp. Before the fix the
+    response is text-only; after the fix the thinking envelope is
+    surfaced alongside the recent turns.
+    """
+    import json as _json
+
+    archive = tmp_path / "events.jsonl"
+    events: list[dict[str, Any]] = []
+    # The thinking block lives at the HEAD of the file (model-side
+    # reasoning at the start of a long task). Its timestamp is
+    # arranged so it falls inside the desc-200 page when a full
+    # forward parse is used — i.e., a working response includes it.
+    events.append({
+        "timestamp": "2026-05-21T20:00:00Z",
+        "event_type": "thinking",
+        "session_id": "s",
+        "account_name": "claude_main",
+        "provider": "claude",
+        "project_key": "myproj",
+        "source_path": "/tmp/raw.jsonl",
+        "source_offset": 0,
+        "cwd": "/tmp/repo",
+        "model_name": "claude-opus-4-7",
+        "payload": {
+            "text": "Hidden reasoning the user opted in to see.",
+            "signature": "opt-in-sig",
+            "raw": {
+                "type": "thinking",
+                "thinking": "Hidden reasoning the user opted in to see.",
+                "signature": "opt-in-sig",
+            },
+        },
+    })
+    # Push the archive past the 1 MB tail-read ceiling so the
+    # tail-read path NEVER reaches byte 0 (where the thinking lives).
+    # Each padding event is ~5 KB so 250+ events comfortably exceeds
+    # 1 MB. Their timestamps are OLDER than the thinking event's so
+    # they don't crowd the desc-200 page out from under it.
+    big_pad = "y" * 5000
+    for i in range(250):
+        events.append({
+            "timestamp": f"2026-05-21T10:{i // 60:02d}:{i % 60:02d}Z",
+            "event_type": "assistant_turn",
+            "session_id": "s",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": "/tmp/raw.jsonl",
+            "source_offset": i + 1,
+            "cwd": "/tmp/repo",
+            "model_name": "claude-opus-4-7",
+            "payload": {"text": f"old pad turn {i} {big_pad}"},
+        })
+    # Recent text turns at the file tail. These DO appear in the
+    # tail-read window (so tail-read returns 30+ envelopes from this
+    # bunch) and they all have NEWER timestamps than the padding —
+    # but older than the thinking. After full-parse desc-sort the
+    # thinking is the newest envelope of all 281 in the file.
+    for i in range(30):
+        events.append({
+            "timestamp": f"2026-05-21T19:{i:02d}:00Z",
+            "event_type": "assistant_turn",
+            "session_id": "s",
+            "account_name": "claude_main",
+            "provider": "claude",
+            "project_key": "myproj",
+            "source_path": "/tmp/raw.jsonl",
+            "source_offset": 251 + i,
+            "cwd": "/tmp/repo",
+            "model_name": "claude-opus-4-7",
+            "payload": {"text": f"recent turn {i}"},
+        })
+    archive.write_text("\n".join(_json.dumps(ev) for ev in events) + "\n")
+    # Sanity: file must exceed the largest tail-read chunk (1 MB)
+    # so the thinking at byte 0 is never inside the tail window.
+    assert archive.stat().st_size > 1_100_000
+    patch_registry([_surface(
+        "operator", SurfaceType.OPERATOR, persona="Polly",
+        transcript_path=archive,
+    )])
+    from pollypm.web_api.chat.transcripts import _parse_cache_clear
+    _parse_cache_clear()
+    # Default direction is ``desc`` and limit=200 — the exact shape
+    # the cockpit / users send. Before the fix the route would
+    # tail-read only the last ~64 KB (~250-300 short envelopes worth)
+    # and drop the thinking block that lived just ahead of that window.
+    response = client.get(
+        "/api/v1/chat/operator/messages?include_thinking=true&limit=200",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["transcript_source"] == "jsonl"
+    types = [m["type"] for m in body["messages"]]
+    assert "thinking" in types, (
+        f"expected at least one thinking envelope, got types={set(types)} "
+        f"(count={len(types)}); regression for #2160"
+    )
+    thinking_msgs = [m for m in body["messages"] if m["type"] == "thinking"]
+    assert thinking_msgs[0]["text"] == "Hidden reasoning the user opted in to see."
+    assert thinking_msgs[0]["metadata"]["signature"] == "opt-in-sig"
+
+
 def test_messages_endpoint_include_thinking_reaches_ingested_surface_archive(
     client, auth_headers, config, project_root, monkeypatch,
 ):


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Claude
- Authoring persona: Claude Builder
- Creator label: claude-created
- Reviewer/merge agent: Codex
- Ownership label: needs-codex
- Self-merge prohibited: yes

## Summary

PR #2208 attempted to fix #2160 but Wave 4A's user-facing verification confirmed every one of 39 tested sessions still returned only `type:text` under `?include_thinking=true&limit=200`. Per Sam's 2h Codex-stall + verification-gap standing instruction, Claude is shipping the actual fix.

## Root cause (one-liner)

The route's tail-read optimization (issue #2070) seeks from EOF and reads only the last ~1 MB; Anthropic extended-thinking blocks usually land near the head of a long conversation, so the tail window almost never sees them — and the user-facing default curl (`limit<=200` + `direction=desc` + `source=auto`) always activates that tail-read.

## What changed

`src/pollypm/web_api/routes/chat_messages.py` — one extra clause in the tail-read gate: `and not include_thinking`. When the caller explicitly opts in to thinking, the route uses the full forward parse so older thinking blocks reach the response. Default `include_thinking=false` is unaffected — the tail-read optimization still fires for every other request.

```python
if (
    source == "auto"
    and direction == "desc"
    and since_id is None
    and limit <= TAIL_READ_LIMIT_THRESHOLD
    and not include_thinking          # NEW (#2160)
):
    tail_hint = limit + 1
```

Plus a regression test (`tests/test_chat_messages_endpoint.py::test_messages_endpoint_include_thinking_surfaces_under_default_curl`) that hits the HTTP endpoint with the exact user-facing curl shape against a >1 MB archive whose thinking block lives outside the tail-read window.

## Before / after (user-facing)

The regression test reproduces the user-facing curl shape exactly. With `git stash` of `chat_messages.py`:

**Before fix** — `curl '.../messages?include_thinking=true&limit=200'`:
```
status: 200
transcript_source: jsonl
types: {'text': 200}      <-- ZERO thinking envelopes
```

**After fix** — same curl:
```
status: 200
transcript_source: jsonl
types: {'thinking': 1, 'text': 199}    <-- thinking surfaces
text: "Hidden reasoning the user opted in to see."
metadata.signature: "opt-in-sig"
```

## Tests

- `tests/test_chat_messages_endpoint.py -k thinking` — **4 passed** (3 existing + 1 new regression)
- `tests/test_chat_messages_endpoint.py` full file — **48 passed**
- `tests/test_chat_transcripts.py` full file — **78 passed**
- `ruff check` on touched files — clean

Test fails without the route patch (verified by `git stash` + re-run).

## Risk

Minimal. The change only affects the path where `include_thinking=true` is explicitly requested — a non-default opt-in flag. Default callers and the cockpit's polling loop are untouched (they don't pass `include_thinking`, so tail-read still activates for them and #2070's perf win is preserved). The trade for thinking-opt-in callers is full-parse latency on long archives, which is acceptable given the flag is explicit.

Closes #2160. Replaces #2208's incomplete fix.