### PR TITLE
feat(web-ui): add inbox and operator task actions

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -304,6 +304,20 @@ paths:
           name: tracked
           schema: { type: boolean }
           description: When true, returns only `tracked=true` projects.
+        - in: query
+          name: q
+          schema: { type: string }
+          description: Filter projects by key, name, path, or persona.
+        - in: query
+          name: search
+          schema: { type: string }
+          description: Alias for `q`.
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum: [name, inbox_desc, recent, recent_desc, urgency]
+          description: Sort projects by name, inbox count, recency, or urgency.
       responses:
         "200":
           description: All registered projects with derived state.
@@ -3227,6 +3241,10 @@ components:
           $ref: "#/components/schemas/TaskCounts"
         open_inbox_count: { type: integer }
         pending_plan_review: { type: boolean }
+        last_activity_at:
+          type: string
+          format: date-time
+          nullable: true
 
     ProjectActivityEntry:
       type: object

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -115,6 +115,7 @@ class Project(BaseModel):
     task_counts: dict[str, int] = Field(default_factory=dict)
     open_inbox_count: int
     pending_plan_review: bool
+    last_activity_at: datetime | None = None
 
 
 class ProjectListResponse(BaseModel):

--- a/src/pollypm/web_api/routes/projects.py
+++ b/src/pollypm/web_api/routes/projects.py
@@ -60,9 +60,72 @@ router = APIRouter(tags=["Projects"])
 def list_projects_endpoint(
     config: ConfigDep,
     tracked: Annotated[bool | None, Query(description="When true, returns only tracked projects.")] = None,
+    q: Annotated[
+        str | None,
+        Query(description="Filter projects by key, name, path, or persona."),
+    ] = None,
+    search: Annotated[
+        str | None,
+        Query(description="Alias for q."),
+    ] = None,
+    sort: Annotated[
+        Literal["name", "inbox_desc", "recent", "recent_desc", "urgency"] | None,
+        Query(description="Sort projects by name, inbox count, recency, or urgency."),
+    ] = None,
 ) -> ProjectListResponse:
     items = list_projects(config, tracked_only=bool(tracked))
+    needle = (q or search or "").strip().lower()
+    if needle:
+        items = [
+            item for item in items
+            if (
+                needle in item.key.lower()
+                or needle in item.name.lower()
+                or needle in item.path.lower()
+                or needle in (item.persona_name or "").lower()
+            )
+        ]
+    if sort == "name":
+        items.sort(key=lambda item: item.name.lower())
+    elif sort == "inbox_desc":
+        items.sort(key=lambda item: (-item.open_inbox_count, item.name.lower()))
+    elif sort in {"recent", "recent_desc"}:
+        items.sort(key=_project_recent_sort_key)
+    elif sort == "urgency":
+        items.sort(key=_project_urgency_sort_key)
     return ProjectListResponse(items=items)
+
+
+def _project_urgency_sort_key(project: Project) -> tuple[int, str]:
+    counts = project.task_counts or {}
+    if not project.tracked or project.glyph == "paused":
+        rank = 5
+    elif counts.get("blocked", 0) > 0 or counts.get("on_hold", 0) > 0:
+        rank = 0
+    elif counts.get("queued", 0) > 0 and (
+        counts.get("in_progress", 0) + counts.get("rework", 0)
+    ) == 0:
+        rank = 1
+    elif (
+        project.pending_plan_review
+        or project.open_inbox_count > 0
+        or counts.get("review", 0) > 0
+    ):
+        rank = 2
+    elif counts.get("in_progress", 0) > 0 or counts.get("rework", 0) > 0:
+        rank = 3
+    else:
+        rank = 4
+    return (rank, project.name.lower())
+
+
+def _project_recent_sort_key(project: Project) -> tuple[bool, float, str]:
+    when = project.last_activity_at
+    return (
+        when is None,
+        -(when.timestamp() if when is not None else 0),
+        project.name.lower(),
+    )
 
 
 @router.get(

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -985,6 +985,10 @@ def _project_to_api_from_tasks(
         for task in tasks
     )
     open_inbox_count = _open_inbox_count_from_tasks(tasks)
+    last_activity_at = _max_datetime(
+        _latest_task_activity(tasks),
+        _latest_audit_activity(key, project),
+    )
     return _project_to_api_from_metrics(
         config,
         key,
@@ -992,6 +996,7 @@ def _project_to_api_from_tasks(
         counts=counts,
         pending_plan_review=pending_plan_review,
         open_inbox_count=open_inbox_count,
+        last_activity_at=last_activity_at,
     )
 
 
@@ -1003,6 +1008,7 @@ def _project_to_api_from_metrics(
     counts: dict[str, int],
     pending_plan_review: bool,
     open_inbox_count: int,
+    last_activity_at: datetime | None = None,
 ) -> APIProject:
     glyph = _glyph_for_project(
         project, counts, pending_plan_review, open_inbox_count
@@ -1021,6 +1027,7 @@ def _project_to_api_from_metrics(
         task_counts=counts,
         open_inbox_count=open_inbox_count,
         pending_plan_review=pending_plan_review,
+        last_activity_at=last_activity_at,
     )
 
 
@@ -1028,6 +1035,7 @@ def _project_to_api(config: PollyPMConfig, key: str, project: KnownProject) -> A
     counts: dict[str, int] = {}
     pending_plan_review = False
     open_inbox_count = 0
+    last_activity_at: datetime | None = None
 
     try:
         with _open_work_service_readonly(
@@ -1041,6 +1049,11 @@ def _project_to_api(config: PollyPMConfig, key: str, project: KnownProject) -> A
                 pending_plan_review = _has_pending_plan_review(svc, key)
             except Exception:  # noqa: BLE001
                 pending_plan_review = False
+            try:
+                latest_tasks = svc.list_tasks(project=key, limit=200)
+                last_activity_at = _latest_task_activity(latest_tasks)
+            except Exception:  # noqa: BLE001
+                last_activity_at = None
     except Exception as exc:  # noqa: BLE001
         logger.debug("project counts: work-service unavailable for %s: %s", key, exc)
 
@@ -1049,6 +1062,10 @@ def _project_to_api(config: PollyPMConfig, key: str, project: KnownProject) -> A
     except Exception as exc:  # noqa: BLE001
         logger.debug("project inbox count failed for %s: %s", key, exc)
 
+    last_activity_at = _max_datetime(
+        last_activity_at,
+        _latest_audit_activity(key, project),
+    )
     return _project_to_api_from_metrics(
         config,
         key,
@@ -1056,7 +1073,42 @@ def _project_to_api(config: PollyPMConfig, key: str, project: KnownProject) -> A
         counts=counts,
         pending_plan_review=pending_plan_review,
         open_inbox_count=open_inbox_count,
+        last_activity_at=last_activity_at,
     )
+
+
+def _max_datetime(a: datetime | None, b: datetime | None) -> datetime | None:
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if _datetime_sort_value(a) >= _datetime_sort_value(b) else b
+
+
+def _datetime_sort_value(value: datetime) -> float:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.timestamp()
+
+
+def _latest_task_activity(tasks: Iterable[Any]) -> datetime | None:
+    latest: datetime | None = None
+    for task in tasks:
+        updated = getattr(task, "updated_at", None)
+        if isinstance(updated, datetime):
+            latest = _max_datetime(latest, updated)
+    return latest
+
+
+def _latest_audit_activity(key: str, project: KnownProject) -> datetime | None:
+    try:
+        events = read_events(key, project_path=project.path, limit=1)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("project audit activity failed for %s: %s", key, exc)
+        return None
+    if not events:
+        return None
+    return _parse_iso(events[-1].ts)
 
 
 def _glyph_for_project(

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -28,6 +28,9 @@
   const AUDIT_LIMIT = 25;
   const ACTIVITY_LIMIT = 40;
   const ACTIVITY_DEFAULT_SINCE = "2d";
+  const INBOX_PAGE_LIMIT = 25;
+  const OPERATOR_ACTOR = "operator";
+  const CLAIM_ACTOR = "worker";
 
   const state = {
     projects: [],
@@ -37,7 +40,10 @@
     projectSort: "urgency",
     surfaces: [],
     taskSurfaces: [],
+    surfaceLoadError: null,
     taskLoadError: null,
+    surfaceLoading: false,
+    taskLoading: false,
     selectedKind: null,
     selectedSurface: null,
     selectedTaskKey: null,
@@ -69,6 +75,26 @@
     activityInFlight: false,
     activityRefreshQueued: false,
     pendingMessages: {},
+    inbox: {
+      items: [],
+      nextCursor: null,
+      loading: false,
+      loadingMore: false,
+      error: null,
+      warning: null,
+      reloadQueued: false,
+      filters: {
+        project: "",
+        state: "",
+        type: "",
+      },
+      selectedId: null,
+      detail: null,
+      detailLoading: false,
+      detailError: null,
+      actionInFlight: {},
+      replyDraft: "",
+    },
   };
 
   // ----- DOM helpers ------------------------------------------------------
@@ -205,7 +231,9 @@
       const detail = body && body.error
         ? body.error.message || body.error.code
         : ("HTTP " + resp.status);
-      throw new Error(detail);
+      const err = new Error(detail);
+      err.status = resp.status;
+      throw err;
     }
     setStatus("ok", "online");
     return resp;
@@ -232,7 +260,9 @@
       const detail = body && body.error
         ? body.error.message || body.error.code
         : ("HTTP " + resp.status);
-      throw new Error(detail);
+      const err = new Error(detail);
+      err.status = resp.status;
+      throw err;
     }
     return resp.json();
   }
@@ -257,6 +287,9 @@
       return;
     }
     state.surfacesInFlight = true;
+    state.surfaceLoading = true;
+    state.taskLoading = true;
+    renderSurfaces();
     try {
       const [sessionsResult, tasksResult, projectsResult] =
         await Promise.allSettled([
@@ -266,19 +299,21 @@
         ]);
 
       if (sessionsResult.status === "rejected") {
+        state.surfaces = [];
         state.taskSurfaces = [];
         state.projects = [];
         state.projectLoadError = null;
         state.taskLoadError = null;
-        renderProjects();
         const err = sessionsResult.reason instanceof Error
           ? sessionsResult.reason
           : new Error(String(sessionsResult.reason));
-        renderSurfaceError(err);
+        state.surfaceLoadError = err;
+        renderProjects();
         return;
       }
       const data = sessionsResult.value;
       state.surfaces = Array.isArray(data.sessions) ? data.sessions : [];
+      state.surfaceLoadError = null;
 
       if (tasksResult.status === "fulfilled") {
         state.taskLoadError = null;
@@ -307,9 +342,11 @@
       }
       renderProjects();
       ensureSelectionVisible();
-      renderSurfaces();
     } finally {
+      state.surfaceLoading = false;
+      state.taskLoading = false;
       state.surfacesInFlight = false;
+      renderSurfaces();
       if (state.surfacesRefreshQueued) {
         state.surfacesRefreshQueued = false;
         loadSurfaces();
@@ -655,15 +692,29 @@
     const hasRegistered = (
       state.surfaces.length > 0
       || state.taskSurfaces.length > 0
+      || state.surfaceLoadError
       || state.taskLoadError
     );
+    const isLoading = state.surfaceLoading || state.taskLoading;
+    if (!hasRegistered && isLoading) {
+      list.appendChild(
+        el("li", { class: "surface-empty", text: "loading surfaces..." }),
+      );
+      return;
+    }
     if (!hasRegistered) {
       list.appendChild(
         el("li", { class: "surface-empty", text: "no surfaces registered" }),
       );
       return;
     }
-    if (surfaces.length === 0 && taskSurfaces.length === 0 && !state.taskLoadError) {
+    if (
+      filter
+      && surfaces.length === 0
+      && taskSurfaces.length === 0
+      && !state.surfaceLoadError
+      && !state.taskLoadError
+    ) {
       list.appendChild(
         el("li", { class: "surface-empty", text: "no matching surfaces" }),
       );
@@ -672,6 +723,18 @@
     if (surfaces.length > 0) {
       appendRailGroup(list, "Chat surfaces");
       for (const s of surfaces) renderChatSurfaceItem(list, s);
+    } else if (state.surfaceLoadError) {
+      appendRailGroup(list, "Chat surfaces");
+      list.appendChild(el("li", {
+        class: "surface-empty",
+        text: "error: chat unavailable: " + state.surfaceLoadError.message,
+      }));
+    } else if (state.surfaceLoading) {
+      appendRailGroup(list, "Chat surfaces");
+      list.appendChild(el("li", {
+        class: "surface-empty",
+        text: "loading chat surfaces...",
+      }));
     }
     if (taskSurfaces.length > 0 || state.taskLoadError) {
       appendRailGroup(list, "Tasks");
@@ -687,9 +750,15 @@
       if (state.taskLoadError) {
         list.appendChild(el("li", {
           class: "surface-empty",
-          text: "tasks unavailable: " + state.taskLoadError.message,
+          text: "error: tasks unavailable: " + state.taskLoadError.message,
         }));
       }
+    } else if (state.taskLoading) {
+      appendRailGroup(list, "Tasks");
+      list.appendChild(el("li", {
+        class: "surface-empty",
+        text: "loading tasks...",
+      }));
     }
   }
 
@@ -744,6 +813,7 @@
     state.selectedKind = "chat";
     state.selectedSurface = name;
     state.selectedTaskKey = null;
+    state.inbox.selectedId = null;
     $("pane-title").textContent = name;
     $("pane-meta").textContent = "";
     $("send-input").disabled = false;
@@ -754,12 +824,51 @@
     if (state.auditExpanded[name]) loadAuditForSurface(name);
   }
 
+  function renderNoSelection() {
+    state.selectedKind = null;
+    state.selectedSurface = null;
+    state.selectedTaskKey = null;
+    state.inbox.selectedId = null;
+    $("pane-title").textContent = "Ready";
+    $("pane-meta").textContent = "";
+    $("send-input").disabled = true;
+    $("send-button").disabled = true;
+    updateStopAgentButton();
+    const openInbox = el("button", {
+      class: "empty-action primary",
+      type: "button",
+      text: "Open inbox",
+    });
+    openInbox.addEventListener("click", () => selectInbox());
+    const refresh = el("button", {
+      class: "empty-action",
+      type: "button",
+      text: "Refresh",
+    });
+    refresh.addEventListener("click", () => {
+      loadSurfaces();
+      pollDashboard();
+    });
+    const list = $("message-list");
+    list.innerHTML = "";
+    list.appendChild(el("div", { class: "empty-state" }, [
+      el("div", { class: "empty-title", text: "No surface selected" }),
+      el("div", {
+        class: "empty-copy",
+        text: "Choose a chat or task from the rail, or review items waiting in the inbox.",
+      }),
+      el("div", { class: "empty-actions" }, [openInbox, refresh]),
+    ]));
+    renderSurfaces();
+  }
+
   function selectTask(key) {
     const task = state.taskSurfaces.find((item) => item.key === key);
     if (!task) return;
     state.selectedKind = "task";
     state.selectedSurface = null;
     state.selectedTaskKey = key;
+    state.inbox.selectedId = null;
     $("pane-title").textContent = task.key;
     $("pane-meta").textContent = [
       task.work_status,
@@ -808,6 +917,15 @@
       }));
     }
     const actions = [];
+    if (data.work_status === "queued" || data.work_status === "rework") {
+      const claim = el("button", {
+        class: "task-action-button primary",
+        type: "button",
+        text: data.work_status === "rework" ? "Resume" : "Start",
+      });
+      claim.addEventListener("click", () => claimTaskFromDetail(data));
+      actions.push(claim);
+    }
     if (data.work_status === "cancelled") {
       const reopen = el("button", {
         class: "task-action-button",
@@ -829,6 +947,32 @@
       children.push(el("div", { class: "task-detail-actions" }, actions));
     }
     list.appendChild(el("div", { class: "task-detail" }, children));
+  }
+
+  async function claimTaskFromDetail(task) {
+    if (!task.project || !task.task_number) return;
+    const path = API + "/tasks/" + encodeURIComponent(task.project)
+      + "/" + encodeURIComponent(task.task_number) + "/claim";
+    try {
+      const result = await apiJson(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ actor: CLAIM_ACTOR }),
+      });
+      renderTaskSummary(result.task || task);
+      if (Array.isArray(result.warnings)) {
+        for (const warning of result.warnings) {
+          if (warning) showToast("error", warning);
+        }
+      }
+      loadSurfaces();
+    } catch (err) {
+      const list = $("message-list");
+      list.appendChild(el("div", {
+        class: "error-banner",
+        text: "start error: " + err.message,
+      }));
+    }
   }
 
   async function cancelTaskFromDetail(task) {
@@ -1260,6 +1404,497 @@
     showToast("ok", "sent interrupt to " + name);
   }
 
