### PR TITLE
fix(heartbeat): thread active config into health jobs

### DIFF
--- a/src/pollypm/core/rail.py
+++ b/src/pollypm/core/rail.py
@@ -197,6 +197,8 @@ class CoreRail:
             rail = HeartbeatRail.from_plugin_host(
                 state_db=self._config.project.state_db,
                 plugin_host=self._plugin_host,
+                config_path=getattr(self._config, "config_path", None),
+                config=self._config,
             )
             rail.start(start_workers=start_workers)
             self._heartbeat_rail = rail

--- a/src/pollypm/heartbeat/boot.py
+++ b/src/pollypm/heartbeat/boot.py
@@ -46,6 +46,18 @@ DEFAULT_WORKER_CONCURRENCY = 4
 DEFAULT_TICK_INTERVAL_SECONDS = 15.0
 
 
+_CONFIG_PATH_AWARE_PLUGINS = frozenset(
+    {
+        "advisor",
+        "core_recurring",
+        "downtime",
+        "memory_curator",
+        "morning_briefing",
+        "task_assignment_notify",
+    }
+)
+
+
 @dataclass(slots=True)
 class WorkerSettings:
     """Subset of ``pollypm.toml`` that controls the worker pool."""
@@ -87,6 +99,29 @@ def load_worker_settings(config_path: Path) -> WorkerSettings:
         poll_interval = 0.5
 
     return WorkerSettings(concurrency=concurrency, poll_interval=poll_interval)
+
+
+def _thread_config_path_into_roster(
+    roster: Roster,
+    registry: Any,
+    config_path: Path | None,
+) -> None:
+    """Thread the active config path into first-party cadence handlers."""
+    if config_path is None:
+        return
+    source_of = getattr(registry, "source_of", None)
+    if not callable(source_of):
+        return
+    config_path_value = str(Path(config_path))
+    for entry in roster.entries:
+        if "config_path" in entry.payload:
+            continue
+        try:
+            source = source_of(entry.handler_name)
+        except Exception:  # noqa: BLE001
+            source = None
+        if source in _CONFIG_PATH_AWARE_PLUGINS:
+            entry.payload["config_path"] = config_path_value
 
 
 class HeartbeatRail:
@@ -180,6 +215,7 @@ class HeartbeatRail:
 
         roster = plugin_host.build_roster()
         registry = plugin_host.job_handler_registry()
+        _thread_config_path_into_roster(roster, registry, config_path)
 
         # Fire the PluginAPI initialize hook now that roster + handler
         # registry are built — before the first heartbeat tick. Failures

--- a/tests/test_core_rail.py
+++ b/tests/test_core_rail.py
@@ -95,7 +95,12 @@ def test_corerail_startable_protocol_recognizes_objects(tmp_path: Path) -> None:
     assert isinstance(_Sub(), Startable)
 
 
-def test_corerail_register_and_start_stop_invokes_in_order(tmp_path: Path) -> None:
+def test_corerail_register_and_start_stop_invokes_in_order(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        CoreRail, "_start_heartbeat_rail", lambda self, *, start_workers=True: None,
+    )
     rail = _rail(tmp_path)
     events: list[str] = []
 
@@ -168,8 +173,13 @@ def test_readonly_supervisor_does_not_register(tmp_path: Path) -> None:
     assert supervisor not in supervisor.core_rail.subsystems()
 
 
-def test_corerail_start_invokes_supervisor_lifecycle(tmp_path: Path) -> None:
+def test_corerail_start_invokes_supervisor_lifecycle(
+    monkeypatch, tmp_path: Path,
+) -> None:
     """CoreRail.start() must run Supervisor.start() (ensure_layout etc.)."""
+    monkeypatch.setattr(
+        CoreRail, "_start_heartbeat_rail", lambda self, *, start_workers=True: None,
+    )
     config = _config(tmp_path)
     supervisor = Supervisor(config)
 
@@ -194,7 +204,10 @@ def test_corerail_start_invokes_supervisor_lifecycle(tmp_path: Path) -> None:
     assert calls == ["layout", "heartbeat", "knowledge"]
 
 
-def test_corerail_start_is_idempotent(tmp_path: Path) -> None:
+def test_corerail_start_is_idempotent(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        CoreRail, "_start_heartbeat_rail", lambda self, *, start_workers=True: None,
+    )
     config = _config(tmp_path)
     supervisor = Supervisor(config)
 
@@ -209,7 +222,12 @@ def test_corerail_start_is_idempotent(tmp_path: Path) -> None:
     assert calls == ["layout", "hb", "kn"]
 
 
