### PR TITLE
fix(web): mint per-bootstrap session cookies

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -32,10 +32,12 @@ info:
        `~/.pollypm/api-token`. Always accepted; canonical mode for
        non-browser clients (cockpit CLI, scripts, curl). Modeled here as
        `bearerAuth`.
-    2. **Session cookie** — `pollypm-session=<token>`, minted by
-       `GET /ui/` only when the caller is a loopback peer, a verified
+    2. **Session cookie** — `pollypm-session=<opaque-session>`, minted
+       by `GET /ui/` only when the caller is a loopback peer, a verified
        tailnet peer (with `tailnet_trust_enabled=True`), or already
-       presented a valid bearer header. Modeled here as `cookieAuth`.
+       presented a valid bearer header. The cookie is signed with the
+       current API token, so token rotation invalidates browser sessions.
+       Modeled here as `cookieAuth`.
     3. **Credential-free tailnet peer** — accepted only when the server
        was constructed with `tailnet_trust_enabled=True`, which `pm
        serve` auto-sets when `detect_tailscale_ip()` returns a verified
@@ -2868,10 +2870,11 @@ components:
       description: |
         Session cookie minted by `GET /ui/` for loopback peers,
         verified tailnet peers (when `tailnet_trust_enabled=True`), or
-        callers presenting a valid bearer header. The cookie value is
-        the same on-disk token as `bearerAuth`; comparison is
-        constant-time. LAN clients receive HTML without `Set-Cookie`
-        and 401 on the first API call. See `docs/web-api-spec.md` §3.
+        callers presenting a valid bearer header. The cookie is an
+        opaque per-browser session value signed with the current API
+        token; the raw bearer token is not stored in the cookie. LAN
+        clients receive HTML without `Set-Cookie` and 401 on the first
+        API call. See `docs/web-api-spec.md` §3.
 
   parameters:
     ProjectKey:

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -148,13 +148,14 @@ auth dependency (`src/pollypm/web_api/auth.py`):
    scripts, curl).
 2. **`pollypm-session` cookie** — minted by `GET /ui/` and then sent
    automatically by the browser on every subsequent `/api/v1/*` request.
-   The cookie value is the same on-disk token; it is compared with the
-   same constant-time check as the header. `GET /ui/` only issues the
-   cookie when the caller is a loopback peer (`127.0.0.1` / `::1`), a
-   verified tailnet peer (CGNAT-range source *and* the app was built with
-   `tailnet_trust_enabled=True`), or already presented a valid bearer
-   header. LAN clients receive the HTML without `Set-Cookie` and get
-   `401` on their first API call.
+   The cookie is an opaque per-browser session value signed with the
+   current on-disk API token; the raw bearer token is not stored in the
+   cookie, and token rotation invalidates existing browser sessions.
+   `GET /ui/` only issues the cookie when the caller is a loopback peer
+   (`127.0.0.1` / `::1`), a verified tailnet peer (CGNAT-range source
+   *and* the app was built with `tailnet_trust_enabled=True`), or already
+   presented a valid bearer header. LAN clients receive the HTML without
+   `Set-Cookie` and get `401` on their first API call.
 3. **Credential-free tailnet peer** — accepted *only* when the app was
    constructed with `tailnet_trust_enabled=True`, which `pm serve` sets
    automatically when `detect_tailscale_ip()` returns a verified

--- a/docs/web-ui-2065-security-spec.md
+++ b/docs/web-ui-2065-security-spec.md
@@ -91,10 +91,12 @@ order:
 
 1. `Authorization: Bearer <token>` header — always accepted, constant-time
    comparison against the on-disk token (`~/.pollypm/api-token`, mode 0600).
