### PR TITLE
fix(plan): emit review handoff on user approval

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -102,7 +102,7 @@ One `pm task done` call per stage. No chaining.
    Then: `pm task done <task_id> --actor architect --output '{"type":"code_change","summary":"Plan synthesized; Risk Ledger folded in","artifacts":[{"kind":"file_change","description":"project plan","path":"docs/project-plan.md"},{"kind":"file_change","description":"session log","path":"docs/planning-session-log.md"}]}'`
    Advances: synthesize → plan_review.
 
-6.5. **plan_review** — reflection pass. Re-read `docs/project-plan.md`, every `docs/planning/candidate_*.md`, every critic verdict, and `docs/planning-session-log.md`. Then REWRITE `docs/project-plan.md` so that — in this exact order — it leads with **Summary** (1-2 sentences), then **Judgment calls** (a variable-length list — could be 0, could be 10+ — each item one line of decision plus 1-2 sentences on why it could go either way; flag only what's genuine, never pad), then the **Plan body** (decomposition, test strategy, magic, sequencing — preserve every module from synthesize), then **Critic synthesis** (where critics disagreed and how you resolved each call). The Risk Ledger stays under the plan body; the top-of-doc judgment-call flags are the short form. Append a `Stage 6.5 plan review` entry to `docs/planning-session-log.md` narrating which judgment calls you flagged and why. The `log_present` gate still applies. Before you call `pm task done`, invoke the `visual-explainer` magic skill (see `<visual_plan_review>`) so the user approves against a rendered HTML page, not a wall of markdown. Then create the plan_review inbox item (see `<plan_review_handoff>` below) so the user sees `v open explainer · d discuss · A approve` when the flow parks at stage 7.
+6.5. **plan_review** — reflection pass. Re-read `docs/project-plan.md`, every `docs/planning/candidate_*.md`, every critic verdict, and `docs/planning-session-log.md`. Then REWRITE `docs/project-plan.md` so that — in this exact order — it leads with **Summary** (1-2 sentences), then **Judgment calls** (a variable-length list — could be 0, could be 10+ — each item one line of decision plus 1-2 sentences on why it could go either way; flag only what's genuine, never pad), then the **Plan body** (decomposition, test strategy, magic, sequencing — preserve every module from synthesize), then **Critic synthesis** (where critics disagreed and how you resolved each call). The Risk Ledger stays under the plan body; the top-of-doc judgment-call flags are the short form. Append a `Stage 6.5 plan review` entry to `docs/planning-session-log.md` narrating which judgment calls you flagged and why. The `log_present` gate still applies. Before you call `pm task done`, invoke the `visual-explainer` magic skill (see `<visual_plan_review>`) so the user approves against a rendered HTML page, not a wall of markdown. Then create the plan_review inbox item (see `<plan_review_handoff>` below) so the user sees `v open explainer · d discuss · A approve` when the flow parks at stage 7. If the notify handoff fails, do not leave the task on `plan_review`; still call `pm task done` so the work service can emit its fallback review card when the task reaches `user_approval`.
    Then: `pm task done <task_id> --actor architect --output '{"type":"code_change","summary":"Plan review pass; judgment calls hoisted","artifacts":[{"kind":"file_change","description":"reviewed project plan","path":"docs/project-plan.md"},{"kind":"file_change","description":"session log","path":"docs/planning-session-log.md"}]}'`
    Advances: plan_review → user_approval.
 
@@ -157,8 +157,8 @@ HTML explainer rather than the raw markdown.
 </visual_plan_review>
 
 <plan_review_handoff>
-At the END of stage 6 (synthesize), AFTER the visual-explainer skill has
-written its HTML and BEFORE you call `pm task done`, you MUST create a
+At the END of stage 6.5 (`plan_review`), AFTER the final plan rewrite
+and AFTER the visual-explainer skill has written its HTML, you MUST create a
 `plan_review` inbox item so the user lands on the rich review UI
 (`v open explainer · d discuss · A approve`) instead of a plain
 notification with a file path.
@@ -196,7 +196,8 @@ Press v to open the explainer, d to discuss with the PM, A to approve." \
 ```
 
 `<task_id>` is the `plan_project` task you've been driving (the one
-you'll `pm task done` next). The `plan_task:` label is what the inbox UI
+you'll advance from `plan_review` to `user_approval` with `pm task done`
+next). The `plan_task:` label is what the inbox UI
 calls `pm task approve` against when the user presses `A`.
 
 Fast-track: if Polly tells you the user said "just do it" / "trust your
@@ -206,11 +207,17 @@ short-circuits the round-trip discussion gate. Default behaviour (no
 fast-track signal) routes the review to Sam.
 
 Once the inbox item is created, proceed with the regular
-`pm task done <task_id> --actor architect --output ...` for stage 6 →
-user_approval. The flow engine will park at stage 7 and wait for either
+`pm task done <task_id> --actor architect --output ...` for
+plan_review → user_approval. The flow engine will park at stage 7 and wait for either
 `pm task approve <task_id>` (from the inbox) or `pm task reject` (with
 feedback). DO NOT also send a separate `pm notify` plan-ready message
 — the plan_review inbox item IS the notification.
+
+If `pm notify` errors or the rich explainer path is unavailable, record
+that in `docs/planning-session-log.md` and still run `pm task done`.
+The work service emits a basic fallback `plan_review` card as soon as
+the task reaches `user_approval`; staying on `plan_review` is worse
+than a less-rich review card.
 </plan_review_handoff>
 
 <watchdog_unstick_mode>

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -2731,6 +2731,25 @@ class PgWorkService:
             result, from_status.value, result.work_status.value
         )
         self._write_review_summary_after_transition(result)
