### PR TITLE
fix(smoke): create queueable smoke task

### DIFF
--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -77,7 +77,17 @@ def task_command_specs(project: str, title: str) -> list[CommandSpec]:
     return [
         CommandSpec(
             name="task create",
-            argv=("pm", "task", "create", "--project", project, title, "--json"),
+            argv=(
+                "pm",
+                "task",
+                "create",
+                "--project",
+                project,
+                "--description",
+                "Lane F smoke validation task.",
+                title,
+                "--json",
+            ),
             timeout_seconds=30,
         ),
         CommandSpec(

--- a/tests/test_smoke_script.py
+++ b/tests/test_smoke_script.py
@@ -27,6 +27,8 @@ def test_task_command_construction() -> None:
         "create",
         "--project",
         "pollypm",
+        "--description",
+        "Lane F smoke validation task.",
         "smoke-090807",
         "--json",
     )


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a real `--description` to the smoke harness `pm task create` command so the subsequent `pm task queue` step satisfies the `has_description` gate.
- Update the smoke command-construction unit test to pin the queueable fixture shape.

## Verification
- `uv run --extra dev ruff check scripts/smoke.py tests/test_smoke_script.py`
- `uv run --extra test pytest tests/test_smoke_script.py -q` (7 passed)
- `python3 scripts/smoke.py --dry-run --base http://127.0.0.1:1 --task-wait-seconds 0` shows `pm task create --project pollypm --description Lane F smoke validation task. ... --json` and exits green.

Closes #2290.
