### PR TITLE
fix: align task and inbox translation surfaces

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1868,6 +1868,10 @@ paths:
           schema:
             $ref: "#/components/schemas/InboxItemState"
         - in: query
+          name: include_drafts
+          description: Include notify-only draft/FYI task rows hidden by default.
+          schema: { type: boolean, default: false }
+        - in: query
           name: limit
           schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
         - in: query
@@ -4598,7 +4602,7 @@ components:
 
     InboxItem:
       type: object
-      required: [id, project, type, state, subject, owner, created_at, updated_at]
+      required: [id, project, type, state, subject, priority, owner, created_at, updated_at]
       properties:
         id: { type: string }
         project: { type: string }
@@ -4607,6 +4611,8 @@ components:
         state:
           $ref: "#/components/schemas/InboxItemState"
         subject: { type: string }
+        priority:
+          $ref: "#/components/schemas/TaskPriority"
         preview: { type: string, description: Short preview of the body. }
         owner:
           $ref: "#/components/schemas/InboxOwner"

--- a/src/pollypm/cli_features/sessions_health.py
+++ b/src/pollypm/cli_features/sessions_health.py
@@ -99,6 +99,10 @@ def _log_mtime_iso(config, session_name: str) -> str | None:
     return datetime.fromtimestamp(stat.st_mtime, UTC).isoformat()
 
 
+def _value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
 def _build_row(
     *,
     config,
@@ -125,6 +129,10 @@ def _build_row(
         "name": session.name,
         "role": session.role,
         "project": session.project,
+        "provider": str(_value(getattr(session, "provider", "")) or ""),
+        "account": getattr(session, "account", "") or "",
+        "window_name": window_name,
+        "tmux_session": storage_session,
         "window": f"{storage_session}:{window_name}",
         "status": status,
         "last_heartbeat_age": _humanize_age(hb_iso),

--- a/src/pollypm/web_api/models.py
+++ b/src/pollypm/web_api/models.py
@@ -619,6 +619,7 @@ class InboxItem(BaseModel):
     type: InboxItemTypeStr
     state: InboxItemStateStr
     subject: str
+    priority: TaskPriorityStr
     preview: str | None = None
     owner: InboxOwnerStr
     thread_id: str | None = None

--- a/src/pollypm/web_api/routes/inbox.py
+++ b/src/pollypm/web_api/routes/inbox.py
@@ -59,6 +59,16 @@ def list_inbox_endpoint(
         ),
     ] = None,
     state: Annotated[str | None, Query()] = None,
+    include_drafts: Annotated[
+        bool,
+        Query(
+            description=(
+                "Include notify-only draft/FYI task rows. Defaults to false "
+                "to match `pm inbox --project`; pass true for the wider "
+                "legacy inbox view."
+            )
+        ),
+    ] = False,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     cursor: Annotated[str | None, Query()] = None,
 ) -> InboxListResponse:
@@ -67,6 +77,7 @@ def list_inbox_endpoint(
         project=project,
         type_filter=type,
         state_filter=state,
+        include_drafts=include_drafts,
         limit=limit,
         cursor=cursor,
     )

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -31,6 +31,7 @@ import psycopg_pool
 from pollypm.audit.log import AuditEvent, read_events
 from pollypm.config import PollyPMConfig, load_config
 from pollypm.models import KnownProject
