### PR TITLE
perf(api): defer claim worker provisioning

### DIFF
--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -170,6 +170,13 @@ _BRIEFING_REGEN_THREAD_PREFIX = "briefing-regen"
 # :data:`_DOCTOR_SHUTDOWN_GRACE_S`.
 _BRIEFING_SHUTDOWN_GRACE_S = 5.0
 
+# Claim worker provisioning is intentionally off the HTTP request path:
+# git worktree creation and tmux/provider startup can take seconds, but
+# the operator's click only needs the atomic DB claim to complete.
+_CLAIM_PROVISION_MAX_WORKERS = 2
+_CLAIM_PROVISION_THREAD_PREFIX = "claim-provision"
+_CLAIM_PROVISION_SHUTDOWN_GRACE_S = 5.0
+
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -214,6 +221,13 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
       work on the executor.
     - ``briefing_inflight_lock``: guards the dict.
 
+    Claims:
+
+    - ``claim_provision_executor``: shared daemon executor for slow
+      post-claim worker provisioning. The DB claim remains synchronous;
+      worktree/tmux launch continues in this pool so ``POST
+      /tasks/{p}/{n}/claim`` returns within the click budget.
+
     Shutdown cancels not-yet-started futures for each executor, then
     calls ``executor.shutdown(wait=False, cancel_futures=True)`` so
     the teardown doesn't block on a wedged worker (a running
@@ -255,6 +269,10 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
     app.state.briefing_inflight: dict[tuple[str, str], concurrent.futures.Future[Any]] = {}
     app.state.briefing_inflight_lock = threading.Lock()
+    app.state.claim_provision_executor = DaemonThreadPoolExecutor(
+        max_workers=_CLAIM_PROVISION_MAX_WORKERS,
+        thread_name_prefix=_CLAIM_PROVISION_THREAD_PREFIX,
+    )
     try:
         yield
     finally:
@@ -272,6 +290,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
                 "lifespan: failed to clear briefing in-flight registry",
                 exc_info=True,
             )
