### PR TITLE
feat(api): add task release endpoint

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1365,9 +1365,54 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
+  /tasks/{project}/{n}/release:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey2"
+      - $ref: "#/components/parameters/TaskNumber"
+    post:
+      tags: [Tasks]
+      operationId: releaseTask
+      summary: Release an active worker claim
+      description: |
+        Moves an active worker-owned task (`in_progress` or `rework`)
+        back to `queued` for recovery from stale or accidental
+        claims. The flow `current_node_id` is preserved so the next
+        claim resumes the same node with a fresh execution visit;
+        `assignee` and `claimed_by_session` are cleared, active node
+        executions are marked `abandoned`, and a transition/audit row
+        records the release reason. Completed/cancelled tasks return
+        `409 invalid_state`.
+
+        `Idempotency-Key` and `If-Match` are intentionally NOT
+        accepted — no replay cache or version-token enforcement
+        exists yet (#2064 round-1, mirrors #2060).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TaskReleaseRequest"
+      responses:
+        "200":
+          description: Task released back to `queued`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
   # Lifecycle REST verbs (#2137) — done / approve / hold / rework /
   # block / review / in_progress. Each mirrors the existing
-  # claim/cancel/reopen pattern: typed envelope on success
+  # claim/cancel/reopen/release pattern: typed envelope on success
   # (`TaskActionResult`), 404 for unknown project/task, 409
   # `invalid_state` for illegal transitions, 422 for body / argument
   # validation, 503 for backing-store outage.
@@ -4127,6 +4172,26 @@ components:
           description: |
             Optional explanation; absent reasons collapse to
             "reopened via API" in the audit row.
+
+    TaskReleaseRequest:
+      type: object
+      additionalProperties: false
+      required: [actor]
+      properties:
+        actor:
+          type: string
+          minLength: 1
+          description: Operator identity recorded on the release transition.
+        reason:
+          type: string
+          description: |
+            Optional explanation; absent reasons collapse to
+            "released via API" in the audit row.
+      description: |
+        `additionalProperties: false` mirrors the runtime
+        `TaskReleaseRequest` model (`extra="forbid"` in
+        `src/pollypm/web_api/models.py`). Unknown keys surface as a
+        `422 validation_error` instead of being silently dropped.
 
     TaskReassignRequest:
       type: object

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -374,6 +374,15 @@ class TaskReopenRequest(BaseModel):
     reason: str | None = None
 
 
+class TaskReleaseRequest(BaseModel):
+    """Body for ``POST /tasks/{project}/{n}/release``."""
+
+    model_config = {"extra": "forbid"}
+
+    actor: str = Field(min_length=1)
+    reason: str | None = None
+
+
 class TaskReassignRequest(BaseModel):
     """Body for ``POST /tasks/{project}/{n}/reassign``.
 

--- a/src/pollypm/web_api/routes/tasks.py
+++ b/src/pollypm/web_api/routes/tasks.py
@@ -39,6 +39,7 @@ from pollypm.web_api.models import (
     TaskListResponse,
     TaskPatchRequest,
     TaskReassignRequest,
+    TaskReleaseRequest,
     TaskReopenRequest,
     TaskReviewRequest,
     TaskReworkRequest,
@@ -58,6 +59,7 @@ from pollypm.web_api.service import (
     patch_task,
     queue_task,
     reassign_task,
+    release_task,
     reopen_task,
     review_task,
     rework_task,
@@ -339,6 +341,35 @@ def reopen_task_endpoint(
     task = reopen_task(config, project, n, reason=reason)
     return TaskActionResult(
         ok=True, message=f"reopened {task.task_id}", task=task
+    )
+
+
+@router.post(
+    "/tasks/{project}/{n}/release",
+    response_model=TaskActionResult,
+    summary="Release an active worker claim",
+    operation_id="releaseTask",
+    responses={
+        "401": {"description": "Missing or invalid bearer token."},
+        "404": {"description": "Project or task not found."},
+        "409": {"description": "Task is not actively claimed."},
+        "422": {"description": "Body validation."},
+        "503": {"description": "Backing store unavailable."},
+    },
+)
+def release_task_endpoint(
+    project: str,
+    n: int,
+    body: TaskReleaseRequest,
+    config: ConfigDep,
+) -> TaskActionResult:
+    if project not in config.projects:
+        raise not_found(f"Project not registered: {project}")
+    task = release_task(
+        config, project, n, actor=body.actor, reason=body.reason
+    )
+    return TaskActionResult(
+        ok=True, message=f"released {task.task_id}", task=task
     )
 
 

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -2072,6 +2072,8 @@ def _run_lifecycle_transition(
     task_number: int,
     verb: str,
     op,
+    *,
+    with_session: bool = False,
 ) -> APITaskDetail:
     """Shared scaffolding for the #2137 lifecycle helpers.
 
@@ -2080,12 +2082,17 @@ def _run_lifecycle_transition(
     ``svc.get`` → :class:`TaskDetail` hydration so each verb's helper
     is two lines of intent + one ``op`` lambda.
     """
-    from pollypm.work.factory import create_work_service
     from pollypm.work.service_support import (
         InvalidTransitionError,
         TaskNotFoundError,
         ValidationError as WorkValidationError,
     )
+    if with_session:
+        from pollypm.work.service_factory import (
+            create_work_service_with_session,
+        )
+    else:
+        from pollypm.work.factory import create_work_service
 
     project = config.projects.get(project_key)
     if project is None:
@@ -2093,9 +2100,19 @@ def _run_lifecycle_transition(
 
     task_id = f"{project_key}/{task_number}"
     try:
-        with create_work_service(
-            config=config, project_key=project_key, project_path=project.path
-        ) as svc:
+        if with_session:
+            svc_cm = create_work_service_with_session(
+                config=config,
+                project_key=project_key,
+                project_path=project.path,
+            )
+        else:
+            svc_cm = create_work_service(
+                config=config,
+                project_key=project_key,
+                project_path=project.path,
+            )
+        with svc_cm as svc:
             try:
                 op(svc, task_id)
             except TaskNotFoundError as exc:
@@ -2264,6 +2281,28 @@ def in_progress_task(
         task_number,
         verb="in_progress",
         op=lambda svc, task_id: svc.force_in_progress(task_id, actor),
+    )
+
+
+def release_task(
+    config: PollyPMConfig,
+    project_key: str,
+    task_number: int,
+    *,
+    actor: str,
+    reason: str | None = None,
+) -> APITaskDetail:
+    """Release ``in_progress`` / ``rework`` back to ``queued``."""
+    release_reason = reason or "released via API"
+    return _run_lifecycle_transition(
+        config,
+        project_key,
+        task_number,
+        verb="release",
+        op=lambda svc, task_id: svc.release(
+            task_id, actor, release_reason
+        ),
+        with_session=True,
     )
 
 

--- a/src/pollypm/work/mock_service.py
+++ b/src/pollypm/work/mock_service.py
@@ -392,6 +392,38 @@ class MockWorkService:
         self._record_transition(task_id, WorkStatus.QUEUED.value, WorkStatus.IN_PROGRESS.value, actor)
         return deepcopy(task)
 
+    def release(
+        self, task_id: str, actor: str, reason: str | None = None
+    ) -> Task:
+        task = self._tasks.get(task_id)
+        if task is None:
+            raise TaskNotFoundError(f"Task '{task_id}' not found.")
+        if task.work_status not in (WorkStatus.IN_PROGRESS, WorkStatus.REWORK):
+            raise InvalidTransitionError(
+                f"Cannot release task in '{task.work_status.value}' state. "
+                "Task must be in 'in_progress' or 'rework' state."
+            )
+
+        old = task.work_status.value
+        now = _now()
+        for exe in self._executions.get(task_id, []):
+            if exe.status == ExecutionStatus.ACTIVE:
+                exe.status = ExecutionStatus.ABANDONED
+                exe.completed_at = now
+        task.work_status = WorkStatus.QUEUED
+        task.assignee = None
+        task.claimed_by_session = None
+        task.updated_at = now
+        self._record_transition(
+            task_id, old, WorkStatus.QUEUED.value, actor, reason
+        )
+        return deepcopy(task)
+
+    def release_stale_claim(
+        self, task_id: str, actor: str, *, reason: str
+    ) -> Task:
+        return self.release(task_id, actor, reason)
+
     def next(self, *, agent: str | None = None, project: str | None = None) -> Task | None:
         candidates = [
             t for t in self._tasks.values()

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -1356,6 +1356,130 @@ class PgWorkService:
         )
         return result
 
+    def release(
+        self, task_id: str, actor: str, reason: str | None = None
+    ) -> Task:
+        """Release an active worker claim back to queued.
+
+        This is the operator/recovery counterpart to the post-commit
+        claim rollback path: only active worker-owned states are legal,
+        the flow node is preserved, active executions are abandoned, and
+        the live assignee/session claim is cleared so a later claim starts
+        a fresh visit at the same node.
+        """
+        project, task_number = _parse_task_id(task_id)
+        now = _now_iso()
+        release_reason = reason or "released via work service"
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT work_status FROM work_tasks "
+                    "WHERE project = %s AND task_number = %s "
+                    "FOR UPDATE",
+                    (project, task_number),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise TaskNotFoundError(f"Task '{task_id}' not found.")
+                current = _coerce_status(str(row[0]))
+                if current not in (WorkStatus.IN_PROGRESS, WorkStatus.REWORK):
+                    raise InvalidTransitionError(
+                        f"Cannot release task in '{current.value}' state. "
+                        "Task must be in 'in_progress' or 'rework' state."
+                    )
+                cur.execute(
+                    "UPDATE work_tasks SET work_status = %s, "
+                    "assignee = NULL, claimed_by_session = NULL, "
+                    "updated_at = %s "
+                    "WHERE project = %s AND task_number = %s",
+                    (WorkStatus.QUEUED.value, now, project, task_number),
+                )
+                cur.execute(
+                    "UPDATE work_node_executions SET status = %s, "
+                    "completed_at = %s "
+                    "WHERE task_project = %s AND task_number = %s "
+                    "AND status = %s",
+                    (
+                        ExecutionStatus.ABANDONED.value,
+                        now,
+                        project,
+                        task_number,
+                        ExecutionStatus.ACTIVE.value,
+                    ),
+                )
+                cur.execute(
+                    "INSERT INTO work_transitions ("
+                    "task_project, task_number, from_state, to_state, "
+                    "actor, reason, created_at"
+                    ") VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                    (
+                        project,
+                        task_number,
+                        current.value,
+                        WorkStatus.QUEUED.value,
+                        actor,
+                        release_reason,
+                        now,
+                    ),
+                )
+            conn.commit()
+
+        self._emit_status_changed_audit(
+            project=project,
+            task_number=task_number,
+            from_state=current.value,
+            to_state=WorkStatus.QUEUED.value,
+            actor=actor,
+            reason=release_reason,
+        )
+        self._finish_worker_session_after_release(
+            task_id,
+            project=project,
+            task_number=task_number,
+            ended_at=now,
+        )
+        result = self.get(task_id)
+        self._sync_transition(result, current.value, WorkStatus.QUEUED.value)
+        return result
+
+    def release_stale_claim(
+        self, task_id: str, actor: str, *, reason: str
+    ) -> Task:
+        return self.release(task_id, actor, reason)
+
+    def _finish_worker_session_after_release(
+        self,
+        task_id: str,
+        *,
+        project: str,
+        task_number: int,
+        ended_at: datetime,
+    ) -> None:
+        session_mgr = self._session_mgr
+        if session_mgr is not None:
+            try:
+                session_mgr.teardown_worker(task_id)
+                return
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "release[%s]: worker teardown failed: %s",
+                    task_id,
+                    exc,
+                )
+        try:
+            self.mark_worker_session_ended(
+                task_project=project,
+                task_number=task_number,
+                ended_at=ended_at,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "release[%s]: worker-session end stamp failed",
+                task_id,
+                exc_info=True,
+            )
+
     def mark_done(self, task_id: str, actor: str) -> Task:
         """Force a task to ``done`` without running the flow.
 

--- a/src/pollypm/work/service.py
+++ b/src/pollypm/work/service.py
@@ -148,6 +148,29 @@ class WorkService(Protocol):
         """
         ...
 
+    def release(
+        self, task_id: str, actor: str, reason: str | None = None
+    ) -> Task:
+        """Release an active worker claim back to ``queued``.
+
+        The task must currently be ``in_progress`` or ``rework``. The
+        implementation clears the live claim owner, abandons any active
+        node execution, records an ``active -> queued`` transition, and
+        preserves ``current_node_id`` so the next claim resumes the same
+        flow node with a fresh visit.
+        """
+        ...
+
+    def release_stale_claim(
+        self, task_id: str, actor: str, *, reason: str
+    ) -> Task:
+        """Compatibility alias for stale-worker recovery callers.
+
+        Same semantics as :meth:`release`; retained for the auto-claim
+        sweeper, which historically probed for ``release_stale_claim``.
+        """
+        ...
+
     def next(self, *, agent: str | None = None, project: str | None = None) -> Task | None:
         """Return the highest-priority queued and unblocked task.
 

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -1299,6 +1299,57 @@ def test_reopen_cancelled_task_returns_to_clean_queue(pg_service):
         assert cur.fetchone()[0] == 0
 
 
+def test_release_active_claim_returns_to_queue_preserving_node(pg_service):
+    from pollypm.work.models import ExecutionStatus, WorkStatus
+
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    claimed = pg_service.claim(task.task_id, actor="alice")
+
+    released = pg_service.release(
+        task.task_id, actor="operator", reason="worker gone"
+    )
+
+    assert released.work_status is WorkStatus.QUEUED
+    assert released.assignee is None
+    assert released.claimed_by_session is None
+    assert released.current_node_id == claimed.current_node_id
+
+    with pg_service._pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT from_state, to_state, reason FROM work_transitions "
+            "WHERE task_project = %s AND task_number = %s "
+            "ORDER BY id DESC LIMIT 1",
+            (task.project, task.task_number),
+        )
+        assert cur.fetchone() == (
+            WorkStatus.IN_PROGRESS.value,
+            WorkStatus.QUEUED.value,
+            "worker gone",
+        )
+        cur.execute(
+            "SELECT COUNT(*) FROM work_node_executions "
+            "WHERE task_project = %s AND task_number = %s "
+            "AND status = %s",
+            (
+                task.project,
+                task.task_number,
+                ExecutionStatus.ACTIVE.value,
+            ),
+        )
+        assert cur.fetchone()[0] == 0
+
+
+def test_release_rejects_terminal_task(pg_service):
+    from pollypm.work.service_support import InvalidTransitionError
+
+    task = _make_draft(pg_service)
+    pg_service.mark_done(task.task_id, actor="user")
+
+    with pytest.raises(InvalidTransitionError):
+        pg_service.release(task.task_id, actor="operator")
+
+
 def test_reopen_rejects_non_cancelled_task(pg_service):
     from pollypm.work.service_support import InvalidTransitionError
 

--- a/tests/test_work_service_protocol_conformance.py
+++ b/tests/test_work_service_protocol_conformance.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import inspect
 from datetime import datetime, timedelta, timezone
-from typing import Any
 
 import pytest
 
@@ -33,6 +32,8 @@ _REQUIRED_PARAMETERS: dict[str, set[str]] = {
     "create": {"created_by", "priority", "description", "kind"},
     "queue": {"skip_gates"},
     "claim": {"skip_gates"},
+    "release": {"reason"},
+    "release_stale_claim": {"reason"},
     "node_done": {"skip_gates"},
     "approve": {"skip_gates"},
     "add_context": {"entry_type"},

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -38,6 +38,8 @@ PHASE_1_PATHS: set[tuple[str, str]] = {
     ("GET", "/events"),
     # Phase 2 wedge — first write endpoint, see #1548.
     ("POST", "/tasks/{project}/{n}/queue"),
+    # Task release/unclaim recovery endpoint (#2114).
+    ("POST", "/tasks/{project}/{n}/release"),
     # Phase 2 — chat GET endpoints (PR #2045).
     ("GET", "/chat/sessions"),
     ("GET", "/chat/{session_name}/messages"),
@@ -235,6 +237,7 @@ def test_static_yaml_does_not_advertise_idempotency_or_ifmatch_on_tasks() -> Non
         "/tasks/{project}/{n}/claim",
         "/tasks/{project}/{n}/cancel",
         "/tasks/{project}/{n}/reopen",
+        "/tasks/{project}/{n}/release",
         "/tasks/{project}/{n}/reassign",
     ]
     for path in task_post_paths:
@@ -340,6 +343,7 @@ def test_static_yaml_declares_503_on_task_write_paths() -> None:
         "/tasks/{project}/{n}/claim",
         "/tasks/{project}/{n}/cancel",
         "/tasks/{project}/{n}/reopen",
+        "/tasks/{project}/{n}/release",
         "/tasks/{project}/{n}/reassign",
     ]
     paths = contract.get("paths", {})
@@ -422,6 +426,7 @@ def test_task_write_endpoints_document_503() -> None:
         "/api/v1/tasks/{project}/{n}/claim",
         "/api/v1/tasks/{project}/{n}/cancel",
         "/api/v1/tasks/{project}/{n}/reopen",
+        "/api/v1/tasks/{project}/{n}/release",
         "/api/v1/tasks/{project}/{n}/reassign",
     ]
     for path in post_paths:
