### PR TITLE
perf(web): reduce dashboard refresh fanout

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -152,14 +152,17 @@ def _render_work_service_issues(
 # computations. Caching at the function itself collapses those two
 # calls into one and dampens navigation-burst churn.
 #
-# Cache key: ``id(config)`` — the cockpit router already invalidates
-# its config cache on mtime change, so a config reload yields a fresh
-# object identity and bypasses this cache automatically. TTL is set at
-# 1.0s to match the existing ``_INBOX_COUNT_CACHE`` wall-clock bucket
-# in :mod:`pollypm.plugins_builtin.core_rail_items.plugin`; freshly
+# Cache key: ``(id(config), id(_pm_inbox_awaits_user_list_uncached))``.
+# The cockpit router already invalidates its config cache on mtime
+# change, so a config reload yields a fresh object identity; including
+# the uncached function identity keeps monkeypatched/test direct paths
+# from inheriting an older cached shape. TTL is set at 1.0s to match the
+# existing ``_INBOX_COUNT_CACHE`` wall-clock bucket in
+# :mod:`pollypm.plugins_builtin.core_rail_items.plugin`; freshly
 # completed work surfaces within ~1 rail tick (0.8s).
 _AWAITS_USER_TTL_SECONDS = 1.0
-_AWAITS_USER_CACHE: dict[int, tuple[float, tuple[object, ...]]] = {}
+_AWAITS_USER_CACHE: dict[tuple[int, int], tuple[float, tuple[object, ...]]] = {}
+_AWAITS_USER_COUNT_CACHE: dict[tuple[int, int], tuple[float, int]] = {}
 
 
 # Move A PR 4 — cache fall-through gate for the cache-routed fast path
@@ -170,7 +173,11 @@ _AWAITS_USER_CACHE: dict[int, tuple[float, tuple[object, ...]]] = {}
 _AWAITS_USER_DIVERGENCE_COUNTER = _DivergenceCounter()
 
 
-def pm_inbox_awaits_user_list(config) -> list[object]:
+def pm_inbox_awaits_user_list(
+    config,
+    *,
+    use_cache: bool = True,
+) -> list[object]:
     """Return every inbox entry across the config that ``awaits_user``.
 
     Single source of truth for "what is waiting on the user across all
@@ -199,19 +206,26 @@ def pm_inbox_awaits_user_list(config) -> list[object]:
     by default. ``POLLYPM_STATE_CACHE=0`` forces fall-through. No runtime
     sampler.
     """
-    cached_result = _maybe_cache_route_awaits_user(config)
-    if cached_result is not None:
-        return cached_result
+    if use_cache:
+        cached_result = _maybe_cache_route_awaits_user(config)
+        if cached_result is not None:
+            return cached_result
 
     import time as _time
 
-    cache_key = id(config)
+    cache_key = (id(config), id(_pm_inbox_awaits_user_list_uncached))
     now = _time.monotonic()
-    cached = _AWAITS_USER_CACHE.get(cache_key)
-    if cached is not None and now - cached[0] < _AWAITS_USER_TTL_SECONDS:
-        return list(cached[1])
+    if use_cache:
+        cached = _AWAITS_USER_CACHE.get(cache_key)
+        if (
+            cached is not None
+            and now - cached[0] < _AWAITS_USER_TTL_SECONDS
+        ):
+            return list(cached[1])
 
     result = _pm_inbox_awaits_user_list_uncached(config)
+    if not use_cache:
+        return result
     # #1957 #1968 perf — stamp the cache AFTER the uncached sweep returns
     # so a cold awaits-user fetch that exceeds the TTL doesn't write a
     # born-expired entry that forces the next caller to recompute.
@@ -390,7 +404,11 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     return cached_items
 
 
-def _pm_inbox_awaits_user_list_uncached(config) -> list[object]:
+def _pm_inbox_awaits_user_list_uncached(
+    config,
+    *,
+    annotate_entries: bool = True,
+) -> list[object]:
     """Underlying implementation of :func:`pm_inbox_awaits_user_list`.
 
     Separated from the public entry point so the cache wrapper stays
@@ -442,11 +460,13 @@ def _pm_inbox_awaits_user_list_uncached(config) -> list[object]:
             for task in inbox_tasks_for_project(
                 pg_inbox_grouped, config, project_key,
             ):
-                item = annotate_inbox_entry(
-                    task_to_inbox_entry(task, db_path=db_path),
-                    known_projects=known_projects,
-                )
+                item = task_to_inbox_entry(task, db_path=db_path)
                 if awaits_user(item):
+                    if annotate_entries:
+                        item = annotate_inbox_entry(
+                            item,
+                            known_projects=known_projects,
+                        )
                     task_entries.setdefault(task.task_id, item)
 
     # pg-path messages: one query covered the whole workspace above.
@@ -474,15 +494,17 @@ def _pm_inbox_awaits_user_list_uncached(config) -> list[object]:
                 if scope and scope in known_projects
                 else project_db_paths.get(_WORKSPACE_DB_KEY, (None, None))[0]
             )
-            item = annotate_inbox_entry(
-                message_row_to_inbox_entry(
-                    row,
-                    source_key=source_key,
-                    db_path=entry_dbpath or Path("."),
-                ),
-                known_projects=known_projects,
+            item = message_row_to_inbox_entry(
+                row,
+                source_key=source_key,
+                db_path=entry_dbpath or Path("."),
             )
             if awaits_user(item):
+                if annotate_entries:
+                    item = annotate_inbox_entry(
+                        item,
+                        known_projects=known_projects,
+                    )
                 msg_key = (str(scope), row_id)
                 message_entries.setdefault(msg_key, item)
 
@@ -502,7 +524,41 @@ def _pm_inbox_awaits_user_list_uncached(config) -> list[object]:
     return collected
 
 
-def _count_inbox_tasks_for_label(config) -> int:
+_pm_inbox_awaits_user_list_uncached._supports_unannotated = True  # type: ignore[attr-defined]
+
+
+def _uncached_awaits_user_count(config) -> int:
+    uncached = _pm_inbox_awaits_user_list_uncached
+    if getattr(uncached, "_supports_unannotated", False):
+        return len(uncached(config, annotate_entries=False))
+    return len(uncached(config))
+
+
+def _direct_awaits_user_count(config) -> int:
+    import time as _time
+
+    cache_key = (id(config), id(_pm_inbox_awaits_user_list_uncached))
+    now = _time.monotonic()
+    cached = _AWAITS_USER_COUNT_CACHE.get(cache_key)
+    if cached is not None and now - cached[0] < _AWAITS_USER_TTL_SECONDS:
+        return cached[1]
+    count = _uncached_awaits_user_count(config)
+    completed_at = _time.monotonic()
+    if len(_AWAITS_USER_COUNT_CACHE) > 8:
+        for stale_key in [
+            k for k, (ts, _v) in _AWAITS_USER_COUNT_CACHE.items()
+            if completed_at - ts >= _AWAITS_USER_TTL_SECONDS
+        ]:
+            _AWAITS_USER_COUNT_CACHE.pop(stale_key, None)
+    _AWAITS_USER_COUNT_CACHE[cache_key] = (completed_at, count)
+    return count
+
+
+def _count_inbox_tasks_for_label(
+    config,
+    *,
+    use_state_cache: bool = True,
+) -> int:
     """Count actionable inbox items across tracked projects + workspace-root.
 
     The cockpit rail is a notification surface, not an activity feed.
@@ -539,10 +595,11 @@ def _count_inbox_tasks_for_label(config) -> int:
     holds (the public helper itself routes through the same cache
     when populated).
     """
-    cached = _maybe_cache_count_awaits_user(config)
-    if cached is not None:
-        return cached
-    return len(pm_inbox_awaits_user_list(config))
+    if use_state_cache:
+        cached = _maybe_cache_count_awaits_user(config)
+        if cached is not None:
+            return cached
+    return _direct_awaits_user_count(config)
 
 
 def _maybe_cache_count_awaits_user(config) -> int | None:

--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -57,6 +57,15 @@ _ALL_TASKS_GROUPED_CACHE: dict[
     int, tuple[float, "dict[str, tuple[Task, ...]] | None"]
 ] = {}
 
+# Same request-local sharing for the inbox-task aggregate. The dashboard
+# count path and the recent-inbox preview path both need the same broad
+# ``inbox_tasks(svc, project=None)`` scan; without this cache one
+# ``/api/v1/dashboard`` request pays that scan twice.
+_INBOX_TASKS_GROUPED_TTL_SECONDS = 1.0
+_INBOX_TASKS_GROUPED_CACHE: dict[
+    int, tuple[float, "dict[str, tuple[Task, ...]] | None"]
+] = {}
+
 
 # --------------------------------------------------------------------------- #
 # Shared pg service handle
@@ -178,6 +187,39 @@ def inbox_tasks_grouped(
     independent ``inbox_tasks(svc, project=key)`` calls — one per
     tracked project — that the sqlite path runs today.
     """
+    cache_key = id(config)
+    now = time.monotonic()
+    cached = _INBOX_TASKS_GROUPED_CACHE.get(cache_key)
+    if (
+        cached is not None
+        and now - cached[0] < _INBOX_TASKS_GROUPED_TTL_SECONDS
+    ):
+        snapshot = cached[1]
+        if snapshot is None:
+            return None
+        return {key: list(rows) for key, rows in snapshot.items()}
+
+    result = _inbox_tasks_grouped_uncached(config)
+    completed_at = time.monotonic()
+    if len(_INBOX_TASKS_GROUPED_CACHE) > 8:
+        for stale_key in [
+            k for k, (ts, _v) in _INBOX_TASKS_GROUPED_CACHE.items()
+            if completed_at - ts >= _INBOX_TASKS_GROUPED_TTL_SECONDS
+        ]:
+            _INBOX_TASKS_GROUPED_CACHE.pop(stale_key, None)
+    snapshot = (
+        None
+        if result is None
+        else {key: tuple(rows) for key, rows in result.items()}
+    )
+    _INBOX_TASKS_GROUPED_CACHE[cache_key] = (completed_at, snapshot)
+    return result
+
+
+def _inbox_tasks_grouped_uncached(
+    config: "PollyPMConfig | None",
+) -> dict[str, list["Task"]] | None:
+    """Underlying implementation of :func:`inbox_tasks_grouped`."""
     svc = _open_pg_service(config)
     if svc is None:
         return None

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -5,6 +5,7 @@ import logging
 import re
 import subprocess
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -211,6 +212,7 @@ class DashboardData:
 _COMMIT_CACHE: dict[tuple[str, int], tuple[float, list["_CachedCommitRow"]]] = {}
 _COMMIT_CACHE_TTL_SECONDS = 60.0
 _COMMIT_PER_PROJECT_TIMEOUT_SECONDS = 2.0
+_COMMIT_LOG_MAX_WORKERS = 8
 
 
 @dataclass(slots=True, frozen=True)
@@ -269,6 +271,14 @@ def _git_log_rows_cached(project_path: Path, hours: int) -> list[_CachedCommitRo
     return rows
 
 
+def _recent_commit_rows_for_project(
+    item: tuple[str, object],
+    hours: int,
+) -> tuple[str, list[_CachedCommitRow]]:
+    key, project = item
+    return key, _git_log_rows_cached(project.path, hours)
+
+
 def _recent_commits(config: PollyPMConfig, hours: int = 24) -> list[CommitInfo]:
     """Get git commits from the last N hours across all projects.
 
@@ -280,8 +290,25 @@ def _recent_commits(config: PollyPMConfig, hours: int = 24) -> list[CommitInfo]:
     now = datetime.now(UTC)
     seen: set[str] = set()
 
-    for key, project in config.projects.items():
-        for row in _git_log_rows_cached(project.path, hours):
+    project_items = list(config.projects.items())
+    if len(project_items) > 1:
+        with ThreadPoolExecutor(
+            max_workers=min(_COMMIT_LOG_MAX_WORKERS, len(project_items)),
+            thread_name_prefix="dashboard-git-log",
+        ) as executor:
+            row_batches = executor.map(
+                lambda item: _recent_commit_rows_for_project(item, hours),
+                project_items,
+            )
+            project_rows = list(row_batches)
+    else:
+        project_rows = [
+            _recent_commit_rows_for_project(item, hours)
+            for item in project_items
+        ]
+
+    for key, rows in project_rows:
+        for row in rows:
             if row.hash7 in seen:
                 continue
             seen.add(row.hash7)
@@ -563,7 +590,11 @@ def _count_inbox_tasks(config: PollyPMConfig) -> int:
     return total
 
 
-def _count_dashboard_inbox_items(config: PollyPMConfig) -> int:
+def _count_dashboard_inbox_items(
+    config: PollyPMConfig,
+    *,
+    use_state_cache: bool = True,
+) -> int:
     """Return the user-facing inbox count shown on the cockpit home.
 
     The cockpit home and rail are the same at-a-glance surface, so their
@@ -573,7 +604,13 @@ def _count_dashboard_inbox_items(config: PollyPMConfig) -> int:
     """
     try:
         from pollypm.cockpit_inbox import _count_inbox_tasks_for_label
-        return int(_count_inbox_tasks_for_label(config) or 0)
+        return int(
+            _count_inbox_tasks_for_label(
+                config,
+                use_state_cache=use_state_cache,
+            )
+            or 0
+        )
     except Exception:  # noqa: BLE001
         logger.warning(
             "_count_dashboard_inbox_items: registered-project count failed; "
@@ -796,7 +833,12 @@ def load_dashboard(config_path: Path) -> tuple[PollyPMConfig, DashboardData]:
     return config, data
 
 
-def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
+def gather(
+    config: PollyPMConfig,
+    store: object | None,
+    *,
+    use_state_cache: bool = True,
+) -> DashboardData:
     """Gather all dashboard data.
 
     Backend-aware: pg installs read through the pg facades; sqlite
@@ -902,7 +944,10 @@ def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
 
     commits = _recent_commits(config, hours=24)
     completed = _completed_issues(config, hours=72)
-    inbox_count = _count_dashboard_inbox_items(config)
+    inbox_count = _count_dashboard_inbox_items(
+        config,
+        use_state_cache=use_state_cache,
+    )
     recent_messages = _recent_inbox_messages(config)
     sweeps = sum(1 for e in day_events if e.event_type == "heartbeat")
     recoveries = sum(1 for e in day_events if "recover" in e.event_type)

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -252,7 +252,7 @@ def _gather_dashboard(config: Any) -> Any:
     """
     from pollypm.dashboard_data import gather
 
-    return gather(config, None)
+    return gather(config, None, use_state_cache=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -364,6 +364,25 @@ def test_dashboard_loads_projects_and_gather_concurrently(
     assert gather_started.is_set()
 
 
+def test_dashboard_route_gather_bypasses_state_cache(
+    config: PollyPMConfig, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_gather(_config, _store, *, use_state_cache):
+        seen["use_state_cache"] = use_state_cache
+        return _make_data()
+
+    monkeypatch.setattr(
+        "pollypm.dashboard_data.gather",
+        fake_gather,
+    )
+
+    dashboard_routes._gather_dashboard(config)
+
+    assert seen == {"use_state_cache": False}
+
+
 # ---------------------------------------------------------------------------
 # Happy paths
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_inbox_perf.py
+++ b/tests/test_dashboard_inbox_perf.py
@@ -1,0 +1,121 @@
+"""Focused perf-regression tests for dashboard inbox rollups."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def test_inbox_tasks_grouped_shares_scan_with_copy_safe_cache(
+    monkeypatch,
+) -> None:
+    import pollypm.cockpit_pg_aggregates as agg
+
+    agg._INBOX_TASKS_GROUPED_CACHE.clear()
+    calls = {"n": 0}
+    task = SimpleNamespace(task_id="demo/1", project="demo")
+
+    def fake_uncached(_config):
+        calls["n"] += 1
+        return {"demo": [task]}
+
+    monkeypatch.setattr(agg, "_inbox_tasks_grouped_uncached", fake_uncached)
+
+    config = object()
+    first = agg.inbox_tasks_grouped(config)
+    assert first == {"demo": [task]}
+    first["demo"].append(SimpleNamespace(task_id="demo/2", project="demo"))
+
+    second = agg.inbox_tasks_grouped(config)
+
+    assert calls["n"] == 1
+    assert second == {"demo": [task]}
+
+
+def test_awaits_user_list_annotates_only_actionable_rows(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    from pollypm import cockpit_inbox
+    from pollypm.inbox.kind import InboxItemKind
+
+    actionable = SimpleNamespace(
+        task_id="demo/1",
+        project="demo",
+        kind=InboxItemKind.APPROVAL_REQUEST,
+        labels=[],
+        title="Approve deployment",
+        description="",
+    )
+    informational = SimpleNamespace(
+        task_id="demo/2",
+        project="demo",
+        kind=InboxItemKind.COMPLETION_FYI,
+        labels=[],
+        title="Deployment complete",
+        description="",
+    )
+    grouped = {"demo": [informational, actionable]}
+    calls = {"annotate": 0}
+
+    def annotate(item, *, known_projects):
+        calls["annotate"] += 1
+        item.triage_label = "annotated"
+        return item
+
+    monkeypatch.setattr(
+        cockpit_inbox,
+        "_inbox_db_sources",
+        lambda _config: [("demo", tmp_path / "state.db", tmp_path)],
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.inbox_tasks_grouped",
+        lambda _config: grouped,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.inbox_tasks_for_project",
+        lambda rows, _config, key: list(rows.get(key, [])),
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.open_messages",
+        lambda _config, *, known_projects: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_inbox_items.annotate_inbox_entry",
+        annotate,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_inbox_items._filter_approved_plan_reviews",
+        lambda items, **_kwargs: list(items),
+    )
+
+    config = SimpleNamespace(projects={"demo": SimpleNamespace()})
+    result = cockpit_inbox._pm_inbox_awaits_user_list_uncached(config)
+
+    assert [item.task_id for item in result] == ["demo/1"]
+    assert result[0].triage_label == "annotated"
+    assert calls["annotate"] == 1
+
+
+def test_dashboard_count_can_bypass_state_cache(monkeypatch) -> None:
+    from pollypm import cockpit_inbox
+
+    monkeypatch.setattr(
+        cockpit_inbox,
+        "_maybe_cache_count_awaits_user",
+        lambda _config: (_ for _ in ()).throw(
+            AssertionError("state cache should not be touched")
+        ),
+    )
+    monkeypatch.setattr(
+        cockpit_inbox,
+        "_pm_inbox_awaits_user_list_uncached",
+        lambda _config: [object(), object()],
+    )
+    cockpit_inbox._AWAITS_USER_COUNT_CACHE.clear()
+
+    count = cockpit_inbox._count_inbox_tasks_for_label(
+        SimpleNamespace(),
+        use_state_cache=False,
+    )
+
+    assert count == 2


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Keeps `/api/v1/dashboard` off the cockpit state-cache startup path so the API request no longer synchronously runs the state-cache full refresh.
- Adds short, copy-safe sharing for the PG inbox-task aggregate used by dashboard inbox count and recent-message preview.
- Adds a count-only awaits-user path that preserves the canonical predicate and plan-review filtering while skipping per-row triage annotation work.
- Refreshes per-project git commit rows in parallel behind the existing 60s commit cache to reduce cold dashboard fanout.

## Perf Evidence
Issue #2276 latest baseline after #2291: median 0.650s, p95 1.357-1.496s, max about 1.497s sans cold start.

After this branch, 30 sequential authenticated `/api/v1/dashboard` requests against local operator state on `pm serve --port 8898`:
- n=30, p50=0.345s, p95=0.701s, p99/max=1.533s, min=0.198s, over 1s=1/30, all HTTP 200.

Earlier in-branch check before the route skipped state-cache startup showed first request at 10.777s; after the API bypass, the state-cache startup spike is gone from this endpoint.

## Verification
- `uv run --extra dev pytest --noconftest tests/test_recent_commits_cache.py tests/test_dashboard_inbox_perf.py tests/test_dashboard_endpoint.py tests/test_state_cache_parity.py -q` -> 75 passed.
- `uv run --extra dev ruff check --ignore E402,F401,F841 src/pollypm/cockpit_inbox.py src/pollypm/cockpit_pg_aggregates.py src/pollypm/dashboard_data.py src/pollypm/web_api/routes/dashboard.py tests/test_dashboard_inbox_perf.py tests/test_dashboard_endpoint.py tests/test_recent_commits_cache.py` -> passed.
- `git diff --check` -> passed.

## Notes
- The endpoint p95 is now below the 1-second click rule on this local repro, but one first-hit sample remains above 1s due remaining cold imports / pool setup. This PR removes the largest dashboard-specific spike and keeps the architecture boundary intact; any remaining cold-start work should be tracked separately if Claude wants to require full max-under-1s before merge.