+        if (
+            result.flow_template_id == "plan_project"
+            and result.current_node_id == "user_approval"
+            and result.work_status == WorkStatus.REVIEW
+        ):
+            try:
+                from pollypm.work.plan_review_emit import (
+                    maybe_emit_plan_review_on_user_approval,
+                )
+
+                maybe_emit_plan_review_on_user_approval(
+                    self, task_id, actor or "architect"
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "plan_review user_approval emit skipped for %s",
+                    task_id,
+                    exc_info=True,
+                )
         return result
 
     def _write_review_summary_after_transition(self, task: Task) -> None:

--- a/src/pollypm/work/plan_review_emit.py
+++ b/src/pollypm/work/plan_review_emit.py
@@ -38,6 +38,13 @@ calls :func:`maybe_emit_plan_review_on_task_done` after the existing
 hook is no-op for the ``plan_project`` flow (its reflection node owns
 the canonical emit) and for tasks that already have an open
 plan_review row — both conditions are checked before any write.
+
+The pg work service also calls
+:func:`maybe_emit_plan_review_on_user_approval` when a ``plan_project``
+task advances from the architect-owned ``plan_review`` work node to the
+human ``user_approval`` review node. That makes the workflow own a
+fallback handoff instead of relying solely on the architect prompt to
+run ``pm notify`` perfectly.
 """
 
 from __future__ import annotations
@@ -79,6 +86,8 @@ _PLAN_OWNING_FLOWS: frozenset[str] = frozenset({
 # ``src/pollypm/plugins_builtin/project_planning/profiles/architect.md``.
 PLAN_REVIEW_LABEL = "plan_review"
 NOTIFY_LABEL = "notify"
+PLAN_PROJECT_FLOW_ID = "plan_project"
+PLAN_APPROVAL_NODE_ID = "user_approval"
 
 
 def is_plan_shaped_task(task: Any) -> bool:
@@ -117,13 +126,26 @@ def task_is_eligible_for_backstop(task: Any) -> bool:
     return True
 
 
+def task_is_pending_plan_approval(task: Any) -> bool:
+    """Return True when a plan_project task is parked for user approval."""
+    flow_id = getattr(task, "flow_template_id", "") or ""
+    if flow_id != PLAN_PROJECT_FLOW_ID:
+        return False
+    node_id = getattr(task, "current_node_id", None) or ""
+    if node_id != PLAN_APPROVAL_NODE_ID:
+        return False
+    status = getattr(task, "work_status", None)
+    status_value = getattr(status, "value", status)
+    return status_value == WorkStatus.REVIEW.value
+
+
 def _plan_task_label(task_id: str) -> str:
     return f"plan_task:{task_id}"
 
 
 def already_has_plan_review_message(
     *,
-    db_path: Path,
+    db_path: Path | None = None,
     project: str,
     plan_task_id: str,
 ) -> bool:
@@ -146,6 +168,7 @@ def already_has_plan_review_message(
     # backend (pg) singleton via ``get_store``. Do NOT close — the
     # store is process-wide. ``db_path`` is retained for source
     # compatibility but no longer drives backend dispatch.
+    _ = db_path
     try:
         from pollypm.config import load_config
         from pollypm.store import get_store
@@ -196,7 +219,11 @@ def already_has_plan_review_message(
     return False
 
 
-def _build_plan_review_body(plan_task_id: str) -> str:
+def _build_plan_review_body(
+    plan_task_id: str,
+    *,
+    source: str = "plan_review_emit",
+) -> str:
     """Render the body the architect normally writes via ``pm notify``.
 
     Mirrors ``profiles/architect.md`` plan_review_handoff template, minus