+  // ----- inbox ------------------------------------------------------------
+
+  function encodePathId(id) {
+    return String(id || "")
+      .split("/")
+      .map((part) => encodeURIComponent(part))
+      .join("/");
+  }
+
+  function inboxListPath(cursor, omitType) {
+    const params = new URLSearchParams();
+    const filters = state.inbox.filters;
+    params.set("limit", String(INBOX_PAGE_LIMIT));
+    if (cursor) params.set("cursor", cursor);
+    if (filters.project.trim()) params.set("project", filters.project.trim());
+    if (filters.state) params.set("state", filters.state);
+    if (filters.type && !omitType) params.set("type", filters.type);
+    return API + "/inbox?" + params.toString();
+  }
+
+  function selectInbox(filterPatch) {
+    state.selectedKind = "inbox";
+    state.selectedSurface = null;
+    state.selectedTaskKey = null;
+    if (filterPatch) {
+      state.inbox.filters = Object.assign(
+        {},
+        state.inbox.filters,
+        filterPatch,
+      );
+    }
+    $("pane-title").textContent = "Inbox";
+    $("pane-meta").textContent = "";
+    $("send-input").disabled = true;
+    $("send-button").disabled = true;
+    updateStopAgentButton();
+    renderSurfaces();
+    renderInboxView();
+    loadInbox(true);
+  }
+
+  async function loadInbox(reset, omitType, preserveSelection) {
+    if (state.inbox.loading || state.inbox.loadingMore) {
+      state.inbox.reloadQueued = true;
+      return;
+    }
+    const cursor = reset ? null : state.inbox.nextCursor;
+    if (!reset && !cursor) return;
+    const selectedId = preserveSelection ? state.inbox.selectedId : null;
+    if (reset) {
+      state.inbox.loading = true;
+      state.inbox.items = [];
+      state.inbox.nextCursor = null;
+      if (!preserveSelection) {
+        state.inbox.selectedId = null;
+        state.inbox.detail = null;
+        state.inbox.detailError = null;
+      }
+    } else {
+      state.inbox.loadingMore = true;
+    }
+    state.inbox.error = null;
+    state.inbox.warning = null;
+    renderInboxView();
+    try {
+      const data = await apiJson(inboxListPath(cursor, Boolean(omitType)));
+      const items = Array.isArray(data.items) ? data.items : [];
+      state.inbox.items = reset ? items : state.inbox.items.concat(items);
+      state.inbox.nextCursor = data.next_cursor || null;
+      if (selectedId) state.inbox.selectedId = selectedId;
+      if (omitType && state.inbox.filters.type) {
+        state.inbox.warning = "Type filtering is unavailable on this API; showing matching state/project items.";
+      }
+    } catch (err) {
+      if (
+        !omitType
+        && state.inbox.filters.type
+        && (err.status === 400 || err.status === 404 || err.status === 422)
+      ) {
+        state.inbox.loading = false;
+        state.inbox.loadingMore = false;
+        await loadInbox(reset, true, preserveSelection);
+        return;
+      }
+      state.inbox.error = err;
+    } finally {
+      state.inbox.loading = false;
+      state.inbox.loadingMore = false;
+      const reloadQueued = state.inbox.reloadQueued;
+      state.inbox.reloadQueued = false;
+      if (state.selectedKind === "inbox") renderInboxView();
+      if (reloadQueued && state.selectedKind === "inbox") {
+        loadInbox(true, false, preserveSelection);
+      }
+    }
+  }
+
+  function inboxMeta(item) {
+    return [
+      item.project,
+      item.type,
+      item.state,
+      item.owner ? "@" + item.owner : "",
+      item.updated_at,
+    ].filter(Boolean).join(" · ");
+  }
+
+  function setInboxAction(key, active) {
+    if (active) state.inbox.actionInFlight[key] = true;
+    else delete state.inbox.actionInFlight[key];
+    renderInboxView();
+  }
+
+  function inboxActionButton(item, action, label, handler, extraClass) {
+    const key = item.id + ":" + action;
+    const btn = el("button", {
+      class: ("inbox-action " + (extraClass || "")).trim(),
+      type: "button",
+      text: label,
+    });
+    btn.disabled = Boolean(state.inbox.actionInFlight[key]);
+    btn.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      handler(item);
+    });
+    return btn;
+  }
+
+  function disabledPlanReviewButton(label) {
+    const btn = el("button", {
+      class: "inbox-action disabled",
+      type: "button",
+      text: label,
+      title: "Plan approve/reject API is not available in this branch.",
+    });
+    btn.disabled = true;
+    return btn;
+  }
+
+  function renderInboxFilters() {
+    const project = el("input", {
+      class: "inbox-filter-input",
+      type: "text",
+      placeholder: "Project",
+      "aria-label": "Filter inbox by project",
+      value: state.inbox.filters.project,
+    });
+    const stateSelect = el("select", {
+      class: "inbox-filter-select",
+      "aria-label": "Filter inbox by state",
+    });
+    const states = [
+      ["", "All states"],
+      ["open", "Open"],
+      ["threaded", "Threaded"],
+      ["waiting-on-pa", "Waiting on PA"],
+      ["waiting-on-pm", "Waiting on PM"],
+      ["resolved", "Resolved"],
+      ["closed", "Closed"],
+    ];
+    for (const pair of states) {
+      const option = el("option", { value: pair[0], text: pair[1] });
+      if (pair[0] === state.inbox.filters.state) option.selected = true;
+      stateSelect.appendChild(option);
+    }
+    const typeSelect = el("select", {
+      class: "inbox-filter-select",
+      "aria-label": "Filter inbox by type",
+    });
+    const types = [
+      ["", "All types"],
+      ["message", "Messages"],
+      ["plan_review", "Plan reviews"],
+    ];
+    for (const pair of types) {
+      const option = el("option", { value: pair[0], text: pair[1] });
+      if (pair[0] === state.inbox.filters.type) option.selected = true;
+      typeSelect.appendChild(option);
+    }
+    project.addEventListener("input", () => {
+      state.inbox.filters.project = project.value || "";
+    });
+    stateSelect.addEventListener("change", () => {
+      state.inbox.filters.state = stateSelect.value || "";
+    });
+    typeSelect.addEventListener("change", () => {
+      state.inbox.filters.type = typeSelect.value || "";
+    });
+    const apply = el("button", {
+      class: "inbox-filter-button primary",
+      type: "submit",
+      text: "Apply",
+    });
+    const clear = el("button", {
+      class: "inbox-filter-button",
+      type: "button",
+      text: "Clear",
+    });
+    clear.addEventListener("click", () => {
+      state.inbox.filters = { project: "", state: "", type: "" };
+      loadInbox(true);
+    });
+    const refresh = el("button", {
+      class: "inbox-filter-button",
+      type: "button",
+      text: "Refresh",
+    });
+    refresh.addEventListener("click", () => loadInbox(true));
+    const form = el("form", { class: "inbox-filters" }, [
+      project,
+      stateSelect,
+      typeSelect,
+      apply,
+      clear,
+      refresh,
+    ]);
+    form.addEventListener("submit", (ev) => {
+      ev.preventDefault();
+      state.inbox.filters = {
+        project: project.value || "",
+        state: stateSelect.value || "",
+        type: typeSelect.value || "",
+      };
+      loadInbox(true);
+    });
+    return form;
+  }
+
+  function renderInboxList() {
+    const children = [];
+    if (state.inbox.warning) {
+      children.push(el("div", {
+        class: "inbox-warning",
+        text: state.inbox.warning,
+      }));
+    }
+    if (state.inbox.error) {
+      children.push(el("div", {
+        class: "error-banner inbox-error",
+        text: "inbox error: " + state.inbox.error.message,
+      }));
+    }
+    if (state.inbox.loading) {
+      children.push(el("div", {
+        class: "message-empty",
+        text: "loading inbox...",
+      }));
+      return el("div", { class: "inbox-list" }, children);
+    }
+    if (state.inbox.items.length === 0 && !state.inbox.error) {
+      children.push(el("div", {
+        class: "message-empty",
+        text: "no inbox items",
+      }));
+      return el("div", { class: "inbox-list" }, children);
+    }
+    for (const item of state.inbox.items) {
+      const rowActions = [
+        inboxActionButton(item, "mark-read", "Mark read", markInboxRead),
+        inboxActionButton(item, "snooze", "Snooze 1h", snoozeInboxItem),
+        inboxActionButton(item, "archive", "Archive", archiveInboxItem, "danger"),
+      ];
+      if (item.type === "plan_review") {
+        rowActions.push(disabledPlanReviewButton("Approve"));
+        rowActions.push(disabledPlanReviewButton("Reject"));
+      }
+      const row = el("div", {
+        class: (
+          "inbox-row "
+          + (state.inbox.selectedId === item.id ? "active" : "")
+        ).trim(),
+        "data-inbox-id": item.id,
+      }, [
+        el("div", { class: "inbox-row-main" }, [
+          el("div", { class: "inbox-subject", text: item.subject || item.id }),
+          el("div", { class: "inbox-meta", text: inboxMeta(item) }),
+          el("div", { class: "inbox-preview", text: item.preview || "" }),
+        ]),
+        el("div", { class: "inbox-row-actions" }, rowActions),
+      ]);
+      row.addEventListener("click", () => selectInboxItem(item.id));
+      children.push(row);
+    }
+    if (state.inbox.nextCursor) {
+      const more = el("button", {
+        class: "inbox-load-more",
+        type: "button",
+        text: state.inbox.loadingMore ? "Loading..." : "Load more",
+      });
+      more.disabled = state.inbox.loadingMore;
+      more.addEventListener("click", () => loadInbox(false));
+      children.push(more);
+    }
+    return el("div", { class: "inbox-list" }, children);
+  }
+
+  function renderInboxDetail() {
+    if (!state.inbox.selectedId) {
+      return el("div", {
+        class: "inbox-detail inbox-detail-empty",
+        text: "Select an inbox item to read the thread.",
+      });
+    }
+    if (state.inbox.detailLoading) {
+      return el("div", {
+        class: "inbox-detail inbox-detail-empty",
+        text: "loading thread...",
+      });
+    }
+    if (state.inbox.detailError) {
+      return el("div", {
+        class: "error-banner inbox-error",
+        text: "thread error: " + state.inbox.detailError.message,
+      });
+    }
+    const detail = state.inbox.detail;
+    if (!detail) {
+      return el("div", {
+        class: "inbox-detail inbox-detail-empty",
+        text: "No thread loaded.",
+      });
+    }
+    const messages = Array.isArray(detail.messages) ? detail.messages : [];
+    const messageNodes = messages.length === 0
+      ? [el("div", { class: "inbox-thread-empty", text: "no replies yet" })]
+      : messages.map((msg) => el("div", { class: "inbox-thread-message" }, [
+        el("div", { class: "inbox-thread-head" }, [
+          el("span", { text: msg.sender || "operator" }),
+          el("span", { text: msg.timestamp || "" }),
+        ]),
+        el("div", { class: "inbox-thread-body", text: msg.body || "" }),
+      ]));
+    const reply = el("textarea", {
+      class: "inbox-reply-input",
+      rows: "3",
+      placeholder: "Reply...",
+      "aria-label": "Reply to inbox item",
+    });
+    reply.value = state.inbox.replyDraft || "";
+    reply.addEventListener("input", () => {
+      state.inbox.replyDraft = reply.value;
+    });
+    const send = el("button", {
+      class: "inbox-filter-button primary",
+      type: "submit",
+      text: "Reply",
+    });
+    const actionKey = detail.id + ":reply";
+    send.disabled = Boolean(state.inbox.actionInFlight[actionKey]);
+    const form = el("form", { class: "inbox-reply-form" }, [reply, send]);
+    form.addEventListener("submit", (ev) => {
+      ev.preventDefault();
+      replyInboxItem(detail, reply.value || "");
+    });
+    const decisionActions = [];
+    if (detail.type === "plan_review") {
+      decisionActions.push(disabledPlanReviewButton("Approve"));
+      decisionActions.push(disabledPlanReviewButton("Reject"));
+    }
+    return el("div", { class: "inbox-detail" }, [
+      el("div", { class: "inbox-detail-title", text: detail.subject || detail.id }),
+      el("div", { class: "inbox-meta", text: inboxMeta(detail) }),
+      detail.preview
+        ? el("div", { class: "inbox-detail-preview", text: detail.preview })
+        : null,
+      decisionActions.length
+        ? el("div", { class: "inbox-decision-actions" }, decisionActions)
+        : null,
+      el("div", { class: "inbox-thread" }, messageNodes),
+      form,
+    ]);
+  }
+
+  function renderInboxView() {
+    if (state.selectedKind !== "inbox") return;
+    $("pane-title").textContent = "Inbox";
+    $("pane-meta").textContent = (
+      state.inbox.items.length + " shown"
+      + (state.inbox.nextCursor ? " · more available" : "")
+    );
+    const list = $("message-list");
+    list.innerHTML = "";
+    list.appendChild(el("div", { class: "inbox-view" }, [
+      renderInboxFilters(),
+      el("div", { class: "inbox-content" }, [
+        renderInboxList(),
+        renderInboxDetail(),
+      ]),
+    ]));
+  }
+
+  async function selectInboxItem(id) {
+    state.inbox.selectedId = id;
+    state.inbox.detail = null;
+    state.inbox.detailError = null;
+    state.inbox.replyDraft = "";
+    await loadInboxDetail(id);
+  }
+
+  async function loadInboxDetail(id) {
+    if (!id) return;
+    state.inbox.detailLoading = true;
+    state.inbox.detailError = null;
+    renderInboxView();
+    try {
+      const data = await apiJson(API + "/inbox/" + encodePathId(id));
+      if (state.selectedKind === "inbox" && state.inbox.selectedId === id) {
+        state.inbox.detail = data;
+      }
+    } catch (err) {
+      if (state.selectedKind === "inbox" && state.inbox.selectedId === id) {
+        state.inbox.detailError = err;
+      }
+    } finally {
+      state.inbox.detailLoading = false;
+      renderInboxView();
+    }
+  }
+
+  async function runInboxAction(item, action, suffix, body, options) {
+    const key = item.id + ":" + action;
+    setInboxAction(key, true);
+    try {
+      await apiJson(API + "/inbox/" + encodePathId(item.id) + suffix, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (options && options.clearSelection) {
+        state.inbox.selectedId = null;
+        state.inbox.detail = null;
+        state.inbox.replyDraft = "";
+      }
+      await loadInbox(true, false, !(options && options.clearSelection));
+      if (state.inbox.selectedId) await loadInboxDetail(state.inbox.selectedId);
+      return true;
+    } catch (err) {
+      state.inbox.error = err;
+      showToast("error", action + " failed: " + err.message);
+      return false;
+    } finally {
+      setInboxAction(key, false);
+    }
+  }
+
+  function markInboxRead(item) {
+    runInboxAction(
+      item,
+      "mark-read",
+      "/mark-read",
+      { actor: OPERATOR_ACTOR },
+      {},
+    );
+  }
+
+  function archiveInboxItem(item) {
+    runInboxAction(
+      item,
+      "archive",
+      "/archive",
+      { reason: "archived from web UI" },
+      { clearSelection: true },
+    );
+  }
+
+  function snoozeInboxItem(item) {
+    runInboxAction(
+      item,
+      "snooze",
+      "/snooze",
+      { duration_seconds: 3600, reason: "snoozed from web UI" },
+      { clearSelection: true },
+    );
+  }
+
+  async function replyInboxItem(item, body) {
+    const text = String(body || "").trim();
+    if (!text) return;
+    const ok = await runInboxAction(
+      item,
+      "reply",
+      "/reply",
+      { body: text, owner: OPERATOR_ACTOR },
+      {},
+    );
+    if (ok) {
+      state.inbox.replyDraft = "";
+      renderInboxView();
+    }
+  }
+
   // ----- dashboard rollups (right rail) ----------------------------------
 
   async function pollDashboard() {
@@ -1300,12 +1935,28 @@
     return scopedFields.indexOf(key) !== -1;
   }
 
-  function buildCard(label, value, cls, scoped) {
+  function buildCard(label, value, cls, scoped, onClick) {
     const labelText = scoped ? label + " (filtered)" : label;
-    return el("div", { class: "rollup-card " + (cls || "") }, [
+    const attrs = { class: "rollup-card " + (cls || "") };
+    if (onClick) {
+      attrs.role = "button";
+      attrs.tabindex = "0";
+      attrs.title = "Open " + label;
+    }
+    const card = el("div", attrs, [
       el("div", { class: "rollup-label", text: labelText }),
       el("div", { class: "rollup-value", text: String(value) }),
     ]);
+    if (onClick) {
+      card.addEventListener("click", onClick);
+      card.addEventListener("keydown", (ev) => {
+        if (ev.key === "Enter" || ev.key === " ") {
+          ev.preventDefault();
+          onClick();
+        }
+      });
+    }
+    return card;
   }
 
   function renderDashboard(data) {
@@ -1335,6 +1986,7 @@
         rollups.open_inbox_count + " items",
         "rollup-attention",
         isScoped(scopedFields, "rollups.open_inbox_count"),
+        () => selectInbox(),
       ));
     }
     if (typeof rollups.pending_plan_reviews === "number") {
@@ -1343,6 +1995,7 @@
         rollups.pending_plan_reviews + " waiting",
         "rollup-attention",
         isScoped(scopedFields, "rollups.pending_plan_reviews"),
+        () => selectInbox({ type: "plan_review" }),
       ));
     }
     if (typeof rollups.alert_count === "number") {
@@ -1612,12 +2265,16 @@
         loadAuditForSurface(state.selectedSurface);
       }
     }
