### PR TITLE
fix(heartbeat): surface auth and capacity blocked sessions

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2129,8 +2129,10 @@ paths:
       description: |
         Mirrors `pm sessions` (#2039) — one row per configured (and
         enabled) session in `[sessions]` config with classification
-        (`healthy` / `stale` / `missing` / `unknown`) derived
-        from the latest heartbeat row plus a tmux storage-closet probe.
+        (`healthy` / `stale` / `missing` / `unknown` plus runtime
+        failure pins such as `auth_broken` / `capacity_exhausted`)
+        derived from the latest heartbeat row, session-runtime state,
+        and a tmux storage-closet probe.
         The operator-set pause marker is surfaced via the separate
         `paused: bool` field so it cannot mask the runtime-health
         classification (see `SessionInfo.paused`). Read-side is
@@ -4788,13 +4790,27 @@ components:
     # ---- Sessions admin (Phase 2 §10) -------------------------------
     SessionStatus:
       type: string
-      enum: [healthy, stale, missing, unknown]
+      enum:
+        - healthy
+        - stale
+        - missing
+        - unknown
+        - auth_broken
+        - capacity_exhausted
+        - provider_outage
+        - blocked
+        - degraded
       description: |
         Live runtime-health classification mirroring `pm sessions`.
         `healthy` = heartbeat <=5min old AND tmux window present.
         `stale` = heartbeat older than 5min. `missing` = tmux window
         absent (beats `stale` — pane is the more urgent problem).
         `unknown` = no heartbeat row yet (fresh boot OR pg outage).
+        Functional failures recorded by the heartbeat/recovery path
+        (`auth_broken`, `capacity_exhausted`, `provider_outage`,
+        `blocked`, `degraded`) override fresh heartbeat liveness while
+        the window is still present, so a provider login/quota screen
+        cannot report as healthy just because the pane is alive.
 
         Pause is NOT a value of this enum. The operator-set pause
         marker is exposed as the separate `SessionInfo.paused`

