### PR TITLE
perf(audit): cache /audit/stats responses to break 10s wall (#2323)

### DIFF
--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -40,6 +40,8 @@ HTTP guardrails added in round 2:
 from __future__ import annotations
 
 import re
+import threading
+import time
 from datetime import datetime, timezone
 from typing import Annotated, Any
 
@@ -70,6 +72,78 @@ _GREP_LIMIT_MAX = 1000
 # regexes without giving an attacker room for a 50 KB catastrophic
 # backtracker (Codex round-1 P0 ReDoS finding).
 _PATTERN_LENGTH_MAX = 200
+
+
+# ---------------------------------------------------------------------------
+# /audit/stats TTL cache (issue #2323).
+#
+# The activity-rollup widget polls ``/audit/stats?since=2d`` every refresh.
+# On a live host with ~250 MB of JSONL across ~50 per-project logs the
+# walker drains the default 10 s ``deadline_seconds`` budget on every call
+# (lines_scanned ~1.7 M before truncation), so every refresh hits the
+# wall-clock cap and the UI sticks at "loading activity…".
+#
+# The fix mirrors the chat-sessions / dashboard #2307 pattern: keep a
+# short TTL cache keyed by the user-facing query shape. Subsequent
+# refreshes inside the TTL return instantly; a cold call still does the
+# full walk (and still respects ``deadline_seconds`` if the walk doesn't
+# finish). 30 s is short enough that "Activity 2d" feels live and long
+# enough that a polling UI sees ≤2 cold calls/min instead of every-poll.
+#
+# The lock collapses stampede: concurrent refreshes after a TTL expiry
+# share one walk instead of N parallel deadline-bound walks (which was
+# the #2294 / #2319 / #2320 thrash pattern). Stats responses are small
+# (~ small dicts), so storing them by value is cheap.
+_STATS_CACHE_TTL_SECONDS = 30.0
+_STATS_CACHE_MAX_ENTRIES = 16
+_STATS_CACHE_LOCK = threading.Lock()
+_STATS_CACHE: dict[
+    tuple[int, str | None, str, float],
+    tuple[float, "AuditStatsResponse"],
+] = {}
+
+
+def _stats_cache_get(
+    key: tuple[int, str | None, str, float],
+    now: float,
+) -> "AuditStatsResponse | None":
+    """Return a cached stats response if it's still within the TTL."""
+    cached = _STATS_CACHE.get(key)
+    if cached is None:
+        return None
+    cached_at, response = cached
+    if now - cached_at >= _STATS_CACHE_TTL_SECONDS:
+        return None
+    return response
+
+
+def _stats_cache_set(
+    key: tuple[int, str | None, str, float],
+    response: "AuditStatsResponse",
+    now: float,
+) -> None:
+    """Store ``response`` and evict stale / overflow entries."""
+    _STATS_CACHE[key] = (now, response)
+    if len(_STATS_CACHE) <= _STATS_CACHE_MAX_ENTRIES:
+        return
+    stale = [
+        k for k, (ts, _v) in _STATS_CACHE.items()
+        if now - ts >= _STATS_CACHE_TTL_SECONDS
+    ]
+    for k in stale:
+        _STATS_CACHE.pop(k, None)
+    # If we're still over budget (no stale entries to evict), drop the
+    # single oldest entry so the dict can't grow without bound from
+    # rare-key churn (e.g. ad-hoc ``since`` values from the CLI).
+    if len(_STATS_CACHE) > _STATS_CACHE_MAX_ENTRIES:
+        oldest_key = min(_STATS_CACHE, key=lambda k: _STATS_CACHE[k][0])
+        _STATS_CACHE.pop(oldest_key, None)
+
+
+def _reset_stats_cache_for_tests() -> None:
+    """Test hook — clear the TTL cache between cases."""
+    with _STATS_CACHE_LOCK:
+        _STATS_CACHE.clear()
 
 
 class AuditGrepResponse(BaseModel):
@@ -462,6 +536,54 @@ def stats_audit_endpoint(
             ),
         )
     since_dt = _parse_since_or_400(since)