+    if (state.selectedKind === "inbox") {
+      loadInbox(true, false, true);
+    }
   }
 
   function refreshFromFallback() {
     pollDashboard();
     loadActivity();
     if (state.selectedSurface) loadHistory(state.selectedSurface);
+    if (state.selectedKind === "inbox") loadInbox(true, false, true);
   }
 
   function requestPushRefresh() {
@@ -1834,6 +2491,7 @@
     wireActivityControls();
     wireSendForm();
     wireStopAgentButton();
+    renderNoSelection();
     setStatus("warn", "connecting…");
     loadSurfaces();
     startEventStream();
@@ -1852,7 +2510,10 @@
     sendMessage: sendMessage,
     selectSurface: selectSurface,
     selectTask: selectTask,
+    selectInbox: selectInbox,
     interruptSurface: interruptSurface,
+    loadInbox: loadInbox,
+    renderInboxView: renderInboxView,
     pollDashboard: pollDashboard,
     loadActivity: loadActivity,
     startEventStream: startEventStream,

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -24,9 +24,17 @@
   const SESSION_ISSUED_COOKIE = "pollypm-session-issued-at";
   const SESSION_EXPIRY_WARNING_MS = 6 * 24 * 60 * 60 * 1000;
   const TASK_RAIL_LIMIT = 200;
+  const TASK_RENDER_LIMIT = 80;
   const AUDIT_LIMIT = 25;
+  const ACTIVITY_LIMIT = 40;
+  const ACTIVITY_DEFAULT_SINCE = "2d";
 
   const state = {
+    projects: [],
+    projectLoadError: null,
+    selectedProject: null,
+    projectFilter: "",
+    projectSort: "urgency",
     surfaces: [],
     taskSurfaces: [],
     taskLoadError: null,
@@ -53,6 +61,14 @@
     auditLoading: {},
     surfaceMidStream: {},
     surfaceFilter: "",
+    activitySince: ACTIVITY_DEFAULT_SINCE,
+    activityEntries: [],
+    activityStats: null,
+    activityLoading: false,
+    activityError: null,
+    activityInFlight: false,
+    activityRefreshQueued: false,
+    pendingMessages: {},
   };
 
   // ----- DOM helpers ------------------------------------------------------
@@ -223,6 +239,18 @@
 
   // ----- surfaces (left rail) --------------------------------------------
 
+  function projectListPath() {
+    const params = new URLSearchParams();
+    if (state.projectFilter.trim()) {
+      params.set("q", state.projectFilter.trim());
+    }
+    if (state.projectSort) {
+      params.set("sort", state.projectSort);
+    }
+    const query = params.toString();
+    return API + "/projects" + (query ? "?" + query : "");
+  }
+
   async function loadSurfaces() {
     if (state.surfacesInFlight) {
       state.surfacesRefreshQueued = true;
@@ -230,25 +258,55 @@
     }
     state.surfacesInFlight = true;
     try {
-      try {
-        const data = await apiJson(API + "/chat/sessions");
-        state.surfaces = Array.isArray(data.sessions) ? data.sessions : [];
-      } catch (err) {
+      const [sessionsResult, tasksResult, projectsResult] =
+        await Promise.allSettled([
+          apiJson(API + "/chat/sessions"),
+          apiJsonOptional(API + "/tasks?limit=" + TASK_RAIL_LIMIT),
+          apiJsonOptional(projectListPath()),
+        ]);
+
+      if (sessionsResult.status === "rejected") {
+        state.taskSurfaces = [];
+        state.projects = [];
+        state.projectLoadError = null;
+        state.taskLoadError = null;
+        renderProjects();
+        const err = sessionsResult.reason instanceof Error
+          ? sessionsResult.reason
+          : new Error(String(sessionsResult.reason));
         renderSurfaceError(err);
         return;
       }
+      const data = sessionsResult.value;
+      state.surfaces = Array.isArray(data.sessions) ? data.sessions : [];
 
-      state.taskLoadError = null;
-      try {
-        const taskData = await apiJsonOptional(
-          API + "/tasks?limit=" + TASK_RAIL_LIMIT,
-        );
+      if (tasksResult.status === "fulfilled") {
+        state.taskLoadError = null;
+        const taskData = tasksResult.value;
         const items = Array.isArray(taskData.items) ? taskData.items : [];
-        state.taskSurfaces = items.map(normalizeTaskSurface);
-      } catch (err) {
+        state.taskSurfaces = dedupeTaskSurfaces(
+          items.map(normalizeTaskSurface),
+        );
+      } else {
         state.taskSurfaces = [];
-        state.taskLoadError = err;
+        state.taskLoadError = tasksResult.reason instanceof Error
+          ? tasksResult.reason
+          : new Error(String(tasksResult.reason));
       }
+
+      if (projectsResult.status === "fulfilled") {
+        state.projectLoadError = null;
+        const projectData = projectsResult.value;
+        state.projects = Array.isArray(projectData.items)
+          ? projectData.items : [];
+      } else {
+        state.projects = [];
+        state.projectLoadError = projectsResult.reason instanceof Error
+          ? projectsResult.reason
+          : new Error(String(projectsResult.reason));
+      }
+      renderProjects();
+      ensureSelectionVisible();
       renderSurfaces();
     } finally {
       state.surfacesInFlight = false;
@@ -275,7 +333,38 @@
       priority: task.priority || "",
       assignee: task.assignee || "",
       updated_at: task.updated_at || "",
+      duplicate_count: task.duplicate_count || 1,
     };
+  }
+
+  function taskDedupeKey(task) {
+    return [
+      task.project || "",
+      task.work_status || "",
+      String(task.title || "").trim().toLowerCase(),
+    ].join("\u0000");
+  }
+
+  function dedupeTaskSurfaces(tasks) {
+    const byKey = {};
+    const out = [];
+    for (const task of tasks) {
+      const key = taskDedupeKey(task);
+      const existing = byKey[key];
+      if (existing) {
+        existing.duplicate_count += 1;
+        if (
+          task.updated_at
+          && (!existing.updated_at || task.updated_at > existing.updated_at)
+        ) {
+          existing.updated_at = task.updated_at;
+        }
+        continue;
+      }
+      byKey[key] = task;
+      out.push(task);
+    }
+    return out;
   }
 
   function taskDotClass(status) {
@@ -289,6 +378,168 @@
 
   function appendRailGroup(list, label) {
     list.appendChild(el("li", { class: "surface-group", text: label }));
+  }
+
+  function countFor(project, name) {
+    const counts = project && typeof project.task_counts === "object"
+      ? project.task_counts : {};
+    return Number(counts && counts[name]) || 0;
+  }
+
+  function activeTaskCount(project) {
+    return countFor(project, "in_progress") + countFor(project, "rework");
+  }
+
+  function projectUrgency(project) {
+    const blocked = countFor(project, "blocked") + countFor(project, "on_hold");
+    const queued = countFor(project, "queued");
+    const active = activeTaskCount(project);
+    const review = countFor(project, "review");
+    if (!project.tracked || project.glyph === "paused") {
+      return { rank: 5, label: "paused", className: "paused" };
+    }
+    if (blocked > 0) {
+      return { rank: 0, label: "blocked", className: "blocked" };
+    }
+    if (queued > 0 && active === 0) {
+      return { rank: 1, label: "stalled", className: "stalled" };
+    }
+    if (project.pending_plan_review || project.open_inbox_count > 0 || review > 0) {
+      return { rank: 2, label: "attention", className: "attention" };
+    }
+    if (active > 0) {
+      return { rank: 3, label: "active", className: "active" };
+    }
+    return { rank: 4, label: "healthy", className: "healthy" };
+  }
+
+  function projectLastActivityMs(project) {
+    const raw = project && project.last_activity_at;
+    if (!raw) return 0;
+    const parsed = Date.parse(raw);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  function projectMeta(project) {
+    const parts = [];
+    const blocked = countFor(project, "blocked") + countFor(project, "on_hold");
+    const queued = countFor(project, "queued");
+    const active = activeTaskCount(project);
+    const inbox = Number(project.open_inbox_count) || 0;
+    if (blocked > 0) parts.push(blocked + " blocked");
+    if (queued > 0) parts.push(queued + " queued");
+    if (active > 0) parts.push(active + " active");
+    if (inbox > 0) parts.push(inbox + " inbox");
+    const last = projectLastActivityMs(project);
+    if (last > 0) parts.push("last " + formatShortTime(project.last_activity_at));
+    return parts.join(" · ") || "no open work";
+  }
+
+  function formatShortTime(value) {
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) return String(value || "");
+    return new Date(parsed).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  function sortProjects(projects) {
+    const sorted = projects.slice();
+    if (state.projectSort === "name") {
+      sorted.sort((a, b) => String(a.name || a.key).localeCompare(String(b.name || b.key)));
+    } else if (state.projectSort === "inbox_desc") {
+      sorted.sort((a, b) => (
+        (Number(b.open_inbox_count) || 0) - (Number(a.open_inbox_count) || 0)
+        || String(a.name || a.key).localeCompare(String(b.name || b.key))
+      ));
+    } else if (state.projectSort === "recent") {
+      sorted.sort((a, b) => (
+        projectLastActivityMs(b) - projectLastActivityMs(a)
+        || String(a.name || a.key).localeCompare(String(b.name || b.key))
+      ));
+    } else {
+      sorted.sort((a, b) => (
+        projectUrgency(a).rank - projectUrgency(b).rank
+        || String(a.name || a.key).localeCompare(String(b.name || b.key))
+      ));
+    }
+    return sorted;
+  }
+
+  function renderProjectItem(list, project) {
+    const urgency = projectUrgency(project);
+    const key = project.key || "";
+    const li = el("li", {
+      "data-project": key,
+      "class": (
+        state.selectedProject === key ? "active " : ""
+      ) + "project-" + urgency.className,
+    }, [
+      el("span", { class: "project-name" }, [
+        el("span", {
+          class: "project-dot project-dot-" + urgency.className,
+        }),
+        document.createTextNode(project.name || key),
+      ]),
+      el("span", {
+        class: "project-meta",
+        text: urgency.label + " · " + projectMeta(project),
+      }),
+    ]);
+    li.addEventListener("click", () => selectProject(key));
+    list.appendChild(li);
+  }
+
+  function renderProjects() {
+    const list = $("project-list");
+    if (!list) return;
+    list.innerHTML = "";
+
+    const all = el("li", {
+      "data-project": "",
+      "class": state.selectedProject ? "project-all" : "project-all active",
+    }, [
+      el("span", { class: "project-name" }, [
+        el("span", { class: "project-dot project-dot-all" }),
+        document.createTextNode("All projects"),
+      ]),
+      el("span", {
+        class: "project-meta",
+        text: state.projects.length + " tracked",
+      }),
+    ]);
+    all.addEventListener("click", () => selectProject(null));
+    list.appendChild(all);
+
+    if (state.projectLoadError) {
+      list.appendChild(el("li", {
+        class: "project-empty",
+        text: "projects unavailable: " + state.projectLoadError.message,
+      }));
+      return;
+    }
+    const filter = state.projectFilter.trim().toLowerCase();
+    const projects = sortProjects(
+      filter
+        ? state.projects.filter((project) => (
+          String(project.key || "").toLowerCase().includes(filter)
+          || String(project.name || "").toLowerCase().includes(filter)
+          || String(project.path || "").toLowerCase().includes(filter)
+          || String(project.persona_name || "").toLowerCase().includes(filter)
+        ))
+        : state.projects,
+    );
+    if (projects.length === 0) {
+      list.appendChild(el("li", {
+        class: "project-empty",
+        text: "no matching projects",
+      }));
+      return;
+    }
+    for (const project of projects) renderProjectItem(list, project);
   }
 
   function renderChatSurfaceItem(list, s) {
@@ -333,6 +584,7 @@
       task.project,
     ].filter(Boolean);
     if (task.assignee) meta.push("@" + task.assignee);
+    if (task.duplicate_count > 1) meta.push("\u00d7" + task.duplicate_count);
     const li = el(
       "li",
       {
@@ -363,24 +615,43 @@
     list.appendChild(li);
   }
 
+  function selectedProjectMatches(project) {
+    return !state.selectedProject || project === state.selectedProject;
+  }
+
+  function surfaceMatchesFilter(surface, filter) {
+    if (!filter) return true;
+    return (
+      String(surface.session_name || "").toLowerCase().includes(filter)
+      || String(surface.project || "").toLowerCase().includes(filter)
+      || String(surface.surface_type || "").toLowerCase().includes(filter)
+      || String(surface.persona || "").toLowerCase().includes(filter)
+    );
+  }
+
+  function taskMatchesFilter(task, filter) {
+    if (!filter) return true;
+    return (
+      String(task.key || "").toLowerCase().includes(filter)
+      || String(task.title || "").toLowerCase().includes(filter)
+      || String(task.project || "").toLowerCase().includes(filter)
+      || String(task.work_status || "").toLowerCase().includes(filter)
+      || String(task.assignee || "").toLowerCase().includes(filter)
+    );
+  }
+
   function renderSurfaces() {
     const list = $("surface-list");
     list.innerHTML = "";
     const filter = state.surfaceFilter.trim().toLowerCase();
-    const surfaces = filter
-      ? state.surfaces.filter((s) => (
-        String(s.session_name || "").toLowerCase().includes(filter)
-      ))
-      : state.surfaces;
-    const taskSurfaces = filter
-      ? state.taskSurfaces.filter((task) => (
-        String(task.key || "").toLowerCase().includes(filter)
-        || String(task.title || "").toLowerCase().includes(filter)
-        || String(task.project || "").toLowerCase().includes(filter)
-        || String(task.work_status || "").toLowerCase().includes(filter)
-        || String(task.assignee || "").toLowerCase().includes(filter)
-      ))
-      : state.taskSurfaces;
+    const surfaces = state.surfaces.filter((s) => (
+      selectedProjectMatches(s.project || "")
+      && surfaceMatchesFilter(s, filter)
+    ));
+    const taskSurfaces = state.taskSurfaces.filter((task) => (
+      selectedProjectMatches(task.project || "")
+      && taskMatchesFilter(task, filter)
+    ));
     const hasRegistered = (
       state.surfaces.length > 0
       || state.taskSurfaces.length > 0
@@ -404,7 +675,15 @@
     }
     if (taskSurfaces.length > 0 || state.taskLoadError) {
       appendRailGroup(list, "Tasks");
-      for (const task of taskSurfaces) renderTaskSurfaceItem(list, task);
+      const visibleTasks = taskSurfaces.slice(0, TASK_RENDER_LIMIT);
+      for (const task of visibleTasks) renderTaskSurfaceItem(list, task);
+      if (taskSurfaces.length > visibleTasks.length) {
+        list.appendChild(el("li", {
+          class: "surface-empty surface-summary",
+          text: "showing " + visibleTasks.length + " of "
+            + taskSurfaces.length + " tasks",
+        }));
+      }
       if (state.taskLoadError) {
         list.appendChild(el("li", {
           class: "surface-empty",
@@ -420,6 +699,45 @@
     list.appendChild(
       el("li", { class: "surface-empty", text: "error: " + err.message }),
     );
+  }
+
+  function clearSelection() {
+    state.selectedKind = null;
+    state.selectedSurface = null;
+    state.selectedTaskKey = null;
+    $("pane-title").textContent = "Select a surface";
+    $("pane-meta").textContent = "";
+    $("send-input").disabled = true;
+    $("send-button").disabled = true;
+    const list = $("message-list");
+    list.innerHTML = "";
+    list.appendChild(el("div", {
+      class: "message-empty",
+      text: "No surface selected.",
+    }));
+    updateStopAgentButton();
+  }
+
+  function ensureSelectionVisible() {
+    if (!state.selectedProject) return;
+    if (state.selectedKind === "chat") {
+      const surface = surfaceByName(state.selectedSurface);
+      if (!surface || surface.project !== state.selectedProject) clearSelection();
+    } else if (state.selectedKind === "task") {
+      const task = state.taskSurfaces.find((item) => (
+        item.key === state.selectedTaskKey
+      ));
+      if (!task || task.project !== state.selectedProject) clearSelection();
+    }
+  }
+
+  function selectProject(key) {
+    state.selectedProject = key || null;
+    ensureSelectionVisible();
+    renderProjects();
+    renderSurfaces();
+    pollDashboard();
+    loadActivity();
   }
 
   function selectSurface(name) {
@@ -736,6 +1054,96 @@
 
   // ----- history (center) ------------------------------------------------
 
+  function pendingMessagesFor(name) {
+    if (!state.pendingMessages[name]) state.pendingMessages[name] = [];
+    return state.pendingMessages[name];
+  }
+
+  function normalizeMessageText(text) {
+    return String(text || "").replace(/\s+/g, " ").trim();
+  }
+
+  function reconcilePendingMessages(name, messages) {
+    const serverTexts = new Set(
+      messages.map((message) => normalizeMessageText(message.text)),
+    );
+    const pending = pendingMessagesFor(name).filter((message) => (
+      message.status === "failed"
+      || !serverTexts.has(normalizeMessageText(message.text))
+    ));
+    state.pendingMessages[name] = pending;
+    return pending;
+  }
+
+  function removeLocalEchoNodes(list) {
+    for (const node of list.querySelectorAll(".message-local-echo")) {
+      node.remove();
+    }
+  }
+
+  function localEchoNode(message) {
+    const status = message.status === "failed"
+      ? "failed"
+      : message.status === "sending" ? "sending" : "pending";
+    const children = [
+      el("div", { class: "message-head" }, [
+        el("span", { class: "message-actor", text: "you" }),
+        el("span", { class: "message-ts", text: message.ts || "" }),
+        el("span", { class: "message-type", text: status }),
+      ]),
+      el("div", { class: "message-text", text: message.text || "" }),
+    ];
+    if (message.error) {
+      children.push(el("div", {
+        class: "message-error",
+        text: "send failed: " + message.error,
+      }));
+    }
+    return el("div", {
+      class: "message message-role-user message-local-echo message-local-"
+        + status,
+      "data-local-message": message.id,
+    }, children);
+  }
+
+  function renderLocalEchoes(name) {
+    if (state.selectedKind !== "chat" || state.selectedSurface !== name) return;
+    const list = $("message-list");
+    removeLocalEchoNodes(list);
+    const pending = pendingMessagesFor(name);
+    if (pending.length === 0) return;
+    const empty = list.querySelector(".message-empty");
+    if (empty) empty.remove();
+    const auditPanel = list.querySelector(".audit-panel");
+    for (const message of pending) {
+      const node = localEchoNode(message);
+      if (auditPanel) list.insertBefore(node, auditPanel);
+      else list.appendChild(node);
+    }
+    list.scrollTop = list.scrollHeight;
+  }
+
+  function addLocalEcho(name, text) {
+    const message = {
+      id: "local-" + Date.now() + "-" + Math.random().toString(16).slice(2),
+      text: text,
+      ts: new Date().toISOString(),
+      status: "sending",
+      error: null,
+    };
+    pendingMessagesFor(name).push(message);
+    renderLocalEchoes(name);
+    return message;
+  }
+
+  function updateLocalEcho(name, id, patch) {
+    const pending = pendingMessagesFor(name);
+    const message = pending.find((item) => item.id === id);
+    if (!message) return;
+    Object.assign(message, patch);
+    renderLocalEchoes(name);
+  }
+
   async function loadHistory(name) {
     if (!name) return;
     if (state.historyInFlight[name]) {
@@ -774,11 +1182,12 @@
     if (data.transcript_source) meta.push("src=" + data.transcript_source);
     $("pane-meta").textContent = meta.join(" · ");
     const msgs = Array.isArray(data.messages) ? data.messages.slice() : [];
+    const pending = reconcilePendingMessages(data.session_name, msgs);
     state.surfaceMidStream[data.session_name] = (
       msgs.length > 0 && messageLooksMidStream(msgs[0])
     );
     updateStopAgentButton();
-    if (msgs.length === 0) {
+    if (msgs.length === 0 && pending.length === 0) {
       list.appendChild(
         el("div", { class: "message-empty", text: "no messages yet" }),
       );
@@ -801,6 +1210,7 @@
         ]),
       );
     }
+    renderLocalEchoes(data.session_name);
     list.scrollTop = list.scrollHeight;
     renderAuditPanel(data.session_name);
   }
@@ -819,14 +1229,26 @@
 
   async function sendMessage(name, text) {
     if (!name || !text) return;
+    const local = addLocalEcho(name, text);
     const path = API + "/chat/" + encodeURIComponent(name) + "/send";
-    await apiFetch(path, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: text }),
-    });
-    // Refresh after a short delay so the new line shows up.
-    setTimeout(() => loadHistory(name), 400);
+    try {
+      await apiFetch(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: text }),
+      });
+      updateLocalEcho(name, local.id, { status: "pending" });
+      // Refresh after a short delay so the server-confirmed line can
+      // replace the local echo once tmux capture catches up.
+      setTimeout(() => loadHistory(name), 400);
+    } catch (err) {
+      updateLocalEcho(name, local.id, {
+        status: "failed",
+        error: err.message || String(err),
+      });
+      showToast("error", "send failed: " + (err.message || String(err)));
+      throw err;
+    }
   }
 
   async function interruptSurface(name) {
@@ -847,7 +1269,12 @@
     }
     state.dashboardInFlight = true;
     try {
-      const data = await apiJson(API + "/dashboard");
+      const params = new URLSearchParams();
+      if (state.selectedProject) params.set("project", state.selectedProject);
+      const query = params.toString();
+      const data = await apiJson(
+        API + "/dashboard" + (query ? "?" + query : ""),
+      );
       renderDashboard(data);
     } catch (err) {
       renderDashboardError(err);
@@ -992,11 +1419,193 @@
     );
   }
 
+  // ----- activity feed (right rail) --------------------------------------
+
+  function activityParams() {
+    const params = new URLSearchParams();
+    params.set("since", state.activitySince || ACTIVITY_DEFAULT_SINCE);
+    if (state.selectedProject) params.set("project", state.selectedProject);
+    return params;
+  }
+
+  function activityGrepPath() {
+    const params = activityParams();
+    params.set("limit", String(ACTIVITY_LIMIT));
+    return API + "/audit/grep?" + params.toString();
+  }
+
+  function activityStatsPath() {
+    return API + "/audit/stats?" + activityParams().toString();
+  }
+
+  async function loadActivity() {
+    if (state.activityInFlight) {
+      state.activityRefreshQueued = true;
+      return;
+    }
+    state.activityInFlight = true;
+    state.activityLoading = true;
+    state.activityError = null;
+    renderActivity();
+    try {
+      const [grepResult, statsResult] = await Promise.allSettled([
+        apiJsonOptional(activityGrepPath()),
+        apiJsonOptional(activityStatsPath()),
+      ]);
+      if (grepResult.status === "fulfilled") {
+        state.activityEntries = Array.isArray(grepResult.value.events)
+          ? grepResult.value.events : [];
+      } else {
+        state.activityEntries = [];
+        state.activityError = grepResult.reason instanceof Error
+          ? grepResult.reason
+          : new Error(String(grepResult.reason));
+      }
+      state.activityStats = statsResult.status === "fulfilled"
+        ? statsResult.value : null;
+      if (statsResult.status === "rejected" && !state.activityError) {
+        state.activityError = statsResult.reason instanceof Error
+          ? statsResult.reason
+          : new Error(String(statsResult.reason));
+      }
+    } finally {
+      state.activityLoading = false;
+      state.activityInFlight = false;
+      renderActivity();
+      if (state.activityRefreshQueued) {
+        state.activityRefreshQueued = false;
+        loadActivity();
+      }
+    }
+  }
+
+  function eventMetadata(entry) {
+    return entry && typeof entry.metadata === "object" && entry.metadata
+      ? entry.metadata : {};
+  }
+
+  function activityCompletedCount(entries) {
+    return entries.filter((entry) => {
+      const eventName = String(entry.event || "").toLowerCase();
+      const meta = eventMetadata(entry);
+      const stateName = String(
+        meta.to_state || meta.work_status || meta.status || "",
+      ).toLowerCase();
+      return (
+        stateName === "done"
+        || eventName.includes("completed")
+        || eventName.includes(".done")
+      );
+    }).length;
+  }
+
+  function activityDecisionCount(entries) {
+    return entries.filter((entry) => {
+      const eventName = String(entry.event || "").toLowerCase();
+      return (
+        eventName.includes("decision")
+        || eventName.includes("approve")
+        || eventName.includes("reject")
+        || eventName.includes("review")
+        || eventName.includes("plan.")
+      );
+    }).length;
+  }
+
+  function activityWarningCount(entries) {
+    return entries.filter((entry) => {
+      const eventName = String(entry.event || "").toLowerCase();
+      const status = String(entry.status || "").toLowerCase();
+      return (
+        status === "warn"
+        || status === "error"
+        || eventName.includes("blocked")
+        || eventName.includes("hold")
+        || eventName.includes("failed")
+      );
+    }).length;
+  }
+
+  function renderActivitySummary(summaryBox, entries) {
+    summaryBox.innerHTML = "";
+    const stats = state.activityStats || {};
+    const total = typeof stats.total === "number" ? stats.total : entries.length;
+    const actors = new Set(entries.map((entry) => entry.actor).filter(Boolean));
+    const cards = [
+      ["events", total],
+      ["done", activityCompletedCount(entries)],
+      ["warnings", activityWarningCount(entries)],
+      ["decisions", activityDecisionCount(entries)],
+      ["actors", actors.size],
+    ];
+    for (const card of cards) {
+      summaryBox.appendChild(el("div", { class: "activity-chip" }, [
+        el("span", { class: "activity-chip-label", text: card[0] }),
+        el("span", { class: "activity-chip-value", text: String(card[1]) }),
+      ]));
+    }
+  }
+
+  function renderActivity() {
+    const summaryBox = $("activity-summary");
+    const feed = $("activity-feed");
+    if (!summaryBox || !feed) return;
+    if (state.activityLoading) {
+      summaryBox.innerHTML = "";
+      feed.innerHTML = "";
+      feed.appendChild(el("div", {
+        class: "activity-empty",
+        text: "loading activity...",
+      }));
+      return;
+    }
+    if (state.activityError) {
+      summaryBox.innerHTML = "";
+      feed.innerHTML = "";
+      feed.appendChild(el("div", {
+        class: "activity-empty",
+        text: "activity unavailable: " + state.activityError.message,
+      }));
+      return;
+    }
+    const entries = state.activityEntries.slice().sort((a, b) => (
+      (Date.parse(b.ts || "") || 0) - (Date.parse(a.ts || "") || 0)
+    ));
+    renderActivitySummary(summaryBox, entries);
+    feed.innerHTML = "";
+    if (entries.length === 0) {
+      feed.appendChild(el("div", {
+        class: "activity-empty",
+        text: "no activity in " + (state.activitySince || ACTIVITY_DEFAULT_SINCE),
+      }));
+      return;
+    }
+    for (const entry of entries.slice(0, ACTIVITY_LIMIT)) {
+      feed.appendChild(el("div", { class: "activity-entry" }, [
+        el("div", { class: "activity-entry-head" }, [
+          el("span", {
+            class: "activity-entry-project",
+            text: entry.project || "workspace",
+          }),
+          el("span", {
+            class: "activity-entry-ts",
+            text: formatShortTime(entry.ts),
+          }),
+        ]),
+        el("div", {
+          class: "activity-entry-line",
+          text: auditSummary(entry),
+        }),
+      ]));
+    }
+  }
+
   // ----- push refresh / fallback polling ---------------------------------
 
   function refreshFromPush() {
     pollDashboard();
     loadSurfaces();
+    loadActivity();
     if (state.selectedSurface) {
       loadHistory(state.selectedSurface);
       if (state.auditExpanded[state.selectedSurface]) {
@@ -1007,6 +1616,7 @@
 
   function refreshFromFallback() {
     pollDashboard();
+    loadActivity();
     if (state.selectedSurface) loadHistory(state.selectedSurface);
   }
 
@@ -1155,9 +1765,7 @@
         return;
       }
       input.value = "";
-      sendMessage(state.selectedSurface, text).catch((err) => {
-        renderHistoryError(err);
-      });
+      sendMessage(state.selectedSurface, text).catch(() => {});
     });
   }
 
@@ -1184,9 +1792,46 @@
     });
   }
 
