### PR TITLE
fix(api): enforce queue endpoint baseline

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1229,6 +1229,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/ValidationError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -489,7 +489,7 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | GET    | `/api/v1/tasks/{project}/{n}` | Task detail — status, node, executions, transitions |
 | POST   | `/api/v1/tasks/{project}/{n}/approve` | Approve plan or code review |
 | POST   | `/api/v1/tasks/{project}/{n}/reject` | Reject + capture reason |
-| POST   | `/api/v1/tasks/{project}/{n}/queue` | Queue a draft task |
+| POST   | `/api/v1/tasks/{project}/{n}/queue` | Queue a draft task; failed pre-queue gates return `422 validation_error` |
 | POST   | `/api/v1/tasks/{project}/{n}/claim` | Claim a queued task (activate first node, keep `assignee` role-derived, record request `actor` as `claimed_by_session`, fires `queued→in_progress`). Returns `429 worker_cap_exceeded` when the project is at `max_parallel_workers` (#2064 round-11). Post-commit cap races may roll the row back to `queued`; the response `message` and `warnings[]` describe the actual state |
 | POST   | `/api/v1/tasks/{project}/{n}/cancel` | Cancel a non-terminal task (mapped to `svc.cancel`; optional `reason` — absent reasons resolve to `"cancelled via API"` in the audit row). In-progress tasks require `?force=true`; without it the API returns `409 confirmation_required` |
 | POST   | `/api/v1/tasks/{project}/{n}/reopen` | Reopen a cancelled task to `queued`, clearing live claim fields and preserving history in `work_transitions` |

--- a/src/pollypm/web_api/routes/tasks.py
+++ b/src/pollypm/web_api/routes/tasks.py
@@ -219,6 +219,7 @@ def get_task_endpoint(project: str, n: int, config: ConfigDep) -> TaskDetail:
         "401": {"description": "Missing or invalid bearer token."},
         "404": {"description": "Project or task not found."},
         "409": {"description": "Task is not in a queueable state."},
+        "422": {"description": "Task failed pre-queue validation gates."},
         # #2064 round-9 blocker #3: the service helper catches
         # ``_BACKING_STORE_ERRORS`` and raises ``service_unavailable``;
         # advertise that here so generated clients branch on the same

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -1632,6 +1632,17 @@ def queue_task(
             config=config, project_key=project_key, project_path=project.path
         ) as svc:
             try:
+                current = svc.get(task_id)
+                if current.work_status.value != "draft":
+                    raise APIError(
+                        status_code=409,
+                        code="invalid_state",
+                        message=(
+                            f"Cannot queue task in '{current.work_status.value}' state. "
+                            "Task must be in 'draft' state."
+                        ),
+                        hint="Only draft tasks can be queued; refresh the task to see the current work_status.",
+                    )
                 svc.queue(task_id, actor)
             except TaskNotFoundError as exc:
                 raise not_found(f"Task not found: {task_id}") from exc

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -1117,11 +1117,35 @@ class PgWorkService:
                 "fast-track queue bypass recorded via --skip-gates",
                 entry_type="human_review_approved",
             )