-   Token rotation via `pm api regen-token` invalidates outstanding sessions
-   on the next request because the dependency reads fresh from disk.
-2. `pollypm-session` cookie — same comparison rules as the header. A stale
-   cookie (from a pre-rotation session) returns a friendlier
+   Token rotation via `pm api regen-token` invalidates outstanding bearer
+   tokens on the next request because the dependency reads fresh from disk.
+2. `pollypm-session` cookie — an opaque per-browser session value signed
+   with the current on-disk token. The raw bearer token is not stored in
+   the cookie. A stale cookie (from a pre-rotation session), expired cookie,
+   tampered cookie, or legacy raw-token cookie returns a friendlier
    `invalid_token` message hinting at a `/ui/` reload.
 3. Credential-free Tailscale CGNAT trust — only when the app was built
    with `tailnet_trust_enabled=True`. Without that gate, a CGNAT-source

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -31,10 +31,12 @@ from pollypm.config import PollyPMConfig, load_config
 from pollypm.web_api.auth import (
     SESSION_ISSUED_COOKIE_NAME,
     SESSION_COOKIE_NAME,
+    SESSION_COOKIE_TTL_SECONDS,
     _extract_token,
     is_tailscale_ip,
     make_bearer_auth_dependency,
     make_sse_auth_dependency,
+    mint_session_cookie,
 )
 from pollypm.web_api.token import DEFAULT_TOKEN_PATH, load_token
 from pollypm.web_api.errors import (
@@ -546,10 +548,10 @@ def create_app(
     )
 
     # v0 web UI (Phase 7) — static SPA at ``/ui/`` with a cookie-bridge
-    # entry point that injects the on-disk token as the
-    # ``pollypm-session`` cookie. The static files (app.js, styles.css)
-    # are served raw; the entry route is custom so it can set the
-    # cookie + return the HTML in one round-trip.
+    # entry point that mints a signed ``pollypm-session`` cookie. The
+    # static files (app.js, styles.css) are served raw; the entry route
+    # is custom so it can set the cookie + return the HTML in one
+    # round-trip.
     _mount_web_ui(
         app,
         token_path=token_path,
@@ -613,10 +615,11 @@ def _attach_security_scheme(app: FastAPI) -> None:
 
     1. ``bearerAuth`` — ``Authorization: Bearer <token>`` header,
        token sourced from ``~/.pollypm/api-token``.
-    2. ``cookieAuth`` — ``pollypm-session`` cookie minted by
+    2. ``cookieAuth`` — signed ``pollypm-session`` cookie minted by
        ``GET /ui/`` for loopback peers, verified tailnet peers, or
-       callers presenting a valid bearer header. Same on-disk token,
-       constant-time comparison.
+       callers presenting a valid bearer header. The raw bearer token
+       is not stored in the cookie; token rotation invalidates the
+       signature.
     3. Credential-free tailnet-peer mode (empty ``{}`` entry in the
        security list) — only honoured when the app was constructed
        with ``tailnet_trust_enabled=True``.
@@ -655,11 +658,12 @@ def _attach_security_scheme(app: FastAPI) -> None:
                     "Session cookie minted by `GET /ui/` for loopback "
                     "peers, verified tailnet peers (when "
                     "`tailnet_trust_enabled=True`), or callers "
-                    "presenting a valid bearer header. The cookie "
-                    "value is the same on-disk token as `bearerAuth`; "
-                    "comparison is constant-time. LAN clients receive "
-                    "HTML without `Set-Cookie` and 401 on the first "
-                    "API call. See `docs/web-api-spec.md` §3."
+                    "presenting a valid bearer header. The cookie is "
+                    "an opaque per-browser session value signed with "
+                    "the current API token; the raw bearer token is "
+                    "not stored in the cookie. LAN clients receive HTML "
+                    "without `Set-Cookie` and 401 on the first API call. "
+                    "See `docs/web-api-spec.md` §3."
                 ),
             },
         }