+
+    # Issue #2323: serve recent results from a short TTL cache to avoid
+    # paying the full walker cost on every UI refresh (the activity
+    # rollup widget polls this endpoint, and on hosts with ~250 MB of
+    # audit JSONL each cold call drains the entire ``deadline_seconds``
+    # budget). The cache key uses the raw ``since`` string so two clients
+    # passing the same shortcut (``2d``) share a slot; ``deadline_seconds``
+    # is included so a tighter-budget caller can't read a stale result
+    # computed under a more generous deadline.
+    cache_key = (id(config), project, since, deadline_seconds)
+    now = time.monotonic()
+    cached = _stats_cache_get(cache_key, now)
+    if cached is not None:
+        return cached
+
+    with _STATS_CACHE_LOCK:
+        # Re-check under the lock to collapse stampedes (multiple polls
+        # arriving in the same window share one walk instead of starting
+        # N parallel deadline-bound walks — the #2294/#2319/#2320 thrash).
+        now = time.monotonic()
+        cached = _stats_cache_get(cache_key, now)
+        if cached is not None:
+            return cached
+
+        response = _compute_audit_stats(
+            config=config,
+            project=project,
+            since_dt=since_dt,
+            deadline_seconds=deadline_seconds,
+        )
+        _stats_cache_set(cache_key, response, time.monotonic())
+        return response
+
+
+def _compute_audit_stats(
+    *,
+    config: Any,
+    project: str | None,
+    since_dt: datetime | None,
+    deadline_seconds: float,
+) -> "AuditStatsResponse":
+    """Walk the audit logs and build the stats response (uncached).
+
+    Split out so the endpoint can wrap the expensive walk with the TTL
+    cache + stampede lock (issue #2323) while keeping the original
+    aggregation semantics in one place. Behavior is identical to the
+    pre-#2323 inlined loop.
+    """
     targets = resolve_target_files(project_filter=project, config=config)
 
     by_event: dict[str, int] = {}

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -34,6 +34,18 @@ from pollypm.config import (
 )
 from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
 from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.routes.audit import _reset_stats_cache_for_tests
+
+
+# Issue #2323: the stats endpoint caches responses for 30 s to keep
+# polling UIs cheap. Cache state is module-global, so without an
+# autouse reset two tests reusing the same ``api_config`` ``id()`` slot
+# (CPython recycles freshly-allocated object addresses across tests)
+# could see a stale envelope from the prior test. Clearing in front of
+# every test keeps the existing semantic assertions exact.
+@pytest.fixture(autouse=True)
+def _reset_audit_stats_cache() -> None:
+    _reset_stats_cache_for_tests()
 
 
 # ---------------------------------------------------------------------------
@@ -1383,4 +1395,142 @@ def test_audit_grep_regex_skips_old_rows_before_pattern(
         f"bounded regex ran on {call_count['n']} rows; "
         f"since=1h should have limited it to <= {len(fresh_rows)} "
         f"(old rows must be filtered BEFORE the pattern)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2323: ``/audit/stats`` TTL cache.
+# ---------------------------------------------------------------------------
+def test_audit_stats_repeats_within_ttl_skip_walker(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated ``/audit/stats`` calls within the TTL share one walk.
+
+    Issue #2323: the activity-rollup widget polls
+    ``/audit/stats?since=2d`` every refresh. On a live host with ~250 MB
+    of audit JSONL each cold call drained the entire
+    ``deadline_seconds`` budget (1.68 M lines scanned before truncation,
+    every call ~10 s). A short TTL cache collapses follow-up polls onto
+    the previous result so the UI never sees the 10 s wall on a refresh.
+
+    This test counts how many times the underlying walker
+    (``iter_matching_events``) runs across N identical requests. The
+    cache contract: only the FIRST call walks; subsequent calls inside
+    the TTL skip the walker entirely.
+    """
+    from pollypm.web_api.routes import audit as audit_route
+
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(event="task.created", status="ok"),
+            _make_event(event="task.created", status="ok"),
+            _make_event(event="task.status_changed", status="warn"),
+        ],
+    )
+
+    # Count walks. ``iter_matching_events`` is imported into the route
+    # module by name, so we patch the module-local symbol.
+    walk_count = {"n": 0}
+    real_iter = audit_route.iter_matching_events
+
+    def counting_iter(*args, **kwargs):  # type: ignore[no-untyped-def]
+        walk_count["n"] += 1
+        yield from real_iter(*args, **kwargs)
+
+    monkeypatch.setattr(audit_route, "iter_matching_events", counting_iter)
+
+    params = {"project": "myproj", "since": "30d"}
+    first = client.get(
+        "/api/v1/audit/stats", params=params, headers=auth_headers
+    )
+    assert first.status_code == 200, first.text
+    first_body = first.json()
+    assert first_body["total"] == 3
+    assert walk_count["n"] == 1
+
+    for _ in range(5):
+        repeat = client.get(
+            "/api/v1/audit/stats", params=params, headers=auth_headers
+        )
+        assert repeat.status_code == 200
+        # Cache must return the byte-identical envelope so callers don't
+        # see a flicker between fresh + cached responses.
+        assert repeat.json() == first_body
+
+    # Five follow-up calls — none should have re-entered the walker.
+    assert walk_count["n"] == 1, (
+        f"expected 1 walker invocation across 6 identical calls inside TTL; "
+        f"got {walk_count['n']}"
+    )
+
+
+def test_audit_stats_cache_key_separates_since_windows(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Different ``since`` windows must NOT share a cache slot.
+
+    A 2 d window and a 7 d window can yield different totals on the same
+    underlying log, so the cache key includes the raw ``since`` string.
+    """
+    from pollypm.web_api.routes import audit as audit_route
+
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(event="old", ts=(now - timedelta(days=5)).isoformat()),
+            _make_event(event="recent", ts=(now - timedelta(hours=1)).isoformat()),
+        ],
+    )
+
+    walk_count = {"n": 0}
+    real_iter = audit_route.iter_matching_events
+
+    def counting_iter(*args, **kwargs):  # type: ignore[no-untyped-def]
+        walk_count["n"] += 1
+        yield from real_iter(*args, **kwargs)
+
+    monkeypatch.setattr(audit_route, "iter_matching_events", counting_iter)
+
+    # 2d window: only the recent event lands.
+    r2d = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj", "since": "2d"},
+        headers=auth_headers,
+    )
+    assert r2d.status_code == 200
+    assert r2d.json()["total"] == 1
+
+    # 7d window: both events land. Different since → fresh walk.
+    r7d = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj", "since": "7d"},
+        headers=auth_headers,
+    )
+    assert r7d.status_code == 200
+    assert r7d.json()["total"] == 2
+
+    # Two distinct cache keys → two walks. (Same-key repeats below
+    # confirm the cache still de-dupes within each key.)
+    assert walk_count["n"] == 2
+
+    # Repeat 2d — must hit cache, not walk again.
+    r2d_again = client.get(
+        "/api/v1/audit/stats",
+        params={"project": "myproj", "since": "2d"},
+        headers=auth_headers,
+    )
+    assert r2d_again.status_code == 200
+    assert r2d_again.json()["total"] == 1
+    assert walk_count["n"] == 2, (
+        f"second 2d call should be cached; saw {walk_count['n']} walks"
     )


