### PR TITLE
docs: clarify isolated resilience and install freshness gates

### DIFF
--- a/docs/test-plan/00-pre-flight-baseline.md
+++ b/docs/test-plan/00-pre-flight-baseline.md
@@ -58,6 +58,31 @@ git rev-parse HEAD
 
 Record the SHA you're testing in your test journal. Every issue you file from now on references this SHA.
 
+### Clean local build artifacts before reinstall evidence
+
+If this run uses a globally installed `pm` from the checkout, remove local build
+artifacts before reinstalling. `uv tool install --force --no-cache .` can still
+consume a stale `build/lib/pollypm/` snapshot left by an earlier wheel build; a
+fresh `src/pollypm/release_check.py` with `GLOBAL_CONFIG_DIR` imported is not
+evidence that the installed tool copied that file.
+
+```bash
+cd /Users/sam/dev/pollypm
+rm -rf build/ dist/
+uv tool install --force --reinstall .
+python - <<'PY'
+import inspect
+import pollypm.release_check as rc
+print(inspect.getsourcefile(rc))
+print("GLOBAL_CONFIG_DIR" in inspect.getsource(rc))
+PY
+pm doctor
+```
+
+If the installed module does not come from the just-reinstalled wheel or the
+source check prints `False`, record the run as blocked on install freshness; do
+not treat `pm doctor` output as valid baseline evidence.
+
 ---
 
 ## 0.2 pytest — full suite

--- a/docs/test-plan/05-resilience-recovery.md
+++ b/docs/test-plan/05-resilience-recovery.md
@@ -6,6 +6,22 @@
 
 **Prereqs:** §00 green. §01 task lifecycle reliable (so we can tell when recovery actually works). §02 translation-layer reliable.
 
+**Control-plane prerequisite for §5.2:** an isolated `pm serve` process is
+not enough to exercise worker-spawn recovery. `pm serve` only hosts the
+HTTP/Web API surface; it does not drain the heartbeat/job queue that runs
+`task_assignment.sweep`, `session.health_sweep`, or the per-task worker
+reclaim path. To mark §5.2 green, run against one of:
+
+- a managed PollyPM home booted with `pm up`, with the rail daemon or cockpit
+  HeartbeatRail alive and draining jobs;
+- an explicit local scheduler/test dispatcher that constructs HeartbeatRail
+  with workers enabled, calls `tick()`, and drains `task_assignment.sweep`.
+
+If the run only has `pm serve` plus CLI/API calls, record §5.2 as
+**unverified**, not passed. `pm heartbeat` by itself is also insufficient
+unless a long-lived rail daemon/cockpit is present to drain the jobs it
+enqueues.
+
 **Important:** these tests are destructive. Run against a non-production PollyPM instance, or accept that you'll have to restart sessions. Have a known-good state snapshot before starting.
 
 **Prereq: §00.0 environment safety check must have passed.** This section will:
@@ -124,25 +140,46 @@ Restart. Same recovery as 5.1.2 — assert PollyPM doesn't accumulate stale stat
 
 ## 5.2 Pane kill mid-task
 
+This is a **control-plane** test, not a Web API test. Before starting, verify
+the scheduler is actually running:
+
+```bash
+pm doctor | grep 'rail-daemon-alive'
+pm status --json | jq '.sessions[] | select(.kind == "per_task" or (.name | startswith("task-")))'
+```
+
+If no per-task workers appear after claiming a task, stop and fix the control
+plane or switch to an explicit scheduler/test dispatcher. Do not substitute an
+isolated `pm serve` run.
+
 ### 5.2.1 Worker pane killed
 
 ```bash
-TID=$(pm task create --project pollypm "test-5-2-1" --json | jq -r .task_id)
+TID=$(pm task create --project pollypm "test-5-2-1" \
+  --description "Exercise §5.2 worker pane recovery" \
+  --json | jq -r .task_id)
 pm task queue "$TID"
-sleep 60  # let worker claim
+pm task claim "$TID" --actor worker
+sleep 60  # let the per-task worker window boot and receive kickoff
 pm task get "$TID"  # Assignee: worker..., Status: in_progress
 
-tmux kill-window -t pollypm:worker_pollypm
+PROJECT=$(printf '%s\n' "$TID" | cut -d/ -f1)
+NUMBER=$(printf '%s\n' "$TID" | cut -d/ -f2)
+tmux kill-window -t "pollypm-storage-closet:task-${PROJECT}-${NUMBER}"
 ```
 
 **Expected cascade (within 3 min):**