@@ -698,10 +702,10 @@ def _mount_web_ui(
 
     Layout:
 
-    - ``GET /ui/`` returns ``index.html`` and sets the
-      ``pollypm-session`` cookie from the on-disk token, so subsequent
-      ``fetch(..., {credentials: 'include'})`` calls authenticate
-      without the user ever seeing the token.
+    - ``GET /ui/`` returns ``index.html`` and sets a signed
+      ``pollypm-session`` cookie, so subsequent ``fetch(...,
+      {credentials: 'include'})`` calls authenticate without the user
+      ever seeing the bearer token.
     - ``GET /ui/{path}`` (e.g. ``app.js``, ``styles.css``) is served by
       :class:`StaticFiles` from the ``ui/`` directory next to this
       module. No auth on the static assets themselves — the bytes are
@@ -736,8 +740,8 @@ def _mount_web_ui(
         authorization: str | None = Header(default=None),
     ) -> Response:
         # Load the token at request time (not app-build time) so a
-        # ``pm api regen-token`` rotation flows into the cookie on the
-        # next page load without an app restart.
+        # ``pm api regen-token`` rotation flows into the cookie signature
+        # on the next page load without an app restart.
         resolved_token_path = token_path or DEFAULT_TOKEN_PATH
         token_value = load_token(resolved_token_path)
         response = FileResponse(index_path, media_type="text/html")
@@ -745,7 +749,7 @@ def _mount_web_ui(
         # Cookie issuance is credential issuance — gate it behind a
         # proven local-operator path so a LAN device (or anyone who
         # can reach this port from a network we don't trust) can't
-        # GET /ui/ and walk away with the bearer token via
+        # GET /ui/ and walk away with a browser credential via
         # Set-Cookie. Three acceptable signals:
         #
         # 1. Authorization: Bearer <token> matches the on-disk token
@@ -784,23 +788,24 @@ def _mount_web_ui(
             # because the v0 deploy is loopback/Tailscale HTTP. When
             # the operator puts this behind TLS they should set
             # ``Secure=True`` via a reverse proxy.
+            issued_at = int(time.time())
             response.set_cookie(
                 key=SESSION_COOKIE_NAME,
-                value=token_value,
+                value=mint_session_cookie(token_value, issued_at=issued_at),
                 httponly=True,
                 samesite="lax",
                 secure=False,
                 path="/",
-                max_age=60 * 60 * 24 * 7,  # 7 days
+                max_age=SESSION_COOKIE_TTL_SECONDS,
             )
             response.set_cookie(
                 key=SESSION_ISSUED_COOKIE_NAME,
-                value=str(int(time.time())),
+                value=str(issued_at),
                 httponly=False,
                 samesite="lax",
                 secure=False,
                 path="/",
-                max_age=60 * 60 * 24 * 7,
+                max_age=SESSION_COOKIE_TTL_SECONDS,
             )
         # If the token file doesn't exist yet, or the caller isn't on
         # a trusted path, we still serve the HTML — the SPA will

--- a/src/pollypm/web_api/auth.py
+++ b/src/pollypm/web_api/auth.py
@@ -6,16 +6,18 @@ that must match the contents of the token file
 (``~/.pollypm/api-token`` by default).
 
 The dependency reads the token fresh from disk on each request so a
-``pm api regen-token`` rotation invalidates outstanding sessions
-immediately — there's no in-memory cache to flush. Personal-use volume
-makes that trivially cheap (one ``open + read`` per request).
+``pm api regen-token`` rotation invalidates outstanding bearer tokens
+and browser sessions immediately — there's no in-memory cache to flush.
+Personal-use volume makes that trivially cheap (one ``open + read`` per
+request).
 
 V0 web UI (Phase 7) extends the auth dependency with two additional
 acceptance modes for browser-driven sessions:
 
-- ``pollypm-session`` cookie — set by ``GET /ui/`` from the on-disk
-  token, so the browser never has to paste / type the token. Same
-  comparison rules as the header (constant-time, rotation invalidates).
+- ``pollypm-session`` cookie — set by ``GET /ui/`` as a per-browser
+  opaque session value signed with the current on-disk token, so the
+  browser never has to paste / type the bearer token. Rotation
+  invalidates the signature.
 - Tailscale CGNAT trust — request ``client.host`` inside the Tailscale
   CGNAT range (``100.64.0.0/10``) is allowed without either credential,
   **but only when the app was built with ``tailnet_trust_enabled=True``**.
@@ -29,10 +31,10 @@ acceptance modes for browser-driven sessions:
 Loopback (``127.0.0.1``, ``::1``) is not auto-trusted by the API auth
 dependency itself — a local process without the bearer token still
 receives 401 from ``/api/v1/...``. However, ``GET /ui/`` deliberately
-mints a ``pollypm-session`` cookie from the on-disk token for any
-loopback caller (and for tailnet callers when the flag above is on) as
-a convenience for the local-operator workflow: a browser on the same
-machine shouldn't have to paste a bearer to view the cockpit. See
+mints a signed ``pollypm-session`` cookie for any loopback caller (and
+for tailnet callers when the flag above is on) as a convenience for the
+local-operator workflow: a browser on the same machine shouldn't have to
+paste a bearer to view the cockpit. See
 ``docs/web-ui-2065-security-spec.md`` decision **d-ii** for the
 signed-off trade-off — loopback-cookie-mint is an explicit local-
 operator bypass, not an oversight.
@@ -40,7 +42,12 @@ operator bypass, not an oversight.
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import ipaddress
+import secrets
+import time
 from pathlib import Path
 
 from fastapi import Cookie, Header, Query, Request
@@ -58,6 +65,9 @@ _TAILSCALE_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
 # Cookie name used by ``GET /ui/`` to seed the browser session.
 SESSION_COOKIE_NAME = "pollypm-session"
 SESSION_ISSUED_COOKIE_NAME = "pollypm-session-issued-at"
+SESSION_COOKIE_TTL_SECONDS = 60 * 60 * 24 * 7
+_SESSION_COOKIE_VERSION = "v1"
+_SESSION_COOKIE_MAX_CLOCK_SKEW_SECONDS = 300
 
 
 def is_tailscale_ip(host: str | None) -> bool:
@@ -108,6 +118,78 @@ def _extract_token(header_value: str | None) -> str | None:
     return value or None
 
 
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _session_cookie_signature(api_token: str, payload: str) -> str:
+    return _b64url(
+        hmac.new(
+            api_token.encode("utf-8"),
+            payload.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+    )
+
+
+def mint_session_cookie(
+    api_token: str,
+    *,
+    issued_at: int | None = None,
+    nonce: str | None = None,
+) -> str:
+    """Return a per-browser opaque session cookie value.
+
+    The raw bearer token never goes into the browser cookie. Instead we
+    sign ``version.issued_at.nonce`` with the current API token as the
+    HMAC key. Since validation reloads the API token from disk on every
+    request, ``pm api regen-token`` invalidates existing browser
+    sessions without a server-side registry.
+    """
+    issued = int(time.time() if issued_at is None else issued_at)
+    session_nonce = nonce or secrets.token_urlsafe(32)
+    payload = f"{_SESSION_COOKIE_VERSION}.{issued}.{session_nonce}"
+    signature = _session_cookie_signature(api_token, payload)
+    return f"{payload}.{signature}"
+
+
+def is_valid_session_cookie(
+    cookie_value: str,
+    api_token: str,
+    *,
+    now: int | None = None,
+) -> bool:
+    """Validate a ``pollypm-session`` cookie against the current API token."""
+    parts = cookie_value.split(".")
+    if len(parts) != 4:
+        return False
+    version, issued_raw, nonce, signature = parts
+    if version != _SESSION_COOKIE_VERSION or not nonce or not signature:
+        return False
+    try:
+        issued_at = int(issued_raw)
+    except ValueError:
+        return False
+
+    current = int(time.time() if now is None else now)
+    if issued_at > current + _SESSION_COOKIE_MAX_CLOCK_SKEW_SECONDS:
+        return False
+    if current - issued_at > SESSION_COOKIE_TTL_SECONDS:
+        return False
+
+    payload = ".".join(parts[:3])
+    expected = _session_cookie_signature(api_token, payload)
+    from secrets import compare_digest
+
+    return compare_digest(signature, expected)
+
+
+def _invalid_session_cookie():
+    return invalid_token(
+        "Session cookie is invalid or expired. Reload /ui/ to refresh it."
+    )
+
+
 def make_bearer_auth_dependency(
     token_path: Path | None = None,
     *,
@@ -120,7 +202,7 @@ def make_bearer_auth_dependency(
 
     Accepts three credential modes (in order):
     1. ``Authorization: Bearer <token>`` header.
-    2. ``pollypm-session`` cookie (web UI).
+    2. Signed ``pollypm-session`` cookie (web UI).
     3. Tailscale CGNAT client IP (no credential needed) — **only when
        ``tailnet_trust_enabled`` is True**.
 
@@ -143,16 +225,14 @@ def make_bearer_auth_dependency(
             default=None, alias=SESSION_COOKIE_NAME,
         ),
     ) -> str:
-        # Determine which credential the caller supplied. We compare
-        # against the on-disk token for both header and cookie modes;
-        # only the Tailscale path skips the comparison entirely.
-        provided: str | None = _extract_token(authorization)
-        from_cookie = False
-        if provided is None and session_cookie:
-            provided = session_cookie.strip() or None
-            from_cookie = provided is not None
+        # Determine which credential the caller supplied. Bearer tokens
+        # compare directly against the on-disk token; session cookies are
+        # signed per-browser values validated with that token as the key.
+        # Only the Tailscale path skips token loading entirely.
+        bearer_token = _extract_token(authorization)
+        cookie_token = session_cookie.strip() if session_cookie else None
 
-        if provided is None:
+        if bearer_token is None and not cookie_token:
             # No credential at all — check Tailscale fallback before
             # rejecting. ``request.client`` is ``None`` for ASGI
             # transports without a peer (rare; treat as unauthenticated).
@@ -175,17 +255,20 @@ def make_bearer_auth_dependency(
         # it's free.
         from secrets import compare_digest
 
-        if not compare_digest(provided, expected):
-            # A stale cookie deserves a clearer hint than the raw
-            # ``invalid_token`` message — the operator likely rotated
-            # the token and the browser is still sending the old one.
-            if from_cookie:
-                raise invalid_token(
-                    "Session cookie does not match the current token. "
-                    "Reload /ui/ to refresh the cookie from disk."
-                )
-            raise invalid_token()
-        return provided
+        if bearer_token is not None:
+            if not compare_digest(bearer_token, expected):
+                raise invalid_token()
+            return bearer_token
+
+        if cookie_token and is_valid_session_cookie(cookie_token, expected):
+            return cookie_token
+
+        if cookie_token:
+            # A stale / tampered / legacy raw-token cookie deserves a
+            # clearer hint than the raw ``invalid_token`` message.
+            raise _invalid_session_cookie()
+
+        raise unauthorized()
 
     return _dependency
 
@@ -224,12 +307,14 @@ def make_sse_auth_dependency(
         ),
     ) -> str:
         provided = _extract_token(authorization)
+        from_cookie = False
         if provided is None:
             # Fall back to the query-string escape hatch.
             if token:
                 provided = token.strip() or None
         if provided is None and session_cookie:
             provided = session_cookie.strip() or None
+            from_cookie = provided is not None
         if provided is None:
             client_host = request.client.host if request.client else None
             if tailnet_trust_enabled and is_tailscale_ip(client_host):
@@ -243,6 +328,11 @@ def make_sse_auth_dependency(
             )
         from secrets import compare_digest
 
+        if from_cookie:
+            if is_valid_session_cookie(provided, expected):
+                return provided
+            raise _invalid_session_cookie()
+
         if not compare_digest(provided, expected):
             raise invalid_token()
         return provided
@@ -252,8 +342,11 @@ def make_sse_auth_dependency(
 
 __all__ = [
     "SESSION_COOKIE_NAME",
+    "SESSION_COOKIE_TTL_SECONDS",
     "_extract_token",
     "is_tailscale_ip",
+    "is_valid_session_cookie",
     "make_bearer_auth_dependency",
     "make_sse_auth_dependency",
+    "mint_session_cookie",
 ]

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -38,7 +38,7 @@ from pollypm.models import (
 )
 from pollypm.projects import project_transcripts_dir
 from pollypm.web_api import create_app, ensure_token
-from pollypm.web_api.auth import SESSION_COOKIE_NAME
+from pollypm.web_api.auth import SESSION_COOKIE_NAME, is_valid_session_cookie
 from pollypm.web_api.chat.envelope import (
     MessageEnvelope,
     MessageRole,
@@ -422,7 +422,10 @@ def test_sessions_endpoint_cookie_auth_uses_bounded_tmux_probe(
 
     boot = client.get("/ui/", headers=auth_headers)
     assert boot.status_code == 200
-    assert boot.cookies.get(SESSION_COOKIE_NAME) == token
+    cookie = boot.cookies.get(SESSION_COOKIE_NAME)
+    assert cookie != token
+    assert cookie is not None
+    assert is_valid_session_cookie(cookie, token) is True
 
     response = client.get("/api/v1/chat/sessions")
     assert response.status_code == 200, response.text

--- a/tests/web_api/test_auth.py
+++ b/tests/web_api/test_auth.py
@@ -10,6 +10,12 @@ Covers spec §3:
 
 from __future__ import annotations
 
+from pollypm.web_api.auth import (
+    SESSION_COOKIE_NAME,
+    SESSION_COOKIE_TTL_SECONDS,
+    is_valid_session_cookie,
+    mint_session_cookie,
+)
 from pollypm.web_api.token import regenerate_token
 
 
@@ -51,6 +57,49 @@ def test_request_with_malformed_header_returns_401_unauthorized(client) -> None:
 def test_valid_token_allows_request(client, auth_headers) -> None:
     response = client.get("/api/v1/projects", headers=auth_headers)
     assert response.status_code == 200
+
+
+def test_session_cookie_mint_is_opaque_unique_and_valid(token: str) -> None:
+    first = mint_session_cookie(token, issued_at=1_000)
+    second = mint_session_cookie(token, issued_at=1_000)
+
+    assert first != second
+    assert first != token
+    assert token not in first
+    assert is_valid_session_cookie(first, token, now=1_000) is True
+    assert is_valid_session_cookie(second, token, now=1_000) is True
+
+
+def test_session_cookie_rejects_tampering_rotation_and_expiry(token: str) -> None:
+    cookie = mint_session_cookie(token, issued_at=1_000, nonce="fixed-nonce")
+    version, issued_at, nonce, signature = cookie.split(".")
+
+    assert (
+        is_valid_session_cookie(
+            f"{version}.{issued_at}.{nonce}-tampered.{signature}",
+            token,
+            now=1_000,
+        )
+        is False
+    )
+    assert is_valid_session_cookie(cookie, f"{token}-rotated", now=1_000) is False
+    assert (
+        is_valid_session_cookie(
+            cookie,
+            token,
+            now=1_000 + SESSION_COOKIE_TTL_SECONDS + 1,
+        )
+        is False
+    )
+
+
+def test_raw_bearer_token_is_not_valid_session_cookie(client, token: str) -> None:
+    response = client.get(
+        "/api/v1/projects",
+        headers={"Cookie": f"{SESSION_COOKIE_NAME}={token}"},
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
 
 
 def test_rotated_token_invalidates_previous(client, auth_headers, token_path) -> None:
@@ -101,3 +150,22 @@ def test_sse_accepts_token_via_query_param(client, token, monkeypatch) -> None:
     # the header-only auth dependency.
     response = client.get(f"/api/v1/projects?token={token}")
     assert response.status_code == 401
+
+
+def test_sse_accepts_signed_session_cookie(client, token: str, monkeypatch) -> None:
+    """The browser EventSource path rides the same signed UI cookie."""
+    monkeypatch.setattr("pollypm.web_api.sse.KEEPALIVE_INTERVAL_S", 0.1)
+    monkeypatch.setattr("pollypm.web_api.sse.TAIL_POLL_INTERVAL_S", 0.02)
+    monkeypatch.setattr("pollypm.web_api.sse.MAX_STREAM_DURATION_S", 0.5)
+
+    boot = client.get("/ui/", headers={"Authorization": f"Bearer {token}"})
+    assert boot.status_code == 200
+    cookie = boot.cookies.get(SESSION_COOKIE_NAME)
+    assert cookie is not None
+    assert cookie != token
+
+    with client.stream("GET", "/api/v1/events") as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        for _ in response.iter_raw():
+            break

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -2,9 +2,8 @@
 
 Covers:
 
-- ``GET /ui/`` returns 200 + sets the ``pollypm-session`` cookie from
-  the on-disk token **only** for trusted callers (loopback / Tailscale
-  / valid bearer).
+- ``GET /ui/`` returns 200 + sets a signed ``pollypm-session`` cookie
+  **only** for trusted callers (loopback / Tailscale / valid bearer).
 - ``GET /ui/`` from a LAN client gets the HTML but no cookie, and a
   subsequent ``/api/`` call returns 401.
 - ``GET /ui/`` HTML carries the anchors the SPA needs
@@ -40,8 +39,10 @@ from pollypm.cli_features.web_api import detect_tailscale_ip
 from pollypm.web_api.auth import (
     SESSION_COOKIE_NAME,
     SESSION_ISSUED_COOKIE_NAME,
+    is_valid_session_cookie,
     is_tailscale_ip,
 )
+from pollypm.web_api.token import regenerate_token
 
 
 def _ui_get_with_peer(app, peer_ip: str, *, headers: dict[str, str] | None = None) -> httpx.Response:
@@ -76,6 +77,14 @@ def _api_get_with_peer(app, peer_ip: str, *, headers: dict[str, str] | None = No
     return asyncio.run(_probe())
 
 
+def _assert_signed_session_cookie(cookie: str | None, token: str) -> str:
+    assert cookie is not None
+    assert cookie != token, "session cookie must not mirror the bearer token"
+    assert token not in cookie, "session cookie must not contain the bearer token"
+    assert is_valid_session_cookie(cookie, token) is True
+    return cookie
+
+
 def test_ui_root_returns_html_and_sets_session_cookie(client: TestClient, token: str) -> None:
     """``GET /ui/`` returns the SPA HTML and seeds the session cookie.
 
@@ -90,7 +99,7 @@ def test_ui_root_returns_html_and_sets_session_cookie(client: TestClient, token:
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     cookie = response.cookies.get(SESSION_COOKIE_NAME)
-    assert cookie == token, "session cookie should mirror on-disk token"
+    _assert_signed_session_cookie(cookie, token)
     issued = response.cookies.get(SESSION_ISSUED_COOKIE_NAME)
     assert issued is not None and issued.isdigit(), (
         "session issue-time cookie should be readable by JS for expiry warnings"
@@ -119,14 +128,32 @@ def test_ui_cookie_set_from_loopback(app, token: str) -> None:
     """Loopback peer is trusted — cookie is issued."""
     resp = _ui_get_with_peer(app, "127.0.0.1")
     assert resp.status_code == 200
-    assert resp.cookies.get(SESSION_COOKIE_NAME) == token
+    _assert_signed_session_cookie(resp.cookies.get(SESSION_COOKIE_NAME), token)
 
 
 def test_ui_cookie_set_from_tailscale_peer(tailnet_app, token: str) -> None:
     """Tailscale CGNAT peer is trusted when tailnet trust is enabled."""
     resp = _ui_get_with_peer(tailnet_app, "100.64.0.5")
     assert resp.status_code == 200
-    assert resp.cookies.get(SESSION_COOKIE_NAME) == token
+    _assert_signed_session_cookie(resp.cookies.get(SESSION_COOKIE_NAME), token)
+
+
+def test_ui_mints_distinct_session_cookies_for_same_tailnet_peer(
+    tailnet_app, token: str,
+) -> None:
+    """Separate browser contexts behind one Tailscale IP get distinct cookies."""
+    first = _ui_get_with_peer(tailnet_app, "100.64.0.5")
+    second = _ui_get_with_peer(tailnet_app, "100.64.0.5")
+
+    first_cookie = _assert_signed_session_cookie(
+        first.cookies.get(SESSION_COOKIE_NAME),
+        token,
+    )
+    second_cookie = _assert_signed_session_cookie(
+        second.cookies.get(SESSION_COOKIE_NAME),
+        token,
+    )
+    assert first_cookie != second_cookie
 
 
 def test_ui_no_cookie_minted_from_cgnat_when_trust_disabled(
@@ -159,7 +186,7 @@ def test_ui_cookie_set_with_valid_bearer_header(app, token: str) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
-    assert resp.cookies.get(SESSION_COOKIE_NAME) == token
+    _assert_signed_session_cookie(resp.cookies.get(SESSION_COOKIE_NAME), token)
 
 
 def test_ui_no_cookie_with_invalid_bearer(app, token: str) -> None:
@@ -263,9 +290,36 @@ def test_auth_via_cookie_works(client: TestClient, token: str) -> None:
     """
     boot = client.get("/ui/", headers={"Authorization": f"Bearer {token}"})
     assert boot.status_code == 200
-    assert boot.cookies.get(SESSION_COOKIE_NAME) == token
+    _assert_signed_session_cookie(boot.cookies.get(SESSION_COOKIE_NAME), token)
     response = client.get("/api/v1/projects")  # no headers — cookie only
     assert response.status_code == 200
+
+
+def test_rotated_token_invalidates_session_cookie(
+    client: TestClient,
+    auth_headers,
+    token_path: Path,
+) -> None:
+    """API token rotation invalidates the signed browser session cookie."""
+    boot = client.get("/ui/", headers=auth_headers)
+    assert boot.status_code == 200
+    assert client.get("/api/v1/projects").status_code == 200
+
+    new_token = regenerate_token(token_path)
+    response = client.get("/api/v1/projects")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_token"
+
+    refreshed = client.get(
+        "/ui/",
+        headers={"Authorization": f"Bearer {new_token}"},
+    )
+    assert refreshed.status_code == 200
+    _assert_signed_session_cookie(
+        refreshed.cookies.get(SESSION_COOKIE_NAME),
+        new_token,
+    )
+    assert client.get("/api/v1/projects").status_code == 200
 
 
 def test_cgnat_trust_enabled_allows_credential_free_from_tailnet(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- `/ui/` now mints a unique opaque signed `pollypm-session` cookie per bootstrap instead of storing the raw API bearer token.
- Cookie validation uses the current on-disk API token as the signing key, so `pm api regen-token` invalidates browser sessions without server-side session state.
- Legacy raw-token cookies are rejected with a reload hint.
- Adds coverage for unique cookies behind the same Tailscale peer, cookie tampering/expiry/rotation, SSE cookie auth, and chat route cookie auth.

Fixes #2245.

## Verification
- `python -m py_compile src/pollypm/web_api/auth.py src/pollypm/web_api/app.py tests/web_api/test_auth.py tests/web_api/test_web_ui.py tests/test_chat_messages_endpoint.py`
- `uv run --with ruff ruff check src/pollypm/web_api/auth.py src/pollypm/web_api/app.py tests/web_api/test_auth.py tests/web_api/test_web_ui.py tests/test_chat_messages_endpoint.py`
- `HOME=$(mktemp -d /tmp/pollypm-cookie.XXXXXX) uv run --extra test pytest tests/web_api/test_auth.py -q` (11 passed)
- `HOME=$(mktemp -d /tmp/pollypm-cookie-focused.XXXXXX) uv run --extra test pytest tests/web_api/test_auth.py tests/web_api/test_web_ui.py tests/test_chat_messages_endpoint.py -q` (115 passed)
- `git diff --check origin/main...HEAD`

Earlier worker attempt with bare `uv run pytest ...` failed before tests because pytest is only installed through the repo test extra.

## Residual Risk
Tabs in the same browser profile still share cookies by normal browser behavior. Separate browser contexts/devices now receive distinct opaque cookie values; this does not add a full multi-user/persona model.