### PR DESCRIPTION
## Summary

Fixes #2323: the activity-rollup widget polls `/audit/stats?since=2d`. On hosts with ~250 MB of audit JSONL the walker drains the entire 10 s `deadline_seconds` budget every call (1.68 M lines scanned before truncation), so every refresh returns HTTP 200 in exactly 10.02 s and the UI sticks at "loading activity…".

Mirrors the dashboard #2307 / chat-sessions pattern:
- Short TTL cache (30 s, max 16 entries) keyed by `(config, project, since, deadline_seconds)`.
- Stampede-collapsing lock so N parallel polls share one walk instead of starting N parallel 10-second walks.
- Cold call still pays the full walker cost (no semantic change to the bounded-walk contract — `_truncated_by_deadline` / `_lines_scanned` still surface accurately on the fresh response).

## Measurement

Live audit home: 52 per-project logs / 249 MB JSONL.

Before (every refresh re-walks):
```
10.069006 200
10.017222 200
10.009217 200
10.018124 200
10.066443 200
```

After (cache hits inside TTL):
```
10.026473 200   # cold
0.007948  200
0.006803  200
0.007094  200
0.006792  200
```

Stampede collapse (5 parallel calls on a fresh key) — all 5 finish at 10.07 s after sharing one walk (vs. 50 s sequential or 5 × 10 s thrash):
```
10.072156 200
10.072580 200
10.072842 200
10.073988 200
10.074529 200
```

## Tradeoffs

- 30 s staleness on the "Activity 2d" rollup is acceptable for a 2-day window.
- Cold-call cost is still 10 s on this dataset — that's the deeper structural issue (walker scans every file top-to-bottom; recent rows live at the tail). A future PR could reverse-scan or maintain a daily-counter sidecar, but that's a bigger refactor with correctness risk and is out of scope for this fix.

## Test plan

- [x] `uv run --extra dev python -m pytest tests/test_audit_endpoint.py` — all 34 tests pass (2 new cache tests + 32 existing semantic tests).
- [x] Live `uv run pm serve` repro: cold call 10.02 s, follow-ups 7 ms inside TTL.
- [x] Stampede test: 5 parallel polls collapse to one walk.
- [ ] UI smoke: confirm Activity 2d rollup loads on the second poll instead of forever-spinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)