-1. Heartbeat tier detects missing pane.
-2. `no_session_spawn` recovery (per #2081 wiring) detects it, respawns `worker_pollypm`.
-3. New worker session picks up `$TID` (or task is re-queued + claimed).
+1. Heartbeat / task-assignment sweep detects the missing per-task pane.
+2. `_recover_dead_claims` releases the stale claim and records
+   `task.reclaimed` / `worker_session_recovered`.
+3. The auto-claim sweep re-claims `$TID`, provisions a fresh
+   `task-${PROJECT}-${NUMBER}` window, and kickoff delivery resumes.
 
 Verify via audit log:
 ```bash
-grep -E 'heartbeat.missing|session.spawn|task.reclaim' ~/.pollypm/audit/pollypm.jsonl | tail -10
+grep -E 'heartbeat.missing|task.reclaimed|worker_session_recovered|worker_auto_claimed' ~/.pollypm/audit/pollypm.jsonl | tail -10
+pm task get "$TID"
+tmux list-windows -t pollypm-storage-closet | grep "task-${PROJECT}-${NUMBER}"
 ```
 
 **Pass:** cascade fires. Task ends in a known state (`done`, `review`, `cancelled`, or queued again), never silently stuck.

--- a/docs/test-plan/README.md
+++ b/docs/test-plan/README.md
@@ -55,7 +55,9 @@ Output: a short journal entry that says "shippable / not-shippable / blocked on 
 Add to the 2-hour slice:
 - Full **§01** (task lifecycle, all subsections)
 - Full **§02** (translation layer, triple-witness)
-- **§05.1 + §05.2 + §05.4** (daemon kill, pane kill, pause-marker enforcement)
+- **§05.1 + §05.2 + §05.4** (daemon kill, pane kill, pause-marker enforcement).
+  §05.2 only counts when run with a managed PollyPM control plane or explicit
+  scheduler/test dispatcher; an isolated `pm serve` run is unverified evidence.
 - **§04.1 + §04.3** (canonical role prompts + auth-marker)
 - **§06.3 + §06.4 + §06.7** at S-scale
 
@@ -188,6 +190,8 @@ This plan exists to support a binary decision. Use these criteria to convert jou
 - §03 1-second click rule met for every interaction tested.
 - §04 canonical prompts pass per role; auth-marker contract enforced; no confident hallucination.
 - §05 daemon kill, pane kill, pause-marker fail-closed all recover within budget.
+  Pane-kill evidence must include the §05.2 control-plane prerequisite; `pm serve`
+  alone cannot make this gate green.
 - §06 M-scale gate green with recorded p50/p95/p99/max for every cell in the budget table.
 - §07 smoke green on the merge commit being shipped.
 
@@ -201,6 +205,8 @@ This plan exists to support a binary decision. Use these criteria to convert jou
 - Any §01 cascade self-heal requires manual operator action.
 - Any §02 triple-witness scenario shows drift between pane, archive, and REST.
 - Any §03 click breaks the 1-second rule.
+- §05.2 is reported from an isolated `pm serve` run without a managed control
+  plane or explicit scheduler/test dispatcher.
 - Any §05 fail-closed scenario fails open (e.g., malformed pause marker silently allows recovery).
 - §5.5.2 Claude subscription failover does not happen automatically, or loses session context.
 - Any §06 M-scale endpoint p95 above budget, or any payload above budget.

--- a/docs/test-plan/automation-promotion.md
+++ b/docs/test-plan/automation-promotion.md
@@ -139,7 +139,7 @@ All of §02 → pytest. Drive a known fixture transcript file, assert envelope s
 | Scenario | Target |
 |---|---|
 | 5.1 `pm serve` kill/restart | Integration test |
-| 5.2 Pane kill mid-task | pytest integration (mock tmux or real) |
+| 5.2 Pane kill mid-task | pytest/integration with managed control plane or local HeartbeatRail dispatcher; HTTP-only `pm serve` cannot cover this |
 | 5.3 DB drop | Integration test with toxiproxy |
 | 5.4 Pause-marker | pytest + integration |
 | 5.5 Token rotation | Playwright |

--- a/docs/test-plan/operator-day-in-the-life.md
+++ b/docs/test-plan/operator-day-in-the-life.md
@@ -70,7 +70,8 @@ They do not read documentation between sessions. They expect to sit down and pic
 1. Worker on project Y stopped responding (Claude session crashed in tmux).
 2. **What the plan must verify (this is the heart of the product):**
    - Heartbeat tier detects within ~60s (§01.5.1, §05.2.3 cascade detection lag).
-   - `no_session_spawn` respawns the worker within 3 min total (§01.5.1, §05.2.1).
+   - Task-assignment recovery releases the stale per-task claim and provisions a
+     fresh worker within 3 min total (§01.5.1, §05.2.1).
    - Task gets re-claimed without operator intervention (§01.1.3).
    - Audit log shows the cascade trail (§01.5.1 audit verification).
    - Operator's UI surfaces "worker was stuck, has been restarted, task continues" — they DON'T have to act (§01.4.5, §03.4).

--- a/docs/test-plan/promotion-status.md
+++ b/docs/test-plan/promotion-status.md
@@ -80,7 +80,7 @@ Use this tracker while executing the ship-readiness plan. Promote manual checks 
 | Scenario | Manual Run | Result | Promoted? | Test Path | Notes |
 |---|---|---|---|---|---|
 | 5.1 `pm serve` kill/restart | — | — | ☐ | — | integration test |
-| 5.2 Pane kill mid-task | — | — | ☐ | — | pytest integration |
+| 5.2 Pane kill mid-task | — | — | ☐ | — | requires managed control plane or local HeartbeatRail dispatcher; `pm serve`-only result is unverified |
 | 5.3 DB drop / reconnect | — | — | ☐ | — | toxiproxy-style integration |
 | 5.4 Pause-marker enforcement | — | — | partial | tests/test_session_paused_marker_wiring.py | extend with §5.4 cells |
 | 5.4.5 Malformed marker fail-closed | — | — | partial | tests/test_session_paused_marker_wiring.py | already covers basic case |


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Document that §5.2 pane-kill recovery requires a managed PollyPM control plane or explicit scheduler/test dispatcher; isolated `pm serve` evidence is unverified.
- Update §5.2 commands and expected cascade language to match per-task worker windows and stale-claim recovery events.
- Add pre-flight install freshness guidance: remove `build/` and `dist/` before trusting a local `uv tool install`, and verify installed `release_check.py` contains the `GLOBAL_CONFIG_DIR` import.
- Propagate the §5.2 control-plane caveat through promotion/readiness docs.

## Issues
Refs #2301
Refs #2302

## Verification
- `uv build --wheel --out-dir /tmp/pollypm-build-check-2302`
- `unzip -p /tmp/pollypm-build-check-2302/pollypm-1.0.0rc3.dev0-py3-none-any.whl pollypm/release_check.py | sed -n '20,32p'` confirmed `from pollypm.config import GLOBAL_CONFIG_DIR` is present after cleaning `build/` and `dist/`.
- `git diff --check`