+  function wireProjectControls() {
+    const filter = $("project-filter");
+    if (filter) {
+      filter.addEventListener("input", () => {
+        state.projectFilter = filter.value || "";
+        renderProjects();
+        loadSurfaces();
+      });
+    }
+    const sort = $("project-sort");
+    if (sort) {
+      sort.value = state.projectSort;
+      sort.addEventListener("change", () => {
+        state.projectSort = sort.value || "urgency";
+        renderProjects();
+        loadSurfaces();
+      });
+    }
+  }
+
+  function wireActivityControls() {
+    const since = $("activity-since");
+    if (since) {
+      since.value = state.activitySince;
+      since.addEventListener("change", () => {
+        state.activitySince = since.value || ACTIVITY_DEFAULT_SINCE;
+        loadActivity();
+      });
+    }
+    const refresh = $("activity-refresh");
+    if (refresh) {
+      refresh.addEventListener("click", () => loadActivity());
+    }
+  }
+
   function init() {
     maybeShowSessionExpiryBanner();
+    wireProjectControls();
     wireSurfaceFilter();
+    wireActivityControls();
     wireSendForm();
     wireStopAgentButton();
     setStatus("warn", "connecting…");
@@ -1209,12 +1854,16 @@
     selectTask: selectTask,
     interruptSurface: interruptSurface,
     pollDashboard: pollDashboard,
+    loadActivity: loadActivity,
     startEventStream: startEventStream,
     startFallbackPolling: startFallbackPolling,
     handleSseEvent: handleSseEvent,
     renderAuditPanel: renderAuditPanel,
     renderSurfaces: renderSurfaces,
+    renderProjects: renderProjects,
     renderDashboard: renderDashboard,
+    renderActivity: renderActivity,
+    dedupeTaskSurfaces: dedupeTaskSurfaces,
     state: state,
   };
 