@@ -752,6 +757,18 @@ def test_task_reopen_request_schema_forbids_extras() -> None:
     assert static_schema.get("additionalProperties") is False
 
     runtime_schema = TaskReopenRequest.model_json_schema()
+    assert runtime_schema.get("additionalProperties") is False
+
+
+def test_task_release_request_schema_forbids_extras() -> None:
+    """Pin ``TaskReleaseRequest`` extras=forbid in runtime + static YAML."""
+    from pollypm.web_api.models import TaskReleaseRequest
+
+    contract = _load_contract()
+    static_schema = contract["components"]["schemas"]["TaskReleaseRequest"]
+    assert static_schema.get("additionalProperties") is False
+
+    runtime_schema = TaskReleaseRequest.model_json_schema()
     assert runtime_schema.get("additionalProperties") is False
 
 

--- a/tests/web_api/test_tasks_lifecycle_endpoints.py
+++ b/tests/web_api/test_tasks_lifecycle_endpoints.py
@@ -1,5 +1,5 @@
-"""Tests for the lifecycle REST endpoints — done / approve / hold /
-rework / block / review / in_progress (#2137).
+"""Tests for the lifecycle REST endpoints — release / done / approve /
+hold / rework / block / review / in_progress (#2137 / #2114).
 
 Each endpoint mirrors the existing ``/claim`` / ``/cancel`` shape:
 ``TaskActionResult`` envelope on success, 409 ``invalid_state`` on
@@ -86,6 +86,55 @@ def _seed_task_in_state(api_config, project_root, *, state: str):
             svc.cancel(task.task_id, actor="tester", reason="test setup")
             return svc.get(task.task_id)
         raise ValueError(f"unsupported test state: {state}")
+
+
+# ---------------------------------------------------------------------------
+# /release
+# ---------------------------------------------------------------------------
+
+
+def test_release_happy_path(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """Release an in-progress task back to queued with audit history."""
+    task = _seed_task_in_state(api_config, project_root, state="in_progress")
+    response = client.post(
+        f"/api/v1/tasks/myproj/{task.task_number}/release",
+        json={"actor": "operator", "reason": "stale claim"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    released = body["task"]
+    assert released["work_status"] == "queued"
+    assert released["assignee"] is None
+    assert released["claimed_by_session"] is None
+    assert released["current_node_id"] == task.current_node_id
+    assert any(
+        transition["from_state"] == "in_progress"
+        and transition["to_state"] == "queued"
+        and transition["reason"] == "stale claim"
+        for transition in released["transitions"]
+    )
+    assert all(
+        execution["status"] != "active"
+        for execution in released["executions"]
+    )
+
+
+def test_release_illegal_from_done(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """Completed tasks cannot be released/unclaimed."""
+    task = _seed_task_in_state(api_config, project_root, state="done")
+    response = client.post(
+        f"/api/v1/tasks/myproj/{task.task_number}/release",
+        json={"actor": "operator"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409, response.text
+    assert response.json()["error"]["code"] == "invalid_state"
 
 
 # ---------------------------------------------------------------------------
@@ -354,6 +403,7 @@ def test_in_progress_illegal_from_done(
 def test_lifecycle_endpoints_require_auth(client) -> None:
     """Every new verb honors the same bearer-auth gate as /claim."""
     for verb in (
+        "release",
         "done",
         "approve",
         "hold",
@@ -372,6 +422,7 @@ def test_lifecycle_endpoints_require_auth(client) -> None:
 def test_lifecycle_endpoints_unknown_project_404(client, auth_headers) -> None:
     """Unknown project key surfaces as 404 with the standard envelope."""
     for verb in (
+        "release",
         "done",
         "approve",
         "hold",


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add `POST /api/v1/tasks/{project}/{n}/release` for stale/accidental active-claim recovery.
- Route release through the work-service lifecycle boundary: `in_progress`/`rework` return to `queued`, assignee and `claimed_by_session` are cleared, active executions are abandoned, `current_node_id` is preserved, and transition/audit history is written.
- Document the endpoint and request schema in OpenAPI, including no idempotency/If-Match support and 503 coverage.

Closes #2114.

## Tests
- `python -m py_compile src/pollypm/work/pg_service.py src/pollypm/work/mock_service.py src/pollypm/work/service.py src/pollypm/web_api/service.py src/pollypm/web_api/routes/tasks.py src/pollypm/web_api/models.py tests/web_api/test_tasks_lifecycle_endpoints.py tests/web_api/test_openapi_conformance.py tests/test_pg_work_service_full.py tests/test_work_service_protocol_conformance.py`
- `uv run --extra test pytest tests/web_api/test_tasks_lifecycle_endpoints.py -q` (19 passed)
- `uv run --extra test pytest tests/web_api/test_tasks_lifecycle_endpoints.py::test_release_happy_path tests/web_api/test_tasks_lifecycle_endpoints.py::test_release_illegal_from_done tests/web_api/test_tasks_lifecycle_endpoints.py::test_lifecycle_endpoints_require_auth tests/web_api/test_tasks_lifecycle_endpoints.py::test_lifecycle_endpoints_unknown_project_404 -q` (4 passed)
- `uv run --extra test pytest tests/test_pg_work_service_full.py::test_release_active_claim_returns_to_queue_preserving_node tests/test_pg_work_service_full.py::test_release_rejects_terminal_task tests/test_work_service_protocol_conformance.py -q` (34 passed)
- `uv run --extra dev --extra test pytest tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31 tests/web_api/test_openapi_conformance.py::test_contract_lists_phase_1_paths tests/web_api/test_openapi_conformance.py::test_implementation_serves_phase_1_paths tests/web_api/test_openapi_conformance.py::test_static_yaml_does_not_advertise_idempotency_or_ifmatch_on_tasks tests/web_api/test_openapi_conformance.py::test_static_yaml_declares_503_on_task_write_paths tests/web_api/test_openapi_conformance.py::test_task_write_endpoints_document_503 tests/web_api/test_openapi_conformance.py::test_task_release_request_schema_forbids_extras -q` (7 passed)
- `uv run --extra dev ruff check src/pollypm/work/pg_service.py src/pollypm/work/mock_service.py src/pollypm/work/service.py src/pollypm/web_api/models.py src/pollypm/web_api/routes/tasks.py src/pollypm/web_api/service.py tests/web_api/test_tasks_lifecycle_endpoints.py tests/web_api/test_openapi_conformance.py tests/test_pg_work_service_full.py tests/test_work_service_protocol_conformance.py`
- `git diff --check`
