### PR TITLE
perf(web): speed cold rail and activity loads

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -782,6 +782,16 @@ paths:
         whether to subscribe to live capture or pull from the JSONL
         archive. Workers are best-effort: a transient work-service
         outage degrades to "configured surfaces only" rather than 500.
+      parameters:
+        - in: query
+          name: include_transcripts
+          schema:
+            type: boolean
+            default: true
+          description: |
+            When false, skips transcript-path discovery for a fast rail
+            bootstrap. Defaults true to preserve the full discovery
+            contract for API clients.
       responses:
         "200":
           description: List of chat surfaces.
@@ -2818,10 +2828,11 @@ paths:
         whole-history aggregation. (Codex P0 finding, PR #2062
         round 2.)
 
-        `deadline_seconds` (default 10.0) imposes a request-level
+        `deadline_seconds` (default 2.5) imposes a request-level
         wall-clock cap on top of the `since` semantic bound, because
-        the walker still reads every target file/line until it parses
-        `ts` and filters. When exceeded, the response sets
+        stats reads live logs newest-first and can skip rotations that
+        clearly predate `since`; the deadline remains the hard cap for
+        mixed or still-recent archives. When exceeded, the response sets
         `_truncated_by_deadline=true` and `_lines_scanned` reports
         how far the walker got across live + rotated logs. (Codex
         P0 finding, PR #2062 round 6.)
@@ -2842,12 +2853,10 @@ paths:
             format: float
             minimum: 0.5
             maximum: 120.0
-            default: 10.0
+            default: 2.5
           description: |
-            Request-level wall-clock budget (seconds). Default 10.0.
-            Stats has a higher default than `/audit/grep` (5.0)
-            because aggregation has no early-exit on match-count.
-            When exceeded the walker stops, the response sets
+            Request-level wall-clock budget (seconds). Default 2.5.
+            When exceeded the stats helper stops, the response sets
             `_truncated_by_deadline=true`, and `_lines_scanned`
             reports how many non-empty lines were examined
             (PR #2062 round 6).

--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -25,6 +25,8 @@ The helpers exposed here:
 * :func:`parse_event_ts` — best-effort ``ts`` → ``datetime`` parser.
 * :func:`iter_matching_events` — apply filters cheap→expensive and
   stream matching dict records.
+* :func:`aggregate_recent_stats` — stats-specific recent-window
+  aggregation optimized for the Web UI Activity rollup.
 
 Nothing here writes to disk; nothing imports from Typer or FastAPI.
 """
@@ -39,6 +41,7 @@ import multiprocessing.connection
 import re
 import time
 import zlib
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable, Iterator, MutableMapping
@@ -308,6 +311,21 @@ _SHORTCUT_UNITS = {
     "d": "days",
     "w": "weeks",
 }
+_TAIL_READ_CHUNK_BYTES = 128 * 1024
+_ARCHIVE_TS_RE = re.compile(r"\.(\d+)(?:\.\d+)?\.gz$")
+
+
+@dataclass(slots=True)
+class AuditStatsAggregate:
+    """Aggregated audit counts plus the route diagnostic counters."""
+
+    total: int = 0
+    by_event: dict[str, int] = field(default_factory=dict)
+    by_severity: dict[str, int] = field(default_factory=dict)
+    truncated_by_deadline: bool = False
+    lines_scanned: int = 0
+    corrupt_archives_skipped: int = 0
+    malformed_rows_skipped: int = 0
 
 
 def parse_since(value: str) -> datetime:
@@ -458,6 +476,152 @@ def open_log_lines(
             fh.close()
         except Exception:  # noqa: BLE001
             pass
+
+
+def _iter_live_log_lines_reverse(path: Path) -> Iterator[str]:
+    """Yield non-empty live JSONL lines newest-first without full-file reads."""
+    try:
+        file_size = path.stat().st_size
+    except OSError as exc:
+        logger.warning("audit.query: stat failed for %s: %s", path, exc)
+        return
+    if file_size <= 0:
+        return
+
+    carry = b""
+    offset = file_size
+    try:
+        with path.open("rb") as handle:
+            while offset > 0:
+                read_size = min(_TAIL_READ_CHUNK_BYTES, offset)
+                offset -= read_size
+                handle.seek(offset)
+                data = handle.read(read_size) + carry
+                lines = data.splitlines()
+                if offset > 0:
+                    if lines:
+                        carry = lines[0]
+                        lines = lines[1:]
+                    else:
+                        carry = data
+                        continue
+                else:
+                    carry = b""
+                for raw in reversed(lines):
+                    stripped = raw.decode("utf-8", errors="replace").strip()
+                    if stripped:
+                        yield stripped
+    except OSError as exc:
+        logger.warning("audit.query: tail read failed for %s: %s", path, exc)
+
+
+def _archive_predates_since(path: Path, since: datetime) -> bool:
+    """Return true when archive metadata proves all rows are older."""
+    if path.suffix != ".gz":
+        return False
+    since_ts = since.timestamp()
+    match = _ARCHIVE_TS_RE.search(path.name)
+    if match is not None:
+        try:
+            return int(match.group(1)) < since_ts
+        except ValueError:
+            pass
+    try:
+        return path.stat().st_mtime < since_ts
+    except OSError:
+        return False
+
+
+def _iter_log_lines_newest_first(
+    path: Path,
+    *,
+    stats: MutableMapping[str, int],
+) -> Iterator[str]:
+    """Yield raw lines newest-first for live files and best-effort archives."""
+    if path.suffix != ".gz":
+        yield from _iter_live_log_lines_reverse(path)
+        return
+    rows = [
+        line.strip()
+        for line in open_log_lines(path, stats=stats)
+        if line.strip()
+    ]
+    yield from reversed(rows)
+
+
+def _stats_deadline_expired(deadline_at: float | None) -> bool:
+    return deadline_at is not None and time.monotonic() >= deadline_at
+
+
+def _apply_stats_record(
+    record: dict,
+    aggregate: AuditStatsAggregate,
+) -> None:
+    aggregate.total += 1
+    event_name = str(record.get("event") or "")
+    severity = str(record.get("status") or "ok")
+    aggregate.by_event[event_name] = aggregate.by_event.get(event_name, 0) + 1
+    aggregate.by_severity[severity] = (
+        aggregate.by_severity.get(severity, 0) + 1
+    )
+
+
+def aggregate_recent_stats(
+    *,
+    targets: Iterable[Path],
+    since: datetime,
+    deadline_s: float | None = None,
+) -> AuditStatsAggregate:
+    """Aggregate recent audit stats without scanning known-old history.
+
+    This is intentionally stats-specific. Grep keeps the complete
+    forward walker because it supports arbitrary pattern semantics,
+    while the Activity rollup only needs counts inside a mandatory
+    ``since`` window. Audit writers append chronologically, so reading
+    live logs newest-first lets this helper stop a target's rotation
+    chain once it sees the first valid row older than ``since``.
+    """
+    stats: dict[str, int] = {}
+    aggregate = AuditStatsAggregate()
+    deadline_at = (
+        time.monotonic() + deadline_s
+        if deadline_s is not None and deadline_s > 0
+        else None
+    )
+
+    for live_path in targets:
+        stop_chain = False
+        for chain_path in walk_log_chain(live_path):
+            if _archive_predates_since(chain_path, since):
+                continue
+            for stripped in _iter_log_lines_newest_first(chain_path, stats=stats):
+                if _stats_deadline_expired(deadline_at):
+                    aggregate.truncated_by_deadline = True
+                    stop_chain = True
+                    break
+                aggregate.lines_scanned += 1
+                try:
+                    record = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                ts_raw = record.get("ts")
+                parsed_ts = (
+                    parse_event_ts(ts_raw) if isinstance(ts_raw, str) else None
+                )
+                if parsed_ts is None:
+                    aggregate.malformed_rows_skipped += 1
+                    continue
+                if parsed_ts < since:
+                    stop_chain = True
+                    break
+                _apply_stats_record(record, aggregate)
+            if stop_chain:
+                break
+
+    aggregate.corrupt_archives_skipped = stats.get("corrupt_archives_skipped", 0)
+    return aggregate
 
 
 # ---------------------------------------------------------------------------
@@ -730,6 +894,8 @@ def iter_matching_events(
 
 
 __all__ = [
+    "AuditStatsAggregate",
+    "aggregate_recent_stats",
     "iter_matching_events",
     "open_log_lines",
     "parse_event_ts",

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -13,6 +13,7 @@ tmp config / tmp token paths.
 from __future__ import annotations
 
 import concurrent.futures
+import hashlib
 import logging
 import threading
 import time
@@ -66,6 +67,9 @@ logger = logging.getLogger(__name__)
 
 
 API_V1_PREFIX = "/api/v1"
+_UI_IMMUTABLE_ASSETS = frozenset({"app.js", "styles.css"})
+_UI_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
+_UI_INDEX_CACHE_CONTROL = "no-cache"
 
 
 # Doctor run/fix work runs in a dedicated thread pool so a slow check
@@ -755,6 +759,51 @@ def _mount_web_ui(
 
     index_path = ui_dir / "index.html"
 
+    def _file_fingerprint(path: Path) -> str:
+        try:
+            stat = path.stat()
+        except OSError:
+            return "missing"
+        return f"{stat.st_mtime_ns:x}-{stat.st_size:x}"
+
+    def _index_etag() -> str:
+        parts = [
+            f"index:{_file_fingerprint(index_path)}",
+            *(f"{name}:{_file_fingerprint(ui_dir / name)}" for name in sorted(_UI_IMMUTABLE_ASSETS)),
+        ]
+        digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:16]
+        return f'"ui-index-{digest}"'
+
+    def _client_has_etag(request: Request, etag: str) -> bool:
+        header = request.headers.get("if-none-match")
+        if not header:
+            return False
+        return any(candidate.strip() == etag for candidate in header.split(","))
+
+    def _versioned_index_html() -> str:
+        html = index_path.read_text(encoding="utf-8")
+        for asset_name in sorted(_UI_IMMUTABLE_ASSETS):
+            asset_version = _file_fingerprint(ui_dir / asset_name)
+            html = html.replace(
+                f"/ui/{asset_name}",
+                f"/ui/{asset_name}?v={asset_version}",
+            )
+        return html
+
+    def _ui_index_response(request: Request) -> Response:
+        etag = _index_etag()
+        headers = {
+            "Cache-Control": _UI_INDEX_CACHE_CONTROL,
+            "ETag": etag,
+        }
+        if _client_has_etag(request, etag):
+            return Response(status_code=304, headers=headers)
+        return Response(
+            _versioned_index_html(),
+            media_type="text/html",
+            headers=headers,
+        )
+
     @app.get("/ui", include_in_schema=False)
     def _ui_root_redirect() -> Response:
         # 307 preserves method + the spec for "the trailing slash form
@@ -777,7 +826,7 @@ def _mount_web_ui(
         # on the next page load without an app restart.
         resolved_token_path = token_path or DEFAULT_TOKEN_PATH
         token_value = load_token(resolved_token_path)
-        response = FileResponse(index_path, media_type="text/html")
+        response = _ui_index_response(request)
 
         # Cookie issuance is credential issuance — gate it behind a
         # proven local-operator path so a LAN device (or anyone who
@@ -867,7 +916,10 @@ def _mount_web_ui(
             return Response("Not Found", status_code=404)
         if not candidate.is_file():
             return Response("Not Found", status_code=404)
-        return FileResponse(candidate)
+        response = FileResponse(candidate)
+        if candidate.name in _UI_IMMUTABLE_ASSETS:
+            response.headers["Cache-Control"] = _UI_ASSET_CACHE_CONTROL
+        return response
 
 
 __all__ = ["API_V1_PREFIX", "create_app"]

--- a/src/pollypm/web_api/chat/registry.py
+++ b/src/pollypm/web_api/chat/registry.py
@@ -165,6 +165,7 @@ def enumerate_chat_surfaces(
     *,
     work_service: Any | None = None,
     tmux_client: Any | None = None,
+    include_transcripts: bool = True,
 ) -> list[ChatSurface]:
     """Return every chat surface (operator/architect/advisor/worker).
 
@@ -195,12 +196,14 @@ def enumerate_chat_surfaces(
         config,
         tmux_state_cache=tmux_state_cache,
         session_index_cache=session_index_cache,
+        include_transcripts=include_transcripts,
     ))
     if work_service is not None:
         surfaces.extend(enumerate_worker_surfaces(
             config, work_service,
             tmux_state_cache=tmux_state_cache,
             session_index_cache=session_index_cache,
+            include_transcripts=include_transcripts,
         ))
     surfaces.sort(key=_surface_sort_key)
     return surfaces
@@ -232,6 +235,7 @@ def enumerate_config_surfaces(
     *,
     tmux_state_cache: dict[str, TmuxWindowState] | None = None,
     session_index_cache: dict[Path, list] | None = None,
+    include_transcripts: bool = True,
 ) -> list[ChatSurface]:
     """Enumerate operator/architect/advisor surfaces from ``config.sessions``.
 
@@ -253,6 +257,7 @@ def enumerate_config_surfaces(
             tmux_session=tmux_session,
             tmux_state_cache=tmux_state_cache,
             session_index_cache=session_index_cache,
+            include_transcripts=include_transcripts,
         )
         if surface is not None:
             surfaces.append(surface)
@@ -265,6 +270,7 @@ def enumerate_worker_surfaces(
     *,
     tmux_state_cache: dict[str, TmuxWindowState] | None = None,
     session_index_cache: dict[Path, list] | None = None,
+    include_transcripts: bool = True,
 ) -> list[ChatSurface]:
     """Enumerate per-task worker surfaces from the work-service.
 
@@ -298,6 +304,7 @@ def enumerate_worker_surfaces(
             tmux_session=tmux_session,
             tmux_state_cache=tmux_state_cache,
             session_index_cache=session_index_cache,
+            include_transcripts=include_transcripts,
         )
         if surface is not None:
             surfaces.append(surface)
@@ -332,6 +339,7 @@ def find_chat_surface(
             tmux_session=storage_session_name(config.project.tmux_session),
             tmux_state_cache=tmux_state_cache,
             session_index_cache=session_index_cache,
+            include_transcripts=True,
         )
 
     parsed = parse_task_window_name(session_name)
@@ -360,6 +368,7 @@ def find_chat_surface(
                 tmux_session=storage_session_name(config.project.tmux_session),
                 tmux_state_cache=tmux_state_cache,
                 session_index_cache=session_index_cache,
+                include_transcripts=True,
             )
     return None
 
@@ -377,6 +386,7 @@ def _config_surface(
     tmux_session: str,
     tmux_state_cache: dict[str, TmuxWindowState] | None,
     session_index_cache: dict[Path, list] | None,
+    include_transcripts: bool,
 ) -> ChatSurface | None:
     if not session.enabled:
         return None
@@ -387,13 +397,15 @@ def _config_surface(
     project_root = _project_root_for_key(config, project_key)
     persona = _persona_for_session(config, session, surface_type)
     cwd = session.cwd if isinstance(session.cwd, Path) else Path(session.cwd or ".")
-    index = _build_session_index(project_root, session_index_cache)
-    transcript_path = lookup_transcript_path(
-        index,
-        cwd=str(cwd),
-        account_name=session.account,
-        provider=str(session.provider),
-    )
+    transcript_path: Path | None = None
+    if include_transcripts:
+        index = _build_session_index(project_root, session_index_cache)
+        transcript_path = lookup_transcript_path(
+            index,
+            cwd=str(cwd),
+            account_name=session.account,
+            provider=str(session.provider),
+        )
     window_name = session.window_name or session_name
     if tmux_state_cache and window_name in tmux_state_cache:
         window_state = tmux_state_cache[window_name]
@@ -423,6 +435,7 @@ def _worker_surface(
     tmux_session: str,
     tmux_state_cache: dict[str, TmuxWindowState] | None,
     session_index_cache: dict[Path, list] | None,
+    include_transcripts: bool,
 ) -> ChatSurface | None:
     project = getattr(record, "task_project", "") or ""
     task_number = getattr(record, "task_number", 0)
@@ -435,13 +448,15 @@ def _worker_surface(
     )
     cwd_for_lookup = str(worktree_path) if worktree_path else None
     provider_value = getattr(record, "provider", "") or ""
-    index = _build_session_index(project_root, session_index_cache)
-    transcript_path = lookup_transcript_path(
-        index,
-        cwd=cwd_for_lookup,
-        account_name=None,  # WorkerSessionRecord doesn't carry account
-        provider=provider_value or None,
-    )
+    transcript_path: Path | None = None
+    if include_transcripts:
+        index = _build_session_index(project_root, session_index_cache)
+        transcript_path = lookup_transcript_path(
+            index,
+            cwd=cwd_for_lookup,
+            account_name=None,  # WorkerSessionRecord doesn't carry account
+            provider=provider_value or None,
+        )
     window_name = session_name
     if tmux_state_cache and window_name in tmux_state_cache:
         window_state = tmux_state_cache[window_name]

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -47,6 +47,7 @@ from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field, ValidationError
 
 from pollypm.audit.query import (
+    aggregate_recent_stats,
     iter_matching_events,
     parse_since,
     resolve_target_files,
@@ -137,10 +138,10 @@ class AuditStatsResponse(BaseModel):
     ``since`` to keep stats bounded (see module docstring).
 
     ``_truncated_by_deadline`` + ``_lines_scanned`` (Codex round-6
-    finding, PR #2062) mirror the grep envelope: ``since`` is a
-    semantic bound but the walker still walks every target file/line
-    until it parses ``ts`` and filters. ``deadline_seconds`` is the
-    request-level wall-clock cap; when it fires the caller can tell
+    finding, PR #2062) mirror the grep envelope. The stats helper
+    reads live logs newest-first and skips clearly old rotations, but
+    ``deadline_seconds`` remains the request-level wall-clock cap for
+    mixed or still-recent archives; when it fires the caller can tell
     a complete aggregation from a bounded one and re-issue with a
     tighter project/since to make progress.
 
@@ -433,9 +434,8 @@ def stats_audit_endpoint(
             ge=0.5,
             le=120.0,
             description=(
-                "Request-level wall-clock budget (seconds). Default 10.0 "
-                "(higher than /audit/grep's 5.0 because aggregation has "
-                "no early-exit on match-count). When exceeded the walker "
+                "Request-level wall-clock budget (seconds). Default 2.5. "
+                "When exceeded the walker "
                 "stops, the response sets _truncated_by_deadline=true, "
                 "and _lines_scanned reports how many non-empty lines "
                 "were examined. Required because `since` is only a "
@@ -444,7 +444,7 @@ def stats_audit_endpoint(
                 "(Codex round-6 finding)."
             ),
         ),
-    ] = 10.0,
+    ] = 2.5,
 ) -> AuditStatsResponse:
     """Return per-event and per-severity counts over the target files.
 
@@ -464,41 +464,21 @@ def stats_audit_endpoint(
     since_dt = _parse_since_or_400(since)
     targets = resolve_target_files(project_filter=project, config=config)
 
-    by_event: dict[str, int] = {}
-    by_severity: dict[str, int] = {}
-    total = 0
-    # Round-3 fix: route stats through the same parse-gated walker as
-    # grep so malformed-ts rows (and the broken-string-compare bug in
-    # round 2) can't inflate ``total``. We pass a ``stats`` dict so
-    # the walker bumps ``malformed_rows_skipped`` for us; round-9
-    # surfaces the counter in the response so callers can distinguish
-    # a clean aggregation from one where archived rows were silently
-    # skipped.
-    walker_stats: dict[str, int] = {}
-    for record in iter_matching_events(
+    aggregate = aggregate_recent_stats(
         targets=targets,
-        pattern=None,
-        literal=None,
         since=since_dt,
-        event_type=None,
-        stats=walker_stats,
         deadline_s=deadline_seconds,
-    ):
-        total += 1
-        event_name = str(record.get("event") or "")
-        severity = str(record.get("status") or "ok")
-        by_event[event_name] = by_event.get(event_name, 0) + 1
-        by_severity[severity] = by_severity.get(severity, 0) + 1
+    )
 
     return AuditStatsResponse(
-        total=total,
-        by_event=by_event,
-        by_severity=by_severity,
+        total=aggregate.total,
+        by_event=aggregate.by_event,
+        by_severity=aggregate.by_severity,
         since=since_dt,
-        _truncated_by_deadline=bool(walker_stats.get("truncated_by_deadline", 0)),
-        _lines_scanned=walker_stats.get("lines_scanned", 0),
-        _corrupt_archives_skipped=walker_stats.get("corrupt_archives_skipped", 0),
-        _malformed_rows_skipped=walker_stats.get("malformed_rows_skipped", 0),
+        _truncated_by_deadline=aggregate.truncated_by_deadline,
+        _lines_scanned=aggregate.lines_scanned,
+        _corrupt_archives_skipped=aggregate.corrupt_archives_skipped,
+        _malformed_rows_skipped=aggregate.malformed_rows_skipped,
     )
 
 

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -157,10 +157,15 @@ class ChatSessionsResponse(BaseModel):
     sessions: list[ChatSurfaceResponse]
 
 
-_CHAT_SESSIONS_TTL_SECONDS = 1.0
+# The Web UI can trigger multiple rail boots in quick succession
+# (initial load, reload, SSE fallback/open transitions). Discovery is
+# read-only and can spend most of its cold cost in tmux + transcript
+# probes, so cache through that reload window instead of re-walking
+# the same surface set every second.
+_CHAT_SESSIONS_TTL_SECONDS = 15.0
 _CHAT_SESSIONS_LOCK = threading.Lock()
 _CHAT_SESSIONS_CACHE: dict[
-    tuple[int, int, int, int],
+    tuple[int, tuple[int, int], bool, int, int, int],
     tuple[float, tuple[ChatSurfaceResponse, ...]],
 ] = {}
 
@@ -410,6 +415,12 @@ def _build_tmux_client() -> TmuxClient | None:
     except Exception:  # noqa: BLE001
         logger.debug("chat_messages: TmuxClient init failed; presence unknown", exc_info=True)
         return None
+
+
+def _chat_sessions_config_cache_token(config: Any) -> tuple[int, int]:
+    sessions = getattr(config, "sessions", None) or {}
+    projects = getattr(config, "projects", None) or {}
+    return (len(sessions), len(projects))
 
 
 def _find_surface(
@@ -1032,7 +1043,19 @@ def _inline_subagent_transcript(
     summary="Discover every chat surface (operator/architect/advisor/worker)",
     operation_id="listChatSessions",
 )
-def list_chat_sessions_endpoint(config: ConfigDep) -> ChatSessionsResponse:
+def list_chat_sessions_endpoint(
+    config: ConfigDep,
+    include_transcripts: Annotated[
+        bool,
+        Query(
+            description=(
+                "When false, skips transcript-path discovery for a fast rail "
+                "bootstrap. Defaults true to preserve the full discovery "
+                "contract for API clients."
+            ),
+        ),
+    ] = True,
+) -> ChatSessionsResponse:
     """GET /api/v1/chat/sessions — return every configured chat surface.
 
     Workers are best-effort: when the work-service can't be opened
@@ -1043,6 +1066,8 @@ def list_chat_sessions_endpoint(config: ConfigDep) -> ChatSessionsResponse:
     """
     cache_key = (
         id(config),
+        _chat_sessions_config_cache_token(config),
+        include_transcripts,
         id(enumerate_chat_surfaces),
         id(_build_tmux_client),
         id(_build_work_service_stub),
@@ -1064,6 +1089,7 @@ def list_chat_sessions_endpoint(config: ConfigDep) -> ChatSessionsResponse:
             config,
             work_service=work_service,
             tmux_client=tmux_client,
+            include_transcripts=include_transcripts,
         )
         rows = tuple(_surface_to_wire(surface) for surface in surfaces)
         completed_at = time.monotonic()

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -39,6 +39,8 @@
     Number.isFinite(railRequestTimeoutOverride)
     && railRequestTimeoutOverride > 0
   ) ? railRequestTimeoutOverride : 10000;
+  const ACTIVITY_REQUEST_TIMEOUT_MS = 3000;
+  const ACTIVITY_STATS_DEADLINE_SECONDS = 2.5;
 
   const state = {
     projects: [],
@@ -401,26 +403,66 @@
     return reason instanceof Error ? reason : new Error(String(reason));
   }
 
-  function railTimeoutError(label) {
-    const timeoutLabel = RAIL_REQUEST_TIMEOUT_MS >= 1000
-      ? Math.round(RAIL_REQUEST_TIMEOUT_MS / 1000) + "s"
-      : RAIL_REQUEST_TIMEOUT_MS + "ms";
+  function timeoutLabel(timeoutMs) {
+    return timeoutMs >= 1000
+      ? Math.round(timeoutMs / 100) / 10 + "s"
+      : timeoutMs + "ms";
+  }
+
+  function requestTimeoutError(label, timeoutMs) {
     return new Error(
-      label + " request timed out after " + timeoutLabel,
+      label + " request timed out after " + timeoutLabel(timeoutMs),
     );
   }
 
+  function railTimeoutError(label) {
+    return requestTimeoutError(label, RAIL_REQUEST_TIMEOUT_MS);
+  }
+
   function railJsonWithTimeout(label, request, opts) {
+    const parentSignal = opts && opts.signal;
+    const controller = new AbortController();
+    const requestOpts = Object.assign({}, opts || {}, {
+      signal: controller.signal,
+    });
+    let timedOut = false;
     let timer = null;
-    const timeout = new Promise((_, reject) => {
-      timer = setTimeout(() => {
-        reject(railTimeoutError(label));
-      }, RAIL_REQUEST_TIMEOUT_MS);
-    });
-    const pending = Promise.resolve().then(() => request(opts));
-    return Promise.race([pending, timeout]).finally(() => {
+    let onParentAbort = null;
+    if (parentSignal) {
+      onParentAbort = () => controller.abort();
+      if (parentSignal.aborted) controller.abort();
+      else parentSignal.addEventListener("abort", onParentAbort, { once: true });
+    }
+    timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, RAIL_REQUEST_TIMEOUT_MS);
+    return Promise.resolve().then(() => request(requestOpts)).catch((err) => {
+      if (timedOut && isAbortError(err)) throw railTimeoutError(label);
+      throw err;
+    }).finally(() => {
       if (timer !== null) clearTimeout(timer);
+      if (parentSignal && onParentAbort) {
+        parentSignal.removeEventListener("abort", onParentAbort);
+      }
     });
+  }
+
+  async function apiJsonOptionalWithTimeout(label, path, timeoutMs) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort();
+    }, timeoutMs);
+    try {
+      return await apiJsonOptional(path, { signal: controller.signal });
+    } catch (err) {
+      if (isAbortError(err)) {
+        throw requestTimeoutError(label, timeoutMs);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   async function loadSurfaces(opts) {
@@ -463,7 +505,7 @@
     renderSurfaces();
     const sessionsPromise = railJsonWithTimeout(
       "chat surfaces",
-      (opts) => apiJson(API + "/chat/sessions", opts),
+      (opts) => apiJson(API + "/chat/sessions?include_transcripts=false", opts),
       { signal: request.signal },
     ).then((data) => {
       if (!ownsRequest()) return;
@@ -2460,7 +2502,9 @@
   }
 
   function activityStatsPath() {
-    return API + "/audit/stats?" + activityParams().toString();
+    const params = activityParams();
+    params.set("deadline_seconds", String(ACTIVITY_STATS_DEADLINE_SECONDS));
+    return API + "/audit/stats?" + params.toString();
   }
 
   async function loadActivity() {
@@ -2474,8 +2518,12 @@
     renderActivity();
     try {
       const [grepResult, statsResult] = await Promise.allSettled([
-        apiJsonOptional(activityGrepPath()),
-        apiJsonOptional(activityStatsPath()),
+        apiJsonOptionalWithTimeout(
+          "activity feed", activityGrepPath(), ACTIVITY_REQUEST_TIMEOUT_MS,
+        ),
+        apiJsonOptionalWithTimeout(
+          "activity stats", activityStatsPath(), ACTIVITY_REQUEST_TIMEOUT_MS,
+        ),
       ]);
       if (grepResult.status === "fulfilled") {
         state.activityEntries = Array.isArray(grepResult.value.events)
@@ -2492,6 +2540,17 @@
         state.activityError = statsResult.reason instanceof Error
           ? statsResult.reason
           : new Error(String(statsResult.reason));
+      } else if (
+        statsResult.status === "fulfilled"
+        && statsResult.value
+        && statsResult.value._truncated_by_deadline
+        && !state.activityError
+      ) {
+        const lines = Number(statsResult.value._lines_scanned || 0);
+        state.activityError = new Error(
+          "activity stats timed out"
+          + (lines > 0 ? " after scanning " + lines + " lines" : ""),
+        );
       }
     } finally {
       state.activityLoading = false;
@@ -2587,10 +2646,19 @@
     if (state.activityError) {
       summaryBox.innerHTML = "";
       feed.innerHTML = "";
-      feed.appendChild(el("div", {
-        class: "activity-empty",
-        text: "activity unavailable: " + state.activityError.message,
-      }));
+      const retry = el("button", {
+        type: "button",
+        class: "fetch-retry",
+        text: "Retry",
+        "aria-label": "Retry loading activity",
+      });
+      retry.addEventListener("click", () => loadActivity());
+      feed.appendChild(el("div", { class: "activity-empty" }, [
+        document.createTextNode(
+          "activity unavailable: " + state.activityError.message,
+        ),
+        retry,
+      ]));
       return;
     }
     const entries = state.activityEntries.slice().sort((a, b) => (

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -639,6 +639,37 @@ def test_stats_empty_log_returns_zero_total(
     assert body["by_severity"] == {}
 
 
+def test_stats_default_deadline_matches_ui_budget(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default stats budget must not soft-hang the Activity rail."""
+    from pollypm.web_api.routes import audit as audit_routes
+    from pollypm.audit.query import AuditStatsAggregate
+
+    captured: dict[str, float | None] = {}
+
+    def fake_aggregate_recent_stats(**kwargs):
+        captured["deadline_s"] = kwargs.get("deadline_s")
+        return AuditStatsAggregate()
+
+    monkeypatch.setattr(
+        audit_routes,
+        "aggregate_recent_stats",
+        fake_aggregate_recent_stats,
+    )
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj", "since": "24h"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured == {"deadline_s": 2.5}
+
+
 # ---------------------------------------------------------------------------
 # Round-2 guardrails (Codex review on PR #2062): ReDoS, malformed rows,
 # unbounded stats. See module docstring in
@@ -1206,43 +1237,25 @@ def test_audit_stats_request_deadline_truncates_large_scan(
     audit_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``deadline_seconds`` must bound ``/audit/stats`` scan + diagnose it.
-
-    Round-5 left stats calling ``iter_matching_events(..., deadline_s=None)``
-    without scanned-line/byte caps or any ``truncated`` response field. A
-    large old history can still force a full synchronous walk just to
-    discard rows older than ``since``.
-
-    Deterministic timing: monkeypatch the walker's ``parse_event_ts`` to
-    add ~3 ms per row so 200 archived rows would unbounded-scan for
-    ~600 ms. With ``deadline_seconds=0.5`` the walker MUST stop early,
-    surface ``_truncated_by_deadline=true``, and the whole request must
-    return in well under the un-bounded baseline. Monkeypatching the ts
-    parser (rather than relying on raw row volume) keeps the test fast
-    and immune to CI host speed variation.
-    """
+    """``deadline_seconds`` still bounds a large in-window archive."""
     import time
 
     from pollypm.audit import query as audit_query
 
-    # Sentinel old timestamp — every row falls outside the ``since=24h``
-    # window, so the walker exercises the parse → since-filter path on
-    # every row but yields nothing (so the body's ``total`` would be 0
-    # if the scan completed). Mirrors the realistic shape Codex
-    # described: large old history + small since window.
-    old_ts = "2020-01-01T00:00:00+00:00"
+    fresh_ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
     total_rows = 200
     archive = _per_project_log(project_root).with_name(
-        "audit.jsonl.1700000000.gz"
+        "audit.jsonl.unstamped.gz"
     )
     _write_jsonl_gz(
         archive,
         [
-            _make_event(event="task.created", subject="old", ts=old_ts)
+            _make_event(event="task.created", subject="fresh", ts=fresh_ts)
             for _ in range(total_rows)
         ],
     )
-    os.utime(archive, (1_700_000_000, 1_700_000_000))
+    now_ts = datetime.now(timezone.utc).timestamp()
+    os.utime(archive, (now_ts, now_ts))
 
     # Slow ``parse_event_ts`` so the unbounded baseline is well above the
     # deadline. Slow ~3 ms per row → 200 rows ≈ 600 ms unbounded.
@@ -1284,8 +1297,95 @@ def test_audit_stats_request_deadline_truncates_large_scan(
     # The walker must have stopped strictly before the full row set
     # (otherwise the deadline didn't actually save work).
     assert 1 <= body.get("_lines_scanned", 0) < total_rows, body
-    # Every row was outside ``since=24h`` so no aggregation is reported.
+    assert 1 <= body["total"] < total_rows
+
+
+def test_audit_stats_skips_archives_that_predate_since(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Obviously old rotations should not spend deadline budget."""
+    from pollypm.audit import query as audit_query
+
+    total_rows = 200
+    archive = _per_project_log(project_root).with_name(
+        "audit.jsonl.1700000000.gz"
+    )
+    _write_jsonl_gz(
+        archive,
+        [
+            _make_event(
+                event="task.created",
+                subject="old",
+                ts="2020-01-01T00:00:00+00:00",
+            )
+            for _ in range(total_rows)
+        ],
+    )
+    os.utime(archive, (1_700_000_000, 1_700_000_000))
+
+    def fail_parse_event_ts(_value: object) -> object:
+        raise AssertionError("old archive should have been skipped")
+
+    monkeypatch.setattr(audit_query, "parse_event_ts", fail_parse_event_ts)
+
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={
+            "project": "myproj",
+            "since": "24h",
+            "deadline_seconds": "0.5",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["_truncated_by_deadline"] is False
+    assert body["_lines_scanned"] == 0
     assert body["total"] == 0
+
+
+def test_audit_stats_stops_live_scan_after_recent_window(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Live stats read newest-first and stop after the first old row."""
+    now = datetime.now(timezone.utc)
+    old_rows = [
+        _make_event(
+            event="task.created",
+            subject=f"old-{idx}",
+            ts=(now - timedelta(days=30)).isoformat(),
+        )
+        for idx in range(200)
+    ]
+    fresh_rows = [
+        _make_event(
+            event="task.created",
+            subject=f"fresh-{idx}",
+            ts=(now - timedelta(minutes=idx + 1)).isoformat(),
+        )
+        for idx in range(3)
+    ]
+    _write_jsonl(_per_project_log(project_root), old_rows + fresh_rows)
+
+    response = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj", "since": "24h"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["_truncated_by_deadline"] is False
+    assert body["_lines_scanned"] == 4
+    assert body["total"] == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -52,6 +52,7 @@ from pollypm.web_api.chat.registry import (
     SurfaceType,
     TmuxWindowState,
 )
+from pollypm.web_api.chat import registry as chat_registry
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
 from pollypm.web_api import service as web_api_service
 
@@ -259,7 +260,10 @@ def patch_registry(monkeypatch: pytest.MonkeyPatch):
     against the same surface list.
     """
     def install(surfaces: list[ChatSurface]) -> None:
-        def fake(config, work_service=None, tmux_client=None):
+        def fake(
+            config, work_service=None, tmux_client=None,
+            include_transcripts=True,
+        ):
             return list(surfaces)
         def fake_find(config, session_name, work_service=None, tmux_client=None):
             for surface in surfaces:
@@ -408,7 +412,10 @@ def test_sessions_endpoint_coalesces_concurrent_discovery(
         lambda _config: None,
     )
 
-    def fake_enumerate(_config, *, work_service=None, tmux_client=None):
+    def fake_enumerate(
+        _config, *, work_service=None, tmux_client=None,
+        include_transcripts=True,
+    ):
         calls["n"] += 1
         time.sleep(0.05)
         return [surface]
@@ -433,6 +440,144 @@ def test_sessions_endpoint_coalesces_concurrent_discovery(
 
     assert results == [["operator"]] * 8
     assert calls == {"n": 1}
+
+
+def test_sessions_endpoint_cache_key_tracks_config_session_count(
+    config, monkeypatch,
+) -> None:
+    chat_messages_routes._CHAT_SESSIONS_CACHE.clear()
+    calls = {"n": 0}
+    surface = _surface("operator", SurfaceType.OPERATOR, persona="Polly")
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_tmux_client",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_work_service_stub",
+        lambda _config: None,
+    )
+
+    def fake_enumerate(
+        _config, *, work_service=None, tmux_client=None,
+        include_transcripts=True,
+    ):
+        calls["n"] += 1
+        return [surface] if _config.sessions else []
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "enumerate_chat_surfaces",
+        fake_enumerate,
+    )
+
+    first = chat_messages_routes.list_chat_sessions_endpoint(config)
+    assert first.sessions == []
+
+    config.sessions["operator"] = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=config.project.root_dir,
+        project="myproj",
+        window_name="pm-operator",
+    )
+
+    second = chat_messages_routes.list_chat_sessions_endpoint(config)
+    assert [row.session_name for row in second.sessions] == ["operator"]
+    assert calls == {"n": 2}
+
+
+def test_sessions_endpoint_lightweight_mode_skips_transcript_indexes(
+    client, auth_headers, config, workspace, monkeypatch,
+) -> None:
+    chat_messages_routes._CHAT_SESSIONS_CACHE.clear()
+    config.sessions["operator"] = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=workspace,
+        project="myproj",
+        window_name="pm-operator",
+    )
+
+    monkeypatch.setattr(chat_messages_routes, "_build_tmux_client", lambda: None)
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_work_service_stub",
+        lambda _config, **_kw: None,
+    )
+    monkeypatch.setattr(
+        chat_registry,
+        "_build_session_index",
+        lambda *_args, **_kwargs: pytest.fail(
+            "include_transcripts=false should skip transcript index scans"
+        ),
+    )
+
+    response = client.get(
+        "/api/v1/chat/sessions?include_transcripts=false",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [row["session_name"] for row in body["sessions"]] == ["operator"]
+    assert body["sessions"][0]["transcript"] == {"source": None, "path": None}
+
+
+def test_sessions_endpoint_cache_key_separates_lightweight_mode(
+    config, monkeypatch,
+) -> None:
+    chat_messages_routes._CHAT_SESSIONS_CACHE.clear()
+    calls: list[bool] = []
+    surface = _surface("operator", SurfaceType.OPERATOR, persona="Polly")
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_tmux_client",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_work_service_stub",
+        lambda _config: None,
+    )
+
+    def fake_enumerate(
+        _config, *, work_service=None, tmux_client=None,
+        include_transcripts=True,
+    ):
+        calls.append(include_transcripts)
+        return [surface]
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "enumerate_chat_surfaces",
+        fake_enumerate,
+    )
+
+    full = chat_messages_routes.list_chat_sessions_endpoint(
+        config,
+        include_transcripts=True,
+    )
+    light = chat_messages_routes.list_chat_sessions_endpoint(
+        config,
+        include_transcripts=False,
+    )
+    cached_light = chat_messages_routes.list_chat_sessions_endpoint(
+        config,
+        include_transcripts=False,
+    )
+
+    assert [row.session_name for row in full.sessions] == ["operator"]
+    assert [row.session_name for row in light.sessions] == ["operator"]
+    assert [row.session_name for row in cached_light.sessions] == ["operator"]
+    assert calls == [True, False]
 
 
 def test_sessions_endpoint_cookie_auth_uses_bounded_tmux_probe(

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -273,10 +273,32 @@ def test_ui_index_contains_required_anchors(client: TestClient) -> None:
     assert "/ui/styles.css" in html
 
 
+def test_ui_index_versions_static_asset_urls(client: TestClient) -> None:
+    html = client.get("/ui/").text
+    assert "/ui/app.js?v=" in html
+    assert "/ui/styles.css?v=" in html
+
+
+def test_ui_index_sets_etag_and_revalidates(client: TestClient) -> None:
+    response = client.get("/ui/")
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-cache"
+    etag = response.headers["etag"]
+    assert etag.startswith('"ui-index-')
+
+    cached = client.get("/ui/", headers={"If-None-Match": etag})
+    assert cached.status_code == 304
+    assert cached.headers["etag"] == etag
+    assert cached.headers["cache-control"] == "no-cache"
+
+
 def test_ui_static_js_served(client: TestClient) -> None:
     """``GET /ui/app.js`` returns the vanilla JS app."""
     response = client.get("/ui/app.js")
     assert response.status_code == 200
+    assert response.headers["cache-control"] == (
+        "public, max-age=31536000, immutable"
+    )
     body = response.text
     assert "credentials" in body, "app.js must use credentials:'include'"
     assert "loadSurfaces" in body
@@ -309,6 +331,9 @@ def test_ui_static_css_served(client: TestClient) -> None:
     """``GET /ui/styles.css`` returns the dark-theme stylesheet."""
     response = client.get("/ui/styles.css")
     assert response.status_code == 200
+    assert response.headers["cache-control"] == (
+        "public, max-age=31536000, immutable"
+    )
     body = response.text
     # Sanity-check that the palette wired through (not an empty file).
     assert "--info" in body or "#5b8aff" in body
@@ -1105,6 +1130,28 @@ def test_ui_app_js_has_surface_audit_panel_hooks(client: TestClient) -> None:
         "loadAuditForSurface",
         "auditPatternForSurface",
         "audit-toggle",
+    ):
+        assert expected in body
+
+
+def test_ui_app_js_uses_lightweight_chat_sessions_for_rail(
+    client: TestClient,
+) -> None:
+    body = client.get("/ui/app.js").text
+    assert '/chat/sessions?include_transcripts=false' in body
+    assert "new AbortController()" in body
+    assert "timedOut && isAbortError(err)" in body
+
+
+def test_ui_app_js_activity_stats_has_timeout_and_retry(client: TestClient) -> None:
+    body = client.get("/ui/app.js").text
+    for expected in (
+        "ACTIVITY_REQUEST_TIMEOUT_MS = 3000",
+        "ACTIVITY_STATS_DEADLINE_SECONDS = 2.5",
+        "apiJsonOptionalWithTimeout",
+        "_truncated_by_deadline",
+        "activity unavailable:",
+        "Retry loading activity",
     ):
         assert expected in body
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a recent-window audit stats aggregator that reads live logs newest-first, skips clearly old rotations, and lowers the default stats deadline to 2.5s for the Activity rail.
- Add a lightweight `GET /api/v1/chat/sessions?include_transcripts=false` mode so the UI rail does not cold-scan transcript indexes just to list surfaces.
- Abort timed-out rail/activity browser requests, surface Activity timeouts with a retry affordance, and add ETag/versioned immutable caching for `/ui/` assets.

Fixes #2323
Fixes #2324
Fixes #2325

## Verification
- `uv run --extra test pytest --noconftest tests/test_audit_endpoint.py tests/test_chat_messages_endpoint.py -q`
- `uv run --extra test pytest tests/web_api/test_web_ui.py -q`
- `uv run --extra test pytest tests/web_api/test_openapi_conformance.py -q`
- `uv run --extra dev ruff check src/pollypm/audit/query.py src/pollypm/web_api/app.py src/pollypm/web_api/chat/registry.py src/pollypm/web_api/routes/audit.py src/pollypm/web_api/routes/chat_messages.py tests/test_audit_endpoint.py tests/test_chat_messages_endpoint.py tests/web_api/test_web_ui.py`
- `git diff --check`