+        transition_reason = None
+        if not skip_gates:
+            from pollypm.work.gates import (
+                GateRegistry,
+                evaluate_gates,
+                has_hard_failure,
+            )
+
+            registry = GateRegistry(project_path=self._project_path)
+            kwargs: dict[str, object] = {"get_task": self.get}
+            if self._project_path is not None:
+                kwargs["project_root"] = self._project_path
+            results = evaluate_gates(
+                task, ["has_description"], registry, **kwargs
+            )
+            if has_hard_failure(results):
+                failing = [r for r in results if not r.passed]
+                reason = failing[0].reason if failing else "unknown gate failure"
+                raise ValidationError(
+                    f"Cannot queue task: gate failed -- {reason}"
+                )
+        else:
+            transition_reason = "fast-track queue bypass recorded via --skip-gates"
         return self._simple_transition(
             task_id,
             from_state=WorkStatus.DRAFT,
             to_state=WorkStatus.QUEUED,
             actor=actor,
+            reason=transition_reason,
         )
 
     def has_human_review_approval(self, task_id: str) -> bool:

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -383,13 +383,6 @@ def _create_standard_task(svc, project="proj", title="My task", description="Do 
 
 
 class TestSkipGates:
-    @pytest.mark.xfail(
-        reason=(
-            "PgWorkService.queue() doesn't enforce description/readiness "
-            "gates yet (#1767, same gap as requires_human_review)"
-        ),
-        strict=False,
-    )
     def test_skip_gates_allows_queue_without_description(self, svc):
         """queue a task with no description but skip_gates=True succeeds."""
         task = _create_standard_task(svc, description="")

--- a/tests/test_pg_work_service.py
+++ b/tests/test_pg_work_service.py
@@ -139,6 +139,7 @@ def test_list_tasks_filter_by_status(pg_service):
     a = pg_service.create(
         title="a", type="task", project="demo",
         flow_template="default", roles={"worker": "x"},
+        description="ready to queue",
     )
     pg_service.create(
         title="b", type="task", project="demo",
@@ -155,6 +156,7 @@ def test_queue_transitions_draft_to_queued(pg_service):
     task = pg_service.create(
         title="x", type="task", project="demo",
         flow_template="default", roles={"worker": "a"},
+        description="ready to queue",
     )
     queued = pg_service.queue(f"demo/{task.task_number}", actor="user")
     assert queued.work_status is WorkStatus.QUEUED
@@ -164,6 +166,7 @@ def test_queue_writes_transition_row(pg_service, pg_schema_pool):
     task = pg_service.create(
         title="x", type="task", project="demo",
         flow_template="default", roles={"worker": "a"},
+        description="ready to queue",
     )
     pg_service.queue(f"demo/{task.task_number}", actor="user")
     with pg_schema_pool.connection() as conn, conn.cursor() as cur:
@@ -182,6 +185,7 @@ def test_queue_is_idempotent(pg_service):
     task = pg_service.create(
         title="x", type="task", project="demo",
         flow_template="default", roles={"worker": "a"},
+        description="ready to queue",
     )
     pg_service.queue(f"demo/{task.task_number}", actor="user")
     second = pg_service.queue(f"demo/{task.task_number}", actor="user")
@@ -230,6 +234,7 @@ def test_state_counts_aggregates(pg_service):
     a = pg_service.create(
         title="a", type="task", project="demo",
         flow_template="default", roles={"worker": "a"},
+        description="ready to queue",
     )
     pg_service.create(
         title="b", type="task", project="demo",

--- a/tests/test_pg_work_service_parity.py
+++ b/tests/test_pg_work_service_parity.py
@@ -32,8 +32,8 @@ Implemented in Slice A (mirrored here):
   labels, acceptance criteria, full round-trip.
 * ``TestGetTask`` — get, missing-raises.
 * ``TestListTasks`` — by project, by status, by type, all.
-* ``TestQueue`` (subset) — happy path only; the validation gates
-  (description-required, requires_human_review) are Slice-B.
+* ``TestQueue`` (subset) — happy path, idempotency, and
+  description-required validation.
 * ``TestCancel`` (subset) — happy path + reject-terminal.
 * ``TestMarkDone`` (subset) — happy path + idempotency.
 * ``TestListNonterminalTasks`` — Slice-A specific (no sqlite mirror).
@@ -41,7 +41,7 @@ Implemented in Slice A (mirrored here):
 Deferred — TODO when each slice lands:
 
 * ``TestUpdateTask`` — Slice B (``update``).
-* ``TestQueue`` validation paths — Slice B (gates).
+* ``TestQueue`` remaining validation paths — Slice B (human review).
 * ``TestClaim`` — Slice B (worker session provisioning).
 * ``TestHoldResume`` / ``TestBlock`` — Slice B (transition manager).
 * ``TestTransitions`` — Slice B (audit emission).
@@ -69,6 +69,7 @@ from pollypm.work.models import (
 from pollypm.work.service_support import (
     InvalidTransitionError,
     TaskNotFoundError,
+    ValidationError,
 )
 
 
@@ -232,9 +233,12 @@ class TestQueue:
         again = pg_work_service.queue(tid, actor="pm")
         assert again.work_status is WorkStatus.QUEUED
 
-    @pytest.mark.skip(reason="description-required gate lands in Slice B.")
     def test_queue_without_description(self, pg_work_service):
-        ...
+        task = _create_pg_task(pg_work_service, description="")
+        with pytest.raises(ValidationError, match="gate failed"):
+            pg_work_service.queue(
+                f"{task.project}/{task.task_number}", actor="pm"
+            )
 
     @pytest.mark.skip(
         reason="requires_human_review gate + skip_gates lands in Slice B."


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Reject non-draft Web API queue requests with `409 invalid_state` before calling the idempotent work-service queue path.
- Restore PG queue `has_description` gate enforcement and preserve `--skip-gates` transition breadcrumbs.
- Document the queue endpoint `422 validation_error` response and update queue gate tests.

Fixes #2272

## Verification
- `uv run --extra test pytest tests/web_api/test_endpoints.py::test_queue_endpoint_409_for_already_queued_task tests/web_api/test_endpoints.py::test_queue_endpoint_422_when_gate_fails --no-header -q`
- `uv run --extra test pytest tests/web_api/test_endpoints.py -q`
- `uv run --extra test pytest tests/test_pg_work_service.py tests/test_pg_work_service_parity.py::TestQueue tests/test_gates.py::TestSkipGates -q`
- `uv run --extra test --with openapi-spec-validator pytest tests/web_api/test_openapi_conformance.py -q`
- `uv run --with ruff ruff check src/pollypm/work/pg_service.py src/pollypm/web_api/service.py src/pollypm/web_api/routes/tasks.py tests/test_pg_work_service.py tests/test_pg_work_service_parity.py tests/test_gates.py`