### PR TITLE
fix(smoke): fail when any smoke check fails

### DIFF
--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -238,8 +238,12 @@ def print_result(result: CheckResult, *, color: bool = True) -> None:
     print(f"{prefix} {result.name}: {result.detail}")
 
 
+def failed_check_names(results: list[CheckResult]) -> list[str]:
+    return [result.name for result in results if not result.ok]
+
+
 def summary_block(sha: str, timestamp: str, results: list[CheckResult]) -> str:
-    failed = [result.name for result in results if not result.ok]
+    failed = failed_check_names(results)
     result_text = "all green" if not failed else f"red on {', '.join(failed)}"
     failed_text = "none" if not failed else ", ".join(failed)
     return "\n".join(
@@ -299,7 +303,7 @@ def run_smoke(args: argparse.Namespace) -> int:
         if spec.name == "task queue" and args.task_wait_seconds > 0 and not args.dry_run:
             time.sleep(args.task_wait_seconds)
 
-    if all(result.ok for result in results):
+    if not failed_check_names(results):
         for spec in fixed_command_specs():
             result, _stdout = run_command(spec, dry_run=args.dry_run)
             results.append(result)
@@ -310,9 +314,9 @@ def run_smoke(args: argparse.Namespace) -> int:
         print(summary_block(sha, timestamp, results))
     else:
         block = summary_block(sha, timestamp, results)
-        color = GREEN if all(result.ok for result in results) else RED
+        color = GREEN if not failed_check_names(results) else RED
         print(f"{BOLD}{color}{block}{RESET}")
-    return 0 if all(result.ok for result in results) else 1
+    return 1 if failed_check_names(results) else 0
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/tests/test_smoke_script.py
+++ b/tests/test_smoke_script.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "smoke.py"
@@ -72,6 +73,42 @@ def test_summary_block_all_green() -> None:
 
     assert "Result: all green" in summary
     assert "Failed checks: none" in summary
+
+
+def test_run_smoke_exits_nonzero_when_slow_rest_check_fails(monkeypatch, capsys) -> None:
+    def fake_rest_check(name: str, _url: str, **_kwargs) -> smoke.CheckResult:
+        if name == "dashboard":
+            return smoke.CheckResult(name, False, "slow response 1.234s", 1.234)
+        return smoke.CheckResult(name, True, "HTTP 200 in 0.010s", 0.010)
+
+    def fake_run_command(
+        spec: smoke.CommandSpec,
+        *,
+        dry_run: bool = False,
+    ) -> tuple[smoke.CheckResult, str]:
+        stdout = '{"task_id": "pollypm/1"}' if spec.name == "task create" else ""
+        return smoke.CheckResult(spec.name, True, "ok in 0.010s", 0.010), stdout
+
+    monkeypatch.setattr(smoke, "run_rest_check", fake_rest_check)
+    monkeypatch.setattr(smoke, "run_command", fake_run_command)
+    monkeypatch.setattr(smoke, "read_token", lambda explicit_token=None: "token")
+    monkeypatch.setattr(smoke, "git_sha", lambda: "abc123")
+    args = SimpleNamespace(
+        base="http://127.0.0.1:8897",
+        token=None,
+        project="pollypm",
+        task_wait_seconds=0,
+        dry_run=False,
+        no_color=True,
+    )
+
+    exit_code = smoke.run_smoke(args)
+
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert "FAIL dashboard: slow response 1.234s" in output
+    assert "Result: red on dashboard" in output
+    assert "Failed checks: dashboard" in output
 
 
 def test_dry_run_avoids_command_execution() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- centralize smoke failure detection around `CheckResult.ok`
- use that predicate for the fixed-check gate, colored summary, and process exit code
- add a regression test for slow dashboard REST checks returning a non-zero smoke exit

## Tests
- `uv run --extra test pytest tests/test_smoke_script.py -q`

Fixes #2321