### PR TITLE
fix(audit): mirror pause skips to canonical log

### DIFF
--- a/src/pollypm/session_paused.py
+++ b/src/pollypm/session_paused.py
@@ -407,10 +407,11 @@ def skip_if_paused(
     is paused.
 
     ``store`` — when supplied, the helper emits a ``session.pause.skip``
-    event via ``store.record_event(scope, sender, subject)`` so the
-    cockpit / audit log records that the loop honoured the marker
-    rather than silently dropping the call. Best-effort: any store
-    error is swallowed so a flaky event-write can't unblock the guard.
+    event via ``store.record_event(scope, sender, subject)`` and the
+    canonical audit log so cockpit readers and ``pm audit`` can both
+    see that the loop honoured the marker rather than silently
+    dropping the call. Best-effort: any event-write error is swallowed
+    so a flaky audit path can't unblock the guard.
 
     ``loop`` / ``reason`` — free-form context used to build the audit
     subject. ``loop`` is the calling site (e.g. ``"supervisor.maybe_recover_session"``,
@@ -432,7 +433,7 @@ def skip_if_paused(
     if not is_paused(config, session_name):
         return False
     if store is not None and _should_emit_skip(session_name, loop):
-        _emit_pause_skip(store, session_name, loop=loop, reason=reason)
+        _emit_pause_skip(config, store, session_name, loop=loop, reason=reason)
     return True
 
 
@@ -473,7 +474,12 @@ def _reset_skip_throttle_for_tests() -> None:
 
 
 def _emit_pause_skip(
-    store: Any, session_name: str, *, loop: str = "", reason: str = "",
+    config: Any,
+    store: Any,
+    session_name: str,
+    *,
+    loop: str = "",
+    reason: str = "",
 ) -> None:
     """Best-effort emit of the ``session.pause.skip`` audit event.
 
@@ -490,9 +496,6 @@ def _emit_pause_skip(
     failure is swallowed: the guard side is the contract, the audit
     event is observability only.
     """
-    record = getattr(store, "record_event", None)
-    if not callable(record):
-        return
     subject_loop = loop or "unknown_loop"
     subject = (
         f"skipped {session_name} — {subject_loop} honored pause marker"
@@ -503,6 +506,15 @@ def _emit_pause_skip(
         "loop": subject_loop,
         "reason": reason,
     }
+    record = getattr(store, "record_event", None)
+    if not callable(record):
+        _emit_pause_skip_audit(
+            config,
+            session_name,
+            subject=subject,
+            payload=payload,
+        )
+        return
     try:
         record(
             scope=session_name,
@@ -510,7 +522,6 @@ def _emit_pause_skip(
             subject=subject,
             payload=payload,
         )
-        return
     except TypeError:
         # Older / legacy ``record_event(session_name, event_type, message)``
         # positional shape — fall through.
@@ -520,6 +531,13 @@ def _emit_pause_skip(
             "session.pause.skip emit (kw) failed for %s", session_name,
             exc_info=True,
         )
+    else:
+        _emit_pause_skip_audit(
+            config,
+            session_name,
+            subject=subject,
+            payload=payload,
+        )
         return
     try:
         record(session_name, PAUSE_SKIP_EVENT_TYPE, subject)
@@ -527,6 +545,49 @@ def _emit_pause_skip(
         logger.debug(
             "session.pause.skip emit (positional) failed for %s",
             session_name, exc_info=True,
+        )
+    _emit_pause_skip_audit(
+        config,
+        session_name,
+        subject=subject,
+        payload=payload,
+    )
+
+
+def _emit_pause_skip_audit(
+    config: Any,
+    session_name: str,
+    *,
+    subject: str,
+    payload: dict[str, Any],
+) -> None:
+    """Mirror pause-skip events into the canonical audit JSONL."""
+    try:
+        from pollypm.audit import emit as _audit_emit
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "session.pause.skip canonical audit import failed for %s",
+            session_name,
+            exc_info=True,
+        )
+        return
+
+    project_key, project_path = _project_audit_context(config)
+    try:
+        _audit_emit(
+            event=PAUSE_SKIP_EVENT_TYPE,
+            project=project_key,
+            subject=subject,
+            actor="system",
+            status="ok",
+            metadata=payload,
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "session.pause.skip canonical audit emit failed for %s",
+            session_name,
+            exc_info=True,
         )
 
 

--- a/tests/test_session_paused_marker_wiring.py
+++ b/tests/test_session_paused_marker_wiring.py
@@ -104,6 +104,18 @@ def _write_marker(config: _FakeConfig, names: list[str]) -> Path:
     return path
 
 
+def _read_pause_skip_audit_events(config: _FakeConfig) -> list[Any]:
+    from pollypm.audit.log import read_events
+    from pollypm.session_paused import PAUSE_SKIP_EVENT_TYPE
+
+    return read_events(
+        config.project.name,
+        project_path=config.project.root_dir,
+        event=PAUSE_SKIP_EVENT_TYPE,
+        limit=20,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Unit — session_paused reader
 # ---------------------------------------------------------------------------
@@ -686,6 +698,15 @@ def test_skip_if_paused_emits_audit_event_on_skip(
     assert "unit_test" in event["subject"]
     assert event["payload"]["loop"] == "unit_test"
     assert event["payload"]["reason"] == "failure_type=missing_window"
+    audit_events = _read_pause_skip_audit_events(config_with_base_dir)
+    assert len(audit_events) == 1
+    audit_event = audit_events[0]
+    assert audit_event.event == PAUSE_SKIP_EVENT_TYPE
+    assert audit_event.project == "demo"
+    assert audit_event.subject == event["subject"]
+    assert audit_event.actor == "system"
+    assert audit_event.status == "ok"
+    assert audit_event.metadata == event["payload"]
 
 
 def test_skip_if_paused_no_store_still_returns_true(
@@ -736,10 +757,12 @@ def test_skip_if_paused_throttles_repeat_audit_emission(
     skip_events = [
         e for e in captured if e.get("sender") == PAUSE_SKIP_EVENT_TYPE
     ]
+    audit_events = _read_pause_skip_audit_events(config_with_base_dir)
     assert len(skip_events) == 1, (
         f"expected 1 throttled skip event, got {len(skip_events)}: "
         f"{skip_events}"
     )
+    assert len(audit_events) == 1
 
 
 def test_skip_if_paused_throttle_is_per_loop(
@@ -792,6 +815,9 @@ def test_skip_if_paused_throttle_is_per_loop(
         "no_session_spawn.auto_recover",
         "supervisor.maybe_recover_session",
     }
+    audit_events = _read_pause_skip_audit_events(config_with_base_dir)
+    assert len(audit_events) == 2
+    assert {event.metadata["loop"] for event in audit_events} == loops
 
 
 def test_skip_if_paused_swallows_store_errors(
@@ -820,6 +846,9 @@ def test_skip_if_paused_swallows_store_errors(
         config_with_base_dir, "operator", store=_FlakyStore(),
         loop="flaky_store",
     ) is True
+    audit_events = _read_pause_skip_audit_events(config_with_base_dir)
+    assert len(audit_events) == 1
+    assert audit_events[0].metadata["loop"] == "flaky_store"
 
 
 # ---------------------------------------------------------------------------
@@ -963,6 +992,9 @@ def test_auto_recover_no_session_skips_paused_session(
     assert any(
         ev.get("sender") == "session.pause.skip" for ev in store.kw_events
     ), store.kw_events
+    audit_events = _read_pause_skip_audit_events(config_with_base_dir)
+    assert len(audit_events) == 1
+    assert audit_events[0].metadata["loop"] == "no_session_spawn.auto_recover"
 
 
 def test_auto_recover_no_session_spawns_when_not_paused(
@@ -1110,6 +1142,12 @@ def test_supervisor_maybe_recover_session_skips_paused_session(
     assert "supervisor.maybe_recover_session" in event["subject"]
     assert event["payload"]["loop"] == "supervisor.maybe_recover_session"
     assert "missing_window" in event["payload"]["reason"]
+    audit_events = _read_pause_skip_audit_events(config_with_base_dir)
+    assert len(audit_events) == 1
+    assert (
+        audit_events[0].metadata["loop"]
+        == "supervisor.maybe_recover_session"
+    )
 
 
 def test_supervisor_maybe_recover_session_proceeds_when_not_paused(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Mirror throttled `session.pause.skip` events into the canonical audit JSONL via `pollypm.audit.emit`.
- Preserve the existing message-store event for cockpit consumers and keep the guard best-effort if either audit path fails.
- Add regression coverage for direct guard calls plus no-session and supervisor recovery skip paths.

Fixes #2282.

## Verification
- `uv run --extra test pytest -q -p no:cacheprovider tests/test_session_paused_marker_wiring.py::test_skip_if_paused_emits_audit_event_on_skip tests/test_session_paused_marker_wiring.py::test_skip_if_paused_throttles_repeat_audit_emission tests/test_session_paused_marker_wiring.py::test_skip_if_paused_throttle_is_per_loop tests/test_session_paused_marker_wiring.py::test_skip_if_paused_swallows_store_errors tests/test_session_paused_marker_wiring.py::test_auto_recover_no_session_skips_paused_session tests/test_session_paused_marker_wiring.py::test_supervisor_maybe_recover_session_skips_paused_session`
- `uv run --extra test pytest -q -p no:cacheprovider tests/test_session_paused_marker_wiring.py`
- `uv run --with ruff ruff check src/pollypm/session_paused.py tests/test_session_paused_marker_wiring.py`
- `git diff --check`