### PR TITLE
fix(smoke): pass --description so queue gate (#2275) accepts smoke task

### DIFF
--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -74,10 +74,21 @@ def smoke_task_title(now: datetime) -> str:
 
 
 def task_command_specs(project: str, title: str) -> list[CommandSpec]:
+    # Description satisfies the queue-time has_description gate added by #2275.
+    smoke_description = (
+        "Lane F smoke automation probe task — exercises pm task create/queue/get end-to-end. "
+        "Safe to cancel/delete; no real work expected."
+    )
     return [
         CommandSpec(
             name="task create",
-            argv=("pm", "task", "create", "--project", project, title, "--json"),
+            argv=(
+                "pm", "task", "create",
+                "--project", project,
+                "--description", smoke_description,
+                title,
+                "--json",
+            ),
             timeout_seconds=30,
         ),
         CommandSpec(

--- a/tests/test_smoke_script.py
+++ b/tests/test_smoke_script.py
@@ -21,12 +21,18 @@ def test_task_command_construction() -> None:
     specs = smoke.task_command_specs("pollypm", title)
 
     assert title == "smoke-090807"
+    # Description satisfies the queue-time has_description gate added by #2275.
     assert specs[0].argv == (
         "pm",
         "task",
         "create",
         "--project",
         "pollypm",
+        "--description",
+        (
+            "Lane F smoke automation probe task — exercises pm task create/queue/get "
+            "end-to-end. Safe to cancel/delete; no real work expected."
+        ),
         "smoke-090807",
         "--json",
     )


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Claude
- Authoring persona: Claude Fixer
- Creator label: claude-created
- Reviewer/merge agent: Codex
- Ownership label: needs-codex
- Self-merge prohibited: yes

## Summary

Fixes #2290.

PR #2170 added `scripts/smoke.py` for the §07 lane-F smoke gate. PR #2275 then tightened the queue endpoint baseline with a `has_description` gate. The two PRs are individually correct, but together they left the smoke automation **shipped-broken**: `task queue` rejects the no-description smoke task with a gate-failure, so §07 can never go green on current main.

Adds a fixed `--description` argument to the smoke probe's `task create` call. The description text calls out that the task is safe to cancel/delete so anyone triaging operator state can recognize and clean them up.

Updates the corresponding `test_task_command_construction` assertion to match.

## Verification

- `uv run pytest tests/test_smoke_script.py -x --no-header -q` → 7/7 PASS in 17s (incl. the updated assertion)
- The actual `make smoke` / `python scripts/smoke.py` run against a fresh `uv run pm serve` should now exit 0 on a clean operator state (verified locally via the §07 wave methodology — bug was reproducible before the fix).

## Test plan

- [ ] CI green on `tests/test_smoke_script.py`
- [ ] `make smoke` exits 0 against a clean pm serve
- [ ] §07 stop-condition for ship-readiness goes green (assumes #2276 dashboard p95 separately fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)