-def test_corerail_stop_reverse_order_with_subsystems(tmp_path: Path) -> None:
+def test_corerail_stop_reverse_order_with_subsystems(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        CoreRail, "_start_heartbeat_rail", lambda self, *, start_workers=True: None,
+    )
     config = _config(tmp_path)
     store = StateStore(config.project.state_db)
     host = extension_host_for_root(str(config.project.root_dir.resolve()))
@@ -236,7 +254,12 @@ def test_corerail_stop_reverse_order_with_subsystems(tmp_path: Path) -> None:
     assert events == ["start:a", "start:b", "stop:b", "stop:a"]
 
 
-def test_corerail_stop_swallows_subsystem_errors(tmp_path: Path) -> None:
+def test_corerail_stop_swallows_subsystem_errors(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        CoreRail, "_start_heartbeat_rail", lambda self, *, start_workers=True: None,
+    )
     config = _config(tmp_path)
     store = StateStore(config.project.state_db)
     host = extension_host_for_root(str(config.project.root_dir.resolve()))
@@ -268,7 +291,10 @@ def test_corerail_stop_swallows_subsystem_errors(tmp_path: Path) -> None:
     assert events == ["good-start", "boom-start", "boom-stop", "good-stop"]
 
 
-def test_corerail_drives_plugin_host_load(tmp_path: Path) -> None:
+def test_corerail_drives_plugin_host_load(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        CoreRail, "_start_heartbeat_rail", lambda self, *, start_workers=True: None,
+    )
     config = _config(tmp_path)
     store = StateStore(config.project.state_db)
     host = extension_host_for_root(str(config.project.root_dir.resolve()))
