### PR TITLE
fix(work): release worker_session row on terminal transitions (fixes #2305)

### DIFF
--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -95,6 +95,18 @@ _CLAIM_CONTESTED_STATUSES = frozenset({
     WorkStatus.REVIEW,
 })
 
+# #2305 — task states that hold an active per-task worker session row
+# (``work_sessions.ended_at IS NULL``). When a transition leaves one of
+# these states for anything else, the session row must be stamped ended
+# or the per-project ``max_parallel_workers`` cap leaks: cap is counted
+# from active session rows, and a leaked row 429s every subsequent claim
+# until ``pm serve`` restarts.
+_WORKER_SESSION_HOLDING_STATUSES = frozenset({
+    WorkStatus.IN_PROGRESS,
+    WorkStatus.REVIEW,
+    WorkStatus.REWORK,
+})
+
 # Per-process dedup for the ``work_db.opened`` audit row (#1808). The
 # event is a doctor / heartbeat diagnostic stamped at first open of a
 # given (subject, project_path) pair — subsequent opens within the
@@ -1906,6 +1918,23 @@ class PgWorkService:
             actor=actor,
             reason=reason,
         )
+        # #2305: release the worker-cap slot when the task leaves an
+        # active worker state for one that does not hold a session
+        # (e.g. ``in_progress``→``done`` via ``mark_done``,
+        # ``in_progress``→``cancelled`` via ``cancel``,
+        # ``in_progress``→``on_hold`` via ``hold``, etc.). The cap is
+        # counted from ``work_sessions WHERE ended_at IS NULL``, so a
+        # leak here 429s every subsequent claim on the project until
+        # ``pm serve`` restarts.
+        if (
+            current in _WORKER_SESSION_HOLDING_STATUSES
+            and to_state not in _WORKER_SESSION_HOLDING_STATUSES
+        ):
+            self._release_worker_session_for_transition(
+                project=project,
+                task_number=task_number,
+                ended_at=now,
+            )
         task = self.get(task_id)
         self._sync_transition(task, current.value, to_state.value)
         return task
@@ -3018,6 +3047,18 @@ class PgWorkService:
                         None,
                     )
                 conn.commit()
