### PR TITLE
perf: coalesce cold poll cache misses

### DIFF
--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -20,6 +20,7 @@ crash the rail.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -56,6 +57,7 @@ _ALL_TASKS_GROUPED_TTL_SECONDS = 1.0
 _ALL_TASKS_GROUPED_CACHE: dict[
     int, tuple[float, "dict[str, tuple[Task, ...]] | None"]
 ] = {}
+_ALL_TASKS_GROUPED_LOCK = threading.Lock()
 
 # Same request-local sharing for the inbox-task aggregate. The dashboard
 # count path and the recent-inbox preview path both need the same broad
@@ -65,6 +67,7 @@ _INBOX_TASKS_GROUPED_TTL_SECONDS = 1.0
 _INBOX_TASKS_GROUPED_CACHE: dict[
     int, tuple[float, "dict[str, tuple[Task, ...]] | None"]
 ] = {}
+_INBOX_TASKS_GROUPED_LOCK = threading.Lock()
 
 
 # --------------------------------------------------------------------------- #
@@ -123,27 +126,36 @@ def all_tasks_grouped(
             return None
         return {key: list(rows) for key, rows in snapshot.items()}
 
-    result = _all_tasks_grouped_uncached(config)
-    # #1957 perf — stamp the cache AFTER the uncached scan returns so a
-    # cold ``SELECT * FROM work_tasks`` that exceeds the TTL doesn't
-    # write a born-expired entry that forces the next caller to recompute.
-    completed_at = time.monotonic()
-    # Best-effort eviction so the cache doesn't grow across long-lived
-    # processes with config reloads (each reload yields a fresh
-    # ``id(config)``).
-    if len(_ALL_TASKS_GROUPED_CACHE) > 8:
-        for stale_key in [
-            k for k, (ts, _v) in _ALL_TASKS_GROUPED_CACHE.items()
-            if completed_at - ts >= _ALL_TASKS_GROUPED_TTL_SECONDS
-        ]:
-            _ALL_TASKS_GROUPED_CACHE.pop(stale_key, None)
-    snapshot = (
-        None
-        if result is None
-        else {key: tuple(rows) for key, rows in result.items()}
-    )
-    _ALL_TASKS_GROUPED_CACHE[cache_key] = (completed_at, snapshot)
-    return result
+    with _ALL_TASKS_GROUPED_LOCK:
+        now = time.monotonic()
+        cached = _ALL_TASKS_GROUPED_CACHE.get(cache_key)
+        if cached is not None and now - cached[0] < _ALL_TASKS_GROUPED_TTL_SECONDS:
+            snapshot = cached[1]
+            if snapshot is None:
+                return None
+            return {key: list(rows) for key, rows in snapshot.items()}
+
+        result = _all_tasks_grouped_uncached(config)
+        # #1957 perf — stamp the cache AFTER the uncached scan returns so a
+        # cold ``SELECT * FROM work_tasks`` that exceeds the TTL doesn't
+        # write a born-expired entry that forces the next caller to recompute.
+        completed_at = time.monotonic()
+        # Best-effort eviction so the cache doesn't grow across long-lived
+        # processes with config reloads (each reload yields a fresh
+        # ``id(config)``).
+        if len(_ALL_TASKS_GROUPED_CACHE) > 8:
+            for stale_key in [
+                k for k, (ts, _v) in _ALL_TASKS_GROUPED_CACHE.items()
+                if completed_at - ts >= _ALL_TASKS_GROUPED_TTL_SECONDS
+            ]:
+                _ALL_TASKS_GROUPED_CACHE.pop(stale_key, None)
+        snapshot = (
+            None
+            if result is None
+            else {key: tuple(rows) for key, rows in result.items()}
+        )
+        _ALL_TASKS_GROUPED_CACHE[cache_key] = (completed_at, snapshot)
+        return result
 
 
 def _all_tasks_grouped_uncached(
@@ -199,21 +211,33 @@ def inbox_tasks_grouped(
             return None
         return {key: list(rows) for key, rows in snapshot.items()}
 
-    result = _inbox_tasks_grouped_uncached(config)
-    completed_at = time.monotonic()
-    if len(_INBOX_TASKS_GROUPED_CACHE) > 8:
-        for stale_key in [
-            k for k, (ts, _v) in _INBOX_TASKS_GROUPED_CACHE.items()
-            if completed_at - ts >= _INBOX_TASKS_GROUPED_TTL_SECONDS
-        ]:
-            _INBOX_TASKS_GROUPED_CACHE.pop(stale_key, None)
-    snapshot = (
-        None
-        if result is None
-        else {key: tuple(rows) for key, rows in result.items()}
-    )
-    _INBOX_TASKS_GROUPED_CACHE[cache_key] = (completed_at, snapshot)
-    return result
+    with _INBOX_TASKS_GROUPED_LOCK:
+        now = time.monotonic()
+        cached = _INBOX_TASKS_GROUPED_CACHE.get(cache_key)
+        if (
+            cached is not None
+            and now - cached[0] < _INBOX_TASKS_GROUPED_TTL_SECONDS
+        ):
+            snapshot = cached[1]
+            if snapshot is None:
+                return None
+            return {key: list(rows) for key, rows in snapshot.items()}
+
+        result = _inbox_tasks_grouped_uncached(config)
+        completed_at = time.monotonic()
+        if len(_INBOX_TASKS_GROUPED_CACHE) > 8:
+            for stale_key in [
+                k for k, (ts, _v) in _INBOX_TASKS_GROUPED_CACHE.items()
+                if completed_at - ts >= _INBOX_TASKS_GROUPED_TTL_SECONDS
+            ]:
+                _INBOX_TASKS_GROUPED_CACHE.pop(stale_key, None)
+        snapshot = (
+            None
+            if result is None
+            else {key: tuple(rows) for key, rows in result.items()}
+        )
+        _INBOX_TASKS_GROUPED_CACHE[cache_key] = (completed_at, snapshot)
+        return result
 
 
 def _inbox_tasks_grouped_uncached(

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any, Literal
@@ -153,6 +155,14 @@ class ChatSessionsResponse(BaseModel):
     """``GET /api/v1/chat/sessions`` envelope."""
 
     sessions: list[ChatSurfaceResponse]
+
+
+_CHAT_SESSIONS_TTL_SECONDS = 1.0
+_CHAT_SESSIONS_LOCK = threading.Lock()
+_CHAT_SESSIONS_CACHE: dict[
+    tuple[int, int, int, int],
+    tuple[float, tuple[ChatSurfaceResponse, ...]],
+] = {}
 
 
 class ChatMessageEnvelope(BaseModel):
@@ -1031,16 +1041,40 @@ def list_chat_sessions_endpoint(config: ConfigDep) -> ChatSessionsResponse:
     endpoint never 500s — the cockpit / frontend depend on it for
     sidebar bootstrap.
     """
-    tmux_client = _build_tmux_client()
-    work_service = _build_work_service_stub(config)
-    surfaces = enumerate_chat_surfaces(
-        config,
-        work_service=work_service,
-        tmux_client=tmux_client,
+    cache_key = (
+        id(config),
+        id(enumerate_chat_surfaces),
+        id(_build_tmux_client),
+        id(_build_work_service_stub),
     )
-    return ChatSessionsResponse(
-        sessions=[_surface_to_wire(surface) for surface in surfaces],
-    )
+    now = time.monotonic()
+    cached = _CHAT_SESSIONS_CACHE.get(cache_key)
+    if cached is not None and now - cached[0] < _CHAT_SESSIONS_TTL_SECONDS:
+        return ChatSessionsResponse(sessions=list(cached[1]))
+
+    with _CHAT_SESSIONS_LOCK:
+        now = time.monotonic()
+        cached = _CHAT_SESSIONS_CACHE.get(cache_key)
+        if cached is not None and now - cached[0] < _CHAT_SESSIONS_TTL_SECONDS:
+            return ChatSessionsResponse(sessions=list(cached[1]))
+
+        tmux_client = _build_tmux_client()
+        work_service = _build_work_service_stub(config)
+        surfaces = enumerate_chat_surfaces(
+            config,
+            work_service=work_service,
+            tmux_client=tmux_client,
+        )
+        rows = tuple(_surface_to_wire(surface) for surface in surfaces)
+        completed_at = time.monotonic()
+        if len(_CHAT_SESSIONS_CACHE) > 8:
+            for stale_key in [
+                k for k, (ts, _v) in _CHAT_SESSIONS_CACHE.items()
+                if completed_at - ts >= _CHAT_SESSIONS_TTL_SECONDS
+            ]:
+                _CHAT_SESSIONS_CACHE.pop(stale_key, None)
+        _CHAT_SESSIONS_CACHE[cache_key] = (completed_at, rows)
+        return ChatSessionsResponse(sessions=list(rows))
 
 
 @router.get(

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -14,8 +14,11 @@ skipped — these tests are self-contained.
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import json
 import subprocess
+import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -385,6 +388,51 @@ def test_sessions_endpoint_surfaces_window_state(
     assert op["window"]["window_name"] == "operator"
     assert op["window"]["pane_id"] == "%99"
     assert op["transcript"]["source"] is None  # no archive in this fixture
+
+
+def test_sessions_endpoint_coalesces_concurrent_discovery(
+    config, monkeypatch,
+) -> None:
+    chat_messages_routes._CHAT_SESSIONS_CACHE.clear()
+    calls = {"n": 0}
+    surface = _surface("operator", SurfaceType.OPERATOR, persona="Polly")
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_tmux_client",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_work_service_stub",
+        lambda _config: None,
+    )
+
+    def fake_enumerate(_config, *, work_service=None, tmux_client=None):
+        calls["n"] += 1
+        time.sleep(0.05)
+        return [surface]
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "enumerate_chat_surfaces",
+        fake_enumerate,
+    )
+
+    start = threading.Event()
+
+    def call_endpoint() -> list[str]:
+        start.wait(timeout=1)
+        response = chat_messages_routes.list_chat_sessions_endpoint(config)
+        return [row.session_name for row in response.sessions]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(call_endpoint) for _ in range(8)]
+        start.set()
+        results = [future.result(timeout=2) for future in futures]
+
+    assert results == [["operator"]] * 8
+    assert calls == {"n": 1}
 
 
 def test_sessions_endpoint_cookie_auth_uses_bounded_tmux_probe(

--- a/tests/test_dashboard_inbox_perf.py
+++ b/tests/test_dashboard_inbox_perf.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+import threading
+import time
 from types import SimpleNamespace
 
 
@@ -30,6 +33,48 @@ def test_inbox_tasks_grouped_shares_scan_with_copy_safe_cache(
 
     assert calls["n"] == 1
     assert second == {"demo": [task]}
+
+
+def test_grouped_task_caches_coalesce_concurrent_cold_misses(
+    monkeypatch,
+) -> None:
+    import pollypm.cockpit_pg_aggregates as agg
+
+    agg._ALL_TASKS_GROUPED_CACHE.clear()
+    agg._INBOX_TASKS_GROUPED_CACHE.clear()
+    calls = {"all": 0, "inbox": 0}
+    task = SimpleNamespace(task_id="demo/1", project="demo")
+
+    def fake_all(_config):
+        calls["all"] += 1
+        time.sleep(0.05)
+        return {"demo": [task]}
+
+    def fake_inbox(_config):
+        calls["inbox"] += 1
+        time.sleep(0.05)
+        return {"demo": [task]}
+
+    monkeypatch.setattr(agg, "_all_tasks_grouped_uncached", fake_all)
+    monkeypatch.setattr(agg, "_inbox_tasks_grouped_uncached", fake_inbox)
+
+    config = object()
+    start = threading.Event()
+
+    def call_both() -> tuple[dict, dict]:
+        start.wait(timeout=1)
+        return (
+            agg.all_tasks_grouped(config) or {},
+            agg.inbox_tasks_grouped(config) or {},
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(call_both) for _ in range(8)]
+        start.set()
+        results = [future.result(timeout=2) for future in futures]
+
+    assert all(result == ({"demo": [task]}, {"demo": [task]}) for result in results)
+    assert calls == {"all": 1, "inbox": 1}
 
 
 def test_awaits_user_list_annotates_only_actionable_rows(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add singleflight locking around cockpit pg task aggregate TTL caches so concurrent dashboard/rail cold misses share one broad pg scan instead of stampeding.
- Add a short TTL/singleflight cache for `GET /api/v1/chat/sessions` discovery so poll bursts do not repeat tmux/work-service/transcript discovery work per concurrent request.
- Keep cache keys tied to config identity and monkeypatched discovery helpers, and preserve copy-safe list returns for aggregate callers.

## Issues
Refs #2306
Refs #2307
Refs #2308
Refs #2309
Refs #2310
Refs #2311

## Verification
- `uv run --extra test pytest tests/test_dashboard_inbox_perf.py::test_grouped_task_caches_coalesce_concurrent_cold_misses tests/test_dashboard_inbox_perf.py::test_inbox_tasks_grouped_shares_scan_with_copy_safe_cache tests/test_chat_messages_endpoint.py::test_sessions_endpoint_coalesces_concurrent_discovery tests/test_chat_messages_endpoint.py::test_sessions_endpoint_lists_all_four_surface_types`
- `uv run --extra dev ruff check src/pollypm/cockpit_pg_aggregates.py src/pollypm/web_api/routes/chat_messages.py tests/test_dashboard_inbox_perf.py tests/test_chat_messages_endpoint.py`

## Notes
This addresses the most direct stampede source behind the M-scale concurrent dashboard/poll symptoms. It still needs Claude review and M-scale before/after measurement before closing the perf issues as fully green.