+from pollypm.notify_task import is_notify_only_inbox_entry
 from pollypm.work import inbox_snooze as _inbox_snooze
 from pollypm.work.inbox_view import (
     inbox_item_type_for_task,
@@ -3759,6 +3760,7 @@ def list_inbox(
     project: str | None = None,
     type_filter: str | None = None,
     state_filter: str | None = None,
+    include_drafts: bool = False,
     limit: int = 50,
     cursor: str | None = None,
 ) -> InboxListPage:
@@ -3779,6 +3781,7 @@ def list_inbox(
         project=project,
         type_filter=type_filter,
         state_filter=state_filter,
+        include_drafts=include_drafts,
         limit=candidate_limit,
     )
     if candidate_limit is None or candidate_complete:
@@ -3790,6 +3793,7 @@ def list_inbox(
             project=project,
             type_filter=type_filter,
             state_filter=state_filter,
+            include_drafts=include_drafts,
             limit=None,
         )
     items.sort(key=lambda item: item.updated_at, reverse=True)
@@ -3854,6 +3858,7 @@ def get_inbox_item(config: PollyPMConfig, item_id: str) -> APIInboxItemDetail | 
         type=target.type,
         state=target.state,
         subject=target.subject,
+        priority=target.priority,
         preview=target.preview,
         owner=target.owner,
         thread_id=target.thread_id,
@@ -3870,6 +3875,7 @@ def _collect_inbox_items(
     project: str | None,
     type_filter: str | None = None,
     state_filter: str | None = None,
+    include_drafts: bool = False,
     limit: int | None = None,
 ) -> tuple[list[APIInboxItem], int, bool]:
     """Load inbox items from the work-service for the requested projects.
@@ -3934,6 +3940,8 @@ def _collect_inbox_items(
                 flow_cache: dict = {}
                 for task in tasks:
                     if task.task_id in snoozed_ids:
+                        continue
+                    if not include_drafts and is_notify_only_inbox_entry(task):
                         continue
                     if not inbox_task_matches_type(task, type_filter):
                         continue
@@ -4241,6 +4249,7 @@ def _task_to_inbox_item(
         type=item_type,
         state=state,
         subject=task.title,
+        priority=_enum_value(getattr(task, "priority", "normal")),
         preview=preview,
         owner=_inbox_owner_for_task(task),
         thread_id=task.task_id,

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -237,6 +237,18 @@ def _project_from_task_id(task_id: str) -> str | None:
     return None
 
 
+def _value(value):
+    return getattr(value, "value", value)
+
+
+def _json_datetime(value):
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
 def _svc(project: str | None = None) -> "WorkService":
     import atexit
 
@@ -469,14 +481,27 @@ def _task_to_dict(task) -> dict:
     # --json`` consumers can read the structured inbox-item
     # discriminator alongside the rest of the task state.
     kind_value = _coerce_inbox_kind(getattr(task, "kind", None)).value
+    transitions = [
+        {
+            "from_state": _value(tr.from_state),
+            "to_state": _value(tr.to_state),
+            "actor": tr.actor,
+            "timestamp": _json_datetime(getattr(tr, "timestamp", None)),
+            "reason": tr.reason,
+        }
+        for tr in sorted(
+            getattr(task, "transitions", None) or [],
+            key=lambda tr: _json_datetime(getattr(tr, "timestamp", None)) or "",
+        )
+    ]
     return {
         "task_id": task.task_id,
         "project": task.project,
         "task_number": task.task_number,
         "title": task.title,
-        "type": task.type.value,
-        "work_status": task.work_status.value,
-        "priority": task.priority.value,
+        "type": _value(task.type),
+        "work_status": _value(task.work_status),
+        "priority": _value(task.priority),
         "kind": kind_value,
         "assignee": task.assignee,
         "claimed_by_session": getattr(task, "claimed_by_session", None),
@@ -494,12 +519,13 @@ def _task_to_dict(task) -> dict:
         "tokens_in": task.total_input_tokens,
         "tokens_out": task.total_output_tokens,
         "session_count": task.session_count,
+        "transitions": transitions,
         "executions": [
             {
                 "node_id": ex.node_id,
                 "visit": ex.visit,
-                "status": ex.status.value if hasattr(ex.status, "value") else ex.status,
-                "decision": (ex.decision.value if ex.decision and hasattr(ex.decision, "value") else ex.decision),
+                "status": _value(ex.status),
+                "decision": _value(ex.decision) if ex.decision else ex.decision,
                 "decision_reason": ex.decision_reason,
             }
             for ex in task.executions

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -555,8 +555,8 @@ def inbox_root(
     # #1013 — hide ``pm notify``-backed stub tasks (chat-flow rows
     # carrying the ``notify`` label) by default.
     if not show_drafts:
-        from pollypm.notify_task import is_notify_inbox_task
-        tasks = [task for task in tasks if not is_notify_inbox_task(task)]
+        from pollypm.notify_task import is_notify_only_inbox_entry
+        tasks = [task for task in tasks if not is_notify_only_inbox_entry(task)]
 
     # #1806 — default-lens curation.
     if apply_curated_filter or awaits_user_only:

--- a/tests/test_cli_task_json_contract.py
+++ b/tests/test_cli_task_json_contract.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pollypm.work.cli import _task_to_dict
+from pollypm.work.models import (
+    Priority,
+    Task,
+    TaskType,
+    Transition,
+    WorkStatus,
+)
+
+
+def test_task_to_dict_includes_rest_shaped_transitions_oldest_first() -> None:
+    late = datetime(2026, 5, 25, 12, 5, tzinfo=UTC)
+    early = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+    task = Task(
+        project="demo",
+        task_number=1,
+        title="Serialize me",
+        type=TaskType.TASK,
+        work_status=WorkStatus.IN_PROGRESS,
+        priority=Priority.HIGH,
+        transitions=[
+            Transition(
+                from_state="queued",
+                to_state="in_progress",
+                actor="worker",
+                timestamp=late,
+                reason="claim",
+            ),
+            Transition(
+                from_state="draft",
+                to_state="queued",
+                actor="pm",
+                timestamp=early,
+                reason=None,
+            ),
+        ],
+    )
+
+    payload = _task_to_dict(task)
+
+    assert payload["transitions"] == [
+        {
+            "from_state": "draft",
+            "to_state": "queued",
+            "actor": "pm",
+            "timestamp": "2026-05-25T12:00:00+00:00",
+            "reason": None,
+        },
+        {
+            "from_state": "queued",
+            "to_state": "in_progress",
+            "actor": "worker",
+            "timestamp": "2026-05-25T12:05:00+00:00",
+            "reason": "claim",
+        },
+    ]

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -202,6 +202,7 @@ def test_list_inbox_response_includes_counts(
         type="message",
         state="open",
         subject="Inbox item",
+        priority="high",
         owner="pm",
         thread_id="myproj/1",
         created_at=now,
@@ -227,6 +228,7 @@ def test_list_inbox_response_includes_counts(
     assert body["has_more"] is True
     assert body["unread_count"] == 2
     assert body["next_cursor"] == "myproj/1"
+    assert body["items"][0]["priority"] == "high"
 
 
 def test_task_list_responses_include_counts(
@@ -2122,10 +2124,11 @@ class _ReadInboxTask:
         status=None,
         kind=None,
         labels: list[str] | None = None,
+        priority=None,
         updated_at: datetime | None = None,
     ) -> None:
         from pollypm.inbox.kind import InboxItemKind
-        from pollypm.work.models import WorkStatus
+        from pollypm.work.models import Priority, WorkStatus
 
         self.task_id = f"myproj/{n}"
         self.project = "myproj"
@@ -2138,6 +2141,7 @@ class _ReadInboxTask:
         self.roles = {"requester": "user", "operator": "pm"}
         self.current_node_id = None
         self.work_status = status or WorkStatus.IN_PROGRESS
+        self.priority = priority or Priority.NORMAL
         self.kind = kind or InboxItemKind.LEGACY
         self.created_at = datetime(2026, 5, 22, 12, 0, tzinfo=timezone.utc)
         self.updated_at = updated_at or self.created_at
@@ -2243,6 +2247,60 @@ def test_list_inbox_type_filter_matches_structured_kind(
     assert body["items"][0]["type"] == "approval_request"
     assert body["items"][0]["metadata"]["kind"] == "approval_request"
     assert svc.candidate_calls[0]["type_filter"] == "approval_request"
+
+
+def test_list_inbox_includes_priority(
+    client, auth_headers, monkeypatch,
+) -> None:
+    from pollypm.work.models import Priority
+
+    svc = _ReadInboxSvc([
+        _ReadInboxTask(1, title="Priority row", priority=Priority.CRITICAL),
+    ])
+    _install_read_inbox_svc(monkeypatch, svc)
+
+    response = client.get("/api/v1/inbox", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["items"][0]["priority"] == "critical"
+
+
+def test_list_inbox_default_hides_notify_only_task_drafts(
+    client, auth_headers, monkeypatch,
+) -> None:
+    svc = _ReadInboxSvc([
+        _ReadInboxTask(1, title="Visible action"),
+        _ReadInboxTask(2, title="Draft notify", labels=["notify"]),
+    ])
+    _install_read_inbox_svc(monkeypatch, svc)
+
+    response = client.get("/api/v1/inbox?project=myproj", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [item["id"] for item in body["items"]] == ["myproj/1"]
+    assert body["total"] == 1
+
+
+def test_list_inbox_include_drafts_restores_notify_only_tasks(
+    client, auth_headers, monkeypatch,
+) -> None:
+    svc = _ReadInboxSvc([
+        _ReadInboxTask(1, title="Visible action"),
+        _ReadInboxTask(2, title="Draft notify", labels=["notify"]),
+    ])
+    _install_read_inbox_svc(monkeypatch, svc)
+
+    response = client.get(
+        "/api/v1/inbox?project=myproj&include_drafts=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [item["id"] for item in body["items"]] == ["myproj/1", "myproj/2"]
+    assert body["total"] == 2
 
 
 def test_list_inbox_limit_passes_bounded_candidate_limit(

--- a/tests/test_sessions_health_cli.py
+++ b/tests/test_sessions_health_cli.py
@@ -29,6 +29,8 @@ def _make_session(
     *,
     role: str = "worker",
     project: str = "demo",
+    provider: str = "claude",
+    account: str = "claude_main",
     window: str | None = None,
     auth_token: str = "",
     enabled: bool = True,
@@ -37,6 +39,8 @@ def _make_session(
         name=name,
         role=role,
         project=project,
+        provider=provider,
+        account=account,
         window_name=window or name,
         auth_token=auth_token,
         enabled=enabled,
@@ -216,6 +220,8 @@ class TestBuildRow:
             health=False,
         )
         assert row["window"] == "pollypm-storage-closet:worker-demo"
+        assert row["window_name"] == "worker-demo"
+        assert row["tmux_session"] == "pollypm-storage-closet"
 
 
 # ---------------------------------------------------------------------------
@@ -422,6 +428,11 @@ class TestSessionsHealthCLI:
         lines = [line for line in result.output.splitlines() if line.strip()]
         payloads = [json.loads(line) for line in lines]
         assert {p["name"] for p in payloads} == {"worker_demo", "worker_other"}
+        by_name = {p["name"]: p for p in payloads}
+        assert by_name["worker_demo"]["provider"] == "claude"
+        assert by_name["worker_demo"]["account"] == "claude_main"
+        assert by_name["worker_demo"]["tmux_session"] == "pollypm-storage-closet"
+        assert by_name["worker_demo"]["window"] == "pollypm-storage-closet:worker-demo"
         # No table header in JSON mode.
         assert "NAME" not in result.output
         # Each payload carries the required keys.
@@ -430,6 +441,10 @@ class TestSessionsHealthCLI:
                 "name",
                 "role",
                 "project",
+                "provider",
+                "account",
+                "window_name",
+                "tmux_session",
                 "window",
                 "status",
                 "last_heartbeat_age",


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add REST-shaped task transitions to `pm task get --json` in chronological order.
- Add `provider`, `account`, `window_name`, and `tmux_session` to `pm sessions --json`.
- Add inbox `priority` to the REST inbox envelope and document the `include_drafts` flag that preserves legacy notify-only rows.
- Align default notify-only filtering between REST inbox and `pm inbox` while preserving an explicit REST opt-in.

## Issues
Refs #2298
Refs #2299
Refs #2300

## Verification
- `uv run --extra test pytest tests/test_cli_task_json_contract.py tests/test_inbox_writes_endpoint.py::test_list_inbox_includes_priority tests/test_inbox_writes_endpoint.py::test_list_inbox_default_hides_notify_only_task_drafts tests/test_inbox_writes_endpoint.py::test_list_inbox_include_drafts_restores_notify_only_tasks tests/test_sessions_health_cli.py::TestSessionsHealthCLI::test_json_output_emits_one_object_per_line tests/test_sessions_health_cli.py::TestBuildRow::test_window_target_includes_storage_session`
- `uv run --extra dev ruff check src/pollypm/work/cli.py src/pollypm/work/inbox_cli.py src/pollypm/cli_features/sessions_health.py src/pollypm/web_api/models.py src/pollypm/web_api/routes/inbox.py src/pollypm/web_api/service.py tests/test_cli_task_json_contract.py tests/test_inbox_writes_endpoint.py tests/test_sessions_health_cli.py`