### PR TITLE
fix(ui): preserve surface rail errors during push refresh

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -63,6 +63,7 @@
     sseStableOpenTimer: null,
     surfacesInFlight: false,
     surfacesRefreshQueued: false,
+    surfacesQueuedPreserveErrors: false,
     dashboardInFlight: false,
     dashboardRefreshQueued: false,
     historyInFlight: {},
@@ -424,12 +425,18 @@
 
   async function loadSurfaces(opts) {
     const force = opts && opts.force;
+    const preserveErrors = opts && opts.preserveErrors;
     if (state.surfacesInFlight) {
       if (force) {
         abortFetchState("surfaces");
         state.surfacesInFlight = false;
+        state.surfacesRefreshQueued = false;
+        state.surfacesQueuedPreserveErrors = false;
       } else {
         state.surfacesRefreshQueued = true;
+        state.surfacesQueuedPreserveErrors = (
+          state.surfacesQueuedPreserveErrors || !!preserveErrors
+        );
         return;
       }
     }
@@ -437,9 +444,11 @@
     state.surfaceLoading = true;
     state.taskLoading = true;
     state.projectLoading = true;
-    state.surfaceLoadError = null;
-    state.taskLoadError = null;
-    state.projectLoadError = null;
+    if (!preserveErrors) {
+      state.surfaceLoadError = null;
+      state.taskLoadError = null;
+      state.projectLoadError = null;
+    }
     const request = beginFetchState(
       "surfaces",
       "surfaces",
@@ -525,8 +534,10 @@
       if (!finishFetchState("surfaces", request.seq)) return;
       state.surfacesInFlight = false;
       if (state.surfacesRefreshQueued) {
+        const queuedPreserveErrors = state.surfacesQueuedPreserveErrors;
         state.surfacesRefreshQueued = false;
-        loadSurfaces();
+        state.surfacesQueuedPreserveErrors = false;
+        loadSurfaces({ preserveErrors: queuedPreserveErrors });
       }
     }
   }
@@ -2618,7 +2629,7 @@
 
   function refreshFromPush() {
     pollDashboard();
-    loadSurfaces();
+    loadSurfaces({ preserveErrors: true });
     loadActivity();
     if (state.selectedSurface) {
       loadHistory(state.selectedSurface);
@@ -2868,7 +2879,7 @@
     setStatus("warn", "connecting…");
     loadSurfaces();
     startEventStream();
-    setInterval(loadSurfaces, 30000);
+    setInterval(() => loadSurfaces({ preserveErrors: true }), 30000);
   }
 
   // Expose for tests / debugging. ``renderDashboard`` is exported so

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -742,6 +742,76 @@ test.describe("surfaces", () => {
     );
   });
 
+  test("SSE queued surface refresh preserves timeout error until success", async ({ page }) => {
+    await page.clock.install({ time: new Date("2026-05-23T00:00:00Z") });
+    await installHealthyEventSource(page);
+    await stubEmptyTasks(page);
+    await stubEmptyProjects(page);
+    await stubEmptyActivity(page);
+    await page.addInitScript(() => {
+      (window as any).__POLLYPM_RAIL_REQUEST_TIMEOUT_MS = 1000;
+    });
+    await page.route("**/api/v1/dashboard", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(0)),
+      }),
+    );
+
+    let sessionRequests = 0;
+    let secondRequestWaiting = false;
+    let releaseFirst: (() => void) | null = null;
+    let releaseSecond: (() => void) | null = null;
+    const firstRequestGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondRequestGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    await page.route("**/api/v1/chat/sessions", async (route) => {
+      sessionRequests += 1;
+      if (sessionRequests === 1) {
+        await firstRequestGate;
+      } else if (sessionRequests === 2) {
+        secondRequestWaiting = true;
+        await secondRequestGate;
+        secondRequestWaiting = false;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      }).catch(() => undefined);
+    });
+
+    await page.goto("/ui/", { waitUntil: "domcontentloaded" });
+    await page.clock.runFor(1);
+    await expect.poll(() => sessionRequests).toBe(1);
+
+    await emitAuditEvent(page, 1);
+    await page.clock.runFor(151);
+    await expect.poll(() =>
+      page.evaluate(() => (window as any).PollyPM.state.surfacesRefreshQueued),
+    ).toBe(true);
+
+    await page.clock.runFor(849);
+    await expect.poll(() => sessionRequests).toBe(2);
+    await expect.poll(() => secondRequestWaiting).toBe(true);
+    await expect(page.locator("#surface-list")).toContainText(
+      "error: chat unavailable: chat surfaces request timed out after 1s",
+      { timeout: 750 },
+    );
+
+    releaseSecond!();
+    await expect(page.locator("#surface-list .surface-empty")).toHaveText(
+      "no surfaces registered",
+      { timeout: 750 },
+    );
+    releaseFirst!();
+  });
+
   test("initial center-pane state shows inline next actions", async ({ page }) => {
     await page.goto("/ui/");
     await expect(page.locator("#pane-title")).toHaveText("Ready");


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Keep existing rail error envelopes visible during SSE/periodic background surface refreshes until replacement data succeeds.
- Carry the preserve-error intent through coalesced queued surface refreshes.
- Add a Playwright regression for the timeout + SSE queued-refresh race from #2286.

## Tests
- `git diff --check`
- `POLLYPM_BASE_URL=http://127.0.0.1:8776 npm test -- --grep 'SSE queued surface refresh'`
- `POLLYPM_BASE_URL=http://127.0.0.1:8776 npm test -- tests/surfaces.spec.ts --project=chromium`

Fixes #2286