### PR TITLE
fix: harden claim races and worker cap accounting

### DIFF
--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -17,6 +17,7 @@ import contextlib
 import logging
 import os
 import re
+import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -120,6 +121,8 @@ _BACKING_STORE_ERRORS: tuple[type[BaseException], ...] = (
     psycopg.OperationalError,
     psycopg_pool.PoolTimeout,
 )
+
+_CLAIM_TRANSIENT_RETRY_DELAYS = (0.02, 0.05, 0.1)
 
 
 @contextlib.contextmanager
@@ -1852,70 +1855,128 @@ def claim_task(
         raise not_found(f"Project not registered: {project_key}")
 
     task_id = f"{project_key}/{task_number}"
+    service_kwargs = {
+        "config": config,
+        "project_key": project_key,
+        "project_path": project.path,
+    }
+    last_store_error: BaseException | None = None
+    for attempt in range(len(_CLAIM_TRANSIENT_RETRY_DELAYS) + 1):
+        try:
+            if provision_scheduler is None:
+                work_service_cm = create_work_service_with_session(
+                    **service_kwargs
+                )
+            else:
+                work_service_cm = create_work_service_with_deferred_session(
+                    **service_kwargs,
+                    schedule=provision_scheduler,
+                )
+            with work_service_cm as svc:
+                try:
+                    svc.claim(task_id, actor)
+                except TaskNotFoundError as exc:
+                    raise not_found(f"Task not found: {task_id}") from exc
+                except InvalidTransitionError as exc:
+                    raise APIError(
+                        status_code=409,
+                        code="invalid_state",
+                        message=(
+                            str(exc) or f"Task {task_id} cannot be claimed."
+                        ),
+                        hint="Only queued+unblocked tasks can be claimed.",
+                    ) from exc
+                except WorkerCapExceededError as exc:
+                    # Normal back-pressure — the project is at its
+                    # ``max_parallel_workers`` ceiling, not a server bug.
+                    raise too_many_requests(
+                        f"Worker cap exceeded for project "
+                        f"{project_key}: {exc}",
+                        code="worker_cap_exceeded",
+                        hint=(
+                            "Wait for an in-progress task on this "
+                            "project to finish, raise "
+                            "`max_parallel_workers` under "
+                            f"`[projects.{project_key}]` in pollypm.toml, "
+                            "or retry the claim once a slot frees up."
+                        ),
+                    ) from exc
+                task = svc.get(task_id)
+                warnings = _collect_claim_warnings(svc, task, task_id)
+                return _task_to_detail_with_plan(task, svc=svc), warnings
+        except _BACKING_STORE_ERRORS as exc:
+            last_store_error = exc
+            conflict = _claim_conflict_after_transient_store_error(
+                config=config,
+                project_key=project_key,
+                project_path=project.path,
+                task_id=task_id,
+            )
+            if conflict is not None:
+                raise conflict from exc
+            if attempt < len(_CLAIM_TRANSIENT_RETRY_DELAYS):
+                time.sleep(_CLAIM_TRANSIENT_RETRY_DELAYS[attempt])
+                continue
+            logger.warning(
+                "claim_task: backing store error for %s: %s",
+                task_id,
+                exc,
+                exc_info=True,
+            )
+            break
+    assert last_store_error is not None
+    raise service_unavailable(
+        f"Backing store unavailable while claiming {task_id}",
+        hint="Retry shortly; check `pm doctor` if the failure persists.",
+    ) from last_store_error
+
+
+def _claim_conflict_after_transient_store_error(
+    *,
+    config: PollyPMConfig,
+    project_key: str,
+    project_path: Path,
+    task_id: str,
+) -> APIError | None:
+    """Map claim-time store contention to conflict after a fresh read.
+
+    In a claim storm, a losing request can occasionally see a pg pool or
+    lock operational error instead of the normal
+    ``InvalidTransitionError``. If a cheap follow-up read shows the row is
+    no longer queued, the correct API shape is the same 409 a normal loser
+    receives. Real outages still fall through to 503.
+    """
+    from pollypm.work.factory import create_work_service
+
     try:
-        service_kwargs = {
-            "config": config,
-            "project_key": project_key,
-            "project_path": project.path,
-        }
-        if provision_scheduler is None:
-            work_service_cm = create_work_service_with_session(
-                **service_kwargs
-            )
-        else:
-            work_service_cm = create_work_service_with_deferred_session(
-                **service_kwargs,
-                schedule=provision_scheduler,
-            )
-        with work_service_cm as svc:
-            try:
-                svc.claim(task_id, actor)
-            except TaskNotFoundError as exc:
-                raise not_found(f"Task not found: {task_id}") from exc
-            except InvalidTransitionError as exc:
-                raise APIError(
-                    status_code=409,
-                    code="invalid_state",
-                    message=str(exc) or f"Task {task_id} cannot be claimed.",
-                    hint="Only queued+unblocked tasks can be claimed.",
-                ) from exc
-            except WorkerCapExceededError as exc:
-                # #2064 round-11 blocker #1: pre-claim cap probe at
-                # ``PgWorkService.claim`` (``pg_service.py:1759-1763``)
-                # raises ``WorkerCapExceededError`` from
-                # ``SessionManager.check_parallel_cap`` (``session_manager.py:418/473``).
-                # That is normal back-pressure — the project is at its
-                # ``max_parallel_workers`` ceiling — not a server bug.
-                # Surface it as ``429`` with a stable
-                # ``worker_cap_exceeded`` code so clients can apply
-                # back-off and operators see the same recovery story
-                # the CLI emits.
-                raise too_many_requests(
-                    f"Worker cap exceeded for project "
-                    f"{project_key}: {exc}",
-                    code="worker_cap_exceeded",
-                    hint=(
-                        "Wait for an in-progress task on this "
-                        "project to finish, raise "
-                        "`max_parallel_workers` under "
-                        f"`[projects.{project_key}]` in pollypm.toml, "
-                        "or retry the claim once a slot frees up."
-                    ),
-                ) from exc
+        with create_work_service(
+            config=config,
+            project_key=project_key,
+            project_path=project_path,
+        ) as svc:
             task = svc.get(task_id)
-            warnings = _collect_claim_warnings(svc, task, task_id)
-            return _task_to_detail_with_plan(task, svc=svc), warnings
-    except _BACKING_STORE_ERRORS as exc:
-        logger.warning(
-            "claim_task: backing store error for %s: %s",
-            task_id,
-            exc,
-            exc_info=True,
-        )
-        raise service_unavailable(
-            f"Backing store unavailable while claiming {task_id}",
-            hint="Retry shortly; check `pm doctor` if the failure persists.",
-        ) from exc
+    except _BACKING_STORE_ERRORS:
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+    status_attr = getattr(task, "work_status", None)
+    status = getattr(status_attr, "value", status_attr)
+    if status == "queued":
+        return None
+    claimant = (
+        getattr(task, "claimed_by_session", None)
+        or getattr(task, "assignee", None)
+        or "another actor"
+    )
+    return APIError(
+        status_code=409,
+        code="invalid_state",
+        message=(
+            f"Task {task_id} cannot be claimed because it is now "
+            f"'{status}' and owned by '{claimant}'."
+        ),
+        hint="Only queued+unblocked tasks can be claimed.",
+    )
 
 
 def _collect_claim_warnings(

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -95,6 +95,12 @@ _CLAIM_CONTESTED_STATUSES = frozenset({
     WorkStatus.REVIEW,
 })
 
+_CAPACITY_CONSUMING_STATUS_VALUES = (
+    WorkStatus.IN_PROGRESS.value,
+    WorkStatus.REWORK.value,
+)
+
+
 # Per-process dedup for the ``work_db.opened`` audit row (#1808). The
 # event is a doctor / heartbeat diagnostic stamped at first open of a
 # given (subject, project_path) pair — subsequent opens within the
@@ -141,6 +147,24 @@ def _is_cap_exceeded_error(exc: BaseException) -> bool:
         if cls.__name__ == "WorkerCapExceededError":
             return True
     return False
+
+
+def _default_parallel_worker_cap() -> int:
+    try:
+        from pollypm.work.session_manager import DEFAULT_MAX_PARALLEL_WORKERS
+
+        return int(DEFAULT_MAX_PARALLEL_WORKERS)
+    except Exception:  # noqa: BLE001
+        return 5
+
+
+def _worker_cap_exceeded_error(message: str) -> RuntimeError:
+    try:
+        from pollypm.work.session_manager import WorkerCapExceededError
+
+        return WorkerCapExceededError(message)
+    except Exception:  # noqa: BLE001
+        return RuntimeError(message)
 
 
 def _coerce_status(raw: str) -> WorkStatus:
@@ -418,6 +442,117 @@ class PgWorkService:
         registered back. Mirrors :meth:`SQLiteWorkService.set_session_manager`.
         """
         self._session_mgr = session_manager
+
+    def _resolve_parallel_cap(self, project: str) -> int:
+        """Return the configured per-project worker cap.
+
+        Kept local to the pg service so the claim transaction can make
+        the cap decision without calling back into ``SessionManager`` and
+        borrowing more pool connections while holding a task row lock.
+        """
+        config = self._config
+        if config is None:
+            return _default_parallel_worker_cap()
+        projects = getattr(config, "projects", {}) or {}
+        proj = projects.get(project)
+        if proj is None:
+            return _default_parallel_worker_cap()
+        override = getattr(proj, "max_parallel_workers", None)
+        if isinstance(override, int) and override > 0:
+            return override
+        legacy = getattr(proj, "max_concurrent_workers", None)
+        if isinstance(legacy, int) and legacy > 0:
+            return legacy
+        return _default_parallel_worker_cap()
+
+    def _lock_worker_capacity_project(self, cur, project: str) -> None:
+        cur.execute(
+            "SELECT pg_advisory_xact_lock(hashtextextended(%s, 0))",
+            (f"work_tasks.worker_cap:{project}",),
+        )
+
+    def _count_capacity_consuming_tasks_locked(
+        self,
+        cur,
+        *,
+        project: str,
+        exclude_task_number: int | None = None,
+    ) -> int:
+        params: list[object] = [
+            project,
+            *_CAPACITY_CONSUMING_STATUS_VALUES,
+        ]
+        sql = (
+            "SELECT COUNT(*) FROM work_tasks "
+            "WHERE project = %s "
+            "AND work_status IN (%s, %s) "
+            "AND claimed_by_session IS NOT NULL"
+        )
+        if exclude_task_number is not None:
+            sql += " AND task_number <> %s"
+            params.append(exclude_task_number)
+        cur.execute(sql, params)
+        row = cur.fetchone()
+        return int(row[0] if row is not None else 0)
+
+    def count_capacity_consuming_tasks(
+        self,
+        *,
+        project: str,
+        exclude_task_id: str | None = None,
+    ) -> int:
+        """Return active worker-capacity consumers for ``project``.
+
+        Capacity is owned by task lifecycle state, not by stale
+        ``work_sessions`` rows. ``work_sessions`` remains the runtime
+        binding/audit table; ``in_progress`` and ``rework`` are the
+        authoritative states that consume worker capacity.
+        """
+        exclude_task_number: int | None = None
+        if exclude_task_id:
+            try:
+                exclude_project, parsed_number = _parse_task_id(exclude_task_id)
+            except ValidationError:
+                exclude_project = ""
+                parsed_number = None
+            if exclude_project == project:
+                exclude_task_number = parsed_number
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            return self._count_capacity_consuming_tasks_locked(
+                cur,
+                project=project,
+                exclude_task_number=exclude_task_number,
+            )
+
+    def _check_parallel_cap_locked(
+        self,
+        cur,
+        *,
+        project: str,
+        task_number: int,
+        task_id: str,
+    ) -> None:
+        """Enforce project worker capacity inside the claim transaction."""
+        cap = self._resolve_parallel_cap(project)
+        self._lock_worker_capacity_project(cur, project)
+        active = self._count_capacity_consuming_tasks_locked(
+            cur,
+            project=project,
+            exclude_task_number=task_number,
+        )
+        if active < cap:
+            return
+        raise _worker_cap_exceeded_error(
+            f"Cannot spawn worker for {task_id}: project {project!r} "
+            f"already has {active} active worker tasks (cap={cap}). "
+            "Why it matters: per-task workers run in parallel up to a "
+            "per-project ceiling so a queue burst doesn't burn every "
+            "provider session at once. "
+            "Fix: wait for one of the running workers to finish, or "
+            "raise the cap by setting "
+            f"`max_parallel_workers = <N>` under `[projects.{project}]` "
+            "in pollypm.toml."
+        )
 
     # ------------------------------------------------------------------
     # Read path
@@ -1744,6 +1879,41 @@ class PgWorkService:
                 exc_info=True,
             )
 
+    def _finish_worker_session_after_capacity_release(
+        self,
+        task_id: str,
+        *,
+        project: str,
+        task_number: int,
+        from_state: WorkStatus,
+        to_state: WorkStatus,
+        ended_at: datetime,
+    ) -> None:
+        """End the worker runtime when a capacity-consuming task exits.
+
+        The cap check no longer trusts ``work_sessions.ended_at``, but
+        terminal/release transitions should still close the runtime
+        binding for auditability and future same-task reclaims.
+        """
+        if to_state in TERMINAL_STATUSES:
+            self._finish_worker_session_after_release(
+                task_id,
+                project=project,
+                task_number=task_number,
+                ended_at=ended_at,
+            )
+            return
+        if from_state.value not in _CAPACITY_CONSUMING_STATUS_VALUES:
+            return
+        if to_state.value in _CAPACITY_CONSUMING_STATUS_VALUES:
+            return
+        self._finish_worker_session_after_release(
+            task_id,
+            project=project,
+            task_number=task_number,
+            ended_at=ended_at,
+        )
+
     def mark_done(self, task_id: str, actor: str) -> Task:
         """Force a task to ``done`` without running the flow.
 
@@ -1908,6 +2078,14 @@ class PgWorkService:
         )
         task = self.get(task_id)
         self._sync_transition(task, current.value, to_state.value)
+        self._finish_worker_session_after_capacity_release(
+            task_id,
+            project=project,
+            task_number=task_number,
+            from_state=current,
+            to_state=to_state,
+            ended_at=now,
+        )
         return task
 
     def _emit_status_changed_audit(
@@ -2716,22 +2894,25 @@ class PgWorkService:
                     if node.type == NodeType.REVIEW
                     else WorkStatus.IN_PROGRESS
                 )
-                # #1737 — pre-claim cap check. Runs INSIDE the
-                # transaction but BEFORE the UPDATE so cap-exceeded
-                # callers don't commit a transition they'll then have
-                # to roll back. The cap check queries worker session
-                # rows (not work_tasks), so it doesn't deadlock against
-                # our row lock. Mirrors the sqlite transition manager.
+                # #2303/#2305 — pre-claim cap check. Runs INSIDE the
+                # transaction and uses this cursor, so a claim storm
+                # cannot starve the pg pool by holding a task row lock
+                # while borrowing extra connections through
+                # SessionManager. Capacity is counted from active task
+                # state (in_progress/rework), not stale work_sessions
+                # rows whose ended_at may be missing after crashes or
+                # older lifecycle paths.
                 if (
                     resolved_target_status is WorkStatus.IN_PROGRESS
                     and not skip_gates
                     and self._session_mgr is not None
                 ):
-                    check_cap = getattr(
-                        self._session_mgr, "check_parallel_cap", None,
+                    self._check_parallel_cap_locked(
+                        cur,
+                        project=project,
+                        task_number=task_number,
+                        task_id=task_id,
                     )
-                    if callable(check_cap):
-                        check_cap(project, task_id)
 
                 cur.execute(
                     "UPDATE work_tasks SET work_status = %s, assignee = %s, "
@@ -3023,6 +3204,27 @@ class PgWorkService:
                 "post-commit provision failure (%s)",
                 project, task_number, exc,
             )
+            self._finish_worker_session_after_release(
+                f"{project}/{task_number}",
+                project=project,
+                task_number=task_number,
+                ended_at=now,
+            )
+            try:
+                self.add_context(
+                    f"{project}/{task_number}",
+                    actor or "system",
+                    "Claim rolled back to queued after worker "
+                    f"provisioning failed: {exc}",
+                    entry_type="claim_rollback",
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "claim rollback context failed for %s/%d",
+                    project,
+                    task_number,
+                    exc_info=True,
+                )
             return True
         except Exception as rollback_exc:  # noqa: BLE001
             logger.warning(
@@ -3228,6 +3430,14 @@ class PgWorkService:
         self._sync_transition(
             result, from_status.value, result.work_status.value
         )
+        self._finish_worker_session_after_capacity_release(
+            task_id,
+            project=task.project,
+            task_number=task.task_number,
+            from_state=from_status,
+            to_state=result.work_status,
+            ended_at=now,
+        )
         self._write_review_summary_after_transition(result)
         if (
             result.flow_template_id == "plan_project"
@@ -3404,6 +3614,12 @@ class PgWorkService:
         # Cascade: any dependents blocked on this task should unblock
         # when approve drives us to DONE. Mirrors sqlite path.
         if result.work_status == WorkStatus.DONE:
+            self._finish_worker_session_after_release(
+                task_id,
+                project=task.project,
+                task_number=task.task_number,
+                ended_at=now,
+            )
             try:
                 self._check_auto_unblock(task_id)
             except Exception:  # noqa: BLE001
@@ -3618,6 +3834,14 @@ class PgWorkService:
         result = self.get(task_id)
         self._sync_transition(
             result, old_status.value, WorkStatus.BLOCKED.value
+        )
+        self._finish_worker_session_after_capacity_release(
+            task_id,
+            project=task.project,
+            task_number=task.task_number,
+            from_state=old_status,
+            to_state=WorkStatus.BLOCKED,
+            ended_at=now,
         )
         return result
 
@@ -4164,6 +4388,14 @@ class PgWorkService:
         )
         result = self.get(task_id)
         self._sync_transition(result, from_status.value, WorkStatus.DONE.value)
+        self._finish_worker_session_after_capacity_release(
+            task_id,
+            project=project,
+            task_number=task_number,
+            from_state=from_status,
+            to_state=WorkStatus.DONE,
+            ended_at=now,
+        )
         # Cascade: any dependents blocked on this task should unblock,
         # same as mark_done. archive_task is effectively 'done' for the
         # chat-flow, so we respect the same contract.
@@ -4973,12 +5205,11 @@ class PgWorkService:
         """Atomically reserve a per-project worker-cap slot (#1883).
 
         Holds a transaction-scoped ``pg_advisory_xact_lock`` keyed on
-        ``"worker_cap:{task_project}"`` while counting active rows and
-        inserting the placeholder. Two concurrent ``provision_worker``
-        calls for different ``task_number``\\s on the same project
-        therefore serialise on the lock; once the first commits its
-        placeholder, the second's COUNT sees the new row and (if at
-        cap) returns ``False`` without inserting.
+        the project while counting active task-state capacity consumers
+        and inserting the placeholder. ``work_sessions`` rows are runtime
+        bindings; they are not the authoritative cap source because old
+        rows can survive with ``ended_at IS NULL`` after interrupted
+        lifecycle paths.
 
         Idempotent for the same ``(task_project, task_number)``: an
         existing row (active or not) short-circuits to ``True`` without
@@ -4989,11 +5220,7 @@ class PgWorkService:
         with self._pool.connection() as conn:
             conn.autocommit = False
             with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT pg_advisory_xact_lock("
-                    "hashtextextended(%s, 0))",
-                    (f"work_sessions.worker_cap:{task_project}",),
-                )
+                self._lock_worker_capacity_project(cur, task_project)
                 # Idempotent path: an existing row for this task
                 # consumes its own slot already.
                 cur.execute(
@@ -5005,12 +5232,11 @@ class PgWorkService:
                 if existing is not None and existing[0] is None:
                     conn.commit()
                     return True
-                cur.execute(
-                    "SELECT COUNT(*) FROM work_sessions "
-                    "WHERE task_project = %s AND ended_at IS NULL",
-                    (task_project,),
+                active = self._count_capacity_consuming_tasks_locked(
+                    cur,
+                    project=task_project,
+                    exclude_task_number=task_number,
                 )
-                active = int(cur.fetchone()[0])
                 if active >= int(cap):
                     conn.rollback()
                     return False

--- a/src/pollypm/work/service_factory.py
+++ b/src/pollypm/work/service_factory.py
@@ -347,7 +347,7 @@ def provision_claimed_worker(
             try:
                 session_mgr.provision_worker(task_id, agent_name)
             except Exception as exc:  # noqa: BLE001
-                _rollback_deferred_claim_if_cap_exceeded(
+                _record_deferred_provision_failure(
                     svc, task, task_id, agent_name, exc
                 )
                 raise
@@ -360,48 +360,40 @@ def provision_claimed_worker(
         )
 
 
-def _rollback_deferred_claim_if_cap_exceeded(
+def _record_deferred_provision_failure(
     svc: Any,
     task: Any,
     task_id: str,
     actor: str,
     exc: BaseException,
 ) -> None:
-    """Mirror PgWorkService.claim's cap-race rollback when available."""
-    if not _is_worker_cap_exceeded(exc):
+    """Audit deferred provisioning failure without undoing the claim.
+
+    The HTTP claim response has already reported success by the time
+    deferred provisioning runs. Rolling the task back in the background
+    makes the 200 response false and hides the ownership boundary from
+    operators. Keep the claim and record an explicit breadcrumb instead.
+    """
+    add_context = getattr(svc, "add_context", None)
+    if not callable(add_context):
         return
-    status = getattr(getattr(task, "work_status", None), "value", None)
-    if status is None:
-        status = getattr(task, "work_status", None)
-    if status != "in_progress":
-        return
-    rollback = getattr(svc, "_rollback_claim_to_queued", None)
-    if not callable(rollback):
-        return
-    node_id = getattr(task, "current_node_id", None)
-    if not node_id:
-        return
+    reason = (
+        "Deferred worker provisioning failed after the task was claimed; "
+        f"claim preserved for {actor}. Error: {exc}"
+    )
     try:
-        rollback(
-            getattr(task, "project"),
-            getattr(task, "task_number"),
-            node_id,
-            actor,
-            exc,
+        add_context(
+            task_id,
+            "system",
+            reason,
+            entry_type="worker_provision_failed",
         )
     except Exception:  # noqa: BLE001
         logger.warning(
-            "deferred claim provision: rollback failed for %s",
+            "deferred claim provision: failed to record context for %s",
             task_id,
             exc_info=True,
         )
-
-
-def _is_worker_cap_exceeded(exc: BaseException) -> bool:
-    for cls in type(exc).__mro__:
-        if cls.__name__ == "WorkerCapExceededError":
-            return True
-    return False
 
 
 def open_project_work_service(project: Any, *, config: Any = None) -> Any | None:

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -357,15 +357,36 @@ class SessionManager:
             return legacy
         return DEFAULT_MAX_PARALLEL_WORKERS
 
-    def _count_active_workers(self, project: str) -> int:
+    def _count_active_workers(
+        self, project: str, *, exclude_task_id: str | None = None,
+    ) -> int:
         """Return the number of currently active worker sessions for a project.
 
-        Counts ``work_sessions`` rows with ``ended_at IS NULL``. The
-        teardown path stamps ``ended_at`` on accept / cancel so this
-        count tracks live per-task tmux windows in steady state. Best
-        effort: a DB error returns 0 so a transient failure doesn't
-        spuriously raise the cap and lock out new claims.
+        Prefer the work service's authoritative task-state count when
+        available. ``work_sessions`` rows are runtime bindings and can
+        survive with ``ended_at IS NULL`` after interrupted older paths;
+        active task states (``in_progress``/``rework``) are the capacity
+        source of truth. Best effort: a DB error returns 0 so a transient
+        failure doesn't spuriously raise the cap and lock out new claims.
         """
+        count_capacity = getattr(
+            self._svc, "count_capacity_consuming_tasks", None,
+        )
+        if callable(count_capacity):
+            try:
+                return int(
+                    count_capacity(
+                        project=project,
+                        exclude_task_id=exclude_task_id,
+                    )
+                    or 0
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "provision_worker[%s]: active-task capacity count "
+                    "failed: %s; falling back to work_sessions",
+                    project, exc,
+                )
         try:
             records = self._svc.list_worker_sessions(
                 project=project, active_only=True,
@@ -396,7 +417,9 @@ class SessionManager:
         if existing is not None and self._existing_session_is_alive(existing):
             return
         cap = self._resolve_parallel_cap(project)
-        active = self._count_active_workers(project)
+        active = self._count_active_workers(
+            project, exclude_task_id=task_id,
+        )
         if active < cap:
             return
         raise WorkerCapExceededError(
@@ -469,7 +492,9 @@ class SessionManager:
         )
         if reserved:
             return
-        active = self._count_active_workers(project)
+        active = self._count_active_workers(
+            project, exclude_task_id=f"{project}/{task_number}",
+        )
         raise WorkerCapExceededError(
             f"Cannot spawn worker for {project}/{task_number}: "
             f"project {project!r} already has {active} active worker "

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -1512,6 +1512,32 @@ def test_block_marks_task_blocked(pg_service):
     assert blocked.work_status is WorkStatus.BLOCKED
 
 
+def test_block_from_active_task_ends_worker_session(pg_service):
+    from datetime import UTC, datetime
+
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    claimed = pg_service.claim(task.task_id, actor="alice")
+    pg_service.upsert_worker_session(
+        task_project=claimed.project,
+        task_number=claimed.task_number,
+        agent_name="alice",
+        pane_id="p",
+        worktree_path="/tmp/wt",
+        branch_name="b",
+        started_at=datetime.now(UTC),
+    )
+    blocker = _make_draft(pg_service, title="blocker")
+
+    pg_service.block(task.task_id, actor="user", blocker_task_id=blocker.task_id)
+
+    assert pg_service.get_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        active_only=True,
+    ) is None
+
+
 def test_blocked_tasks_filter_by_project(pg_service):
     task = _drive_to_review(pg_service)
     pg_service.node_done(
@@ -1682,6 +1708,50 @@ def test_worker_session_active_only_filter(pg_service):
     assert rec_any is not None
     assert rec_any.total_input_tokens == 100
     assert rec_any.total_output_tokens == 200
+
+
+def test_force_review_from_active_task_ends_worker_session(pg_service):
+    from datetime import UTC, datetime
+
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    claimed = pg_service.claim(task.task_id, actor="alice")
+    pg_service.upsert_worker_session(
+        task_project=claimed.project,
+        task_number=claimed.task_number,
+        agent_name="alice",
+        pane_id="p",
+        worktree_path="/tmp/wt",
+        branch_name="b",
+        started_at=datetime.now(UTC),
+    )
+
+    pg_service.force_review(task.task_id, actor="alice")
+
+    assert pg_service.get_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        active_only=True,
+    ) is None
+
+
+def test_capacity_count_ignores_unclaimed_active_rows(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    claimed_task = _make_draft(pg_service, title="claimed")
+    pg_service.queue(claimed_task.task_id, actor="user")
+    pg_service.claim(claimed_task.task_id, actor="alice")
+    orphan = _make_draft(pg_service, title="orphan")
+    pg_service.queue(orphan.task_id, actor="user")
+    orphan = pg_service.force_in_progress(orphan.task_id, actor="operator")
+
+    assert orphan.work_status is WorkStatus.IN_PROGRESS
+    assert orphan.claimed_by_session is None
+    assert pg_service.count_capacity_consuming_tasks(project="demo") == 1
+    assert pg_service.count_capacity_consuming_tasks(
+        project="demo",
+        exclude_task_id=claimed_task.task_id,
+    ) == 0
 
 
 def test_list_worker_sessions_active_only(pg_service):

--- a/tests/test_tasks_writes_endpoint.py
+++ b/tests/test_tasks_writes_endpoint.py
@@ -674,10 +674,10 @@ def test_claim_endpoint_uses_lifespan_executor_for_deferred_provision(
     assert response.status_code == 200, response.text
 
 
-def test_deferred_provision_cap_race_rolls_claim_back(
+def test_deferred_provision_failure_keeps_claim_and_records_context(
     api_config, task_store, monkeypatch
 ) -> None:
-    """Deferred worker-cap races keep the existing queued rollback."""
+    """Deferred provisioning failures are auditable without undoing 200."""
     task = _seed(task_store, n=103, work_status=WorkStatus.IN_PROGRESS)
     task.claimed_by_session = "alice"
     task.current_node_id = "node-start"
@@ -689,8 +689,8 @@ def test_deferred_provision_cap_race_rolls_claim_back(
         def provision_worker(self, task_id: str, agent_name: str) -> None:
             raise WorkerCapExceededError("cap exceeded")
 
-    class _RollbackWorkService(FakeWorkService):
-        def __enter__(self) -> "_RollbackWorkService":
+    class _ProvisionFailureWorkService(FakeWorkService):
+        def __enter__(self) -> "_ProvisionFailureWorkService":
             return self
 
         def __exit__(self, *exc: object) -> None:
@@ -699,29 +699,25 @@ def test_deferred_provision_cap_race_rolls_claim_back(
         def set_session_manager(self, mgr: object) -> None:
             self._session_mgr = mgr
 
-        def _rollback_claim_to_queued(
+        def add_context(
             self,
-            project: str,
-            task_number: int,
-            node_id: str,
+            task_id: str,  # noqa: ARG002
             actor: str,
-            exc: BaseException,
-        ) -> bool:
-            self.rollback_call = (
-                project,
-                task_number,
-                node_id,
-                actor,
-                str(exc),
+            text: str,
+            *,
+            entry_type: str = "note",
+        ) -> FakeContextEntry:
+            entry = FakeContextEntry(
+                actor=actor,
+                text=text,
+                entry_type=entry_type,
             )
-            task = self.get(f"{project}/{task_number}")
-            task.work_status = WorkStatus.QUEUED
-            task.claimed_by_session = None
-            return True
+            task.context.append(entry)
+            return entry
 
-    svc = _RollbackWorkService(task_store)
+    svc = _ProvisionFailureWorkService(task_store)
 
-    def _factory(**_kwargs: object) -> _RollbackWorkService:
+    def _factory(**_kwargs: object) -> _ProvisionFailureWorkService:
         return svc
 
     def _attach(svc: object, **_kwargs: object) -> _CapExceededSessionManager:
@@ -747,15 +743,14 @@ def test_deferred_provision_cap_race_rolls_claim_back(
         agent_name="alice",
     )
 
-    assert svc.rollback_call == (
-        "myproj",
-        103,
-        "node-start",
-        "alice",
-        "cap exceeded",
-    )
-    assert task.work_status == WorkStatus.QUEUED
-    assert task.claimed_by_session is None
+    assert task.work_status == WorkStatus.IN_PROGRESS
+    assert task.claimed_by_session == "alice"
+    assert len(task.context) == 1
+    entry = task.context[0]
+    assert entry.entry_type == "worker_provision_failed"
+    assert entry.actor == "system"
+    assert "claim preserved for alice" in entry.text
+    assert "cap exceeded" in entry.text
 
 
 def test_claim_surfaces_last_provision_error_warning(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Retry transient claim-time store contention and map losing claim races to `409 invalid_state` when a fresh read shows another claimant won.
- Move worker-cap enforcement into the pg claim transaction and count authoritative active claimed task rows, not stale `work_sessions` rows.
- Preserve successful deferred API claims when background worker provisioning fails, and record an auditable context breadcrumb instead of silently rolling the task back after returning 200.
- Stamp worker-session end time when active task state exits worker-capacity states, including review, blocked, queued release, and terminal transitions.

## Issues
Refs #2303
Refs #2304
Refs #2305

## Verification
- `uv run --extra test pytest tests/test_tasks_writes_endpoint.py::test_deferred_provision_failure_keeps_claim_and_records_context tests/test_tasks_writes_endpoint.py::test_claim_worker_cap_exceeded_returns_429 tests/test_pg_work_service_full.py::test_block_from_active_task_ends_worker_session tests/test_pg_work_service_full.py::test_force_review_from_active_task_ends_worker_session tests/test_pg_work_service_full.py::test_capacity_count_ignores_unclaimed_active_rows`
- `uv run --extra dev ruff check src/pollypm/web_api/service.py src/pollypm/work/pg_service.py src/pollypm/work/service_factory.py src/pollypm/work/session_manager.py tests/test_pg_work_service_full.py tests/test_tasks_writes_endpoint.py`