--- a/src/pollypm/web_api/ui/index.html
+++ b/src/pollypm/web_api/ui/index.html
@@ -21,13 +21,37 @@
 
 <main id="layout">
   <aside id="surface-rail" aria-label="Chat surfaces">
+    <h2 class="rail-title">Projects</h2>
+    <div class="project-controls">
+      <input
+        id="project-filter"
+        class="rail-input"
+        type="search"
+        placeholder="Search projects"
+        aria-label="Search projects"
+        autocomplete="off"
+      />
+      <select
+        id="project-sort"
+        class="rail-select"
+        aria-label="Sort projects"
+      >
+        <option value="urgency">Urgency</option>
+        <option value="recent">Recent</option>
+        <option value="name">Name</option>
+        <option value="inbox_desc">Inbox</option>
+      </select>
+    </div>
+    <ul id="project-list" class="project-list">
+      <li class="project-empty">loading…</li>
+    </ul>
     <h2 class="rail-title">Surfaces</h2>
     <div class="surface-filter-wrap">
       <input
         id="surface-filter"
-        class="surface-filter"
+        class="rail-input surface-filter"
         type="search"
-        placeholder="Filter surfaces"
+        placeholder="Search surfaces"
         aria-label="Filter surfaces"
         autocomplete="off"
       />
