### PR TITLE
perf(api): remove task list hydration fanout

### DIFF
--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -1230,7 +1230,7 @@ def list_project_tasks(
             if len(tasks) > limit and page:
                 next_cursor = str(getattr(page[-1], "task_number", 0))
             return [
-                _task_to_summary(_task_for_summary(svc, t)) for t in page
+                _task_to_summary(t) for t in page
             ], next_cursor, total
     except _BACKING_STORE_ERRORS as exc:
         logger.warning(
@@ -1310,7 +1310,7 @@ def list_all_tasks(
     warnings: list[dict[str, object]] = []
 
     if include_untracked:
-        tasks = _list_tasks_from_workspace(config, project=project, hydrate=True)
+        tasks = _list_tasks_from_workspace(config, project=project)
         for task in tasks:
             if not _task_matches_list_filters(
                 task,
@@ -1361,7 +1361,7 @@ def list_all_tasks(
                 since=since,
             ):
                 continue
-            summaries.append(_task_to_summary(_task_for_summary(svc, task)))
+            summaries.append(_task_to_summary(task))
 
     try:
         dropped_count = _count_untracked_matches(

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -510,15 +510,16 @@ class PgWorkService:
         # avoid the N+1 hit on big result sets.
         keys = [(str(r[0]), int(r[1])) for r in rows]
         rels_by_key = self._load_relationships_bulk(keys)
-        tasks = [
-            self._row_to_task(
+        transitions_by_key = self._load_transitions_bulk(keys)
+        tasks = []
+        for row in rows:
+            key = (str(row[0]), int(row[1]))
+            task = self._row_to_task(
                 row,
-                relationships=rels_by_key.get(
-                    (str(row[0]), int(row[1])), None
-                ),
+                relationships=rels_by_key.get(key, None),
             )
-            for row in rows
-        ]
+            task.transitions = transitions_by_key.get(key, [])
+            tasks.append(task)
         # ``blocked`` post-filter mirrors the sqlite behaviour: the column
         # is derived from ``work_status``, so callers passing
         # ``blocked=True/False`` get the same surface either backend.
@@ -751,6 +752,40 @@ class PgWorkService:
             for r in rows
         ]
 
+    def _load_transitions_bulk(
+        self, keys: list[tuple[str, int]]
+    ) -> dict[tuple[str, int], list[Transition]]:
+        """Load transition history for many tasks in one query."""
+        if not keys:
+            return {}
+        pairs = list(dict.fromkeys(keys))
+        projects = [project for project, _number in pairs]
+        task_numbers = [number for _project, number in pairs]
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT task_project, task_number, from_state, to_state, "
+                "actor, reason, created_at "
+                "FROM work_transitions "
+                "WHERE (task_project, task_number) IN ("
+                "SELECT * FROM unnest(%s::text[], %s::int[])) "
+                "ORDER BY task_project, task_number, id ASC",
+                (projects, task_numbers),
+            )
+            rows = cur.fetchall()
+        by_key: dict[tuple[str, int], list[Transition]] = {}
+        for row in rows:
+            key = (str(row[0]), int(row[1]))
+            by_key.setdefault(key, []).append(
+                Transition(
+                    from_state=str(row[2]),
+                    to_state=str(row[3]),
+                    actor=str(row[4]),
+                    reason=row[5],
+                    timestamp=row[6],
+                )
+            )
+        return by_key
+
     def _load_context_entries(
         self, project: str, task_number: int
     ) -> list[ContextEntry]:
@@ -815,32 +850,28 @@ class PgWorkService:
         """
         if not keys:
             return {}
-        out: dict[tuple[str, int], dict] = {key: _empty_rels() for key in keys}
-        # We don't have a single VALUES clause that scales to thousands
-        # of rows ergonomically, so issue one query that pulls every
-        # row touching ANY of the keys, then bucket in Python.
-        where_clauses: list[str] = []
-        params: list[object] = []
-        for project, number in keys:
-            where_clauses.append(
-                "(from_project = %s AND from_task_number = %s) "
-                "OR (to_project = %s AND to_task_number = %s)"
-            )
-            params.extend([project, number, project, number])
-        clause = " OR ".join(where_clauses)
+        pairs = list(dict.fromkeys(keys))
+        out: dict[tuple[str, int], dict] = {key: _empty_rels() for key in pairs}
+        projects = [project for project, _number in pairs]
+        task_numbers = [number for _project, number in pairs]
         sql = (
+            "WITH keys(project, task_number) AS ("
+            "SELECT * FROM unnest(%s::text[], %s::int[])) "
             "SELECT from_project, from_task_number, "
             "to_project, to_task_number, kind "
-            f"FROM work_task_dependencies WHERE {clause}"
+            "FROM work_task_dependencies d "
+            "JOIN keys k ON "
+            "(d.from_project = k.project AND d.from_task_number = k.task_number) "
+            "OR (d.to_project = k.project AND d.to_task_number = k.task_number)"
         )
         with self._pool.connection() as conn, conn.cursor() as cur:
-            cur.execute(sql, params)
+            cur.execute(sql, (projects, task_numbers))
             all_rows = cur.fetchall()
         # Bucket by both endpoints (outgoing and incoming relative to
         # each key) and re-use the same aggregator the per-task path
         # uses, so the wire shape is identical.
-        key_set = set(keys)
-        bucket: dict[tuple[str, int], list[tuple]] = {k: [] for k in keys}
+        key_set = set(pairs)
+        bucket: dict[tuple[str, int], list[tuple]] = {k: [] for k in pairs}
         for row in all_rows:
             from_p, from_n, to_p, to_n, kind = (
                 str(row[0]),

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -165,6 +165,66 @@ def test_list_tasks_timing_uses_latest_transition(
     assert item["age_seconds"] > item["dwell_seconds"]
 
 
+def test_list_all_tasks_uses_list_rows_without_per_item_refetch(
+    api_config, monkeypatch
+) -> None:
+    """The flat task list must not turn a page into N extra ``get`` calls."""
+    from contextlib import contextmanager
+    from types import SimpleNamespace
+
+    from pollypm.web_api import service as svc_mod
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+
+    class FakeTask(SimpleNamespace):
+        @property
+        def task_id(self) -> str:
+            return f"{self.project}/{self.task_number}"
+
+    task = FakeTask(
+        project="myproj",
+        task_number=1,
+        title="No refetch",
+        work_status="queued",
+        type="task",
+        priority="normal",
+        assignee=None,
+        claimed_by_session=None,
+        current_node_id=None,
+        plan_version=1,
+        created_at=now - timedelta(hours=1),
+        updated_at=now,
+        transitions=[
+            SimpleNamespace(to_state="queued", timestamp=now - timedelta(minutes=5))
+        ],
+    )
+
+    class FakeService:
+        def list_tasks(self, *, project=None, **_kwargs):
+            if project in (None, "myproj"):
+                return [task]
+            return []
+
+        def get(self, task_id):  # pragma: no cover - failure path
+            raise AssertionError(f"unexpected per-item refetch: {task_id}")
+
+    @contextmanager
+    def fake_open(**_kwargs):
+        yield FakeService()
+
+    monkeypatch.setattr(svc_mod, "_open_work_service_readonly", fake_open)
+
+    items, next_cursor, warnings, total = svc_mod.list_all_tasks(
+        api_config, limit=10
+    )
+
+    assert [item.task_id for item in items] == ["myproj/1"]
+    assert items[0].state_entered_at == now - timedelta(minutes=5)
+    assert next_cursor is None
+    assert warnings == []
+    assert total == 1
+
+
 def test_list_tasks_project_filter(
     api_config, client, auth_headers, project_root, workspace_root
 ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Remove per-row `svc.get()` hydration from the task list API paths; list rows are now used directly.
- Bulk-load PgWorkService transitions so timing fields still use the latest transition without N extra reads.
- Replace the relationship bulk hydrator's generated OR chain with an `unnest` join so broad task scans scale with one bounded query shape.

Addresses #2274, #2276, and #2277. The direct fix is the `/api/v1/tasks?limit=200` N+1 fanout called out in #2277; this also reduces the shared broad task scan used during dashboard/cold-load fanout, but live operator-load p95 should still be remeasured after review.

## Perf Evidence
Synthetic `list_all_tasks(limit=200)` benchmark against the old branch and this branch, with a fake work-service `get()` sleeping 2ms to model the removed per-row store round-trip:

- Before: n=40, tasks=200, get_calls=8000, p50=2.3519s, p95=2.9172s, p99=2.9574s, max=2.9574s
- After: n=40, tasks=200, get_calls=0, p50=0.0029s, p95=0.0031s, p99=0.0033s, max=0.0033s

## Verification
- `uv run --extra test pytest tests/web_api/test_tasks_list_endpoint.py tests/test_pg_work_service.py tests/test_dashboard_endpoint.py tests/test_dashboard_data_pg.py -q` -> 57 passed
- `uv run --with ruff ruff check src/pollypm/work/pg_service.py src/pollypm/web_api/service.py tests/web_api/test_tasks_list_endpoint.py`