@@ -204,6 +231,14 @@ def _build_plan_review_body(plan_task_id: str) -> str:
     explainer — the user opens the project drilldown surface from #1401
     instead).
     """
+    if source == "user_approval":
+        return (
+            f"A project plan task ({plan_task_id}) is waiting at "
+            "user_approval.\n"
+            "\n"
+            "Open the project drilldown to read the plan and decide whether "
+            "to approve, request changes, or discuss with the PM."
+        )
     return (
         f"A plan task ({plan_task_id}) reached done without a "
         f"plan_review handoff (backstop emit, see #1511).\n"
@@ -238,6 +273,7 @@ def emit_plan_review_for_task(
     task: Any,
     actor: str = "audit_watchdog",
     requester: str = "user",
+    source: str = "plan_review_emit",
 ) -> str | None:
     """Create the ``plan_review`` message + inbox task for ``task``.
 
@@ -262,12 +298,7 @@ def emit_plan_review_for_task(
     if not plan_task_id or not project:
         return None
     db_path = getattr(svc, "_db_path", None)
-    if db_path is None:
-        logger.debug(
-            "plan_review_emit: svc has no _db_path, skipping for %s", plan_task_id,
-        )
-        return None
-    db_path = Path(db_path)
+    db_path = Path(db_path) if db_path is not None else None
 
     if already_has_plan_review_message(
         db_path=db_path, project=project, plan_task_id=plan_task_id,
@@ -275,7 +306,7 @@ def emit_plan_review_for_task(
         return None
 
     subject = f"Plan ready for review: {project}"
-    body = _build_plan_review_body(plan_task_id)
+    body = _build_plan_review_body(plan_task_id, source=source)
     target_label = _plan_task_label(plan_task_id)
     labels = [
         PLAN_REVIEW_LABEL,
@@ -323,7 +354,7 @@ def emit_plan_review_for_task(
                 "requester": requester,
                 "user_prompt": user_prompt,
                 "plan_task_id": plan_task_id,
-                "backstop_source": "plan_review_emit",
+                "backstop_source": source,
             },
             state="closed",  # mirrors session_runtime.notify for immediate tier
             kind=InboxItemKind.PLAN_REVIEW_PENDING.value,
@@ -393,7 +424,7 @@ def emit_plan_review_for_task(
                     "user_prompt": user_prompt,
                     "plan_task_id": plan_task_id,
                     "task_id": inbox_task_id,
-                    "backstop_source": "plan_review_emit",
+                    "backstop_source": source,
                 },
             )
         except Exception:  # noqa: BLE001
@@ -437,12 +468,46 @@ def maybe_emit_plan_review_on_task_done(
     )
 
 
+def maybe_emit_plan_review_on_user_approval(
+    svc: Any,
+    task_id: str,
+    actor: str,
+) -> str | None:
+    """Emit a fallback plan-review card when plan_project reaches user_approval.
+
+    The happy path is still the architect's explicit ``pm notify`` with
+    rich labels such as ``explainer:<path>``. This hook is the narrow
+    workflow backstop: when the canonical plan task is already parked at
+    the human approval node and no plan_review message exists, create the
+    basic review card so the operator approval loop is exercisable.
+    """
+    try:
+        task = svc.get(task_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "plan_review_emit: get(%s) failed for user_approval emit: %s",
+            task_id, exc, exc_info=True,
+        )
+        return None
+    if not task_is_pending_plan_approval(task):
+        return None
+    return emit_plan_review_for_task(
+        svc=svc,
+        task=task,
+        actor=actor or "architect",
+        requester="user",
+        source="user_approval",
+    )
+
+
 __all__ = [
     "PLAN_REVIEW_LABEL",
     "PLAN_SHAPED_LABELS",
     "already_has_plan_review_message",
     "emit_plan_review_for_task",
     "is_plan_shaped_task",
+    "maybe_emit_plan_review_on_user_approval",
     "maybe_emit_plan_review_on_task_done",
     "task_is_eligible_for_backstop",
+    "task_is_pending_plan_approval",
 ]

--- a/tests/test_architect_stage_transitions.py
+++ b/tests/test_architect_stage_transitions.py
@@ -299,6 +299,47 @@ def test_plan_review_done_advances_to_user_approval_and_flips_to_review(
     assert result.work_status.value == "review"
 
 
+def test_plan_review_done_triggers_user_approval_handoff_backstop(
+    svc: PgWorkService,
+    project_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the canonical plan task parks at user_approval, workflow
+    code emits the fallback review card if the prompt-driven notify was
+    missed."""
+    task_id = _create_and_claim_plan_task(svc)
+    _advance_to(svc, task_id, "plan_review", project_root)
+    assert svc.get(task_id).current_node_id == "plan_review"
+
+    (project_root / "docs" / "project-plan.md").write_text(
+        "# Project plan\n\n## Summary\n\n## Judgment calls\n\n"
+        "## Plan body\n\n## Critic synthesis\n",
+        encoding="utf-8",
+    )
+    (project_root / "docs" / "planning-session-log.md").write_text(
+        "# Session log\n\n## Stage 6.5 plan review\nFlags hoisted.\n",
+        encoding="utf-8",
+    )
+
+    calls: list[tuple[object, str, str]] = []
+
+    def fake_emit(svc_arg, task_id_arg: str, actor_arg: str) -> None:
+        calls.append((svc_arg, task_id_arg, actor_arg))
+
+    monkeypatch.setattr(
+        "pollypm.work.plan_review_emit.maybe_emit_plan_review_on_user_approval",
+        fake_emit,
+    )
+
+    svc.node_done(
+        task_id,
+        "architect",
+        _done_output("plan_review", "docs/project-plan.md"),
+    )
+
+    assert calls == [(svc, task_id, "architect")]
+
+
 @pytest.mark.xfail(
     reason=(
         "PgWorkService._resolve_project_path looks up project via "
@@ -410,3 +451,16 @@ def test_architect_prompt_includes_stage_transitions_block() -> None:
     # HALT instruction at user_approval is load-bearing — without it
     # Archie might try to advance past the human touchpoint.
     assert "HALT" in text
+
+
+def test_architect_prompt_handoff_matches_plan_review_node() -> None:
+    """The handoff instructions must match the actual flow graph:
+    synthesize -> plan_review -> user_approval."""
+    text = ARCHITECT_PROFILE_PATH.read_text(encoding="utf-8")
+    handoff = text.split("<plan_review_handoff>", 1)[1].split(
+        "</plan_review_handoff>", 1
+    )[0]
+    assert "stage 6.5 (`plan_review`)" in handoff
+    assert "plan_review → user_approval" in handoff
+    assert "stage 6 →\nuser_approval" not in handoff
+    assert "still run `pm task done`" in handoff

--- a/tests/test_plan_review_emit.py
+++ b/tests/test_plan_review_emit.py
@@ -42,6 +42,7 @@ from pollypm.audit.watchdog import (
     scan_events,
 )
 from pollypm.work.models import WorkStatus
+from pollypm.work import plan_review_emit as plan_review_emit_module
 from pollypm.work.plan_review_emit import (
     PLAN_REVIEW_LABEL,
     PLAN_SHAPED_LABELS,
@@ -49,7 +50,9 @@ from pollypm.work.plan_review_emit import (
     emit_plan_review_for_task,
     is_plan_shaped_task,
     maybe_emit_plan_review_on_task_done,
+    maybe_emit_plan_review_on_user_approval,
     task_is_eligible_for_backstop,
+    task_is_pending_plan_approval,
 )
 
 
@@ -101,6 +104,57 @@ class _FakeSvc:
         number = self._next_task_number
         self._next_task_number += 1
         return _FakeCreatedTask(task_id=f"{project}/{number}")
+
+
+class _FakeSvcNoDbPath:
+    """Pg-shaped fake: no legacy ``_db_path`` attribute."""
+
+    def __init__(self, *, task: _FakeTask) -> None:
+        self._task = task
+        self.create_calls: list[dict[str, Any]] = []
+
+    def get(self, task_id: str) -> _FakeTask:
+        assert task_id == self._task.task_id
+        return self._task
+
+    def create(self, **kwargs: Any) -> _FakeCreatedTask:
+        self.create_calls.append(kwargs)
+        project = kwargs.get("project") or self._task.project
+        return _FakeCreatedTask(task_id=f"{project}/99")
+
+
+class _MemoryMessageStore:
+    """Small in-memory stand-in for the configured message store."""
+
+    def __init__(self) -> None:
+        self._messages: list[dict[str, Any]] = []
+        self._next_id = 1
+
+    def query_messages(self, *, scope: str) -> list[dict[str, Any]]:
+        return [dict(row) for row in self._messages if row.get("scope") == scope]
+
+    def enqueue_message(self, **kwargs: Any) -> int:
+        message_id = self._next_id
+        self._next_id += 1
+        row = {"id": message_id, **kwargs}
+        self._messages.append(row)
+        return message_id
+
+    def update_message(self, message_id: int, *, payload: dict[str, Any]) -> None:
+        for row in self._messages:
+            if row.get("id") == message_id:
+                row["payload"] = payload
+                return
+        raise KeyError(message_id)
+
+
+@pytest.fixture(autouse=True)
+def fake_message_store(monkeypatch: pytest.MonkeyPatch) -> _MemoryMessageStore:
+    """Keep plan-review emit tests off the operator's real message store."""
+    store = _MemoryMessageStore()
+    monkeypatch.setattr("pollypm.config.load_config", lambda: object())
+    monkeypatch.setattr("pollypm.store.get_store", lambda config: store)
+    return store
 
 
 @pytest.fixture
@@ -167,6 +221,28 @@ def test_eligibility_excludes_plan_project_flow() -> None:
     assert task_is_eligible_for_backstop(standard)
 
 
+def test_pending_plan_approval_requires_plan_project_user_node() -> None:
+    task = _FakeTask(
+        project="p",
+        task_number=1,
+        flow_template_id="plan_project",
+        work_status=WorkStatus.REVIEW,
+    )
+    task.current_node_id = "user_approval"
+    assert task_is_pending_plan_approval(task)
+
+    task.current_node_id = "plan_review"
+    assert not task_is_pending_plan_approval(task)
+
+    task.current_node_id = "user_approval"
+    task.work_status = WorkStatus.IN_PROGRESS
+    assert not task_is_pending_plan_approval(task)
+
+    task.work_status = WorkStatus.REVIEW
+    task.flow_template_id = "standard"
+    assert not task_is_pending_plan_approval(task)
+
+
 # ---------------------------------------------------------------------------
 # Part A — post-done hook + idempotence
 # ---------------------------------------------------------------------------
@@ -207,6 +283,29 @@ def test_emit_creates_message_and_task(db_path: Path) -> None:
         project="coffeeboardnm",
         plan_task_id="coffeeboardnm/1",
     )
+
+
+def test_emit_does_not_require_legacy_db_path(
+    fake_message_store: _MemoryMessageStore,
+) -> None:
+    """Pg services no longer carry sqlite's ``_db_path`` escape hatch."""
+    task = _FakeTask(
+        project="coffeeboardnm",
+        task_number=1,
+        labels=["poc-plan"],
+        flow_template_id="standard",
+        work_status=WorkStatus.DONE,
+    )
+    svc = _FakeSvcNoDbPath(task=task)
+
+    inbox_task_id = plan_review_emit_module.emit_plan_review_for_task(
+        svc=svc, task=task, actor="audit_watchdog", requester="user",
+    )
+
+    assert inbox_task_id == "coffeeboardnm/99"
+    assert len(fake_message_store._messages) == 1
+    assert len(svc.create_calls) == 1
+    assert fake_message_store._messages[0]["payload"]["task_id"] == "coffeeboardnm/99"
 
 
 def test_emit_is_idempotent(db_path: Path) -> None:
@@ -277,6 +376,39 @@ def test_maybe_emit_fires_for_standard_flow_plan(db_path: Path) -> None:
         project="coffeeboardnm",
         plan_task_id="coffeeboardnm/1",
     )
+
+
+def test_user_approval_emit_uses_plan_project_review_node(monkeypatch) -> None:
+    task = _FakeTask(
+        project="bikepath",
+        task_number=1,
+        flow_template_id="plan_project",
+        work_status=WorkStatus.REVIEW,
+    )
+    task.current_node_id = "user_approval"
+    svc = _FakeSvcNoDbPath(task=task)
+    calls: list[dict[str, Any]] = []
+
+    def fake_emit(**kwargs: Any) -> str:
+        calls.append(kwargs)
+        return "bikepath/99"
+
+    monkeypatch.setattr(
+        plan_review_emit_module,
+        "emit_plan_review_for_task",
+        fake_emit,
+    )
+
+    result = maybe_emit_plan_review_on_user_approval(
+        svc, task.task_id, "architect",
+    )
+
+    assert result == "bikepath/99"
+    assert calls[0]["svc"] is svc
+    assert calls[0]["task"] is task
+    assert calls[0]["actor"] == "architect"
+    assert calls[0]["requester"] == "user"
+    assert calls[0]["source"] == "user_approval"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Remove the legacy `_db_path` gate that made pg-backed plan-review emission skip real services.
- Add a pg workflow backstop: when `plan_project` advances to `user_approval`, emit a fallback `plan_review` handoff if the prompt-driven notification was missed.
- Correct the architect prompt so the handoff is tied to stage `6.5 plan_review -> user_approval`.
- Isolate plan-review emit tests from the live operator message store.

Fixes #2214.

## Verification
- `python -m py_compile src/pollypm/work/pg_service.py src/pollypm/work/plan_review_emit.py tests/test_architect_stage_transitions.py tests/test_plan_review_emit.py`
- `uv run --with ruff ruff check src/pollypm/work/pg_service.py src/pollypm/work/plan_review_emit.py tests/test_architect_stage_transitions.py tests/test_plan_review_emit.py`
- `uv run --extra test pytest tests/test_plan_review_emit.py tests/test_architect_stage_transitions.py 'tests/test_project_planning_plugin.py::test_profile_prompt_is_substantive[architect]' tests/test_project_planning_plugin.py::test_plan_review_sits_between_critic_panel_and_user_approval -q` (30 passed, 1 xfailed)
- `git diff --check origin/main...HEAD`

Note: direct `pytest` without the repo `test` extra is not available in this env.