+        _shutdown_daemon_executor(
+            app.state.claim_provision_executor,
+            label="claim provisioning executor",
+            grace_s=_CLAIM_PROVISION_SHUTDOWN_GRACE_S,
+        )
         _shutdown_daemon_executor(
             app.state.briefing_executor,
             label="briefing executor",

--- a/src/pollypm/web_api/routes/tasks.py
+++ b/src/pollypm/web_api/routes/tasks.py
@@ -19,10 +19,12 @@ refresh state in one round-trip (spec §5.3 wrapper).
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Callable
 from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 
 from pollypm.web_api.errors import APIError, invalid_request, not_found
 from pollypm.web_api.models import (
@@ -64,6 +66,32 @@ from pollypm.web_api.service import (
 )
 
 router = APIRouter(tags=["Tasks"])
+logger = logging.getLogger(__name__)
+
+
+def _claim_provision_scheduler(
+    request: Request,
+) -> Callable[[Callable[[], None]], object] | None:
+    executor = getattr(request.app.state, "claim_provision_executor", None)
+    if executor is None:
+        return None
+
+    def _schedule(work: Callable[[], None]) -> object:
+        future = executor.submit(work)
+
+        def _log_failure(done) -> None:
+            try:
+                done.result()
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "claim worker provisioning task failed",
+                    exc_info=True,
+                )
+
+        future.add_done_callback(_log_failure)
+        return future
+
+    return _schedule
 
 
 @router.get(
@@ -248,6 +276,7 @@ def claim_task_endpoint(
     project: str,
     n: int,
     body: TaskClaimRequest,
+    request: Request,
     config: ConfigDep,
 ) -> TaskActionResult:
     if project not in config.projects:
@@ -257,7 +286,13 @@ def claim_task_endpoint(
     # and SessionManager attach failures (#2064 round-10). They never
     # fail the request; the envelope's ``warnings`` field lets the
     # client surface a banner alongside the ``in_progress`` task.
-    task, warnings = claim_task(config, project, n, actor=body.actor)
+    task, warnings = claim_task(
+        config,
+        project,
+        n,
+        actor=body.actor,
+        provision_scheduler=_claim_provision_scheduler(request),
+    )
     # #2064 round-11 blocker #2: the message must reflect the actual
     # post-claim state. The post-commit cap race
     # (``pg_service.py:1917-1939``) can roll the row back to

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -17,7 +17,7 @@ import contextlib
 import logging
 import os
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1622,6 +1622,7 @@ def claim_task(
     task_number: int,
     *,
     actor: str,
+    provision_scheduler: Callable[[Callable[[], None]], object] | None = None,
 ) -> tuple[APITaskDetail, list[str]]:
     """Atomically claim a queued task via the work-service.
 
@@ -1652,8 +1653,15 @@ def claim_task(
     surface with the same recovery wording the CLI emits at
     ``work/cli.py:912-929`` so cockpit operators see the same
     story regardless of channel.
+
+    When ``provision_scheduler`` is supplied by the Web API route, the
+    worker-session provisioning side effect is scheduled after the DB
+    claim instead of blocking the HTTP response. The synchronous path is
+    retained for CLI-like callers and tests that need immediate warning
+    collection.
     """
     from pollypm.work.service_factory import (
+        create_work_service_with_deferred_session,
         create_work_service_with_session,
     )
     from pollypm.work.service_support import (
@@ -1674,11 +1682,21 @@ def claim_task(
 
     task_id = f"{project_key}/{task_number}"
     try:
-        with create_work_service_with_session(
-            config=config,
-            project_key=project_key,
-            project_path=project.path,
-        ) as svc:
+        service_kwargs = {
+            "config": config,
+            "project_key": project_key,
+            "project_path": project.path,
+        }
+        if provision_scheduler is None:
+            work_service_cm = create_work_service_with_session(
+                **service_kwargs
+            )
+        else:
+            work_service_cm = create_work_service_with_deferred_session(
+                **service_kwargs,
+                schedule=provision_scheduler,
+            )
+        with work_service_cm as svc:
             try:
                 svc.claim(task_id, actor)
             except TaskNotFoundError as exc:

--- a/src/pollypm/work/service_factory.py
+++ b/src/pollypm/work/service_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
 from pathlib import Path
 from typing import Any
@@ -14,7 +15,7 @@ def attach_session_manager(
     *,
     project_path: Path,
     config: Any = None,
-) -> None:
+) -> Any | None:
     """Wire a :class:`SessionManager` onto an already-constructed work service.
 
     Mirrors the per-task worker lifecycle wiring that ``pm`` CLI calls
@@ -53,12 +54,12 @@ def attach_session_manager(
         _record_attach_error(
             svc, f"SessionManager imports failed: {exc}"
         )
-        return
+        return None
     try:
         if not (project_path.exists() and (project_path / ".git").exists()):
-            return
+            return None
     except OSError:
-        return
+        return None
 
     # #2064 round-11 blocker #4: stamping ``_session_attach_error``
     # on SessionService construction failure was a false positive
@@ -109,6 +110,7 @@ def attach_session_manager(
         # path). DO NOT stamp ``_session_attach_error``; the
         # warning at ``_collect_claim_warnings`` would otherwise
         # falsely claim "no per-task tmux lane was provisioned".
+        return session_mgr
     except Exception as exc:  # noqa: BLE001
         logger.debug(
             "attach_session_manager: SessionManager wire-up failed",
@@ -126,6 +128,7 @@ def attach_session_manager(
             _record_attach_error(
                 svc, f"SessionManager wire-up failed: {exc}"
             )
+        return None
 
 
 def _record_attach_error(svc: Any, message: str) -> None:
@@ -203,6 +206,204 @@ def create_work_service_with_session(
     return svc
 
 
+class _DeferredProvisionSessionManager:
+    """SessionManager facade that defers slow worker provisioning.
+
+    ``PgWorkService.claim`` uses the attached manager for two things:
+    a cheap pre-claim cap probe and the expensive post-commit
+    ``provision_worker`` side effect. The Web API needs the first part
+    before returning but must not make the HTTP response wait for git
+    worktree creation and tmux/provider launch. This facade forwards
+    the cap probe to the real manager and schedules provisioning on
+    the caller-owned executor.
+    """
+
+    def __init__(
+        self,
+        real_manager: Any,
+        *,
+        config: Any,
+        project_key: str,
+        project_path: Path,
+        schedule: Callable[[Callable[[], None]], object],
+    ) -> None:
+        self._real_manager = real_manager
+        self._config = config
+        self._project_key = project_key
+        self._project_path = project_path
+        self._schedule = schedule
+
+    def check_parallel_cap(self, project: str, task_id: str) -> None:
+        check_cap = getattr(self._real_manager, "check_parallel_cap", None)
+        if callable(check_cap):
+            check_cap(project, task_id)
+
+    def provision_worker(self, task_id: str, agent_name: str) -> None:
+        def _run() -> None:
+            provision_claimed_worker(
+                config=self._config,
+                project_key=self._project_key,
+                project_path=self._project_path,
+                task_id=task_id,
+                agent_name=agent_name,
+            )
+
+        self._schedule(_run)
+
+
+def create_work_service_with_deferred_session(
+    *,
+    config: Any,
+    project_key: str,
+    project_path: Path,
+    schedule: Callable[[Callable[[], None]], object],
+    sync_manager: Any = None,
+) -> Any:
+    """Construct a work service with post-claim provisioning deferred.
+
+    This is the Web API variant of
+    :func:`create_work_service_with_session`. It still wires a real
+    ``SessionManager`` so ``claim()`` can run the same pre-claim
+    parallel-cap check as the CLI, but replaces the post-commit
+    provisioning call with an executor-scheduled background task.
+    """
+    from pollypm.work.factory import create_work_service
+
+    svc = create_work_service(
+        config=config,
+        project_path=project_path,
+        project_key=project_key,
+        sync_manager=sync_manager,
+    )
+    try:
+        session_mgr = attach_session_manager(
+            svc, project_path=project_path, config=config
+        )
+        if session_mgr is not None:
+            svc.set_session_manager(
+                _DeferredProvisionSessionManager(
+                    session_mgr,
+                    config=config,
+                    project_key=project_key,
+                    project_path=project_path,
+                    schedule=schedule,
+                )
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "create_work_service_with_deferred_session: "
+            "attach_session_manager raised unexpectedly",
+            exc_info=True,
+        )
+        _record_attach_error(svc, f"SessionManager attach failed: {exc}")
+    return svc
+
+
+def provision_claimed_worker(
+    *,
+    config: Any,
+    project_key: str,
+    project_path: Path,
+    task_id: str,
+    agent_name: str,
+) -> None:
+    """Provision the per-task worker for an already-claimed API task."""
+    from pollypm.work.factory import create_work_service
+
+    try:
+        with create_work_service(
+            config=config,
+            project_path=project_path,
+            project_key=project_key,
+        ) as svc:
+            session_mgr = attach_session_manager(
+                svc, project_path=project_path, config=config
+            )
+            if session_mgr is None:
+                logger.warning(
+                    "deferred claim provision: no SessionManager for %s",
+                    task_id,
+                )
+                return
+            try:
+                task = svc.get(task_id)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "deferred claim provision: task %s disappeared",
+                    task_id,
+                    exc_info=True,
+                )
+                return
+            status = getattr(getattr(task, "work_status", None), "value", None)
+            if status is None:
+                status = getattr(task, "work_status", None)
+            if status not in {"in_progress", "review"}:
+                logger.info(
+                    "deferred claim provision: skip %s in state %r",
+                    task_id,
+                    status,
+                )
+                return
+            try:
+                session_mgr.provision_worker(task_id, agent_name)
+            except Exception as exc:  # noqa: BLE001
+                _rollback_deferred_claim_if_cap_exceeded(
+                    svc, task, task_id, agent_name, exc
+                )
+                raise
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "deferred claim provision failed for %s: %s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
+
+
+def _rollback_deferred_claim_if_cap_exceeded(
+    svc: Any,
+    task: Any,
+    task_id: str,
+    actor: str,
+    exc: BaseException,
+) -> None:
+    """Mirror PgWorkService.claim's cap-race rollback when available."""
+    if not _is_worker_cap_exceeded(exc):
+        return
+    status = getattr(getattr(task, "work_status", None), "value", None)
+    if status is None:
+        status = getattr(task, "work_status", None)
+    if status != "in_progress":
+        return
+    rollback = getattr(svc, "_rollback_claim_to_queued", None)
+    if not callable(rollback):
+        return
+    node_id = getattr(task, "current_node_id", None)
+    if not node_id:
+        return
+    try:
+        rollback(
+            getattr(task, "project"),
+            getattr(task, "task_number"),
+            node_id,
+            actor,
+            exc,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "deferred claim provision: rollback failed for %s",
+            task_id,
+            exc_info=True,
+        )
+
+
+def _is_worker_cap_exceeded(exc: BaseException) -> bool:
+    for cls in type(exc).__mro__:
+        if cls.__name__ == "WorkerCapExceededError":
+            return True
+    return False
+
+
 def open_project_work_service(project: Any, *, config: Any = None) -> Any | None:
     """Open a per-project work service, returning None on failure.
 
@@ -252,6 +453,8 @@ def open_project_work_service(project: Any, *, config: Any = None) -> Any | None
 
 __all__ = [
     "attach_session_manager",
+    "create_work_service_with_deferred_session",
     "create_work_service_with_session",
     "open_project_work_service",
+    "provision_claimed_worker",
 ]

--- a/tests/test_tasks_writes_endpoint.py
+++ b/tests/test_tasks_writes_endpoint.py
@@ -21,7 +21,9 @@ plumbing.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import threading
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -54,6 +56,7 @@ from pollypm.work.service_support import (
 # ``attach_session_manager`` exception lands on
 # ``svc._session_attach_error``.
 from pollypm.work.service_factory import (  # noqa: E402
+    create_work_service_with_deferred_session as _REAL_DEFERRED_FACTORY,
     create_work_service_with_session as _REAL_CREATE_WORK_SERVICE_WITH_SESSION,
 )
 
@@ -423,6 +426,11 @@ def patched_work_service(
         "create_work_service_with_session",
         _fake_factory,
     )
+    monkeypatch.setattr(
+        work_service_factory,
+        "create_work_service_with_deferred_session",
+        _fake_factory,
+    )
     # The web-api READ helpers (``_open_work_service_readonly``)
     # already wrap ``create_work_service`` via ``contextlib.contextmanager``
     # so the patch on the factory module reaches both call sites.
@@ -550,6 +558,204 @@ def test_claim_happy_path_warnings_empty(
     body = response.json()
     assert "warnings" in body, body
     assert body["warnings"] == []
+
+
+def test_claim_task_defers_worker_provisioning(
+    api_config, task_store, monkeypatch
+) -> None:
+    """API claims return before slow worktree/tmux provisioning runs."""
+    _seed(task_store, n=102, work_status=WorkStatus.QUEUED)
+
+    class _SlowSessionManager:
+        def __init__(self) -> None:
+            self.cap_checks: list[tuple[str, str]] = []
+            self.provisions: list[tuple[str, str]] = []
+
+        def check_parallel_cap(self, project: str, task_id: str) -> None:
+            self.cap_checks.append((project, task_id))
+
+        def provision_worker(self, task_id: str, agent_name: str) -> None:
+            time.sleep(0.15)
+            self.provisions.append((task_id, agent_name))
+
+    class _ProvisioningWorkService(FakeWorkService):
+        def set_session_manager(self, mgr: object) -> None:
+            self._session_mgr = mgr
+
+        def claim(self, task_id: str, actor: str) -> FakeTask:
+            mgr = getattr(self, "_session_mgr")
+            mgr.check_parallel_cap("myproj", task_id)
+            task = super().claim(task_id, actor)
+            mgr.provision_worker(task_id, actor)
+            return task
+
+    attached_managers: list[_SlowSessionManager] = []
+    scheduled: list[Callable[[], None]] = []
+
+    def _factory(**_kwargs: object) -> _ProvisioningWorkService:
+        return _ProvisioningWorkService(task_store)
+
+    def _attach(svc: object, **_kwargs: object) -> _SlowSessionManager:
+        mgr = _SlowSessionManager()
+        svc.set_session_manager(mgr)
+        attached_managers.append(mgr)
+        return mgr
+
+    def _schedule(work: Callable[[], None]) -> None:
+        scheduled.append(work)
+
+    from pollypm.web_api.service import claim_task
+    from pollypm.work import factory as work_factory
+    from pollypm.work import service_factory as work_service_factory
+
+    monkeypatch.setattr(work_factory, "create_work_service", _factory)
+    monkeypatch.setattr(
+        work_service_factory,
+        "attach_session_manager",
+        _attach,
+    )
+    monkeypatch.setattr(
+        work_service_factory,
+        "create_work_service_with_deferred_session",
+        _REAL_DEFERRED_FACTORY,
+    )
+
+    started = time.perf_counter()
+    detail, warnings = claim_task(
+        api_config,
+        "myproj",
+        102,
+        actor="alice",
+        provision_scheduler=_schedule,
+    )
+    elapsed = time.perf_counter() - started
+
+    assert detail.work_status == "in_progress"
+    assert warnings == []
+    assert elapsed < 0.05
+    assert len(scheduled) == 1
+    assert attached_managers[0].cap_checks == [("myproj", "myproj/102")]
+    assert attached_managers[0].provisions == []
+
+    scheduled[0]()
+    assert attached_managers[-1].provisions == [("myproj/102", "alice")]
+
+
+def test_claim_endpoint_uses_lifespan_executor_for_deferred_provision(
+    api_config, token_path, token, task_store, monkeypatch
+) -> None:
+    """Route requests use the app-owned executor when lifespan is active."""
+    _seed(task_store, n=104, work_status=WorkStatus.QUEUED)
+    scheduled = threading.Event()
+
+    def _deferred_factory(**kwargs: object) -> FakeWorkService:
+        schedule = kwargs.get("schedule")
+        assert callable(schedule)
+        schedule(scheduled.set)
+        return FakeWorkService(task_store)
+
+    from pollypm.work import service_factory as work_service_factory
+
+    monkeypatch.setattr(
+        work_service_factory,
+        "create_work_service_with_deferred_session",
+        _deferred_factory,
+    )
+
+    app = create_app(config=api_config, token_path=token_path)
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/api/v1/tasks/myproj/104/claim",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"actor": "alice"},
+        )
+        assert scheduled.wait(timeout=1.0)
+
+    assert response.status_code == 200, response.text
+
+
+def test_deferred_provision_cap_race_rolls_claim_back(
+    api_config, task_store, monkeypatch
+) -> None:
+    """Deferred worker-cap races keep the existing queued rollback."""
+    task = _seed(task_store, n=103, work_status=WorkStatus.IN_PROGRESS)
+    task.claimed_by_session = "alice"
+    task.current_node_id = "node-start"
+
+    class WorkerCapExceededError(RuntimeError):
+        pass
+
+    class _CapExceededSessionManager:
+        def provision_worker(self, task_id: str, agent_name: str) -> None:
+            raise WorkerCapExceededError("cap exceeded")
+
+    class _RollbackWorkService(FakeWorkService):
+        def __enter__(self) -> "_RollbackWorkService":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def set_session_manager(self, mgr: object) -> None:
+            self._session_mgr = mgr
+
+        def _rollback_claim_to_queued(
+            self,
+            project: str,
+            task_number: int,
+            node_id: str,
+            actor: str,
+            exc: BaseException,
+        ) -> bool:
+            self.rollback_call = (
+                project,
+                task_number,
+                node_id,
+                actor,
+                str(exc),
+            )
+            task = self.get(f"{project}/{task_number}")
+            task.work_status = WorkStatus.QUEUED
+            task.claimed_by_session = None
+            return True
+
+    svc = _RollbackWorkService(task_store)
+
+    def _factory(**_kwargs: object) -> _RollbackWorkService:
+        return svc
+
+    def _attach(svc: object, **_kwargs: object) -> _CapExceededSessionManager:
+        mgr = _CapExceededSessionManager()
+        svc.set_session_manager(mgr)
+        return mgr
+
+    from pollypm.work import factory as work_factory
+    from pollypm.work import service_factory as work_service_factory
+
+    monkeypatch.setattr(work_factory, "create_work_service", _factory)
+    monkeypatch.setattr(
+        work_service_factory,
+        "attach_session_manager",
+        _attach,
+    )
+
+    work_service_factory.provision_claimed_worker(
+        config=api_config,
+        project_key="myproj",
+        project_path=api_config.projects["myproj"].path,
+        task_id="myproj/103",
+        agent_name="alice",
+    )
+
+    assert svc.rollback_call == (
+        "myproj",
+        103,
+        "node-start",
+        "alice",
+        "cap exceeded",
+    )
+    assert task.work_status == WorkStatus.QUEUED
+    assert task.claimed_by_session is None
 
 
 def test_claim_surfaces_last_provision_error_warning(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Keep the `/api/v1/tasks/{project}/{n}/claim` DB transition and worker-cap pre-check synchronous.
- Move slow worker provisioning (git worktree + tmux/provider launch) onto an app-owned bounded daemon executor so the HTTP response is not blocked by post-claim side effects.
- Preserve deferred cap-race rollback behavior when the background provisioner hits `WorkerCapExceededError`.
- Add focused route/service tests for deferred scheduling, lifespan executor usage, and cap-race rollback.

Fixes #2218.

## Perf Evidence
Injected slow provisioner benchmark, 15 samples, 120ms synthetic provisioning delay:

- Before/synchronous path: p50=200.28ms, p95=259.52ms, p99=267.94ms, max=267.94ms
- After/deferred path: p50=0.04ms, p95=0.06ms, p99=0.13ms, max=0.13ms
- Background jobs scheduled: 15

This isolates the request-path effect of provisioning; live tmux/provider startup remains environment-dependent but now runs after the claim response.

## Tests
- `uv run --extra dev ruff check src/pollypm/work/service_factory.py src/pollypm/web_api/service.py src/pollypm/web_api/routes/tasks.py src/pollypm/web_api/app.py tests/test_tasks_writes_endpoint.py`
- `python -m py_compile src/pollypm/work/service_factory.py src/pollypm/web_api/service.py src/pollypm/web_api/routes/tasks.py src/pollypm/web_api/app.py tests/test_tasks_writes_endpoint.py`
- `HOME=$(mktemp -d /tmp/pollypm-2218-home.XXXXXX) uv run --extra test pytest --noconftest tests/test_tasks_writes_endpoint.py -q` (60 passed)
- `HOME=$(mktemp -d /tmp/pollypm-2218-home.XXXXXX) uv run --extra test pytest tests/web_api/test_openapi_conformance.py -q` (24 passed)
- `git diff --check`
