### PR TITLE
fix(web): repair UI deep links and task-list hot path

### DIFF
--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -25,7 +25,6 @@ from fastapi import Depends, FastAPI, Header, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
-from fastapi.staticfiles import StaticFiles
 
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.web_api.auth import (
@@ -848,14 +847,27 @@ def _mount_web_ui(
         # `pm api regen-token`).
         return response
 
-    # Static assets served raw. ``html=False`` keeps StaticFiles from
-    # hijacking the bare ``/ui/`` path (we've already taken that route
-    # above with the cookie-setting handler).
-    app.mount(
-        "/ui",
-        StaticFiles(directory=str(ui_dir), html=False),
-        name="ui-static",
-    )
+    ui_root = ui_dir.resolve()
+    spa_deep_links = {"", "inbox", "tasks", "alerts"}
+
+    @app.get("/ui/{asset_path:path}", include_in_schema=False)
+    def _ui_static_asset(
+        asset_path: str,
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> Response:
+        normalized = asset_path.strip("/")
+        if normalized in spa_deep_links:
+            return _ui_index(request, authorization)
+
+        candidate = (ui_dir / asset_path).resolve()
+        try:
+            candidate.relative_to(ui_root)
+        except ValueError:
+            return Response("Not Found", status_code=404)
+        if not candidate.is_file():
+            return Response("Not Found", status_code=404)
+        return FileResponse(candidate)
 
 
 __all__ = ["API_V1_PREFIX", "create_app"]

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -40,6 +40,7 @@ from pollypm.work.inbox_view import (
     is_inbox_task,
     is_inbox_task_identity,
 )
+from pollypm.work.models import TaskSummaryCursorError, TaskSummaryProjection
 from pollypm.web_api.errors import (
     APIError,
     not_found,
@@ -1306,6 +1307,19 @@ def list_all_tasks(
     rows were omitted.
     """
     status_filter = set(statuses or [])
+    fast_page = _list_all_tasks_summary_page(
+        config,
+        project=project,
+        statuses=statuses,
+        assignee=assignee,
+        since=since,
+        include_untracked=include_untracked,
+        limit=limit,
+        cursor=cursor,
+    )
+    if fast_page is not None:
+        return fast_page
+
     summaries: list[APITaskSummary] = []
     warnings: list[dict[str, object]] = []
 
@@ -1397,11 +1411,104 @@ def list_all_tasks(
     )
 
 
+def _list_all_tasks_summary_page(
+    config: PollyPMConfig,
+    *,
+    project: str | None,
+    statuses: list[str] | None,
+    assignee: str | None,
+    since: datetime | None,
+    include_untracked: bool,
+    limit: int,
+    cursor: str | None,
+) -> tuple[list[APITaskSummary], str | None, list[dict[str, object]], int] | None:
+    workspace_root = _workspace_root_path(config)
+    tracked_keys = _tracked_project_keys(config)
+    # Multi-project reads keep the older per-project path so one failed
+    # project still surfaces as a partial-failure warning.
+    if not include_untracked and len(tracked_keys) > 1:
+        return None
+    try:
+        with _open_work_service_readonly(
+            config=config,
+            project_key="__workspace__",
+            project_path=workspace_root,
+        ) as svc:
+            list_page = getattr(svc, "list_task_summary_page", None)
+            count_matches = getattr(svc, "count_task_summary_matches", None)
+            if not callable(list_page) or not callable(count_matches):
+                return None
+
+            projects: tuple[str, ...] | None
+            page_project: str | None = None
+            if include_untracked:
+                projects = None
+                page_project = project
+            elif project is not None:
+                projects = (project,) if project in tracked_keys else ()
+            else:
+                projects = tracked_keys
+
+            rows, next_cursor, total = list_page(
+                projects=projects,
+                project=page_project,
+                work_statuses=tuple(statuses or ()),
+                assignee=assignee,
+                since=since,
+                limit=limit,
+                cursor=cursor,
+            )
+            warnings: list[dict[str, object]] = []
+            if not include_untracked:
+                if project is None:
+                    dropped_count = count_matches(
+                        exclude_projects=tracked_keys,
+                        work_statuses=tuple(statuses or ()),
+                        assignee=assignee,
+                        since=since,
+                    )
+                elif project not in tracked_keys:
+                    dropped_count = count_matches(
+                        project=project,
+                        work_statuses=tuple(statuses or ()),
+                        assignee=assignee,
+                        since=since,
+                    )
+                else:
+                    dropped_count = 0
+                if dropped_count:
+                    warnings.append(
+                        {
+                            "code": "untracked_filtered",
+                            "dropped_count": dropped_count,
+                            "reason": "untracked_projects",
+                        }
+                    )
+            return (
+                [_task_summary_projection_to_api(row) for row in rows],
+                next_cursor,
+                warnings,
+                total,
+            )
+    except TaskSummaryCursorError as exc:
+        raise StaleCursorError(str(exc)) from exc
+    except _BACKING_STORE_ERRORS:
+        return None
+
+
 def _tracked_project_keys(config: PollyPMConfig) -> tuple[str, ...]:
     return tuple(
         key
         for key, proj in config.projects.items()
         if getattr(proj, "tracked", True)
+    )
+
+
+def _workspace_root_path(config: PollyPMConfig) -> Path:
+    return Path(
+        getattr(config.project, "workspace_root", None)
+        or getattr(config.project, "root_dir", None)
+        or Path.cwd()
     )
 
 
@@ -1417,15 +1524,11 @@ def _task_for_summary(svc, task):
 def _list_tasks_from_workspace(
     config: PollyPMConfig, *, project: str | None, hydrate: bool = False
 ):
-    workspace_root = (
-        getattr(config.project, "workspace_root", None)
-        or getattr(config.project, "root_dir", None)
-        or Path.cwd()
-    )
+    workspace_root = _workspace_root_path(config)
     with _open_work_service_readonly(
         config=config,
         project_key="__workspace__",
-        project_path=Path(workspace_root),
+        project_path=workspace_root,
     ) as svc:
         tasks = svc.list_tasks(project=project)
         if hydrate:
@@ -3454,6 +3557,30 @@ def _task_to_summary(task) -> APITaskSummary:
         dwell_seconds=timing["dwell_seconds"],
         age_seconds=timing["age_seconds"],
         updated_at=getattr(task, "updated_at", None),
+    )
+
+
+def _task_summary_projection_to_api(row: TaskSummaryProjection) -> APITaskSummary:
+    created_at = _as_aware_datetime(row.created_at)
+    state_entered_at = _as_aware_datetime(row.state_entered_at) or created_at
+    now = datetime.now(timezone.utc)
+    return APITaskSummary(
+        task_id=row.task_id,
+        project=row.project,
+        task_number=row.task_number,
+        title=row.title,
+        work_status=row.work_status,
+        type=row.type,
+        priority=row.priority,
+        assignee=row.assignee,
+        claimed_by_session=row.claimed_by_session,
+        current_node_id=row.current_node_id,
+        plan_version=row.plan_version,
+        created_at=created_at,
+        state_entered_at=state_entered_at,
+        dwell_seconds=_elapsed_seconds(state_entered_at, now),
+        age_seconds=_elapsed_seconds(created_at, now),
+        updated_at=_as_aware_datetime(row.updated_at),
     )
 
 

--- a/src/pollypm/work/models.py
+++ b/src/pollypm/work/models.py
@@ -189,6 +189,30 @@ class Transition:
     reason: str | None = None
 
 
+class TaskSummaryCursorError(ValueError):
+    """Raised when a paged task-summary cursor is malformed or stale."""
+
+
+@dataclass(slots=True)
+class TaskSummaryProjection:
+    """Read-optimized task-list row owned by the work-service facade."""
+
+    task_id: str
+    project: str
+    task_number: int
+    title: str
+    work_status: str
+    type: str
+    priority: str
+    assignee: str | None = None
+    claimed_by_session: str | None = None
+    current_node_id: str | None = None
+    plan_version: int | None = None
+    created_at: datetime | None = None
+    state_entered_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
 # ---------------------------------------------------------------------------
 # Flow models
 # ---------------------------------------------------------------------------

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -65,6 +65,8 @@ from pollypm.work.models import (
     OutputType,
     Priority,
     Task,
+    TaskSummaryCursorError,
+    TaskSummaryProjection,
     TaskType,
     TERMINAL_STATUSES,
     Transition,
@@ -527,6 +529,100 @@ class PgWorkService:
             tasks = [task for task in tasks if task.blocked == blocked]
         return tasks
 
+    def list_task_summary_page(
+        self,
+        *,
+        projects: tuple[str, ...] | list[str] | None = None,
+        project: str | None = None,
+        work_statuses: tuple[str, ...] | list[str] | None = None,
+        assignee: str | None = None,
+        since: datetime | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> tuple[list[TaskSummaryProjection], str | None, int]:
+        """Return a cursor page of task-list summaries without full hydration."""
+        where, params = self._task_summary_where(
+            projects=projects,
+            project=project,
+            work_statuses=work_statuses,
+            assignee=assignee,
+            since=since,
+        )
+        total = self._count_task_summary_where(where, params)
+        epoch = datetime.min.replace(tzinfo=UTC)
+        page_where = list(where)
+        page_params = list(params)
+
+        if cursor is not None:
+            cursor_updated_at, cursor_task_id = self._parse_task_summary_cursor(cursor)
+            anchor_where = [
+                *where,
+                "COALESCE(wt.updated_at, %s) = %s",
+                "(wt.project || '/' || wt.task_number::text) = %s",
+            ]
+            anchor_params = [*params, epoch, cursor_updated_at, cursor_task_id]
+            if not self._task_summary_exists(anchor_where, anchor_params):
+                raise TaskSummaryCursorError("stale task summary cursor")
+            page_where.append(
+                "(COALESCE(wt.updated_at, %s), "
+                "(wt.project || '/' || wt.task_number::text)) < (%s, %s)"
+            )
+            page_params.extend([epoch, cursor_updated_at, cursor_task_id])
+
+        clause = (" WHERE " + " AND ".join(page_where)) if page_where else ""
+        capped_limit = max(1, int(limit))
+        sql = (
+            "SELECT wt.project, wt.task_number, wt.title, wt.work_status, "
+            "wt.type, wt.priority, wt.assignee, wt.claimed_by_session, "
+            "wt.current_node_id, wt.plan_version, wt.created_at, wt.updated_at, "
+            "COALESCE(("
+            "SELECT tr.created_at FROM work_transitions tr "
+            "WHERE tr.task_project = wt.project "
+            "AND tr.task_number = wt.task_number "
+            "AND tr.to_state = wt.work_status "
+            "ORDER BY tr.id DESC LIMIT 1"
+            "), wt.created_at) AS state_entered_at "
+            "FROM work_tasks wt"
+            + clause
+            + " ORDER BY COALESCE(wt.updated_at, %s) DESC, "
+            "(wt.project || '/' || wt.task_number::text) DESC "
+            "LIMIT %s"
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, [*page_params, epoch, capped_limit + 1])
+            rows = cur.fetchall()
+
+        projections = [self._row_to_task_summary_projection(row) for row in rows]
+        page = projections[:capped_limit]
+        next_cursor: str | None = None
+        if len(projections) > capped_limit and page:
+            last = page[-1]
+            next_cursor = (
+                f"{(last.updated_at or epoch).isoformat()}|{last.task_id}"
+            )
+        return page, next_cursor, total
+
+    def count_task_summary_matches(
+        self,
+        *,
+        projects: tuple[str, ...] | list[str] | None = None,
+        exclude_projects: tuple[str, ...] | list[str] | None = None,
+        project: str | None = None,
+        work_statuses: tuple[str, ...] | list[str] | None = None,
+        assignee: str | None = None,
+        since: datetime | None = None,
+    ) -> int:
+        """Count task-summary matches without hydrating task rows."""
+        where, params = self._task_summary_where(
+            projects=projects,
+            exclude_projects=exclude_projects,
+            project=project,
+            work_statuses=work_statuses,
+            assignee=assignee,
+            since=since,
+        )
+        return self._count_task_summary_where(where, params)
+
     def list_inbox_candidate_tasks(
         self,
         *,
@@ -636,6 +732,114 @@ class PgWorkService:
             )
             for row in rows
         ]
+
+    def _task_summary_where(
+        self,
+        *,
+        projects: tuple[str, ...] | list[str] | None = None,
+        exclude_projects: tuple[str, ...] | list[str] | None = None,
+        project: str | None = None,
+        work_statuses: tuple[str, ...] | list[str] | None = None,
+        assignee: str | None = None,
+        since: datetime | None = None,
+    ) -> tuple[list[str], list[object]]:
+        where: list[str] = []
+        params: list[object] = []
+        if projects is not None:
+            allowed = tuple(str(value) for value in projects)
+            if not allowed:
+                where.append("FALSE")
+            else:
+                where.append("wt.project = ANY(%s)")
+                params.append(list(allowed))
+        if exclude_projects:
+            excluded = tuple(str(value) for value in exclude_projects)
+            where.append("wt.project <> ALL(%s)")
+            params.append(list(excluded))
+        if project is not None:
+            where.append("wt.project = %s")
+            params.append(project)
+        if work_statuses:
+            statuses = tuple(str(value) for value in work_statuses)
+            where.append("wt.work_status = ANY(%s)")
+            params.append(list(statuses))
+        if assignee is not None:
+            where.append("wt.assignee = %s")
+            params.append(assignee)
+        if since is not None:
+            where.append("(wt.updated_at IS NULL OR wt.updated_at > %s)")
+            params.append(since)
+        return where, params
+
+    def _count_task_summary_where(
+        self, where: list[str], params: list[object]
+    ) -> int:
+        clause = (" WHERE " + " AND ".join(where)) if where else ""
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM work_tasks wt" + clause, params)
+            row = cur.fetchone()
+        return int(row[0] if row else 0)
+
+    def _task_summary_exists(
+        self, where: list[str], params: list[object]
+    ) -> bool:
+        clause = (" WHERE " + " AND ".join(where)) if where else ""
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM work_tasks wt" + clause + " LIMIT 1", params)
+            return cur.fetchone() is not None
+
+    def _parse_task_summary_cursor(
+        self, cursor: str
+    ) -> tuple[datetime, str]:
+        try:
+            updated_raw, task_id = cursor.split("|", 1)
+            updated_at = datetime.fromisoformat(updated_raw)
+        except (TypeError, ValueError) as exc:
+            raise TaskSummaryCursorError("invalid task summary cursor") from exc
+        if not task_id:
+            raise TaskSummaryCursorError("invalid task summary cursor")
+        if updated_at.tzinfo is None or updated_at.tzinfo.utcoffset(updated_at) is None:
+            updated_at = updated_at.replace(tzinfo=UTC)
+        else:
+            updated_at = updated_at.astimezone(UTC)
+        return updated_at, task_id
+
+    def _row_to_task_summary_projection(
+        self, row: tuple
+    ) -> TaskSummaryProjection:
+        (
+            project,
+            task_number,
+            title,
+            work_status,
+            type_raw,
+            priority,
+            assignee,
+            claimed_by_session,
+            current_node_id,
+            plan_version,
+            created_at,
+            updated_at,
+            state_entered_at,
+        ) = row
+        task_number_int = int(task_number)
+        project_str = str(project)
+        return TaskSummaryProjection(
+            task_id=f"{project_str}/{task_number_int}",
+            project=project_str,
+            task_number=task_number_int,
+            title=str(title),
+            work_status=str(work_status),
+            type=str(type_raw),
+            priority=str(priority),
+            assignee=assignee,
+            claimed_by_session=claimed_by_session,
+            current_node_id=current_node_id,
+            plan_version=int(plan_version or 1),
+            created_at=created_at,
+            state_entered_at=state_entered_at,
+            updated_at=updated_at,
+        )
 
     def _row_to_task(
         self,

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -18,9 +18,11 @@ state across runs.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
 
+from pollypm.work.models import TaskSummaryProjection
 from pollypm.work.factory import create_work_service
 
 from .conftest import make_task
@@ -141,7 +143,12 @@ def test_list_tasks_timing_uses_latest_transition(
     db_path = api_config.project.state_db
     db_path.parent.mkdir(parents=True, exist_ok=True)
     with create_work_service(db_path=db_path, project_path=project_root) as svc:
-        task = make_task(svc, project="myproj", title="Queued timing")
+        task = make_task(
+            svc,
+            project="myproj",
+            title="Queued timing",
+            description="queueable task",
+        )
         svc.queue(task.task_id, actor="tester")
 
     now = datetime.now(timezone.utc).replace(microsecond=0)
@@ -170,7 +177,6 @@ def test_list_all_tasks_uses_list_rows_without_per_item_refetch(
 ) -> None:
     """The flat task list must not turn a page into N extra ``get`` calls."""
     from contextlib import contextmanager
-    from types import SimpleNamespace
 
     from pollypm.web_api import service as svc_mod
 
@@ -207,6 +213,61 @@ def test_list_all_tasks_uses_list_rows_without_per_item_refetch(
 
         def get(self, task_id):  # pragma: no cover - failure path
             raise AssertionError(f"unexpected per-item refetch: {task_id}")
+
+    @contextmanager
+    def fake_open(**_kwargs):
+        yield FakeService()
+
+    monkeypatch.setattr(svc_mod, "_open_work_service_readonly", fake_open)
+
+    items, next_cursor, warnings, total = svc_mod.list_all_tasks(
+        api_config, limit=10
+    )
+
+    assert [item.task_id for item in items] == ["myproj/1"]
+    assert items[0].state_entered_at == now - timedelta(minutes=5)
+    assert next_cursor is None
+    assert warnings == []
+    assert total == 1
+
+
+def test_list_all_tasks_uses_summary_page_without_full_hydration(
+    api_config, monkeypatch
+) -> None:
+    from contextlib import contextmanager
+
+    from pollypm.web_api import service as svc_mod
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+
+    class FakeService:
+        def list_task_summary_page(self, **kwargs):
+            assert kwargs["projects"] == ("myproj",)
+            assert kwargs["limit"] == 10
+            return (
+                [
+                    TaskSummaryProjection(
+                        task_id="myproj/1",
+                        project="myproj",
+                        task_number=1,
+                        title="Projected",
+                        work_status="queued",
+                        type="task",
+                        priority="normal",
+                        created_at=now - timedelta(hours=1),
+                        state_entered_at=now - timedelta(minutes=5),
+                        updated_at=now,
+                    )
+                ],
+                None,
+                1,
+            )
+
+        def count_task_summary_matches(self, **_kwargs):
+            return 0
+
+        def list_tasks(self, **_kwargs):  # pragma: no cover - failure path
+            raise AssertionError("summary page must avoid full task hydration")
 
     @contextmanager
     def fake_open(**_kwargs):
@@ -334,7 +395,12 @@ def test_list_tasks_status_filter_or_semantics(
         # another so we have a status nobody asks for.
         make_task(svc, project="myproj", title="Drafty")
         cancelled = make_task(svc, project="myproj", title="Cancelled one")
-        queued = make_task(svc, project="myproj", title="Queued one")
+        queued = make_task(
+            svc,
+            project="myproj",
+            title="Queued one",
+            description="queueable task",
+        )
         svc.queue(queued.task_id, actor="tester")
         svc.cancel(cancelled.task_id, actor="tester", reason="cleanup")
 

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -27,12 +27,14 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+import socket
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
 import httpx
 import pytest
+import uvicorn
 from fastapi.testclient import TestClient
 
 from pollypm.cli_features.web_api import detect_tailscale_ip
@@ -115,6 +117,48 @@ def test_ui_deep_links_return_spa_shell_and_set_session_cookie(
         assert response.headers["content-type"].startswith("text/html")
         assert "/ui/app.js" in response.text
         _assert_signed_session_cookie(response.cookies.get(SESSION_COOKIE_NAME), token)
+
+
+def test_ui_deep_links_return_spa_shell_from_live_uvicorn(app, token: str) -> None:
+    async def _probe() -> None:
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+
+        server = uvicorn.Server(
+            uvicorn.Config(
+                app,
+                host="127.0.0.1",
+                port=port,
+                log_level="warning",
+            )
+        )
+        task = asyncio.create_task(server.serve())
+        try:
+            for _ in range(500):
+                if server.started:
+                    break
+                await asyncio.sleep(0.01)
+            assert server.started, "uvicorn server did not start"
+
+            async with httpx.AsyncClient() as ac:
+                for path in ("/ui/inbox", "/ui/tasks", "/ui/alerts"):
+                    response = await ac.get(
+                        f"http://127.0.0.1:{port}{path}",
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
+                    assert response.status_code == 200
+                    assert response.headers["content-type"].startswith("text/html")
+                    assert "/ui/app.js" in response.text
+                    _assert_signed_session_cookie(
+                        response.cookies.get(SESSION_COOKIE_NAME),
+                        token,
+                    )
+        finally:
+            server.should_exit = True
+            await task
+
+    asyncio.run(_probe())
 
 
 # -------- P0 #1: cookie issuance gating ---------------------------------


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Replace the `/ui` `StaticFiles` mount with an explicit asset route so `/ui/inbox`, `/ui/tasks`, and `/ui/alerts` always serve the SPA shell and mint the session cookie.
- Add a Postgres task-summary page facade for `/api/v1/tasks` so the hot path pages/counts summaries without hydrating full task records, relationships, and complete transition histories.
- Keep the multi-project partial-failure path on the existing per-project reader to preserve warning semantics.

## Verification
- `uv run --extra dev ruff check src/pollypm/web_api/app.py src/pollypm/web_api/service.py src/pollypm/work/models.py src/pollypm/work/pg_service.py tests/web_api/test_web_ui.py tests/web_api/test_tasks_list_endpoint.py`
- `uv run --extra test pytest tests/web_api/test_web_ui.py -q` (60 passed)
- `uv run --extra test pytest tests/web_api/test_tasks_list_endpoint.py -q` (18 passed)
- Live branch run from this worktree on port 8897: `/ui/inbox`, `/ui/tasks`, `/ui/alerts` all returned 200.
- Live `/api/v1/tasks?limit=200` timings on the local ~99KB response: 0.539s, 0.592s, 0.306s, 0.593s, 0.439s.

Closes #2288.
Closes #2289.