+            # #2305: ensure the worker-cap slot is released. The session
+            # manager's failure path already calls
+            # ``_release_cap_slot_on_failure`` for the cap-exceeded race
+            # that triggered this rollback, but for any other provision
+            # failure that lands here we belt-and-suspender stamp
+            # ``ended_at`` so a leaked placeholder can't 429 the next
+            # claim.
+            self._release_worker_session_for_transition(
+                project=project,
+                task_number=task_number,
+                ended_at=now,
+            )
             logger.warning(
                 "claim rollback: %s/%d returned to queued after "
                 "post-commit provision failure (%s)",
@@ -3228,6 +3269,19 @@ class PgWorkService:
         self._sync_transition(
             result, from_status.value, result.work_status.value
         )
+        # #2305: if the advance landed on a state that no longer holds a
+        # worker session (terminal ``done``, plus ``queued``/``on_hold``
+        # bypass nodes), free the cap slot. ``review`` and a new
+        # ``in_progress`` keep the row active for the next node.
+        if (
+            from_status in _WORKER_SESSION_HOLDING_STATUSES
+            and result.work_status not in _WORKER_SESSION_HOLDING_STATUSES
+        ):
+            self._release_worker_session_for_transition(
+                project=task.project,
+                task_number=task.task_number,
+                ended_at=now,
+            )
         self._write_review_summary_after_transition(result)
         if (
             result.flow_template_id == "plan_project"
@@ -5142,6 +5196,49 @@ class PgWorkService:
                     (ended_at, task_project, task_number),
                 )
             conn.commit()
+
+    def _release_worker_session_for_transition(
+        self,
+        *,
+        project: str,
+        task_number: int,
+        ended_at: str | datetime,
+    ) -> None:
+        """End any active worker session row for ``(project, task_number)``.
+
+        #2305 — the per-project worker-cap (``max_parallel_workers``)
+        counts ``work_sessions`` rows with ``ended_at IS NULL``. Pre-fix
+        only :meth:`release` and the teardown helpers stamped
+        ``ended_at``; transitions through :meth:`mark_done`,
+        :meth:`force_review`, :meth:`cancel`, :meth:`hold`, the
+        ``node_done`` terminal advance, and the post-commit claim
+        rollback all left the row open. After enough such transitions
+        the project hit cap and every subsequent claim returned 429
+        ``worker_cap_exceeded`` until ``pm serve`` restarted.
+
+        This helper stamps ``ended_at`` only on rows that are still
+        active so re-running it is a no-op and we don't accidentally
+        backdate an already-ended row. Best-effort: a DB error is
+        logged at debug and swallowed because the surfaced transition
+        is the primary signal; the next claim will re-evaluate cap
+        from source-of-truth.
+        """
+        try:
+            with self._pool.connection() as conn:
+                conn.autocommit = False
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE work_sessions SET ended_at = %s "
+                        "WHERE task_project = %s AND task_number = %s "
+                        "AND ended_at IS NULL",
+                        (ended_at, project, task_number),
+                    )
+                conn.commit()
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "release worker session for %s/%d failed",
+                project, task_number, exc_info=True,
+            )
 
     def update_worker_session_tokens(
         self,

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -1755,3 +1755,138 @@ def test_available_flows_returns_some_templates(pg_service):
 def test_get_flow_returns_template(pg_service):
     tmpl = pg_service.get_flow("standard")
     assert tmpl.name == "standard"
+
+
+# ---------------------------------------------------------------------------
+# #2305 worker-cap counter leak — terminal transitions must release
+# the per-project ``work_sessions`` row so the cap doesn't saturate
+# and 429 every subsequent claim until ``pm serve`` restarts.
+# ---------------------------------------------------------------------------
+
+
+def _seed_active_session(svc, task):
+    """Simulate a successfully-provisioned worker session row."""
+    from datetime import UTC, datetime
+
+    svc.upsert_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        agent_name="alice",
+        pane_id=f"pane-{task.task_number}",
+        worktree_path=f"/tmp/wt-{task.task_number}",
+        branch_name=f"task/{task.task_number}",
+        started_at=datetime.now(UTC),
+    )
+
+
+def _active_session_count(svc, project: str) -> int:
+    return len(
+        svc.list_worker_sessions(project=project, active_only=True)
+    )
+
+
+def test_mark_done_releases_worker_cap_slot(pg_service):
+    """#2305 — ``mark_done`` from ``in_progress`` ends the session row."""
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    _seed_active_session(pg_service, task)
+
+    assert _active_session_count(pg_service, task.project) == 1
+    pg_service.mark_done(task.task_id, actor="operator")
+    # The cap slot must be freed so a follow-up claim doesn't 429.
+    assert _active_session_count(pg_service, task.project) == 0
+
+
+def test_cancel_releases_worker_cap_slot(pg_service):
+    """#2305 — ``cancel`` from ``in_progress`` ends the session row."""
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    _seed_active_session(pg_service, task)
+
+    assert _active_session_count(pg_service, task.project) == 1
+    pg_service.cancel(task.task_id, actor="operator", reason="oops")
+    assert _active_session_count(pg_service, task.project) == 0
+
+
+def test_hold_releases_worker_cap_slot(pg_service):
+    """#2305 — ``hold`` from ``in_progress`` ends the session row."""
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    _seed_active_session(pg_service, task)
+
+    assert _active_session_count(pg_service, task.project) == 1
+    pg_service.hold(task.task_id, actor="operator", reason="pause")
+    assert _active_session_count(pg_service, task.project) == 0
+
+
+def test_force_review_releases_worker_cap_slot(pg_service):
+    """#2305 — ``force_review`` moves in_progress→review.
+
+    ``review`` is itself a holding state (the reviewer node is still
+    associated with the worker session), so the cap slot is preserved.
+    Approving / rejecting the review later will free it via the
+    terminal advance / rework path.
+    """
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    _seed_active_session(pg_service, task)
+
+    assert _active_session_count(pg_service, task.project) == 1
+    pg_service.force_review(task.task_id, actor="operator")
+    # review still holds a session row; cap is unchanged.
+    assert _active_session_count(pg_service, task.project) == 1
+
+
+def test_cap_does_not_leak_across_repeated_done_cycles(pg_service):
+    """#2305 regression — N successive claim→done cycles must not saturate cap.
+
+    Pre-fix: ``mark_done`` left ``ended_at IS NULL`` so each cycle
+    incremented the active count. After ``max_parallel_workers``
+    cycles every subsequent claim 429'd until ``pm serve`` restarted.
+    Post-fix: source-of-truth re-counts zero between cycles.
+    """
+    project = "demo"
+    for _ in range(5):
+        task = _make_draft(pg_service, project=project)
+        pg_service.queue(task.task_id, actor="user")
+        pg_service.claim(task.task_id, actor="alice")
+        _seed_active_session(pg_service, task)
+        pg_service.mark_done(task.task_id, actor="operator")
+    # All five sessions must be terminated; the cap counter (counted
+    # from ``work_sessions`` rows with ``ended_at IS NULL``) must be 0.
+    assert _active_session_count(pg_service, project) == 0
+
+
+def test_release_worker_session_helper_is_idempotent(pg_service):
+    """The helper must not bump ``ended_at`` on an already-ended row."""
+    from datetime import UTC, datetime
+
+    task = _make_draft(pg_service)
+    _seed_active_session(pg_service, task)
+    first_end = datetime.now(UTC).isoformat()
+    pg_service._release_worker_session_for_transition(
+        project=task.project,
+        task_number=task.task_number,
+        ended_at=first_end,
+    )
+    rec_after_first = pg_service.get_worker_session(
+        task_project=task.project, task_number=task.task_number
+    )
+    assert rec_after_first is not None
+    assert rec_after_first.ended_at is not None
+    # A second release with a different timestamp must not overwrite —
+    # the helper only updates rows where ``ended_at IS NULL``.
+    pg_service._release_worker_session_for_transition(
+        project=task.project,
+        task_number=task.task_number,
+        ended_at=datetime.now(UTC).isoformat(),
+    )
+    rec_after_second = pg_service.get_worker_session(
+        task_project=task.project, task_number=task.task_number
+    )
+    assert rec_after_second is not None
+    assert rec_after_second.ended_at == rec_after_first.ended_at


