### PR TITLE
fix(cascade): emit audit event when role-lane self-heal fails

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -162,6 +162,16 @@ EVENT_WATCHDOG_TIER3_DISPATCH_FAILED = "watchdog.tier3_dispatch_failed"
 # so forensic reads can confirm which queued / in-flight task drove
 # the spawn.
 EVENT_WATCHDOG_WORKER_LANE_SPAWNED = "audit.worker_lane_spawned"
+# #2225 — fires when the ``role_session_missing`` self-heal attempt
+# fails (missing role metadata, missing config, supervisor load raise,
+# tmux launch raise, reviewer provision returned ``None``, etc). One
+# event per failed attempt; metadata carries ``role``, ``project``,
+# ``task_subject``, and ``reason`` (a short token identifying which
+# guard / except branch fired). Without this event the audit log shows
+# repeated ``audit.finding`` rows for ``role_session_missing`` with no
+# corresponding spawn or failure trace, making it impossible to tell
+# whether the cascade tried and failed vs never tried at all.
+EVENT_WATCHDOG_WORKER_LANE_FAILED = "audit.worker_lane_failed"
 # #1546 — fires when the watchdog repairs a tracked project whose
 # canonical ``.pollypm/state.db`` is missing (only legacy archives
 # remain). Metadata carries ``project_key`` and ``project_path`` so
