### PR TITLE
perf(api): trim chat sessions and dashboard dispatch

### DIFF
--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -106,6 +106,7 @@ class _SessionIndexEntry:
     path: Path
     session_id: str
     cwd: str
+    cwd_normalized: str
     account_name: str
     provider: str
     mtime: float
@@ -133,6 +134,7 @@ def build_session_index(transcripts_root: Path) -> list[_SessionIndexEntry]:
         return list(cached[1])
 
     entries: list[_SessionIndexEntry] = []
+    cwd_normalize_cache: dict[str, str] = {}
     for child_name, mtime, _size in signature:
         events_path = transcripts_root / child_name / "events.jsonl"
         fingerprint = _read_first_event_fingerprint(events_path)
@@ -141,6 +143,10 @@ def build_session_index(transcripts_root: Path) -> list[_SessionIndexEntry]:
             # unidentifiable transcript to the wrong surface.
             continue
         session_id, cwd, account_name, provider = fingerprint
+        cwd_normalized = cwd_normalize_cache.get(cwd)
+        if cwd_normalized is None:
+            cwd_normalized = _normalize_cwd(cwd)
+            cwd_normalize_cache[cwd] = cwd_normalized
         # Prefer the directory name as the canonical session_id (the
         # ingestor names dirs by session_id), but fall back to the event's
         # session_id if the dir name diverges.
@@ -148,6 +154,7 @@ def build_session_index(transcripts_root: Path) -> list[_SessionIndexEntry]:
             path=events_path,
             session_id=child_name or session_id,
             cwd=cwd,
+            cwd_normalized=cwd_normalized,
             account_name=account_name,
             provider=provider,
             mtime=mtime,