### PR DESCRIPTION
## Agent Identity
- Agent: claude (subagent for #2305)
- Branch: `claude/2305-worker-cap-from-pg-state`
- Worktree: `.claude/worktrees/agent-a4adf7114683a353d`
- HEAD SHA: e45bb6fb71ca697804fdc4f9e29b80ca064f58e0

## Summary
Fixes #2305 — per-project worker-cap (`max_parallel_workers`) counter leaks on every terminal transition that bypasses `release()` / `teardown_worker`. The cap is counted from `work_sessions WHERE ended_at IS NULL`, and pre-fix `mark_done`, `cancel`, `force_review`, `hold`, the `node_done` terminal advance, and `_rollback_claim_to_queued` all left the row open. After enough cycles the project saturated cap (default 5) and every subsequent claim returned `429 worker_cap_exceeded` until `pm serve` restarted — blocking cascade recovery from ever healing.

## Diagnosis
- `PgWorkService._simple_transition` (the shared body for `mark_done` / `cancel` / `force_review` / `force_in_progress` / `hold`) wrote the transition + audit row but never stamped `ended_at` on the associated `work_sessions` row.
- `_advance_to_node_locked`'s terminal branch (called from `node_done`) did the same — terminal `DONE` left the session row open.
- `_rollback_claim_to_queued` rolled the task back to `queued` but relied on `_release_cap_slot_on_failure` in session_manager to free the slot. That helper only fires on the cap-exceeded race path; other provision failures left the row open.

## Fix
Adds idempotent helper `_release_worker_session_for_transition(project, task_number, ended_at)` that stamps `ended_at` only when the row is still active (`AND ended_at IS NULL` in the WHERE clause). Wired into the three leak paths above. Net +97 LoC in `pg_service.py` (mostly defensive comments + the helper); +135 LoC in `tests/test_pg_work_service_full.py` (6 new regression tests).

The fix keeps the SOURCE-OF-TRUTH semantics the issue asked for: the cap count comes from `work_sessions` rows (the placeholder reservation row is correctly inserted under the advisory lock at claim, and now correctly stamped on every terminal transition). I did NOT switch to counting `work_tasks WHERE work_status='in_progress'` because that would break the #1883 atomic-reservation guarantee (advisory lock + COUNT + INSERT placeholder serialises concurrent claims; a `work_tasks` count would race against the inter-tx UPDATE).

## Before / After
**Repro (regression test `test_cap_does_not_leak_across_repeated_done_cycles`)**: 5 cycles of `claim → seed_session → mark_done`.
- **Before (current main)**: `_active_session_count = 5` after 5 cycles. At default `max_parallel_workers=5`, the 6th claim would 429 indefinitely.
- **After**: `_active_session_count = 0`. Cap correctly tracks terminal transitions; subsequent claims succeed.

5 of 5 new tests fail against `main` (confirmed via `git stash` + re-run); 6 of 6 pass with the fix.

## Test Results
- `tests/test_pg_work_service_full.py` — 130 passed (incl. 6 new `#2305` regression tests), 1 pre-existing flake (unrelated home-write guard on `test_state_counts_aggregates`).
- `tests/test_pg_work_service.py` / `_extra.py` / `_parity.py` — all pre-existing failures; not touched by this fix.

## Cascade-Recovery Mitigation
This advances #2303 + #2304 mitigation: rolled-back claims now reliably release their cap slot via two independent code paths (`_release_cap_slot_on_failure` in `session_manager.py` for the cap-exceeded race, plus the new `_release_worker_session_for_transition` belt-and-suspenders in `_rollback_claim_to_queued` for every other provision failure).

## Test plan
- [x] Confirm bug exists on main (5 leaked rows after 5 done cycles).
- [x] Confirm fix removes leak (0 active rows after 5 cycles).
- [x] Re-run `tests/test_pg_work_service_full.py` end-to-end.
- [ ] Codex review for SQL correctness + atomicity of advisory-lock interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)