@@ -1132,6 +1142,7 @@ __all__ = [
     "EVENT_WATCHDOG_OPERATOR_DISPATCHED",
     "EVENT_WATCHDOG_TIER3_DISPATCH_FAILED",
     "EVENT_WATCHDOG_WORKER_LANE_SPAWNED",
+    "EVENT_WATCHDOG_WORKER_LANE_FAILED",
     "EVENT_WATCHDOG_PROJECT_TRACKED_MODE_REPAIRED",
     "EVENT_DAEMON_REAPED",
     "EVENT_DAEMON_REVIVED",

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -1504,6 +1504,48 @@ def _self_heal_duplicate_advisor_tasks_counter(
     }
 
 
+def _emit_worker_lane_failed(
+    *,
+    project_key: str,
+    finding: Finding,
+    role: str,
+    reason: str,
+    project_path: Path | None,
+) -> None:
+    """#2225 — best-effort forensic event for a failed role-lane spawn.
+
+    Mirrors the success emit at the tail of
+    :func:`_self_heal_role_session_missing` so operators can grep the
+    audit log for ``audit.worker_lane_failed`` rows to see *why* a
+    ``role_session_missing`` finding is not producing a spawn. Without
+    this, the failure path is silent and indistinguishable (in the audit
+    log) from "the cascade never tried."
+    """
+    try:
+        from pollypm.audit import emit as _audit_emit
+        from pollypm.audit.log import EVENT_WATCHDOG_WORKER_LANE_FAILED
+
+        _audit_emit(
+            event=EVENT_WATCHDOG_WORKER_LANE_FAILED,
+            project=project_key,
+            subject=finding.subject,
+            actor="audit_watchdog",
+            status="warn",
+            metadata={
+                "role": role,
+                "project": project_key,
+                "task_subject": finding.subject,
+                "reason": reason,
+            },
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: emit worker_lane_failed failed",
+            exc_info=True,
+        )
+
+
 def _self_heal_role_session_missing(
     finding: Finding,
     *,
@@ -1523,12 +1565,26 @@ def _self_heal_role_session_missing(
     Idempotent — when the existing session lookup hits a match, we no-op
     and return ``{"worker_lane_spawned": 0}`` so the counter doesn't lie
     about how many lanes were actually created.
+
+    #2225 — every failure return path now emits an
+    ``audit.worker_lane_failed`` event with a ``reason`` token so the
+    audit log carries a positive signal that the cascade *attempted* a
+    spawn and the attempt failed (vs the prior silent path that left
+    operators staring at repeated ``audit.finding`` rows with no
+    corresponding spawn / failure event).
     """
     counters = {"worker_lane_spawned": 0, "worker_lane_failed": 0}
     meta = finding.metadata or {}
     role = meta.get("role") or ""
     if not role:
         counters["worker_lane_failed"] += 1
+        _emit_worker_lane_failed(
+            project_key=project_key,
+            finding=finding,
+            role="",
+            reason="missing_role_metadata",
+            project_path=project_path,
+        )
         return counters
     if role == "worker":
         # Per-task workers are provisioned automatically by ``pm task
@@ -1549,6 +1605,13 @@ def _self_heal_role_session_missing(
             task_id = finding.subject or ""
         if not task_id or "/" not in task_id:
             counters["worker_lane_failed"] += 1
+            _emit_worker_lane_failed(
+                project_key=project_key,
+                finding=finding,
+                role=role,
+                reason="reviewer_missing_task_id",
+                project_path=project_path,
+            )
             return counters
         try:
             from pollypm.config import DEFAULT_CONFIG_PATH, load_config
@@ -1560,17 +1623,38 @@ def _self_heal_role_session_missing(
                 "for %s", task_id, exc_info=True,
             )
             counters["worker_lane_failed"] += 1
+            _emit_worker_lane_failed(
+                project_key=project_key,
+                finding=finding,
+                role=role,
+                reason="reviewer_import_failed",
+                project_path=project_path,
+            )
             return counters
         cfg_path = config_path
         if cfg_path is None and DEFAULT_CONFIG_PATH.exists():
             cfg_path = DEFAULT_CONFIG_PATH
         if cfg_path is None:
             counters["worker_lane_failed"] += 1
+            _emit_worker_lane_failed(
+                project_key=project_key,
+                finding=finding,
+                role=role,
+                reason="reviewer_missing_config",
+                project_path=project_path,
+            )
             return counters
         try:
             cfg = load_config(cfg_path)
         except Exception:  # noqa: BLE001
             counters["worker_lane_failed"] += 1
+            _emit_worker_lane_failed(
+                project_key=project_key,
+                finding=finding,
+                role=role,
+                reason="reviewer_load_config_failed",
+                project_path=project_path,
+            )
             return counters
         try:
             # #1887 — thread ``config=cfg`` through the factory so the
@@ -1634,9 +1718,23 @@ def _self_heal_role_session_missing(
                 task_id, exc_info=True,
             )
             counters["worker_lane_failed"] += 1
+            _emit_worker_lane_failed(
+                project_key=project_key,
+                finding=finding,
+                role=role,
+                reason="reviewer_provision_raised",
+                project_path=project_path,
+            )
             return counters
         if window is None:
             counters["worker_lane_failed"] += 1
+            _emit_worker_lane_failed(
+                project_key=project_key,
+                finding=finding,
+                role=role,
+                reason="reviewer_provision_returned_none",
+                project_path=project_path,
+            )
         else:
             counters["worker_lane_spawned"] += 1
         return counters
@@ -1657,6 +1755,13 @@ def _self_heal_role_session_missing(
                 cfg_path = DEFAULT_CONFIG_PATH
             else:
                 counters["worker_lane_failed"] += 1
+                _emit_worker_lane_failed(
+                    project_key=project_key,
+                    finding=finding,
+                    role=role,
+                    reason="missing_config_path",
+                    project_path=project_path,
+                )
                 return counters
         supervisor = cli_mod._load_supervisor(cfg_path)
         existing = next(
@@ -1680,12 +1785,19 @@ def _self_heal_role_session_missing(
         else:
             session = existing
         cli_mod.launch_worker_session(cfg_path, session.name)
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         logger.warning(
             "audit.watchdog: role-lane spawn failed for %s/%s",
             project_key, role, exc_info=True,
         )
         counters["worker_lane_failed"] += 1
+        _emit_worker_lane_failed(
+            project_key=project_key,
+            finding=finding,
+            role=role,
+            reason=f"spawn_raised:{type(exc).__name__}",
+            project_path=project_path,
+        )
         return counters
     counters["worker_lane_spawned"] += 1
     # Best-effort forensic event so operators can grep the audit log

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -992,6 +992,154 @@ def test_tier1_healer_role_session_missing_reviewer_role_routes_per_task(
 
 
 # ---------------------------------------------------------------------------
+# #2225 — failure path emits an audit event so operators can see the
+# cascade *tried* and failed (vs the prior silent path that only
+# logged ``audit.finding`` rows without any spawn/failure signal).
+# ---------------------------------------------------------------------------
+
+
+def test_self_heal_role_session_missing_emits_failed_event_on_missing_role(
+    tmp_path: Path,
+) -> None:
+    """A finding with no ``role`` metadata fails fast — the failure
+    path must emit ``audit.worker_lane_failed`` so the audit log
+    surfaces the attempt + reason.
+
+    #2225 regression: pre-fix the failure paths only logged via
+    ``logger.warning`` (process-local) and bumped a counter — the
+    audit log carried no positive signal that the cascade tried.
+    """
+    from pollypm.audit.log import EVENT_WATCHDOG_WORKER_LANE_FAILED
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _self_heal_role_session_missing,
+    )
+
+    finding = Finding(
+        rule=RULE_ROLE_SESSION_MISSING,
+        tier=TIER_1,
+        project="demo",
+        subject="demo/7",
+        metadata={},  # explicitly empty — no "role" key
+    )
+    counters = _self_heal_role_session_missing(
+        finding,
+        project_key="demo",
+        project_path=None,
+        config_path=tmp_path / "pollypm.toml",
+    )
+    assert counters["worker_lane_failed"] == 1
+    rows = read_events("demo", event=EVENT_WATCHDOG_WORKER_LANE_FAILED)
+    assert len(rows) >= 1
+    last = rows[-1]
+    assert last.subject == "demo/7"
+    assert (last.metadata or {}).get("reason") == "missing_role_metadata"
+
+
+def test_self_heal_role_session_missing_emits_failed_event_on_spawn_raise(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """When ``create_worker_session`` / ``launch_worker_session`` raises,
+    the catch-all path must emit ``audit.worker_lane_failed`` with a
+    ``reason`` that captures the exception type token.
+
+    #2225 regression: pre-fix the operator could see 1000+ findings
+    with zero spawn AND zero failure events; this assertion makes
+    sure the audit log carries the attempt signal even when the
+    spawn machinery raises.
+    """
+    from pollypm.audit.log import EVENT_WATCHDOG_WORKER_LANE_FAILED
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _self_heal_role_session_missing,
+    )
+
+    class _StubSession:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _StubSupervisorConfig:
+        def __init__(self) -> None:
+            self.sessions: dict[str, Any] = {}
+
+    class _StubSupervisor:
+        def __init__(self) -> None:
+            self.config = _StubSupervisorConfig()
+
+    def _stub_load_supervisor(_path: Any) -> _StubSupervisor:
+        return _StubSupervisor()
+
+    def _stub_create(*_args: Any, **kwargs: Any) -> _StubSession:
+        return _StubSession(f"{kwargs['role']}-{kwargs['project_key']}")
+
+    def _stub_launch_raises(_cfg: Any, _name: str) -> None:
+        raise RuntimeError("tmux unreachable")
+
+    import pollypm.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_load_supervisor", _stub_load_supervisor)
+    monkeypatch.setattr(cli_mod, "create_worker_session", _stub_create)
+    monkeypatch.setattr(cli_mod, "launch_worker_session", _stub_launch_raises)
+
+    finding = Finding(
+        rule=RULE_ROLE_SESSION_MISSING,
+        tier=TIER_1,
+        project="demo",
+        subject="demo/42",
+        metadata={"role": "advisor", "expected_window": "advisor-demo"},
+    )
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("[project]\nname = 'Demo'\n")
+    counters = _self_heal_role_session_missing(
+        finding,
+        project_key="demo",
+        project_path=None,
+        config_path=config_path,
+    )
+    assert counters["worker_lane_failed"] == 1
+    assert counters["worker_lane_spawned"] == 0
+    rows = read_events("demo", event=EVENT_WATCHDOG_WORKER_LANE_FAILED)
+    assert len(rows) >= 1
+    last = rows[-1]
+    assert last.subject == "demo/42"
+    meta = last.metadata or {}
+    assert meta.get("role") == "advisor"
+    assert meta.get("project") == "demo"
+    # Reason token includes the exception class so operators can
+    # triage without re-running the cadence.
+    assert "RuntimeError" in (meta.get("reason") or "")
+
+
+def test_self_heal_role_session_missing_reviewer_missing_task_id_emits_failed(
+    tmp_path: Path,
+) -> None:
+    """The reviewer branch's task-id guard also emits the failure
+    event, distinguishable by ``reason=reviewer_missing_task_id``."""
+    from pollypm.audit.log import EVENT_WATCHDOG_WORKER_LANE_FAILED
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _self_heal_role_session_missing,
+    )
+
+    finding = Finding(
+        rule=RULE_ROLE_SESSION_MISSING,
+        tier=TIER_1,
+        project="demo",
+        # subject has no slash — task_id reconstruction will also fail.
+        subject="demo",
+        metadata={"role": "reviewer", "status": "review"},
+    )
+    counters = _self_heal_role_session_missing(
+        finding,
+        project_key="demo",
+        project_path=None,
+        config_path=tmp_path / "pollypm.toml",
+    )
+    assert counters["worker_lane_failed"] == 1
+    rows = read_events("demo", event=EVENT_WATCHDOG_WORKER_LANE_FAILED)
+    assert len(rows) >= 1
+    last = rows[-1]
+    assert (last.metadata or {}).get("reason") == "reviewer_missing_task_id"
+
+
+# ---------------------------------------------------------------------------
 # Tier-3 operator dispatch — throttle, audit emit, no-op for ineligible rules
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Claude
- Authoring persona: Claude Fixer
- Creator label: claude-created
- Reviewer/merge agent: Codex
- Ownership label: needs-codex

## Diagnosis (#2225)

The cascade for advisor/architect pane respawn is *almost* fully wired:

- Detector emits `audit.finding{rule=role_session_missing}` whenever an
  open task's expected `<role>-<project>` tmux window is missing.
- `_TIER1_HEALERS[RULE_ROLE_SESSION_MISSING] = _self_heal_role_session_missing`
  is registered in `audit_watchdog.py`.
- The healer calls `cli_mod.create_worker_session` + `launch_worker_session`,
  and on success emits `audit.worker_lane_spawned`.

But every **failure** return path inside the healer is silent — it bumps
the `worker_lane_failed` counter and logs at WARNING (process-local),
with no audit-log row. So operators observing the audit log see:

```
1356 role_session_missing findings (pollypm.jsonl, 2026-05-09 .. 2026-05-24)
   1 worker_lane_spawned
   0 worker_lane_failed
```

…which is indistinguishable from "the cascade detected the missing pane
and then did nothing." There is no forensic surface that tells the
operator *whether the cascade tried* or *why the attempt failed*.

(For context: the 1342 worker-role findings are intentionally no-op'd by
the healer per #2023 — per-task workers spawn via `pm task claim`, not
via a long-running `worker-<project>` lane. The 13 actionable advisor
findings are the ones #2225 is about.)

## Fix (minimum-diff)

Adds a new `EVENT_WATCHDOG_WORKER_LANE_FAILED = "audit.worker_lane_failed"`
event and a `_emit_worker_lane_failed(...)` helper. Every failure return
inside `_self_heal_role_session_missing` now emits one event with a
short `reason` token so the audit log carries the attempt signal:

| Path | `reason` |
|---|---|
| `meta["role"]` missing | `missing_role_metadata` |
| advisor/architect `config_path` unresolvable | `missing_config_path` |
| advisor/architect spawn raises | `spawn_raised:<ExceptionClass>` |
| reviewer branch — no task_id | `reviewer_missing_task_id` |
| reviewer branch — imports raise | `reviewer_import_failed` |
| reviewer branch — config unresolvable | `reviewer_missing_config` |
| reviewer branch — load_config raises | `reviewer_load_config_failed` |
| reviewer branch — provision_reviewer raises | `reviewer_provision_raised` |
| reviewer branch — provision_reviewer returns None | `reviewer_provision_returned_none` |

Mirrors the existing `audit.worker_lane_spawned` emit shape — no logic
change, no new dependencies, no refactor. Just adds the forensic
surface so the next time an advisor/architect pane goes un-respawned,
the audit log carries `audit.worker_lane_failed` rows with the
exception class / guard name and operators can triage without
re-running the cadence.

## Scope note for reviewers

This PR is **diagnostic visibility**, not the underlying spawn-bug fix.
With this in place, the next observation of "advisor pane killed, no
respawn" will produce `audit.worker_lane_failed` rows whose `reason`
tokens point at the specific failure mode, and a targeted follow-up
can fix that mode. Without this, the failure is unobservable in audit
and #2225 stays "the cascade detects but does nothing."

If the operator-observed symptom turns out to be "no finding fires at
all" (i.e., the detector skips advisor entirely when no open advisor
task exists, which is by design — see `_detect_role_session_missing`
which iterates `open_tasks`), that's a separate detector-scope issue,
not a cascade-action gap.

## Tests

`HOME=$(mktemp -d) uv run --extra test pytest tests/test_heartbeat_cascade_foundation.py -k role_session_missing -q`
→ **13 passed** (10 pre-existing + 3 new):

- `test_self_heal_role_session_missing_emits_failed_event_on_missing_role`
- `test_self_heal_role_session_missing_emits_failed_event_on_spawn_raise`
- `test_self_heal_role_session_missing_reviewer_missing_task_id_emits_failed`

Each asserts the `audit.worker_lane_failed` row lands with the right
`subject`, `role`, `project`, and `reason` token.

## Pre-existing failures (NOT caused by this PR)

A broader `pytest -k 'cascade or pane or respawn or watchdog'` shows 18
pre-existing failures (cockpit / supervisor / persona / heartbeat /
test_heartbeat_role_respawn). Verified on `origin/main` without this
PR's changes — they predate this branch. Not fixed here to keep the
diff minimal.

## Scope note (revised 2026-05-24 after Codex review)

This PR is **diagnostic visibility only** — it does NOT fix the #2225 respawn contract. The actual root-cause fix (advisor/architect lane is recreated within the recovery window) is left as a follow-up because the current healer leaves the advisor/architect failure paths as `worker_lane_failed` returns without retry/respawn. This PR makes those failure returns visible in the audit log so the next operator (or fixer) can reason about *why* respawn isn't happening before changing the spawn logic.

Refs #2225 (do not auto-close).

## Test plan
- [ ] CI green on `tests/test_heartbeat_cascade_foundation.py`
- [ ] Grep pollypm.jsonl for `audit.worker_lane_failed` after next pane-kill smoke; expect rows with `reason` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