@@ -318,7 +344,9 @@ def test_corerail_start_retries_transient_first_party_heartbeat_import(
             self.roster = type("_Roster", (), {"entries": []})()
 
         @classmethod
-        def from_plugin_host(cls, *, state_db, plugin_host):
+        def from_plugin_host(
+            cls, *, state_db, plugin_host, config_path=None, config=None
+        ):
             return cls()
 
         def start(self, *, start_workers: bool = True) -> None:
@@ -355,6 +383,62 @@ def test_corerail_start_retries_transient_first_party_heartbeat_import(
     finally:
         rail.stop()
     assert stopped == [True]
+
+
+def test_corerail_start_threads_active_config_into_heartbeat_rail(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    import pollypm.core.rail as rail_mod
+
+    captured: dict[str, object] = {}
+
+    class _FakeHost:
+        def plugins(self):
+            return {}
+
+    class _FakeHeartbeatRail:
+        def __init__(self) -> None:
+            self.roster = type("_Roster", (), {"entries": []})()
+
+        @classmethod
+        def from_plugin_host(
+            cls, *, state_db, plugin_host, config_path=None, config=None
+        ):
+            captured.update(
+                {
+                    "state_db": state_db,
+                    "plugin_host": plugin_host,
+                    "config_path": config_path,
+                    "config": config,
+                }
+            )
+            return cls()
+
+        def start(self, *, start_workers: bool = True) -> None:
+            captured["start_workers"] = start_workers
+
+        def stop(self) -> None:
+            captured["stopped"] = True
+
+    monkeypatch.setattr(
+        rail_mod, "_load_heartbeat_rail_class", lambda: _FakeHeartbeatRail,
+    )
+
+    config = _config(tmp_path)
+    config.config_path = tmp_path / "workspace" / "pollypm.toml"
+    host = _FakeHost()
+    store = StateStore(config.project.state_db)
+    rail = CoreRail(config, store, host)
+
+    rail.start(start_workers=False)
+    try:
+        assert captured["state_db"] == config.project.state_db
+        assert captured["plugin_host"] is host
+        assert captured["config_path"] == config.config_path
+        assert captured["config"] is config
+        assert captured["start_workers"] is False
+    finally:
+        rail.stop()
 
 
 def test_corerail_start_does_not_retry_non_first_party_missing_dependency(

--- a/tests/test_heartbeat_health_public_path.py
+++ b/tests/test_heartbeat_health_public_path.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import typer
+from typer.testing import CliRunner
+
+from pollypm.config import write_config
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    ProjectKind,
+    ProjectSettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProviderKind,
+    SessionConfig,
+    SessionLaunchSpec,
+)
+
+
+def _config(tmp_path: Path) -> PollyPMConfig:
+    root = tmp_path / "workspace"
+    base = root / ".pollypm"
+    logs_dir = base / "logs"
+    snapshots_dir = base / "snapshots"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    snapshots_dir.mkdir(parents=True, exist_ok=True)
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PublicHealthTest",
+            root_dir=root,
+            tmux_session="pollypm-test",
+            workspace_root=tmp_path,
+            base_dir=base,
+            logs_dir=logs_dir,
+            snapshots_dir=snapshots_dir,
+            state_db=base / "state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_controller"),
+        accounts={
+            "claude_controller": AccountConfig(
+                name="claude_controller",
+                provider=ProviderKind.CLAUDE,
+                email="claude@example.com",
+                home=base / "homes" / "claude_controller",
+            ),
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_controller",
+                cwd=root,
+                project="pollypm",
+                window_name="pm-operator",
+                auth_token="a" * 64,
+            ),
+        },
+        projects={
+            "pollypm": KnownProject(
+                key="pollypm",
+                path=root,
+                name="PollyPM",
+                kind=ProjectKind.FOLDER,
+            ),
+        },
+    )
+
+
+def _cli_app() -> typer.Typer:
+    from pollypm.cli_features import sessions_health
+
+    app = typer.Typer()
+    sessions_health.register_sessions_health_command(app)
+
+    @app.command("_marker")
+    def _marker() -> None:  # pragma: no cover - keeps subcommand mode enabled
+        return None
+
+    return app
+
+
+def test_heartbeat_rail_threads_active_config_path_into_core_recurring_payload(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.heartbeat import Roster
+    from pollypm.heartbeat import boot as boot_mod
+    from pollypm.jobs import JobHandlerRegistry
+
+    class _FakeQueue:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.enqueued: list[dict[str, Any]] = []
+
+        def enqueue(
+            self,
+            handler_name: str,
+            payload: dict[str, Any],
+            *,
+            dedupe_key: str | None = None,
+            run_after: datetime | None = None,
+        ) -> int:
+            self.enqueued.append(
+                {
+                    "handler_name": handler_name,
+                    "payload": payload,
+                    "dedupe_key": dedupe_key,
+                    "run_after": run_after,
+                }
+            )
+            return len(self.enqueued)
+
+        def has_recent_or_active_dedupe(self, *_args: Any, **_kwargs: Any) -> bool:
+            return False
+
+    class _FakePool:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.is_running = False
+
+        def start(self, *, concurrency: int = 1) -> None:
+            self.is_running = True
+
+        def stop(self, *, timeout: float = 10.0) -> None:
+            self.is_running = False
+
+    registry = JobHandlerRegistry()
+    registry.register(
+        name="session.health_sweep",
+        handler=lambda payload: {"payload": payload},
+        plugin_name="core_recurring",
+    )
+    roster = Roster()
+    roster.register(
+        schedule="@on_startup",
+        handler_name="session.health_sweep",
+        payload={},
+        dedupe_key="session.health_sweep",
+    )
+
+    class _FakeHost:
+        def build_roster(self):
+            return roster
+
+        def job_handler_registry(self):
+            return registry
+
+    monkeypatch.setattr(boot_mod, "JobQueue", _FakeQueue)
+    monkeypatch.setattr(boot_mod, "JobWorkerPool", _FakePool)
+    monkeypatch.setattr(
+        "pollypm.storage.pg_pool.get_rw_pool", lambda _config=None: object()
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_migrations.apply_migrations", lambda _pool: None
+    )
+
+    config_path = tmp_path / "alternate" / "pollypm.toml"
+    rail = boot_mod.HeartbeatRail.from_plugin_host(
+        state_db=tmp_path / "state.db",
+        plugin_host=_FakeHost(),
+        config_path=config_path,
+        config=object(),
+    )
+
+    result = rail.tick(datetime.now(UTC))
+
+    assert result.enqueued_count == 1
+    assert result.enqueued[0].payload["config_path"] == str(config_path)
+
+
+def test_session_health_sweep_write_is_visible_to_pm_sessions_health(
+    pg_schema_pool,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.cli_features import sessions_health
+    from pollypm.heartbeats.api import SupervisorHeartbeatAPI
+    from pollypm.heartbeats.local import LocalHeartbeatBackend
+    from pollypm.plugins_builtin.core_recurring import plugin as recurring_plugin
+    from pollypm.storage.pg_migrations import apply_migrations
+    import pollypm.supervisor as supervisor_mod
+
+    apply_migrations(pg_schema_pool)
+
+    config = _config(tmp_path)
+    config_path = config.project.base_dir / "pollypm.toml"
+    write_config(config, config_path, force=True)
+
+    launch = SessionLaunchSpec(
+        session=config.sessions["operator"],
+        account=config.accounts["claude_controller"],
+        window_name="pm-operator",
+        log_path=config.project.logs_dir / "operator.log",
+        command="claude",
+    )
+    launch.log_path.write_text("ready\n", encoding="utf-8")
+    snapshot_path = config.project.snapshots_dir / "operator.txt"
+
+    fake_window = SimpleNamespace(
+        name="pm-operator",
+        pane_id="%42",
+        pane_current_command="claude",
+        pane_dead=False,
+        pane_pid=None,
+    )
+
+    def _plan_launches(self):
+        return [launch]
+
+    def _window_map(self):
+        return {(self.storage_closet_session_name(), "pm-operator"): fake_window}
+
+    def _write_snapshot(self, _window, _snapshot_lines):
+        snapshot_path.write_text("operator is ready\n", encoding="utf-8")
+        return snapshot_path, "operator is ready"
+
+    monkeypatch.setattr(
+        supervisor_mod, "sync_token_ledger_for_config", lambda _config: []
+    )
+    monkeypatch.setattr(
+        supervisor_mod, "_load_sweep_stale_notifies_with_retry",
+        lambda: lambda _store: None,
+    )
+    monkeypatch.setattr(supervisor_mod.Supervisor, "_check_fd_pressure", lambda self: None)
+    monkeypatch.setattr(supervisor_mod.Supervisor, "plan_launches", _plan_launches)
+    monkeypatch.setattr(supervisor_mod.Supervisor, "window_map", _window_map)
+    monkeypatch.setattr(supervisor_mod.Supervisor, "write_snapshot", _write_snapshot)
+    monkeypatch.setattr(
+        supervisor_mod.Supervisor,
+        "tmux_session_for_launch",
+        lambda self, _launch: self.storage_closet_session_name(),
+    )
+    monkeypatch.setattr(
+        supervisor_mod.Supervisor,
+        "_sweep_stale_alerts",
+        lambda self, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        supervisor_mod.Supervisor,
+        "_sweep_recovered_recovery_alerts",
+        lambda self, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        supervisor_mod.Supervisor, "ensure_heartbeat_schedule", lambda self: None
+    )
+    monkeypatch.setattr(
+        SupervisorHeartbeatAPI,
+        "record_checkpoint",
+        lambda self, context, *, alerts: None,
+    )
+    monkeypatch.setattr(
+        LocalHeartbeatBackend,
+        "_dispatch_health_intervention",
+        lambda self, api, context: None,
+    )
+    monkeypatch.setattr(
+        recurring_plugin,
+        "sweep_ephemeral_sessions",
+        lambda *_args, **_kwargs: {
+            "considered": 0,
+            "alerts_raised": 0,
+            "skipped_planned": 0,
+            "zombie_task_windows_killed": 0,
+        },
+    )
+
+    result = recurring_plugin.session_health_sweep_handler(
+        {"config_path": str(config_path), "snapshot_lines": 20}
+    )
+
+    assert result["alerts_raised"] == 0
+
+    monkeypatch.setattr(
+        sessions_health,
+        "_list_windows",
+        lambda _name: {
+            "pm-operator": SimpleNamespace(
+                pane_current_command="claude", pane_pid=4242
+            )
+        },
+    )
+    cli_result = CliRunner().invoke(
+        _cli_app(), ["sessions", "--json", "--config", str(config_path)]
+    )
+
+    assert cli_result.exit_code == 0, cli_result.output
+    rows = [
+        json.loads(line)
+        for line in cli_result.output.splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["name"] == "operator"
+    assert row["status"] == "healthy"
+    assert row["last_heartbeat_iso"]
+    assert row["last_heartbeat_age"] != "none"


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Thread the loaded config and config_path from CoreRail into HeartbeatRail.
- Include the active config path in first-party heartbeat cadence job payloads such as session.health_sweep.
- Add a public-path regression proving a heartbeat written by the rail is visible through pm sessions --health using the same config/PG path.

Fixes #2248.
Fixes #2136.
Fixes #2139.

## Verification
- git diff --check origin/main...HEAD
- python -m py_compile src/pollypm/core/rail.py src/pollypm/heartbeat/boot.py tests/test_core_rail.py tests/test_heartbeat_health_public_path.py
- uv run --with ruff ruff check src/pollypm/core/rail.py src/pollypm/heartbeat/boot.py tests/test_core_rail.py tests/test_heartbeat_health_public_path.py
- HOME=mktemp uv run --extra test pytest -q tests/test_core_rail.py tests/test_pg_pool_config.py tests/test_heartbeat_health_public_path.py (31 passed)
- HOME=mktemp uv run --extra test pytest -q tests/test_core_recurring_migration.py tests/test_pg_pool_config.py::test_heartbeat_rail_from_config_threads_config_to_get_rw_pool tests/test_rail_ticker.py (33 passed)
- HOME=mktemp uv run --extra test pytest -q tests/test_task_assignment_recovery_audit.py tests/test_pg_heartbeats.py tests/test_heartbeat_health_public_path.py (9 passed)
- HOME=mktemp uv run --extra test pytest -q tests/test_heartbeat_cascade_foundation.py -k 'role_session_missing or maybe_dispatch_to_operator_dispatched or tier3' (11 passed, 37 deselected)

Note: a broader ad hoc cascade command hit an existing environment-sensitive state_db_missing healer test that expects a configured default home when config_path=None; the targeted heartbeat/cascade contracts above pass.