@@ -70,6 +94,25 @@
     <h2 class="rail-title">Dashboard</h2>
     <div id="dashboard-rollups" class="dashboard-rollups">
       <div class="rollup-empty">loading…</div>
+    </div>
+    <h2 class="rail-title">Activity</h2>
+    <div class="activity-controls">
+      <select id="activity-since" class="rail-select" aria-label="Activity window">
+        <option value="24h">24h</option>
+        <option value="2d" selected>2d</option>
+        <option value="7d">7d</option>
+      </select>
+      <button
+        id="activity-refresh"
+        class="activity-refresh"
+        type="button"
+      >Refresh</button>
+    </div>
+    <div id="activity-summary" class="activity-summary">
+      <div class="activity-empty">loading…</div>
+    </div>
+    <div id="activity-feed" class="activity-feed">
+      <div class="activity-empty">loading…</div>
     </div>
   </aside>
 </main>

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -431,12 +431,53 @@ section#message-pane {
   cursor: pointer;
 }
 .task-action-button:hover {
-  border-color: var(--accent);
+  border-color: var(--info);
+  color: var(--text-heading-bright);
+}
+.task-action-button.primary {
+  border-color: rgba(91, 138, 255, 0.65);
   color: var(--text-heading-bright);
 }
 .task-action-button.danger {
   border-color: rgba(239, 68, 68, 0.45);
   color: #fecaca;
+}
+
+.empty-state {
+  max-width: 520px;
+  margin: 72px auto 0;
+  padding: 0 16px;
+  text-align: center;
+}
+.empty-title {
+  color: var(--text-heading-bright);
+  font-size: 16px;
+  font-weight: 600;
+}
+.empty-copy {
+  color: var(--text-muted);
+  font-size: 13px;
+  margin: 8px 0 16px;
+}
+.empty-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.empty-action {
+  padding: 7px 11px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-body);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+}
+.empty-action.primary {
+  border-color: var(--info);
+  color: var(--text-heading-bright);
 }
 
 .audit-panel {
@@ -570,6 +611,14 @@ section#message-pane {
   border-radius: 6px;
   padding: 10px 12px;
   margin: 0 0 8px;
+}
+.rollup-card[role="button"] {
+  cursor: pointer;
+}
+.rollup-card[role="button"]:hover,
+.rollup-card[role="button"]:focus {
+  border-color: var(--info);
+  outline: none;
 }
 .rollup-empty {
   color: var(--text-muted);
@@ -743,6 +792,193 @@ section#message-pane {
   color: var(--blocked);
 }
 
+.inbox-view {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 100%;
+}
+.inbox-filters {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 10px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+}
+.inbox-filter-input,
+.inbox-filter-select {
+  min-width: 120px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-body);
+  font: inherit;
+  font-size: 12.5px;
+}
+.inbox-filter-input:focus,
+.inbox-filter-select:focus,
+.inbox-reply-input:focus {
+  outline: none;
+  border-color: var(--info);
+}
+.inbox-filter-button,
+.inbox-action,
+.inbox-load-more {
+  padding: 6px 9px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-body);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+.inbox-filter-button.primary {
+  border-color: var(--info);
+  color: var(--text-heading-bright);
+}
+.inbox-action.danger {
+  border-color: rgba(239, 68, 68, 0.45);
+  color: #fecaca;
+}
+.inbox-action:disabled,
+.inbox-action.disabled,
+.inbox-filter-button:disabled,
+.inbox-load-more:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.inbox-content {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.9fr) minmax(320px, 1.1fr);
+  gap: 12px;
+  min-height: 0;
+}
+.inbox-list,
+.inbox-detail {
+  min-width: 0;
+}
+.inbox-row,
+.inbox-detail {
+  background: var(--bg-row);
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+}
+.inbox-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 10px;
+  margin-bottom: 8px;
+  cursor: pointer;
+}
+.inbox-row:hover,
+.inbox-row.active {
+  border-color: var(--info);
+  background: var(--bg-row-hover);
+}
+.inbox-row-actions {
+  display: flex;
+  align-content: flex-start;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-width: 220px;
+}
+.inbox-subject,
+.inbox-detail-title {
+  color: var(--text-heading-bright);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.inbox-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-top: 3px;
+  overflow-wrap: anywhere;
+}
+.inbox-preview,
+.inbox-detail-preview {
+  color: var(--text-body);
+  font-size: 12.5px;
+  margin-top: 7px;
+  overflow-wrap: anywhere;
+}
+.inbox-warning {
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--waiting);
+  border-radius: 6px;
+  background: rgba(240, 196, 90, 0.08);
+  color: var(--waiting);
+  font-size: 12px;
+}
+.inbox-error {
+  margin: 0 0 8px;
+}
+.inbox-load-more {
+  width: 100%;
+}
+.inbox-detail {
+  padding: 12px;
+}
+.inbox-detail-empty,
+.inbox-thread-empty {
+  color: var(--text-muted);
+  font-style: italic;
+}
+.inbox-decision-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+.inbox-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+.inbox-thread-message {
+  border-top: 1px solid var(--border-line);
+  padding-top: 8px;
+}
+.inbox-thread-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+.inbox-thread-body {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 12.5px;
+}
+.inbox-reply-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+.inbox-reply-input {
+  width: 100%;
+  resize: vertical;
+  min-height: 72px;
+  padding: 8px 9px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-body);
+  font: inherit;
+  font-size: 12.5px;
+}
+
 /* Mobile / tablet — collapse the three-column grid into a single
  * stacked column so 360–768px viewports (phones in portrait, small
  * tablets) don't horizontally overflow. The cockpit-tinted message
@@ -803,6 +1039,23 @@ section#message-pane {
     /* Free up a little horizontal room — the brand mark + name are
      * enough on a phone. */
     display: none;
+  }
+  .empty-state {
+    margin-top: 28px;
+  }
+  .inbox-content {
+    grid-template-columns: 1fr;
+  }
+  .inbox-row {
+    grid-template-columns: 1fr;
+  }
+  .inbox-row-actions {
+    justify-content: flex-start;
+    max-width: none;
+  }
+  .inbox-filter-input,
+  .inbox-filter-select {
+    flex: 1 1 130px;
   }
 }
 

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -138,10 +138,18 @@ aside#dashboard-rail {
   color: var(--text-muted);
 }
 
+.project-controls,
+.activity-controls {
+  display: flex;
+  gap: 6px;
+  padding: 0 12px 8px;
+}
+
 .surface-filter-wrap {
   padding: 0 12px 8px;
 }
-.surface-filter {
+.rail-input,
+.rail-select {
   width: 100%;
   padding: 7px 9px;
   border: 1px solid var(--border-line);
@@ -151,13 +159,79 @@ aside#dashboard-rail {
   font: inherit;
   font-size: 12.5px;
 }
-.surface-filter::placeholder {
+.rail-input::placeholder {
   color: var(--text-muted);
 }
-.surface-filter:focus {
+.rail-input:focus,
+.rail-select:focus {
   outline: none;
   border-color: var(--info);
 }
+.rail-select {
+  flex: 0 0 86px;
+}
+
+.project-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 8px 8px;
+}
+.project-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  margin: 2px 0;
+  border-radius: 6px;
+  cursor: pointer;
+  background: var(--bg-row);
+  border: 1px solid transparent;
+}
+.project-list li:hover {
+  background: var(--bg-row-hover);
+}
+.project-list li.active {
+  background: var(--bg-row-active);
+  border-color: var(--info);
+}
+.project-list li.project-empty {
+  background: transparent;
+  color: var(--text-muted);
+  cursor: default;
+  font-style: italic;
+}
+.project-name {
+  color: var(--text-heading);
+  font-weight: 600;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+.project-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+.project-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--idle);
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.project-dot-blocked { background: var(--blocked); }
+.project-dot-stalled { background: var(--attention); }
+.project-dot-attention { background: var(--waiting); }
+.project-dot-active { background: var(--info); }
+.project-dot-healthy { background: var(--working); }
+.project-dot-paused,
+.project-dot-all { background: var(--idle); }
+.project-blocked { border-left: 2px solid var(--blocked) !important; }
+.project-stalled { border-left: 2px solid var(--attention) !important; }
+.project-attention { border-left: 2px solid var(--waiting) !important; }
+.project-active { border-left: 2px solid var(--info) !important; }
+.project-healthy { border-left: 2px solid var(--working) !important; }
 
 .surface-list {
   list-style: none;
@@ -285,6 +359,22 @@ section#message-pane {
 .message-role-user   .message-actor { color: var(--info); }
 .message-role-agent  .message-actor { color: var(--working); }
 .message-role-system .message-actor { color: var(--attention); }
+.message-local-echo {
+  border-color: rgba(91, 138, 255, 0.55);
+}
+.message-local-pending,
+.message-local-sending {
+  opacity: 0.82;
+}
+.message-local-failed {
+  border-color: var(--blocked);
+  background: rgba(255, 95, 109, 0.08);
+}
+.message-error {
+  margin-top: 6px;
+  color: var(--blocked);
+  font-size: 12px;
+}
 .message-text {
   color: var(--text-body);
   white-space: pre-wrap;
@@ -501,6 +591,88 @@ section#message-pane {
 .rollup-attention .rollup-value { color: var(--attention); }
 .rollup-blocked   .rollup-value { color: var(--blocked); }
 .rollup-working   .rollup-value { color: var(--working); }
+
+.activity-refresh {
+  flex: 0 0 auto;
+  padding: 7px 9px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-body);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+.activity-refresh:hover {
+  border-color: var(--info);
+  color: var(--text-heading-bright);
+}
+.activity-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  padding: 0 12px 10px;
+}
+.activity-chip {
+  min-width: 0;
+  padding: 7px 8px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-row);
+}
+.activity-chip-label {
+  display: block;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.activity-chip-value {
+  display: block;
+  color: var(--text-heading-bright);
+  font-size: 17px;
+  font-weight: 600;
+  margin-top: 2px;
+}
+.activity-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 12px 16px;
+}
+.activity-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 8px;
+}
+.activity-entry {
+  padding: 8px 9px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-row);
+}
+.activity-entry-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 3px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+.activity-entry-project {
+  color: var(--text-label);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.activity-entry-ts {
+  flex: 0 0 auto;
+}
+.activity-entry-line {
+  color: var(--text-body);
+  font-size: 11.5px;
+  overflow-wrap: anywhere;
+}
 
 .error-banner {
   margin: 12px 18px;

--- a/tests/playwright/tests/inbox.spec.ts
+++ b/tests/playwright/tests/inbox.spec.ts
@@ -1,0 +1,226 @@
+import { test, expect } from "@playwright/test";
+
+const ITEM = {
+  id: "demo/1",
+  project: "demo",
+  type: "plan_review",
+  state: "waiting-on-pm",
+  subject: "Plan ready",
+  preview: "Review the proposed plan.",
+  owner: "operator",
+  thread_id: "demo/1",
+  created_at: "2026-05-23T00:00:00Z",
+  updated_at: "2026-05-23T00:10:00Z",
+  metadata: { task_id: "demo/1", labels: ["plan_review"] },
+};
+
+const SECOND_ITEM = {
+  ...ITEM,
+  id: "demo/2",
+  subject: "Follow-up question",
+  type: "message",
+  state: "open",
+  updated_at: "2026-05-23T00:05:00Z",
+};
+
+async function stubChrome(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/chat/sessions", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [] }),
+    }),
+  );
+  await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
+  await page.route("**/api/v1/dashboard", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rollups: {
+          open_inbox_count: 2,
+          pending_plan_reviews: 1,
+          alert_count: 0,
+        },
+        daemon_status: "up",
+        active_sessions: [],
+        recent_messages: [],
+        projects: [],
+        generated_at: "2026-05-23T00:00:00Z",
+        scoped_fields: [],
+      }),
+    }),
+  );
+  await page.route("**/api/v1/events**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "",
+    }),
+  );
+}
+
+test.describe("inbox panel", () => {
+  test("dashboard inbox card opens browsable list with load more and disabled plan decisions", async ({ page }) => {
+    await stubChrome(page);
+
+    const inboxUrls: string[] = [];
+    await page.route("**/api/v1/inbox?**", (route) => {
+      const url = new URL(route.request().url());
+      inboxUrls.push(url.search);
+      const cursor = url.searchParams.get("cursor");
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          cursor === "page-2"
+            ? { items: [SECOND_ITEM], next_cursor: null }
+            : { items: [ITEM], next_cursor: "page-2" },
+        ),
+      });
+    });
+    await page.route("**/api/v1/inbox/demo/1", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ...ITEM,
+          messages: [
+            {
+              id: "demo/1#0",
+              sender: "architect",
+              timestamp: "2026-05-23T00:09:00Z",
+              body: "Please review.",
+            },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await page.locator(".rollup-card[title='Open inbox']").click();
+    await expect(page.locator("#pane-title")).toHaveText("Inbox");
+    await expect(page.locator("[data-inbox-id='demo/1']")).toContainText("Plan ready");
+    await expect(page.locator(".inbox-action.disabled", { hasText: "Approve" })).toBeDisabled();
+
+    await page.locator(".inbox-load-more").click();
+    await expect(page.locator("[data-inbox-id='demo/2']")).toContainText("Follow-up question");
+    expect(inboxUrls.some((search) => search.includes("cursor=page-2"))).toBe(true);
+
+    await page.locator("[data-inbox-id='demo/1']").click();
+    await expect(page.locator(".inbox-thread-body")).toContainText("Please review.");
+  });
+
+  test("inbox filters and actions call existing API routes", async ({ page }) => {
+    await stubChrome(page);
+
+    let filteredRequestSeen = false;
+    let markReadActor = "";
+    let replyOwner = "";
+    let snoozeSeconds = 0;
+    let archiveReason = "";
+
+    await page.route("**/api/v1/inbox?**", (route) => {
+      const url = new URL(route.request().url());
+      if (
+        url.searchParams.get("project") === "demo"
+        && url.searchParams.get("state") === "waiting-on-pm"
+        && url.searchParams.get("type") === "plan_review"
+      ) {
+        filteredRequestSeen = true;
+      }
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [ITEM], next_cursor: null }),
+      });
+    });
+    await page.route("**/api/v1/inbox/demo/1", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...ITEM, messages: [] }),
+      }),
+    );
+    await page.route("**/api/v1/inbox/demo/1/mark-read", async (route) => {
+      markReadActor = (await route.request().postDataJSON()).actor;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ task_id: "demo/1" }),
+      });
+    });
+    await page.route("**/api/v1/inbox/demo/1/reply", async (route) => {
+      const body = await route.request().postDataJSON();
+      replyOwner = body.owner;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ task_id: "demo/1" }),
+      });
+    });
+    await page.route("**/api/v1/inbox/demo/1/snooze", async (route) => {
+      snoozeSeconds = (await route.request().postDataJSON()).duration_seconds;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ task_id: "demo/1" }),
+      });
+    });
+    await page.route("**/api/v1/inbox/demo/1/archive", async (route) => {
+      archiveReason = (await route.request().postDataJSON()).reason;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ task_id: "demo/1" }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator(".rollup-card[title='Open inbox']").click();
+    await page.locator(".inbox-filter-input").fill("demo");
+    await page.locator(".inbox-filter-select").first().selectOption("waiting-on-pm");
+    await page.locator(".inbox-filter-select").nth(1).selectOption("plan_review");
+    await page.locator(".inbox-filter-button.primary").click();
+    await expect.poll(() => filteredRequestSeen).toBe(true);
+
+    await page.locator("[data-inbox-id='demo/1']").click();
+    await page.locator(".inbox-action", { hasText: "Mark read" }).click();
+    await expect.poll(() => markReadActor).toBe("operator");
+
+    await page.locator("[data-inbox-id='demo/1']").click();
+    await page.locator(".inbox-reply-input").fill("Looks good.");
+    await page.locator(".inbox-reply-form .inbox-filter-button.primary").click();
+    await expect.poll(() => replyOwner).toBe("operator");
+
+    await page.locator(".inbox-action", { hasText: "Snooze 1h" }).click();
+    await expect.poll(() => snoozeSeconds).toBe(3600);
+
+    await page.locator(".inbox-action", { hasText: "Archive" }).click();
+    await expect.poll(() => archiveReason).toContain("web UI");
+  });
+
+  test("plan review dashboard card opens inbox filtered to plan reviews", async ({ page }) => {
+    await stubChrome(page);
+    let typeFilter = "";
+    await page.route("**/api/v1/inbox?**", (route) => {
+      const url = new URL(route.request().url());
+      typeFilter = url.searchParams.get("type") || "";
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [ITEM], next_cursor: null }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator(".rollup-card[title='Open plan reviews']").click();
+    await expect.poll(() => typeFilter).toBe("plan_review");
+  });
+});

