### PR TITLE
fix(ui): add inbox deep link and structured route 404s

### DIFF
--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -42,6 +42,7 @@ from pollypm.web_api.token import DEFAULT_TOKEN_PATH, load_token
 from pollypm.web_api.errors import (
     APIError,
     handle_api_error,
+    handle_not_found,
     handle_unhandled_exception,
     handle_validation_error,
 )
@@ -478,6 +479,7 @@ def create_app(
     # shape.
     app.add_exception_handler(APIError, handle_api_error)
     app.add_exception_handler(RequestValidationError, handle_validation_error)
+    app.add_exception_handler(404, handle_not_found)
     app.add_exception_handler(Exception, handle_unhandled_exception)
 
     # Wire the briefings provider so /api/v1/briefings reports
@@ -729,6 +731,9 @@ def _mount_web_ui(
       ``pollypm-session`` cookie, so subsequent ``fetch(...,
       {credentials: 'include'})`` calls authenticate without the user
       ever seeing the bearer token.
+    - ``GET /ui/inbox`` (and the dashboard-adjacent ``/ui/tasks`` /
+      ``/ui/alerts`` aliases) serve the same SPA shell so bookmarked
+      operator surfaces don't fall through to the static-file 404.
     - ``GET /ui/{path}`` (e.g. ``app.js``, ``styles.css``) is served by
       :class:`StaticFiles` from the ``ui/`` directory next to this
       module. No auth on the static assets themselves — the bytes are
@@ -757,6 +762,12 @@ def _mount_web_ui(
         # is canonical" without altering verbs.
         return Response(status_code=307, headers={"Location": "/ui/"})
 
+    @app.get("/ui/alerts/", include_in_schema=False)
+    @app.get("/ui/alerts", include_in_schema=False)
+    @app.get("/ui/tasks/", include_in_schema=False)
+    @app.get("/ui/tasks", include_in_schema=False)
+    @app.get("/ui/inbox/", include_in_schema=False)
+    @app.get("/ui/inbox", include_in_schema=False)
     @app.get("/ui/", include_in_schema=False)
     def _ui_index(
         request: Request,

--- a/src/pollypm/web_api/errors.py
+++ b/src/pollypm/web_api/errors.py
@@ -203,6 +203,11 @@ async def handle_validation_error(
     return error_response(api_err)
 
 
+async def handle_not_found(request: Request, _exc: Exception) -> JSONResponse:
+    api_err = not_found(f"{request.url.path} is not a known endpoint")
+    return error_response(api_err)
+
+
 async def handle_unhandled_exception(_request: Request, exc: Exception) -> JSONResponse:
     """Last-resort catch — never let a stack trace leak."""
     api_err = APIError(
@@ -218,6 +223,7 @@ __all__ = [
     "conflict",
     "error_response",
     "handle_api_error",
+    "handle_not_found",
     "handle_unhandled_exception",
     "handle_validation_error",
     "internal_error",

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -2203,19 +2203,21 @@
           return;
         }
       }
+      if (card.target === "inbox") {
+        selectInbox(card.filter || undefined);
+        return;
+      }
       renderDashboardDrilldown(card);
     };
   }
 
   // Dashboard rail cards always render as buttons with a Playwright-friendly
-  // aria-label and route through `dashboardCardAction` for drill-down. PR
-  // #2266's `selectInbox` workflow remains reachable via the inbox surface
-  // rail entry; merging both click semantics into the same card produced
-  // ambiguous routing, so we standardize on the PR #2172 button shape here.
+  // aria-label and route through `dashboardCardAction` for drill-down.
   function buildCard(label, value, cls, scoped, action, detail) {
     const labelText = scoped ? label + " (filtered)" : label;
     const button = el("button", {
       type: "button",
+      role: "button",
       class: "rollup-card " + (cls || ""),
       "aria-label": "Open dashboard detail for " + labelText + ": " + value,
     }, [
@@ -2257,10 +2259,10 @@
         dashboardCardAction({
           label: "inbox",
           value: rollups.open_inbox_count + " items",
-          target: "surface",
-          detail: "Opens an active chat surface when one is visible.",
+          target: "inbox",
+          detail: "Opens the inbox view.",
         }, data),
-        "Open an active chat surface",
+        "Open inbox",
       ));
     }
     if (typeof rollups.pending_plan_reviews === "number") {
@@ -2272,10 +2274,11 @@
         dashboardCardAction({
           label: "plan reviews",
           value: rollups.pending_plan_reviews + " waiting",
-          target: "review-task",
-          detail: "Opens a visible task waiting on review when available.",
+          target: "inbox",
+          filter: { type: "plan_review" },
+          detail: "Opens inbox items waiting on plan review.",
         }, data),
-        "Open a review task",
+        "Open plan reviews",
       ));
     }
     if (typeof rollups.alert_count === "number") {
@@ -2799,6 +2802,14 @@
     }
   }
 
