### PR TITLE
fix(web_api): clear claimed_by_session on reopen

### DIFF
--- a/src/pollypm/work/mock_service.py
+++ b/src/pollypm/work/mock_service.py
@@ -520,6 +520,9 @@ class MockWorkService:
         task.work_status = WorkStatus.QUEUED
         task.assignee = None
         task.current_node_id = None
+        # #2220: clear the prior worker's session id so a reopened
+        # task doesn't trip "already claimed" checks on the next claim.
+        task.claimed_by_session = None
         task.updated_at = _now()
         self._record_transition(
             task_id,

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -1318,9 +1318,14 @@ class PgWorkService:
                         ExecutionStatus.ACTIVE.value,
                     ),
                 )
+                # #2220: also clear claimed_by_session so the queued
+                # row doesn't carry the prior worker's session id —
+                # otherwise the next claim attempt sees a stale
+                # "already claimed" breadcrumb on a freshly queued task.
                 cur.execute(
                     "UPDATE work_tasks SET work_status = %s, "
                     "assignee = NULL, current_node_id = NULL, "
+                    "claimed_by_session = NULL, "
                     "updated_at = %s "
                     "WHERE project = %s AND task_number = %s",
                     (WorkStatus.QUEUED.value, now, project, task_number),

--- a/tests/web_api/test_tasks_lifecycle_endpoints.py
+++ b/tests/web_api/test_tasks_lifecycle_endpoints.py
@@ -369,6 +369,50 @@ def test_lifecycle_endpoints_require_auth(client) -> None:
         assert response.status_code == 401, (verb, response.text)
 
 
+# ---------------------------------------------------------------------------
+# /reopen — claim-cleanup regression (#2220)
+# ---------------------------------------------------------------------------
+
+
+def test_reopen_clears_claimed_by_session(
+    api_config, client, auth_headers, project_root
+) -> None:
+    """A reopened task must NULL out claimed_by_session (#2220).
+
+    Black-box session 2026-05-24 found a cancel+reopen cycle left the
+    queued row carrying the prior worker's session id. The next claim
+    attempt could then trip "already claimed" guards on a task the
+    operator just explicitly re-queued. Pin the cleanup on the reopen
+    path so the bug can't regress.
+    """
+    # Seed a cancelled task whose flow has been claimed once — that's
+    # what writes claimed_by_session in the first place. The shared
+    # ``_seed_task_in_state(..., state="cancelled")`` helper does:
+    # queue -> claim (claimed_by_session="agent-1") -> cancel.
+    task = _seed_task_in_state(api_config, project_root, state="cancelled")
+    assert task.claimed_by_session is not None, (
+        "test precondition: cancel-from-in-progress should leave "
+        "claimed_by_session set so reopen has something to clear"
+    )
+
+    # ``TaskReopenRequest`` is reason-only (no ``actor``); the route
+    # supplies actor="api" itself.
+    response = client.post(
+        f"/api/v1/tasks/myproj/{task.task_number}/reopen",
+        json={"reason": "rerun"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["task"]["work_status"] == "queued"
+    assert body["task"]["claimed_by_session"] is None, (
+        "claimed_by_session must be cleared on reopen (#2220), got "
+        f"{body['task']['claimed_by_session']!r}"
+    )
+
+
 def test_lifecycle_endpoints_unknown_project_404(client, auth_headers) -> None:
     """Unknown project key surfaces as 404 with the standard envelope."""
     for verb in (


### PR DESCRIPTION
## Summary
- Clear `claimed_by_session` (set to NULL) when `/api/v1/tasks/{project}/{n}/reopen` flips a cancelled task back to `queued`. Without this, the reopened row carries the prior worker's session id and the next claim attempt can trip "already claimed" guards on a task the operator just re-queued.
- Mirror the same cleanup in `MockWorkService.reopen` for symmetry with the existing `_rollback_claim_to_queued` precedent in `pg_service`.
- Regression test in `tests/web_api/test_tasks_lifecycle_endpoints.py` pins the behavior end-to-end: seed → claim → cancel → reopen → assert response.task.claimed_by_session is None.

## Context
Triage 2026-05-24: closing PR #2251 dropped this scope. PR #2254 shipped the lifecycle REST verbs (done/approve/hold/rework/block/review/in_progress) but the reopen-cleanup chunk wasn't part of that diff. Minimum-diff fix per RC-stability guidance.

Closes #2220.

## Test plan
- [x] `pytest tests/web_api/test_tasks_lifecycle_endpoints.py -x -q` — 18 passed (17 existing + new regression).
- [x] `pytest tests/test_pg_work_service_full.py -k "reopen or cancel"` — 3 passed.
- [ ] (Codex) full suite via CI.

Touched files:
- `src/pollypm/work/pg_service.py` — add `claimed_by_session = NULL` to the reopen UPDATE.
- `src/pollypm/work/mock_service.py` — clear `task.claimed_by_session` in the in-memory reopen path.
- `tests/web_api/test_tasks_lifecycle_endpoints.py` — new `test_reopen_clears_claimed_by_session`.

Robot generated by [Claude Code](https://claude.com/claude-code)