@@ -182,6 +189,15 @@ def _session_index_signature(
     return tuple(entries)
 
 
+def _normalize_cwd(cwd: str | None) -> str:
+    if not cwd:
+        return ""
+    try:
+        return str(Path(cwd).resolve())
+    except (OSError, RuntimeError):
+        return str(cwd)
+
+
 def lookup_transcript_path(
     index: list[_SessionIndexEntry],
     *,
@@ -207,29 +223,19 @@ def lookup_transcript_path(
     """
     if not index or not cwd:
         return None
-    try:
-        normalized = str(Path(cwd).resolve())
-    except (OSError, RuntimeError):
-        normalized = str(cwd)
-    matches: list[_SessionIndexEntry] = []
+    normalized = _normalize_cwd(cwd)
+    best: _SessionIndexEntry | None = None
     for entry in index:
-        if not entry.cwd:
-            continue
-        try:
-            entry_cwd = str(Path(entry.cwd).resolve())
-        except (OSError, RuntimeError):
-            entry_cwd = entry.cwd
+        entry_cwd = entry.cwd_normalized or _normalize_cwd(entry.cwd)
         if entry_cwd != normalized:
             continue
         if account_name and entry.account_name and entry.account_name != account_name:
             continue
         if provider and entry.provider and entry.provider != provider:
             continue
-        matches.append(entry)
-    if not matches:
-        return None
-    matches.sort(key=lambda item: item.mtime, reverse=True)
-    return matches[0].path
+        if best is None or entry.mtime > best.mtime:
+            best = entry
+    return best.path if best is not None else None
 
 
 def resolve_transcript_path(

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -22,6 +22,7 @@ The route's behaviour mirrors the cockpit per spec §3.3 edge cases:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Annotated, Any
@@ -265,7 +266,7 @@ def _gather_dashboard(config: Any) -> Any:
     summary="Aggregate dashboard / cockpit state",
     operation_id="getDashboard",
 )
-def get_dashboard_endpoint(
+async def get_dashboard_endpoint(
     config: ConfigDep,
     project: Annotated[
         str | None,
@@ -314,37 +315,39 @@ def get_dashboard_endpoint(
             hint="Drop ?project= to fetch the whole-system snapshot.",
         )
 
-    # Projects view — list_projects is the authoritative cockpit row
-    # builder; reuse it so the rollups derived below match the project
-    # rows exactly.
-    try:
-        projects_all = list_projects(config)
-    except Exception as exc:  # noqa: BLE001
+    projects_result, data_result = await asyncio.gather(
+        asyncio.to_thread(list_projects, config),
+        asyncio.to_thread(_gather_dashboard, config),
+        return_exceptions=True,
+    )
+    if isinstance(projects_result, Exception):
         # list_projects swallows per-project failures internally; a
         # raise here means the config itself is unreadable.
-        logger.warning("dashboard: list_projects failed: %s", exc)
+        logger.warning("dashboard: list_projects failed: %s", projects_result)
         raise service_unavailable(
             "Failed to load project list for dashboard",
             hint="Check `pm doctor` and config.toml health.",
-        ) from exc
+        ) from projects_result
+    if isinstance(data_result, Exception):
+        logger.warning("dashboard: gather failed: %s", data_result)
+        raise service_unavailable(
+            "Dashboard gather failed; backing store may be unreachable",
+            hint="Retry shortly; check `pm doctor` for pg pool health.",
+        ) from data_result
+
+    # Projects view — list_projects is the authoritative cockpit row
+    # builder; reuse it so the rollups derived below match the project
+    # rows exactly. In parallel, gather loads the aggregate dashboard
+    # payload (active sessions, commits, tokens, …). Transient pg outages
+    # surface as 503 per spec §3.3 final bullet; a healthy daemon-down
+    # state is captured below as ``daemon_status="down"`` (200, not 503).
+    projects_all = projects_result
+    data = data_result
 
     if project is not None:
         projects_view = [p for p in projects_all if p.key == project]
     else:
         projects_view = list(projects_all)
-
-    # Aggregate dashboard payload (active sessions, commits, tokens,
-    # …). Transient pg outages surface as 503 per spec §3.3 final
-    # bullet; a healthy daemon-down state is captured below as
-    # ``daemon_status="down"`` (200, not 503).
-    try:
-        data = _gather_dashboard(config)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("dashboard: gather failed: %s", exc)
-        raise service_unavailable(
-            "Dashboard gather failed; backing store may be unreachable",
-            hint="Retry shortly; check `pm doctor` for pg pool health.",
-        ) from exc
 
     # Derive daemon health from the UNFILTERED gather result. This is a
     # system-wide signal — a caller polling ``?project=foo`` must still

--- a/src/pollypm/web_api/routes/health.py
+++ b/src/pollypm/web_api/routes/health.py
@@ -8,6 +8,7 @@ this one.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from functools import cache
 
 from fastapi import APIRouter, Request
 
@@ -17,6 +18,7 @@ from pollypm.web_api.models import HealthResponse
 router = APIRouter(tags=["Health"])
 
 
+@cache
 def _server_version() -> str:
     """Best-effort PollyPM package version.
 
@@ -44,7 +46,7 @@ _STARTED_AT = datetime.now(timezone.utc)
     summary="Liveness + version info",
     operation_id="getHealth",
 )
-def get_health(request: Request) -> HealthResponse:
+async def get_health(request: Request) -> HealthResponse:
     tailnet_trust_enabled = bool(
         getattr(request.app.state, "tailnet_trust_enabled", False)
     )

--- a/tests/test_chat_transcripts.py
+++ b/tests/test_chat_transcripts.py
@@ -1440,6 +1440,46 @@ def test_lookup_returns_none_without_cwd(tmp_path: Path) -> None:
     assert lookup_transcript_path(index, cwd="") is None
 
 
+def test_lookup_uses_pre_normalized_index_cwds(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Surface-list lookups must not resolve every archive cwd per surface."""
+    shared_cwd = tmp_path / "shared"
+    shared_cwd.mkdir()
+    normalized = str(shared_cwd.resolve())
+    index = [
+        transcripts_module._SessionIndexEntry(
+            path=tmp_path / f"session-{idx}" / "events.jsonl",
+            session_id=f"session-{idx}",
+            cwd=str(shared_cwd),
+            cwd_normalized=normalized,
+            account_name="codex_primary",
+            provider="codex",
+            mtime=float(idx),
+        )
+        for idx in range(1000)
+    ]
+
+    calls = {"count": 0}
+    real_resolve = Path.resolve
+
+    def counting_resolve(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        calls["count"] += 1
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", counting_resolve)
+
+    resolved = lookup_transcript_path(
+        index,
+        cwd=str(shared_cwd),
+        account_name="codex_primary",
+        provider="codex",
+    )
+
+    assert resolved == tmp_path / "session-999" / "events.jsonl"
+    assert calls["count"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Envelope id stability
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -12,6 +12,7 @@ harness which these tests intentionally avoid.
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -335,6 +336,32 @@ def test_list_projects_uses_pg_bulk_task_snapshot(
     assert by_key["myproj"].pending_plan_review is True
     assert by_key["myproj"].open_inbox_count == 1
     assert by_key["myproj"].task_counts["review"] == 1
+
+
+def test_dashboard_loads_projects_and_gather_concurrently(
+    client, auth_headers, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_started = threading.Event()
+    gather_started = threading.Event()
+
+    def fake_list_projects(_config):
+        project_started.set()
+        assert gather_started.wait(1.0)
+        return [_api_project("myproj")]
+
+    def fake_gather(_config):
+        gather_started.set()
+        assert project_started.wait(1.0)
+        return _make_data()
+
+    monkeypatch.setattr(dashboard_routes, "list_projects", fake_list_projects)
+    monkeypatch.setattr(dashboard_routes, "_gather_dashboard", fake_gather)
+
+    response = client.get("/api/v1/dashboard", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    assert project_started.is_set()
+    assert gather_started.is_set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web_api/test_endpoints.py
+++ b/tests/web_api/test_endpoints.py
@@ -8,6 +8,7 @@ so the test path matches what the cockpit uses.
 
 from __future__ import annotations
 
+import inspect
 import sqlite3
 
 import pytest
@@ -23,6 +24,29 @@ def test_health_returns_status_ok(client) -> None:
     body = response.json()
     assert body["status"] == "ok"
     assert isinstance(body["schema_version"], int)
+
+
+def test_health_handler_stays_off_sync_threadpool(monkeypatch) -> None:
+    import importlib.metadata
+
+    from pollypm.web_api.routes import health as health_routes
+
+    calls = {"count": 0}
+
+    def fake_version(package: str) -> str:
+        assert package == "pollypm"
+        calls["count"] += 1
+        return "9.9.9"
+
+    health_routes._server_version.cache_clear()
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+    try:
+        assert inspect.iscoroutinefunction(health_routes.get_health)
+        assert health_routes._server_version() == "9.9.9"
+        assert health_routes._server_version() == "9.9.9"
+        assert calls["count"] == 1
+    finally:
+        health_routes._server_version.cache_clear()
 
 
 def test_list_projects_returns_registered_project(client, auth_headers) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Remove repeated per-surface `Path.resolve()` work from chat transcript index lookups, keeping `/api/v1/chat/sessions` response shape unchanged while cutting fixed cold-load work.
- Make dashboard/health handlers async where they were dispatching avoidable synchronous work from the request path.
- Cache server version lookup and load dashboard projects/gather concurrently.

Fixes #2201.
Fixes #2140.

## Benchmark
Synthetic `enumerate_chat_surfaces` benchmark with 51 sessions and 1200 transcript dirs:
- Before: cold `2727.2ms`, warm1 `2787.42ms`, warm2 `2736.08ms`
- After: cold `161.87ms`, warm1 `57.69ms`, warm2 `31.07ms`

## Verification
- `python -m py_compile src/pollypm/web_api/chat/transcripts.py src/pollypm/web_api/routes/dashboard.py src/pollypm/web_api/routes/health.py tests/test_chat_transcripts.py tests/test_dashboard_endpoint.py tests/web_api/test_endpoints.py`
- `uv run --with ruff ruff check src/pollypm/web_api/chat/transcripts.py src/pollypm/web_api/routes/dashboard.py src/pollypm/web_api/routes/health.py tests/test_chat_transcripts.py tests/test_dashboard_endpoint.py tests/web_api/test_endpoints.py`
- `HOME=$(mktemp -d /tmp/pollypm-chatperf.XXXXXX) uv run --extra test pytest --noconftest tests/test_dashboard_endpoint.py -q` (19 passed)
- `HOME=$(mktemp -d /tmp/pollypm-chatperf-transcripts2.XXXXXX) uv run --extra test pytest tests/test_chat_transcripts.py::test_lookup_uses_pre_normalized_index_cwds -q` (1 passed)
- `HOME=$(mktemp -d /tmp/pollypm-chatperf-endpoints2.XXXXXX) uv run --extra test pytest tests/web_api/test_endpoints.py::test_health_handler_stays_off_sync_threadpool tests/test_dashboard_endpoint.py::test_dashboard_loads_projects_and_gather_concurrently -q` (2 passed)
- `HOME=$(mktemp -d /tmp/pollypm-chatperf-openapi.XXXXXX) uv run --extra dev pytest tests/web_api/test_openapi_conformance.py -q` (24 passed)
- `git diff --check origin/main...HEAD`

## Residual Risk
Live 30-sample curl budgets were not rerun against the production-like `pm serve`/PG fixture. Dashboard tail latency can still be dominated by DB/git/filesystem work inside gather; this removes additional fixed blocking on top of the already-merged #2255 hot-path work.