+  function initialUiRoute() {
+    const path = window.location && window.location.pathname
+      ? window.location.pathname.replace(/\/+$/, "")
+      : "";
+    if (path === "/ui/inbox") return "inbox";
+    return null;
+  }
+
   function init() {
     maybeShowSessionExpiryBanner();
     wireProjectControls();
@@ -2806,7 +2817,11 @@
     wireActivityControls();
     wireSendForm();
     wireStopAgentButton();
-    renderNoSelection();
+    if (initialUiRoute() === "inbox") {
+      selectInbox();
+    } else {
+      renderNoSelection();
+    }
     setStatus("warn", "connecting…");
     loadSurfaces();
     startEventStream();

--- a/tests/playwright/tests/inbox.spec.ts
+++ b/tests/playwright/tests/inbox.spec.ts
@@ -67,6 +67,21 @@ async function stubChrome(page: import("@playwright/test").Page) {
 }
 
 test.describe("inbox panel", () => {
+  test("inbox deep link opens the inbox view on boot", async ({ page }) => {
+    await stubChrome(page);
+    await page.route("**/api/v1/inbox?**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [ITEM], next_cursor: null }),
+      }),
+    );
+
+    await page.goto("/ui/inbox");
+    await expect(page.locator("#pane-title")).toHaveText("Inbox");
+    await expect(page.locator("[data-inbox-id='demo/1']")).toContainText("Plan ready");
+  });
+
   test("dashboard inbox card opens browsable list with load more and disabled plan decisions", async ({ page }) => {
     await stubChrome(page);
 

--- a/tests/web_api/test_endpoints.py
+++ b/tests/web_api/test_endpoints.py
@@ -523,6 +523,18 @@ def test_validation_error_shape_for_bad_query(client, auth_headers) -> None:
     assert all("field" in row and "message" in row for row in body["details"])
 
 
+def test_unknown_api_route_uses_structured_not_found(client, auth_headers) -> None:
+    response = client.get("/api/v1/nonexistent", headers=auth_headers)
+    assert response.status_code == 404
+    body = response.json()
+    assert body == {
+        "error": {
+            "code": "not_found",
+            "message": "/api/v1/nonexistent is not a known endpoint",
+        }
+    }
+
+
 # ---------------------------------------------------------------------------
 # Backing-store failures during work-service construction map to 503.
 #

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -106,6 +106,17 @@ def test_ui_root_returns_html_and_sets_session_cookie(client: TestClient, token:
     )
 
 
+def test_ui_deep_links_return_spa_shell_and_set_session_cookie(
+    client: TestClient, token: str,
+) -> None:
+    for path in ("/ui/inbox", "/ui/tasks", "/ui/alerts"):
+        response = client.get(path, headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html")
+        assert "/ui/app.js" in response.text
+        _assert_signed_session_cookie(response.cookies.get(SESSION_COOKIE_NAME), token)
+
+
 # -------- P0 #1: cookie issuance gating ---------------------------------
 
 
@@ -242,6 +253,12 @@ def test_ui_app_js_uses_sse_refresh_with_polling_fallback(
     assert "POLL_MESSAGES_MS" not in body
     assert "POLL_DASHBOARD_MS" not in body
     assert "setInterval(pollDashboard" not in body
+
+
+def test_ui_app_js_selects_inbox_for_deep_link(client: TestClient) -> None:
+    body = client.get("/ui/app.js").text
+    assert 'path === "/ui/inbox"' in body
+    assert "selectInbox();" in body
 
 
 def test_ui_static_css_served(client: TestClient) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Serve `/ui/inbox`, `/ui/tasks`, and `/ui/alerts` through the SPA shell instead of falling through to static 404s.
- Auto-open the inbox view for `/ui/inbox` and route inbox/plan-review dashboard cards to the inbox workflow.
- Return the standard typed error envelope for unknown API routes.

Fixes #2278.
Fixes #2280.

## Verification
- `node --check src/pollypm/web_api/ui/app.js`
- `git diff --check`
- `uv run --extra test pytest tests/web_api/test_web_ui.py::test_ui_deep_links_return_spa_shell_and_set_session_cookie tests/web_api/test_web_ui.py::test_ui_app_js_selects_inbox_for_deep_link tests/web_api/test_web_ui.py::test_render_dashboard_real_payload_executes tests/web_api/test_endpoints.py::test_unknown_api_route_uses_structured_not_found -q`
- `uv run --extra test pytest tests/web_api/test_web_ui.py tests/web_api/test_endpoints.py -q`
- `uv run --with ruff ruff check src/pollypm/web_api/app.py src/pollypm/web_api/errors.py tests/web_api/test_web_ui.py tests/web_api/test_endpoints.py`
- `npm ci` in `tests/playwright`
- `POLLYPM_BASE_URL=http://127.0.0.1:8898 npx playwright test tests/inbox.spec.ts --project=chromium`