--- a/tests/playwright/tests/mobile_viewport.spec.ts
+++ b/tests/playwright/tests/mobile_viewport.spec.ts
@@ -40,4 +40,60 @@ test.describe("mobile viewport", () => {
     });
     expect(overflow, "horizontal overflow in CSS pixels").toBeLessThanOrEqual(1);
   });
+
+  test("surface list renders at 360px before optional task rail request completes", async ({ page }) => {
+    await page.setViewportSize({ width: 360, height: 800 });
+    await page.route("**/api/v1/dashboard", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          rollups: {},
+          daemon_status: "up",
+          active_sessions: [],
+          recent_messages: [],
+          projects: [],
+          generated_at: "2026-05-23T00:00:00Z",
+          scoped_fields: [],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessions: [
+            {
+              session_name: "mobile-operator",
+              surface_type: "operator",
+              persona: "polly",
+              project: "demo",
+              window: { present: true, pane_dead: false },
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/events**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: "",
+      }),
+    );
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      });
+    });
+
+    await page.goto("/ui/", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("li[data-session='mobile-operator']")).toBeVisible();
+    const railBox = await page.locator("#surface-rail").boundingBox();
+    expect(railBox?.width ?? 0).toBeGreaterThan(0);
+  });
 });

--- a/tests/playwright/tests/send_message.spec.ts
+++ b/tests/playwright/tests/send_message.spec.ts
@@ -68,9 +68,43 @@ async function stubDashboard(page: import("@playwright/test").Page) {
   );
 }
 
+async function stubProjects(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/projects**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
+}
+
+async function stubActivity(page: import("@playwright/test").Page) {
+  await page.route("**/api/v1/audit/stats**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        total: 0,
+        by_event: {},
+        by_severity: {},
+        since: "2026-05-21T00:00:00Z",
+      }),
+    }),
+  );
+  await page.route("**/api/v1/audit/grep**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ events: [], next_cursor: null }),
+    }),
+  );
+}
+
 test.describe("send message", () => {
   test.beforeEach(async ({ page }) => {
     await stubDashboard(page);
+    await stubProjects(page);
+    await stubActivity(page);
   });
 
   test("typing + clicking Send POSTs to /chat/{name}/send", async ({ page }) => {
@@ -110,6 +144,71 @@ test.describe("send message", () => {
     await input.fill("hello");
     await page.locator("#send-button").click();
     await expect(input).toHaveValue("");
+  });
+
+  test("local echo appears while send is in flight", async ({ page }) => {
+    await stubSurfaces(page);
+    await stubMessages(page);
+
+    let releaseSend: (() => void) | null = null;
+    const sendGate = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    await page.route("**/api/v1/chat/operator/send", async (route) => {
+      await sendGate;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "queued" }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    await page.locator("#send-input").fill("optimistic hello");
+    await page.locator("#send-button").click();
+    await expect(page.locator(".message-local-echo")).toContainText(
+      "optimistic hello",
+    );
+    await expect(page.locator(".message-local-echo .message-type")).toHaveText(
+      "sending",
+    );
+    releaseSend!();
+    await expect(page.locator(".message-local-echo .message-type")).toHaveText(
+      "pending",
+    );
+  });
+
+  test("failed send leaves visible inline error", async ({ page }) => {
+    await stubSurfaces(page);
+    await stubMessages(page);
+    await page.route("**/api/v1/chat/operator/send", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            code: "unsafe_mid_tool",
+            message: "Refusing to send while the agent has an open tool_use",
+          },
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await page.locator("li[data-session='operator']").click();
+    await page.locator("#send-input").fill("blocked send");
+    await page.locator("#send-button").click();
+    await expect(page.locator(".message-local-echo")).toContainText(
+      "blocked send",
+    );
+    await expect(page.locator(".message-local-echo .message-type")).toHaveText(
+      "failed",
+    );
+    await expect(page.locator(".message-error")).toContainText(
+      "Refusing to send",
+    );
+    await expect(page.locator(".toast")).toContainText("send failed");
   });
 
   test("send is disabled until a surface is selected", async ({ page }) => {

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -185,6 +185,38 @@ test.describe("surfaces", () => {
     );
   }
 
+  async function stubEmptyProjects(page: import("@playwright/test").Page) {
+    await page.route("**/api/v1/projects**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      }),
+    );
+  }
+
+  async function stubEmptyActivity(page: import("@playwright/test").Page) {
+    await page.route("**/api/v1/audit/stats**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          total: 0,
+          by_event: {},
+          by_severity: {},
+          since: "2026-05-21T00:00:00Z",
+        }),
+      }),
+    );
+    await page.route("**/api/v1/audit/grep**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ events: [], next_cursor: null }),
+      }),
+    );
+  }
+
   test("left rail renders surface list after load", async ({ page }) => {
     await page.goto("/ui/");
     const list = page.locator("#surface-list");
@@ -497,6 +529,8 @@ test.describe("surfaces", () => {
   test("surface refreshes coalesce while a request is in flight", async ({ page }) => {
     await installHealthyEventSource(page);
     await stubEmptyTasks(page);
+    await stubEmptyProjects(page);
+    await stubEmptyActivity(page);
 
     let dashboardRequests = 0;
     await page.route("**/api/v1/dashboard", (route) => {
@@ -541,6 +575,58 @@ test.describe("surfaces", () => {
     expect(sessionRequests).toBe(2);
   });
 
+  test("initial rail load requests sessions tasks and projects in parallel", async ({ page }) => {
+    await stubEmptyActivity(page);
+    await page.route("**/api/v1/dashboard", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(0)),
+      }),
+    );
+
+    let releaseSessions: (() => void) | null = null;
+    const sessionsGate = new Promise<void>((resolve) => {
+      releaseSessions = resolve;
+    });
+    let sessionRequests = 0;
+    let taskRequests = 0;
+    let projectRequests = 0;
+
+    await page.route("**/api/v1/chat/sessions", async (route) => {
+      sessionRequests += 1;
+      await sessionsGate;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      });
+    });
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) => {
+      taskRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      });
+    });
+    await page.route("**/api/v1/projects**", (route) => {
+      projectRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await expect.poll(() => sessionRequests).toBe(1);
+    await expect.poll(() => taskRequests).toBe(1);
+    await expect.poll(() => projectRequests).toBe(1);
+    releaseSessions!();
+    await waitForSurfaceRailTerminal(page);
+  });
+
   test("initial center-pane state shows 'Select a surface'", async ({ page }) => {
     await page.goto("/ui/");
     await expect(page.locator("#pane-title")).toHaveText("Select a surface");
@@ -549,6 +635,8 @@ test.describe("surfaces", () => {
   });
 
   test("task surfaces render in a separate rail group", async ({ page }) => {
+    await stubEmptyProjects(page);
+    await stubEmptyActivity(page);
     await page.route("**/api/v1/chat/sessions", (route) =>
       route.fulfill({
         status: 200,
@@ -611,6 +699,223 @@ test.describe("surfaces", () => {
     );
   });
 
+  test("project switcher filters surfaces and shows urgency", async ({ page }) => {
+    await stubEmptyActivity(page);
+    let dashboardProject: string | null = null;
+    await page.route("**/api/v1/dashboard**", (route) => {
+      const url = new URL(route.request().url());
+      dashboardProject = url.searchParams.get("project");
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          rollups: { tracked_count: 2, open_inbox_count: 0, pending_plan_reviews: 0 },
+          daemon_status: "up",
+          active_sessions: [],
+          recent_messages: [],
+          projects: [],
+          generated_at: "2026-05-23T00:00:00Z",
+          scoped_fields: [],
+        }),
+      });
+    });
+    await page.route("**/api/v1/projects**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            {
+              key: "alpha",
+              name: "Alpha",
+              path: "/tmp/alpha",
+              tracked: true,
+              kind: "git",
+              glyph: "amber",
+              task_counts: { blocked: 2, queued: 1 },
+              open_inbox_count: 0,
+              pending_plan_review: false,
+              last_activity_at: "2026-05-23T00:00:00Z",
+            },
+            {
+              key: "beta",
+              name: "Beta",
+              path: "/tmp/beta",
+              tracked: true,
+              kind: "git",
+              glyph: "amber",
+              task_counts: { queued: 3 },
+              open_inbox_count: 0,
+              pending_plan_review: false,
+              last_activity_at: null,
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessions: [
+            {
+              session_name: "alpha-worker",
+              surface_type: "worker",
+              persona: "worker",
+              project: "alpha",
+              window: { present: true, pane_dead: false },
+            },
+            {
+              session_name: "beta-worker",
+              surface_type: "worker",
+              persona: "worker",
+              project: "beta",
+              window: { present: true, pane_dead: false },
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    const alpha = page.locator("li[data-project='alpha']");
+    await expect(alpha).toContainText("blocked");
+    await expect(alpha).toContainText("2 blocked");
+    await alpha.click();
+    await expect(page.locator("li[data-session='alpha-worker']")).toBeVisible();
+    await expect(page.locator("li[data-session='beta-worker']")).toHaveCount(0);
+    await expect.poll(() => dashboardProject).toBe("alpha");
+  });
+
+  test("task rail collapses duplicate watchdog-style entries", async ({ page }) => {
+    await stubEmptyProjects(page);
+    await stubEmptyActivity(page);
+    await stubEmptySessions(page);
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            {
+              task_id: "a",
+              project: "demo",
+              task_number: 1,
+              title: "Project demo has queued tasks but no activity",
+              work_status: "queued",
+              type: "task",
+              priority: "normal",
+            },
+            {
+              task_id: "b",
+              project: "demo",
+              task_number: 2,
+              title: "Project demo has queued tasks but no activity",
+              work_status: "queued",
+              type: "task",
+              priority: "normal",
+            },
+            {
+              task_id: "c",
+              project: "demo",
+              task_number: 3,
+              title: "Real follow-up",
+              work_status: "blocked",
+              type: "task",
+              priority: "high",
+            },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await expect(page.locator("li[data-task]")).toHaveCount(2);
+    await expect(page.locator("li[data-task='demo/1']")).toContainText("×2");
+  });
+
+  test("activity panel renders returning-operator digest", async ({ page }) => {
+    await stubEmptyProjects(page);
+    await stubEmptySessions(page);
+    await stubEmptyTasks(page);
+    await page.route("**/api/v1/dashboard", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(0)),
+      }),
+    );
+    await page.route("**/api/v1/audit/stats**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          total: 3,
+          by_event: { "task.status_changed": 1, "plan.approved": 1 },
+          by_severity: { ok: 2, warn: 1 },
+          since: "2026-05-21T00:00:00Z",
+        }),
+      }),
+    );
+    await page.route("**/api/v1/audit/grep**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          events: [
+            {
+              schema: 1,
+              ts: "2026-05-23T00:00:00Z",
+              project: "demo",
+              event: "task.status_changed",
+              subject: "demo/7",
+              actor: "agent-1",
+              status: "ok",
+              metadata: { to_state: "done" },
+            },
+            {
+              schema: 1,
+              ts: "2026-05-23T00:01:00Z",
+              project: "demo",
+              event: "watchdog.warning",
+              subject: "demo",
+              actor: "polly",
+              status: "warn",
+              metadata: {},
+            },
+            {
+              schema: 1,
+              ts: "2026-05-23T00:02:00Z",
+              project: "demo",
+              event: "plan.approved",
+              subject: "demo/8",
+              actor: "sam",
+              status: "ok",
+              metadata: {},
+            },
+          ],
+          next_cursor: null,
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await expect(page.locator("#activity-summary")).toContainText("events");
+    await expect(page.locator("#activity-summary")).toContainText("3");
+    await expect(page.locator("#activity-summary")).toContainText("warnings");
+    await expect(page.locator("#activity-summary")).toContainText("decisions");
+    await expect(page.locator("#activity-feed")).toContainText("plan.approved");
+    await expect(page.locator("#activity-feed")).toContainText("watchdog.warning");
+  });
+
   test("audit panel expands and queries current surface scope", async ({ page }) => {
     await page.route("**/api/v1/chat/*/messages*", (route) =>
       route.fulfill({
@@ -642,8 +947,27 @@ test.describe("surfaces", () => {
         }),
       }),
     );
+    await page.route("**/api/v1/audit/stats**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          total: 0,
+          by_event: {},
+          by_severity: {},
+          since: "2026-05-21T00:00:00Z",
+        }),
+      }),
+    );
     await page.route("**/api/v1/audit/grep**", (route) => {
       const url = new URL(route.request().url());
+      if (!url.searchParams.get("pattern")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ events: [], next_cursor: null }),
+        });
+      }
       expect(url.searchParams.get("project")).toBe("demo");
       expect(url.searchParams.get("pattern")).toBe("demo/4");
       expect(url.searchParams.get("limit")).toBe("25");

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -627,9 +627,11 @@ test.describe("surfaces", () => {
     await waitForSurfaceRailTerminal(page);
   });
 