--- a/src/pollypm/cli_features/sessions_health.py
+++ b/src/pollypm/cli_features/sessions_health.py
@@ -55,6 +55,9 @@ from pollypm.session_health import (
     latest_heartbeat as _latest_heartbeat,
 )
 from pollypm.session_health import (
+    latest_session_runtime as _latest_session_runtime,
+)
+from pollypm.session_health import (
     list_storage_closet_windows as _list_windows,
 )
 from pollypm.session_health import (
@@ -75,6 +78,7 @@ __all_shared__ = (
     "_classify_status",
     "_humanize_age",
     "_latest_heartbeat",
+    "_latest_session_runtime",
     "_list_windows",
     "_storage_session_name",
 )
@@ -108,7 +112,13 @@ def _build_row(
     heartbeat = _latest_heartbeat(config, session.name)
     hb_iso = getattr(heartbeat, "created_at", None) if heartbeat else None
     age = _age_seconds(hb_iso)
-    status = _classify_status(window_present=window is not None, age_seconds=age)
+    runtime = _latest_session_runtime(config, session.name)
+    status = _classify_status(
+        window_present=window is not None,
+        age_seconds=age,
+        runtime_status=getattr(runtime, "status", None),
+        last_failure_type=getattr(runtime, "last_failure_type", None),
+    )
     token_state = "ok" if (getattr(session, "auth_token", "") or "") else "missing"
 
     row: dict[str, Any] = {
@@ -237,7 +247,11 @@ __all__ = [
     "register_sessions_health_command",
     "sessions_health",
     "_STALE_HEARTBEAT_SECONDS",
+    "_STORAGE_CLOSET_SUFFIX",
     "_classify_status",
     "_humanize_age",
+    "_latest_heartbeat",
+    "_latest_session_runtime",
+    "_list_windows",
     "_build_row",
 ]

--- a/src/pollypm/heartbeats/api.py
+++ b/src/pollypm/heartbeats/api.py
@@ -247,6 +247,20 @@ class SupervisorHeartbeatAPI:
             reason=reason,
         )
 
+    def mark_account_capacity_exhausted(
+        self,
+        account_name: str,
+        provider: str,
+        *,
+        reason: str,
+    ) -> None:
+        self.supervisor.store.upsert_account_runtime(
+            account_name=account_name,
+            provider=provider,
+            status="exhausted",
+            reason=reason,
+        )
+
     def recent_snapshot_hashes(self, session_name: str, *, limit: int = 3) -> list[str]:
         return [
             item.snapshot_hash

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -9,6 +9,12 @@ from typing import Any
 
 from pollypm.heartbeats.base import HeartbeatBackend, HeartbeatSessionContext
 from pollypm.persona_drift import detect_persona_drift
+from pollypm.provider_failures import (
+    AUTH_FAILURE_PATTERNS,
+    CAPACITY_FAILURE_PATTERNS,
+    has_auth_failure,
+    has_capacity_failure,
+)
 from pollypm.recovery.base import (
     InterventionHistoryEntry,
     SessionHealth,
@@ -554,16 +560,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
     # recovery (auth, missing window, pane_dead, role_crashed) counts.
     _CRASH_LOOP_ATTEMPT_THRESHOLD = 2
 
-    _AUTH_FAILURE_PATTERNS = (
-        "authentication failure",
-        "not authenticated",
-        "login required",
-        "please login",
-        "please log in",
-        "invalid api key",
-        "disabled claude subscription",
-        "use an anthropic api key",
-    )
+    _AUTH_FAILURE_PATTERNS = AUTH_FAILURE_PATTERNS
+    _CAPACITY_FAILURE_PATTERNS = CAPACITY_FAILURE_PATTERNS
     _WAITING_PATTERNS = (
         "let me know",
         "waiting for your",
@@ -846,6 +844,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         alerts.extend(self._handle_persona_drift(api, context))
 
         status_locked = self._handle_auth_failure(api, context, alerts)
+        if not status_locked:
+            status_locked = self._handle_capacity_failure(api, context, alerts)
 
         if context.pane_dead:
             status_locked = True
@@ -1168,8 +1168,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         """
         combined_text = "\n".join(
             part for part in [context.transcript_delta, context.pane_text] if part
-        ).lower()
-        if any(pattern in combined_text for pattern in self._AUTH_FAILURE_PATTERNS):
+        )
+        if has_auth_failure(combined_text):
             _emit_routed_alert(
                 api,
                 session_name=context.session_name,
@@ -1212,6 +1212,55 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             )
             return True
         api.clear_alert(context.session_name, "auth_broken")
+        return False
+
+    def _handle_capacity_failure(
+        self,
+        api,
+        context: HeartbeatSessionContext,
+        alerts: list[str],
+    ) -> bool:
+        """Detect provider usage/quota exhaustion and trigger failover."""
+        combined_text = "\n".join(
+            part for part in [context.transcript_delta, context.pane_text] if part
+        )
+        if has_capacity_failure(combined_text):
+            _emit_routed_alert(
+                api,
+                session_name=context.session_name,
+                alert_type="capacity_exhausted",
+                severity="error",
+                message=(
+                    f"Window {context.window_name} reported a usage or quota limit"
+                ),
+                subject=f"{context.session_name} account capacity exhausted",
+                suggested_action=(
+                    "Open Settings to inspect account capacity, then "
+                    "restart the session from Workers."
+                ),
+            )
+            marker = getattr(api, "mark_account_capacity_exhausted", None)
+            if marker is not None:
+                marker(
+                    context.account_name,
+                    context.provider,
+                    reason="live session reported capacity exhaustion",
+                )
+            self._set_session_status(
+                api,
+                context,
+                "capacity_exhausted",
+                reason="Provider usage or quota limit reported",
+            )
+            alerts.append("capacity_exhausted")
+            self._recover_session(
+                api,
+                context,
+                failure_type="capacity_exhausted",
+                message="Provider usage or quota limit reported",
+            )
+            return True
+        api.clear_alert(context.session_name, "capacity_exhausted")
         return False
 
     def _handle_persona_drift(
@@ -1700,15 +1749,21 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         except Exception:  # noqa: BLE001
             placeholder_idle = False
 
+        from pollypm.capacity import CapacityState
+
+        pane_failure_text = context.transcript_delta or context.pane_text or ""
+
         return SessionSignals(
             session_name=context.session_name,
             window_present=context.window_present,
             pane_dead=context.pane_dead,
             output_stale=not bool(context.transcript_delta),
             snapshot_repeated=repeated,
-            auth_failure=any(
-                p in (context.transcript_delta or context.pane_text or "").lower()
-                for p in self._AUTH_FAILURE_PATTERNS
+            auth_failure=has_auth_failure(pane_failure_text),
+            capacity_state=(
+                CapacityState.EXHAUSTED
+                if has_capacity_failure(pane_failure_text)
+                else CapacityState.UNKNOWN
             ),
             has_transcript_delta=bool(context.transcript_delta),
             last_verdict=context.cursor.last_verdict if context.cursor else "",

--- a/src/pollypm/provider_failures.py
+++ b/src/pollypm/provider_failures.py
@@ -1,0 +1,72 @@
+"""Provider-facing failure text classifiers.
+
+The heartbeat backend and supervisor alert boundary both inspect live
+provider panes. Keep the provider error vocabulary here so quota/login
+wording does not drift between those callers.
+"""
+
+from __future__ import annotations
+
+
+AUTH_FAILURE_PATTERNS: tuple[str, ...] = (
+    "authentication failure",
+    "invalid authentication credentials",
+    "authentication_error",
+    "not authenticated",
+    "not logged in",
+    "login required",
+    "please run /login",
+    "run /login",
+    "please login",
+    "please log in",
+    "invalid api key",
+    "disabled claude subscription",
+    "use an anthropic api key",
+)
+
+CAPACITY_FAILURE_PATTERNS: tuple[str, ...] = (
+    "usage limit",
+    "quota exceeded",
+    "0% left",
+    "out of credits",
+    "credit balance is too low",
+    "you've hit your limit",
+    "you have hit your limit",
+    "hit your limit",
+    "usage-credits",
+)
+
+PROVIDER_OUTAGE_PATTERNS: tuple[str, ...] = (
+    "temporarily unavailable",
+    "try again later",
+    "server error",
+    "overloaded",
+    "service unavailable",
+)
+
+
+def _contains_any(text: str, patterns: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(pattern in lowered for pattern in patterns)
+
+
+def has_auth_failure(text: str) -> bool:
+    return _contains_any(text, AUTH_FAILURE_PATTERNS)
+
+
+def has_capacity_failure(text: str) -> bool:
+    return _contains_any(text, CAPACITY_FAILURE_PATTERNS)
+
+
+def has_provider_outage(text: str) -> bool:
+    return _contains_any(text, PROVIDER_OUTAGE_PATTERNS)
+
+
+__all__ = [
+    "AUTH_FAILURE_PATTERNS",
+    "CAPACITY_FAILURE_PATTERNS",
+    "PROVIDER_OUTAGE_PATTERNS",
+    "has_auth_failure",
+    "has_capacity_failure",
+    "has_provider_outage",
+]

--- a/src/pollypm/session_health.py
+++ b/src/pollypm/session_health.py
@@ -87,11 +87,18 @@ def classify_status(
     *,
     window_present: bool,
     age_seconds: int | None,
+    runtime_status: str | None = None,
+    last_failure_type: str | None = None,
 ) -> str:
-    """Return one of ``healthy`` / ``stale`` / ``missing`` / ``unknown``.
+    """Return a user-facing session-health status.
 
     ``missing`` wins over ``stale`` — when the tmux window is gone the
     pane is the more urgent problem and reporting both would be noisy.
+
+    Runtime failure pins win over heartbeat freshness when the window
+    is still present. A session that is actively printing "not logged
+    in" or "you've hit your limit" can keep emitting fresh heartbeats;
+    the persisted runtime failure is the functional health signal.
 
     The pause marker is intentionally NOT consulted here (Codex PR #2061
     round 2). Pause is informational only — folding it into ``status``
@@ -99,11 +106,47 @@ def classify_status(
     """
     if not window_present:
         return "missing"
+    runtime_override = runtime_status_override(
+        runtime_status=runtime_status,
+        last_failure_type=last_failure_type,
+    )
+    if runtime_override is not None:
+        return runtime_override
     if age_seconds is None:
         return "unknown"
     if age_seconds > STALE_HEARTBEAT_SECONDS:
         return "stale"
     return "healthy"
+
+
+def runtime_status_override(
+    *,
+    runtime_status: str | None,
+    last_failure_type: str | None = None,
+) -> str | None:
+    """Return the functional-failure status that should override liveness.
+
+    The runtime table is the source of truth for failures detected by the
+    heartbeat/recovery path. Keep this mapping narrow so ordinary
+    lifecycle states such as ``idle`` do not shadow the mechanical
+    heartbeat classification.
+    """
+    status = (runtime_status or "").strip()
+    failure = (last_failure_type or "").strip()
+    failure_pinned = status in {"recovering", "blocked", "degraded"}
+    if status == "auth_broken" or (failure_pinned and failure == "auth_broken"):
+        return "auth_broken"
+    if status in {"capacity_exhausted", "exhausted", "blocked_no_capacity"}:
+        return "capacity_exhausted"
+    if failure_pinned and failure in {"capacity_exhausted", "capacity_low"}:
+        return "capacity_exhausted"
+    if status == "provider_outage" or (
+        failure_pinned and failure == "provider_outage"
+    ):
+        return "provider_outage"
+    if status in {"blocked", "degraded"} and failure:
+        return status
+    return None
 
 
 def latest_heartbeat(config: Any, session_name: str) -> Any | None:
@@ -123,6 +166,24 @@ def latest_heartbeat(config: Any, session_name: str) -> Any | None:
     except Exception:  # noqa: BLE001
         logger.debug(
             "latest_heartbeat lookup failed for %s",
+            session_name,
+            exc_info=True,
+        )
+        return None
+
+
+def latest_session_runtime(config: Any, session_name: str) -> Any | None:
+    """Fetch the latest session runtime row; ``None`` on any failure."""
+    try:
+        from pollypm.storage.pg_sessions import get_session_runtime as _pg
+    except Exception:  # noqa: BLE001
+        logger.debug("pg_sessions import failed", exc_info=True)
+        return None
+    try:
+        return _pg(session_name, config=config)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "session_runtime lookup failed for %s",
             session_name,
             exc_info=True,
         )
@@ -351,8 +412,10 @@ __all__ = [
     "classify_status",
     "humanize_age",
     "latest_heartbeat",
+    "latest_session_runtime",
     "list_storage_closet_windows",
     "parse_iso",
     "probe_strict_turn_active",
+    "runtime_status_override",
     "storage_session_name",
 ]

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -2653,41 +2653,27 @@ class Supervisor:
         return self._pane_has_auth_failure(lowered_pane)
 
     def _pane_has_auth_failure(self, lowered_pane: str) -> bool:
-        patterns = [
-            "please run /login",
-            "invalid authentication credentials",
-            "authentication_error",
-            "not authenticated",
-        ]
-        return any(pattern in lowered_pane for pattern in patterns)
+        from pollypm.provider_failures import has_auth_failure
+
+        return has_auth_failure(lowered_pane)
 
     def pane_has_capacity_failure(self, lowered_pane: str) -> bool:
         """Public alert-boundary detector for provider quota failures."""
         return self._pane_has_capacity_failure(lowered_pane)
 
     def _pane_has_capacity_failure(self, lowered_pane: str) -> bool:
-        patterns = [
-            "usage limit",
-            "quota exceeded",
-            "0% left",
-            "out of credits",
-            "credit balance is too low",
-        ]
-        return any(pattern in lowered_pane for pattern in patterns)
+        from pollypm.provider_failures import has_capacity_failure
+
+        return has_capacity_failure(lowered_pane)
 
     def pane_has_provider_outage(self, lowered_pane: str) -> bool:
         """Public alert-boundary detector for upstream provider outages."""
         return self._pane_has_provider_outage(lowered_pane)
 
     def _pane_has_provider_outage(self, lowered_pane: str) -> bool:
-        patterns = [
-            "temporarily unavailable",
-            "try again later",
-            "server error",
-            "overloaded",
-            "service unavailable",
-        ]
-        return any(pattern in lowered_pane for pattern in patterns)
+        from pollypm.provider_failures import has_provider_outage
+
+        return has_provider_outage(lowered_pane)
 
     def _primary_failure(self, alerts: list[str]) -> str | None:
         for alert_type in [

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -34,7 +34,7 @@ Design notes
 ------------
 
 * **Read-side health.** Shares the :mod:`pollypm.session_health`
-  classification (``healthy`` / ``stale`` / ``missing`` / ``unknown``)
+  classification (mechanical liveness plus runtime failure pins)
   with the ``pm sessions`` CLI so the API returns the same status
   field an operator sees there (Codex PR #2061 round 5 blocker 3 —
   single source of truth for the contract). Heartbeats come from the
@@ -77,8 +77,9 @@ Design notes
   ``status="paused"`` and operators would believe the daemon had
   quiesced when in fact the session was simply absent. ``status``
   reflects pure runtime health (``healthy`` / ``stale`` /
-  ``missing`` / ``unknown``) and ``paused`` carries the operator
-  intent. The response ``message`` and OpenAPI description both
+  ``missing`` / ``unknown`` plus functional failures such as
+  ``auth_broken`` and ``capacity_exhausted``) and ``paused`` carries
+  the operator intent. The response ``message`` and OpenAPI description both
   spell out which loops do and do not yet consume the marker so an
   operator is never misled. Both operations are idempotent and
   return 200, and concurrent writes are serialised by an
@@ -115,6 +116,9 @@ from pollypm.session_health import (
 )
 from pollypm.session_health import (
     latest_heartbeat as _latest_heartbeat,
+)
+from pollypm.session_health import (
+    latest_session_runtime as _latest_session_runtime,
 )
 from pollypm.session_health import (
     list_storage_closet_windows as _list_storage_closet_windows,
@@ -177,7 +181,17 @@ class SessionInfo(BaseModel):
     window_name: str
     tmux_session: str
     window_present: bool
-    status: Literal["healthy", "stale", "missing", "unknown"]
+    status: Literal[
+        "healthy",
+        "stale",
+        "missing",
+        "unknown",
+        "auth_broken",
+        "capacity_exhausted",
+        "provider_outage",
+        "blocked",
+        "degraded",
+    ]
     last_heartbeat_iso: str | None = None
     last_heartbeat_age_seconds: int | None = None
     auth_token_present: bool
@@ -471,9 +485,12 @@ def _build_session_info(
     hb_iso = getattr(heartbeat, "created_at", None) if heartbeat else None
     age = _age_seconds(hb_iso)
     window_present = window is not None
+    runtime = _latest_session_runtime(config, session.name)
     status = _classify_status(
         window_present=window_present,
         age_seconds=age,
+        runtime_status=getattr(runtime, "status", None),
+        last_failure_type=getattr(runtime, "last_failure_type", None),
     )
     auth_token_present = bool(getattr(session, "auth_token", "") or "")
     return SessionInfo(

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -171,6 +171,15 @@ class FakeHeartbeatAPI:
     def mark_account_auth_broken(self, account_name: str, provider: str, *, reason: str) -> None:
         self.account_marks.append((account_name, provider, reason))
 
+    def mark_account_capacity_exhausted(
+        self,
+        account_name: str,
+        provider: str,
+        *,
+        reason: str,
+    ) -> None:
+        self.account_marks.append((account_name, provider, reason))
+
     def recent_snapshot_hashes(self, session_name: str, *, limit: int = 3) -> list[str]:
         return self._hashes.get(session_name, [])[:limit]
 
@@ -999,6 +1008,40 @@ def test_local_heartbeat_backend_marks_auth_broken_on_org_disabled() -> None:
     assert api.account_marks == [
         ("claude_controller", "claude", "live session reported authentication failure")
     ]
+
+
+def test_local_heartbeat_backend_marks_login_prompt_auth_broken() -> None:
+    pane_text = "Not logged in · Please run /login"
+    api = FakeHeartbeatAPI([_context(transcript_delta=pane_text)])
+
+    LocalHeartbeatBackend().run(api)
+
+    assert api.statuses["worker_pollypm"][0] == "auth_broken"
+    assert ("worker_pollypm", "auth_broken") in api.alerts
+    assert any(
+        session == "worker_pollypm" and failure_type == "auth_broken"
+        for session, failure_type, _ in api.recoveries
+    )
+
+
+def test_local_heartbeat_backend_marks_capacity_exhausted() -> None:
+    pane_text = (
+        "You've hit your limit · resets May 26 at 8pm "
+        "(America/Denver)\n/usage-credits to finish what you're working on."
+    )
+    api = FakeHeartbeatAPI([_context(transcript_delta=pane_text)])
+
+    LocalHeartbeatBackend().run(api)
+
+    assert api.statuses["worker_pollypm"][0] == "capacity_exhausted"
+    assert ("worker_pollypm", "capacity_exhausted") in api.alerts
+    assert api.account_marks == [
+        ("claude_controller", "claude", "live session reported capacity exhaustion")
+    ]
+    assert any(
+        session == "worker_pollypm" and failure_type == "capacity_exhausted"
+        for session, failure_type, _ in api.recoveries
+    )
 
 
 def test_local_heartbeat_backend_triggers_recovery_on_auth_broken() -> None:

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -1,0 +1,15 @@
+from pollypm.provider_failures import has_auth_failure, has_capacity_failure
+
+
+def test_auth_failure_detects_claude_login_prompt() -> None:
+    assert has_auth_failure("Not logged in · Please run /login")
+
+
+def test_capacity_failure_detects_claude_limit_prompt() -> None:
+    assert has_capacity_failure(
+        "You've hit your limit · resets May 26 at 8pm\n/usage-credits"
+    )
+
+
+def test_capacity_failure_ignores_regular_status_text() -> None:
+    assert not has_capacity_failure("Claude Code ready; 72% left")

--- a/tests/test_sessions_admin_endpoint.py
+++ b/tests/test_sessions_admin_endpoint.py
@@ -315,6 +315,29 @@ def patch_heartbeat(monkeypatch: pytest.MonkeyPatch):
     return install
 
 
+@pytest.fixture(autouse=True)
+def patch_session_runtime_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        sessions_admin_routes,
+        "_latest_session_runtime",
+        lambda _config, _name: None,
+    )
+
+
+@pytest.fixture
+def patch_session_runtime(monkeypatch: pytest.MonkeyPatch):
+    """Install a stub for ``_latest_session_runtime`` on the route module."""
+
+    def install(values: dict[str, SimpleNamespace | None]) -> None:
+        monkeypatch.setattr(
+            sessions_admin_routes,
+            "_latest_session_runtime",
+            lambda _config, name: values.get(name),
+        )
+
+    return install
+
+
 @pytest.fixture
 def patch_tmux_windows(monkeypatch: pytest.MonkeyPatch):
     """Install a stub for ``_list_storage_closet_windows``."""
@@ -479,6 +502,29 @@ def test_list_sessions_marks_missing_when_window_absent(
     # Missing window beats heartbeat staleness (matches CLI behavior).
     assert by_name["operator"]["status"] == "missing"
     assert by_name["operator"]["window_present"] is False
+
+
+def test_list_sessions_surfaces_runtime_failure_status(
+    client,
+    auth_headers,
+    patch_heartbeat,
+    patch_session_runtime,
+    patch_tmux_windows,
+):
+    patch_heartbeat({"operator": "2026-05-21T10:00:00Z"})
+    patch_session_runtime({
+        "operator": SimpleNamespace(
+            status="recovering",
+            last_failure_type="capacity_exhausted",
+        )
+    })
+    patch_tmux_windows(["operator"])
+
+    response = client.get("/api/v1/sessions", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    by_name = {s["name"]: s for s in response.json()["sessions"]}
+    assert by_name["operator"]["status"] == "capacity_exhausted"
 
 
 def test_list_sessions_requires_bearer_auth(client):

--- a/tests/test_sessions_health_cli.py
+++ b/tests/test_sessions_health_cli.py
@@ -106,6 +106,48 @@ class TestClassifier:
             == "stale"
         )
 
+    def test_runtime_auth_failure_overrides_fresh_heartbeat(self) -> None:
+        assert (
+            mod._classify_status(
+                window_present=True,
+                age_seconds=5,
+                runtime_status="auth_broken",
+            )
+            == "auth_broken"
+        )
+
+    def test_runtime_capacity_failure_overrides_fresh_heartbeat(self) -> None:
+        assert (
+            mod._classify_status(
+                window_present=True,
+                age_seconds=5,
+                runtime_status="recovering",
+                last_failure_type="capacity_exhausted",
+            )
+            == "capacity_exhausted"
+        )
+
+    def test_missing_window_still_wins_over_runtime_failure(self) -> None:
+        assert (
+            mod._classify_status(
+                window_present=False,
+                age_seconds=5,
+                runtime_status="auth_broken",
+            )
+            == "missing"
+        )
+
+    def test_recovered_runtime_does_not_pin_old_failure(self) -> None:
+        assert (
+            mod._classify_status(
+                window_present=True,
+                age_seconds=5,
+                runtime_status="healthy",
+                last_failure_type="capacity_exhausted",
+            )
+            == "healthy"
+        )
+
 
 # ---------------------------------------------------------------------------
 # humanize_age
@@ -138,6 +180,7 @@ class TestHumanize:
 class TestBuildRow:
     def test_token_ok_when_session_has_auth_token(self, monkeypatch) -> None:
         monkeypatch.setattr(mod, "_latest_heartbeat", lambda *_, **__: None)
+        monkeypatch.setattr(mod, "_latest_session_runtime", lambda *_, **__: None)
         session = _make_session("worker_demo", auth_token="cafebabe" * 8)
         row = mod._build_row(
             config=_make_config(sessions={"worker_demo": session}),
@@ -150,6 +193,7 @@ class TestBuildRow:
 
     def test_token_missing_for_legacy_session(self, monkeypatch) -> None:
         monkeypatch.setattr(mod, "_latest_heartbeat", lambda *_, **__: None)
+        monkeypatch.setattr(mod, "_latest_session_runtime", lambda *_, **__: None)
         session = _make_session("worker_legacy", auth_token="")
         row = mod._build_row(
             config=_make_config(sessions={"worker_legacy": session}),
@@ -162,6 +206,7 @@ class TestBuildRow:
 
     def test_window_target_includes_storage_session(self, monkeypatch) -> None:
         monkeypatch.setattr(mod, "_latest_heartbeat", lambda *_, **__: None)
+        monkeypatch.setattr(mod, "_latest_session_runtime", lambda *_, **__: None)
         session = _make_session("worker_demo", window="worker-demo")
         row = mod._build_row(
             config=_make_config(sessions={"worker_demo": session}),
@@ -209,6 +254,7 @@ class TestLatestHeartbeatPgOnly:
         monkeypatch.setattr(
             mod, "_list_windows", lambda _name: {"worker-demo": _fake_window()}
         )
+        monkeypatch.setattr(mod, "_latest_session_runtime", lambda *_, **__: None)
 
         result = runner.invoke(_build_cli_app(), ["sessions", "--json"])
         assert result.exit_code == 0, result.output
@@ -228,6 +274,7 @@ def _install_fakes(
     sessions: dict[str, SimpleNamespace],
     windows: dict[str, SimpleNamespace],
     heartbeats: dict[str, SimpleNamespace | None],
+    runtimes: dict[str, SimpleNamespace | None] | None = None,
 ) -> None:
     config = _make_config(sessions=sessions)
     monkeypatch.setattr(
@@ -238,6 +285,12 @@ def _install_fakes(
         mod,
         "_latest_heartbeat",
         lambda _config, session_name: heartbeats.get(session_name),
+    )
+    runtimes = runtimes or {}
+    monkeypatch.setattr(
+        mod,
+        "_latest_session_runtime",
+        lambda _config, session_name: runtimes.get(session_name),
     )
 
 
@@ -382,6 +435,34 @@ class TestSessionsHealthCLI:
                 "last_heartbeat_age",
                 "token",
             } <= payload.keys()
+
+    def test_json_output_surfaces_runtime_failure_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = _make_session(
+            "operator",
+            role="operator-pm",
+            window="pm-operator",
+            auth_token="t" * 16,
+        )
+        _install_fakes(
+            monkeypatch,
+            sessions={"operator": session},
+            windows={"pm-operator": _fake_window()},
+            heartbeats={"operator": _heartbeat(seconds_ago=5)},
+            runtimes={
+                "operator": SimpleNamespace(
+                    status="auth_broken",
+                    last_failure_type="auth_broken",
+                )
+            },
+        )
+
+        result = runner.invoke(_build_cli_app(), ["sessions", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output.strip().splitlines()[0])
+        assert payload["status"] == "auth_broken"
 
     def test_health_flag_adds_diagnostic_columns(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Fixes #2295 and #2297 by detecting live provider login and quota-limit panes instead of treating fresh heartbeat output as healthy.
- Adds shared provider failure text classifiers used by both the heartbeat backend and supervisor alert boundary.
- Surfaces runtime failure pins (`auth_broken`, `capacity_exhausted`, etc.) through `pm sessions` and the sessions-admin API/OpenAPI so functional failures do not disappear behind mechanical liveness.

## Verification
- `uv run --with pytest pytest tests/test_provider_failures.py tests/test_sessions_health_cli.py tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_marks_auth_broken tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_marks_login_prompt_auth_broken tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_marks_capacity_exhausted tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_triggers_recovery_on_auth_broken tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_triggers_recovery_on_org_disabled -q`
- `uv run --with pytest pytest --noconftest tests/test_sessions_admin_endpoint.py -q`
- `uv run python -m compileall -q src/pollypm/provider_failures.py src/pollypm/session_health.py src/pollypm/cli_features/sessions_health.py src/pollypm/web_api/routes/sessions_admin.py src/pollypm/supervisor.py src/pollypm/heartbeats/local.py src/pollypm/heartbeats/api.py tests/test_provider_failures.py tests/test_sessions_health_cli.py tests/test_heartbeat_plugin_api.py tests/test_sessions_admin_endpoint.py`
- `uv run --with ruff ruff check --select E9,F821 ...` on the changed Python files

## Notes
- A full `tests/test_heartbeat_plugin_api.py` run still has unrelated environment-sensitive failures in existing checkpoint-count tests and subprocess monkeypatch teardown. The focused heartbeat tests for this change pass.