-  test("initial center-pane state shows 'Select a surface'", async ({ page }) => {
+  test("initial center-pane state shows inline next actions", async ({ page }) => {
     await page.goto("/ui/");
-    await expect(page.locator("#pane-title")).toHaveText("Select a surface");
+    await expect(page.locator("#pane-title")).toHaveText("Ready");
+    await expect(page.locator(".empty-title")).toHaveText("No surface selected");
+    await expect(page.locator(".empty-action.primary")).toHaveText("Open inbox");
     await expect(page.locator("#send-input")).toBeDisabled();
     await expect(page.locator("#send-button")).toBeDisabled();
   });
@@ -697,6 +699,101 @@ test.describe("surfaces", () => {
     await expect(page.locator("#message-list")).toContainText(
       "Visible task detail",
     );
+  });
+
+  test("queued task detail Start posts to claim endpoint as worker", async ({ page }) => {
+    let claimActor = "";
+    await stubEmptyProjects(page);
+    await stubEmptyActivity(page);
+    await page.route("**/api/v1/chat/sessions", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      }),
+    );
+    await page.route("**/api/v1/dashboard", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(0)),
+      }),
+    );
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            {
+              task_id: "task-queued",
+              project: "demo",
+              task_number: 4,
+              title: "Queued rail item",
+              work_status: "queued",
+              type: "task",
+              priority: "normal",
+              assignee: "",
+              updated_at: "2026-05-23T00:00:00Z",
+            },
+          ],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/tasks/demo/4", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          task_id: "task-queued",
+          project: "demo",
+          task_number: 4,
+          title: "Queued rail item",
+          work_status: "queued",
+          type: "task",
+          priority: "normal",
+          assignee: "",
+          updated_at: "2026-05-23T00:00:00Z",
+          description: "Visible task detail",
+          relationships: {},
+          transitions: [],
+          executions: [],
+        }),
+      }),
+    );
+    await page.route("**/api/v1/tasks/demo/4/claim", async (route) => {
+      claimActor = (await route.request().postDataJSON()).actor;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          message: "claimed demo/4",
+          warnings: [],
+          task: {
+            task_id: "task-queued",
+            project: "demo",
+            task_number: 4,
+            title: "Queued rail item",
+            work_status: "in_progress",
+            type: "task",
+            priority: "normal",
+            assignee: "worker",
+            updated_at: "2026-05-23T00:01:00Z",
+            description: "Visible task detail",
+            relationships: {},
+            transitions: [],
+            executions: [],
+          },
+        }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator("li[data-task='demo/4']").click();
+    await page.locator(".task-action-button.primary", { hasText: "Start" }).click();
+    await expect.poll(() => claimActor).toBe("worker");
+    await expect(page.locator("#message-list")).toContainText("in_progress");
   });
 
   test("project switcher filters surfaces and shows urgency", async ({ page }) => {

--- a/tests/web_api/test_endpoints.py
+++ b/tests/web_api/test_endpoints.py
@@ -58,6 +58,57 @@ def test_list_projects_tracked_filter(api_config, client, auth_headers) -> None:
     assert keys == ["myproj"]
 
 
+def test_list_projects_search_sort_and_activity(
+    api_config, client, auth_headers, project_root
+) -> None:
+    from pollypm.models import KnownProject, ProjectKind
+
+    alpha_root = project_root.parent / "alpha"
+    zeta_root = project_root.parent / "zeta"
+    alpha_root.mkdir()
+    zeta_root.mkdir()
+    (alpha_root / ".pollypm").mkdir()
+    (zeta_root / ".pollypm").mkdir()
+    api_config.projects["alpha"] = KnownProject(
+        key="alpha",
+        path=alpha_root,
+        name="Alpha",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+    api_config.projects["zeta"] = KnownProject(
+        key="zeta",
+        path=zeta_root,
+        name="Zeta",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+
+    with create_work_service(
+        db_path=api_config.project.state_db,
+        project_path=project_root,
+    ) as svc:
+        make_task(svc, project="zeta", title="Inbox A", flow_template="chat")
+        make_task(svc, project="zeta", title="Inbox B", flow_template="chat")
+        make_task(svc, project="alpha", title="Recent work")
+
+    response = client.get("/api/v1/projects?q=alp", headers=auth_headers)
+    assert response.status_code == 200
+    assert [item["key"] for item in response.json()["items"]] == ["alpha"]
+
+    response = client.get("/api/v1/projects?sort=name", headers=auth_headers)
+    assert response.status_code == 200
+    names = [item["name"] for item in response.json()["items"]]
+    assert names == sorted(names)
+
+    response = client.get("/api/v1/projects?sort=inbox_desc", headers=auth_headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"][0]["key"] == "zeta"
+    alpha = next(item for item in body["items"] if item["key"] == "alpha")
+    assert alpha["last_activity_at"] is not None
+
+
 def test_get_project_drilldown_returns_404_for_unknown(client, auth_headers) -> None:
     response = client.get("/api/v1/projects/nope", headers=auth_headers)
     assert response.status_code == 404

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1048,6 +1048,40 @@ def test_ui_app_js_has_surface_audit_panel_hooks(client: TestClient) -> None:
         assert expected in body
 
 
+def test_ui_app_js_has_inbox_panel_hooks(client: TestClient) -> None:
+    """The web UI exposes the API-backed inbox panel and write actions."""
+    body = client.get("/ui/app.js").text
+    for expected in (
+        "selectInbox",
+        "/inbox?",
+        "/mark-read",
+        "/archive",
+        "/snooze",
+        "/reply",
+        "Load more",
+        "Type filtering is unavailable",
+        "Plan approve/reject API is not available",
+    ):
+        assert expected in body
+
+
+def test_ui_app_js_claims_queued_tasks_as_worker(client: TestClient) -> None:
+    """Task detail Start uses the existing claim endpoint with CLI parity."""
+    body = client.get("/ui/app.js").text
+    assert 'CLAIM_ACTOR = "worker"' in body
+    assert ' + "/claim"' in body
+    assert "JSON.stringify({ actor: CLAIM_ACTOR })" in body
+
+
+def test_ui_empty_state_points_to_inbox_without_modal(client: TestClient) -> None:
+    """First-run/no-selection state is an inline action surface."""
+    body = client.get("/ui/app.js").text
+    assert "renderNoSelection" in body
+    assert "No surface selected" in body
+    assert "Open inbox" in body
+    assert "Refresh" in body
+
+
 # -------- Round-5: executable renderDashboard coverage ------------------
 #
 # Codex round-5 blocker: the prior three tests (static greps over
@@ -1392,6 +1426,25 @@ def test_selecting_task_surface_disables_chat_send() -> None:
 
 
 def test_task_detail_surfaces_cancel_and_reopen_actions() -> None:
+    queued = _node_render_surface_rail({
+        "tasks": [
+            {
+                "key": "myproj/10",
+                "task_id": "task-10",
+                "project": "myproj",
+                "task_number": "10",
+                "title": "Queued work",
+                "work_status": "queued",
+                "type": "task",
+                "priority": "normal",
+                "assignee": "",
+                "updated_at": "2026-05-23T00:00:00Z",
+            },
+        ],
+        "selectTask": "myproj/10",
+    })
+    assert "Start" in queued["messages"]
+
     active = _node_render_surface_rail({
         "tasks": [
             {
@@ -1499,6 +1552,8 @@ def test_render_dashboard_real_payload_executes() -> None:
     assert ">up<" in rendered, "daemon status 'up' missing"
     assert ">4<" in rendered, "active_sessions count (len=4) missing"
     assert ">5<" in rendered, "tracked_count value 5 missing"
+    assert 'role="button"' in rendered
+    assert 'title="Open inbox"' in rendered
 
     # Color-coding contract: daemon=up → rollup-working; alert_count>0
     # → rollup-blocked. Pin these too so a future restyle that drops


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a browsable Web UI inbox with pagination, project/state/type filters, thread detail, reply, mark-read, snooze, and archive actions.
- Add task detail Start/Resume/Reopen/Cancel actions, including queued-task claim via the public `/api/v1/tasks/{project}/{n}/claim` contract.
- Add first-run empty-state guidance and mobile rail loading coverage so the 360px viewport renders usable surface/task state.

## Issues
Addresses #2217.
Addresses #2213.
Addresses #2204.
Addresses #2202.
Addresses #2199.

## Verification
- `node --check src/pollypm/web_api/ui/app.js`
- `HOME=$(mktemp -d /tmp/pollypm-home.XXXXXX) uv run --extra test pytest tests/web_api/test_web_ui.py -q` — 57 passed
- `git diff --check origin/main...HEAD`
- `POLLYPM_BASE_URL=http://127.0.0.1:8765 npx playwright test tests/inbox.spec.ts tests/surfaces.spec.ts --project=chromium` — 20 passed
- `POLLYPM_BASE_URL=http://127.0.0.1:8765 npx playwright test tests/mobile_viewport.spec.ts --project=mobile-chrome` — 3 passed

## Notes
This branch also carries the browser followup commit that was previously stacked on #2256; #2256 merged into its stack branch but was not present on current `main`, so this PR is based directly on `main` with those UI followups included.

Plan-review items now show and can be filtered/commented from the inbox. The approve/reject buttons are rendered disabled with explicit copy because the decision REST API is not present on this UI stack yet.
