### PR TITLE
fix(rail): fail loud on daemon startup loops

### DIFF
--- a/src/pollypm/cli_features/alerts.py
+++ b/src/pollypm/cli_features/alerts.py
@@ -471,12 +471,13 @@ def heartbeat_status(
     from pollypm import cli as cli_mod
     from pollypm.config import load_config
     from pollypm.rail_daemon_supervisor import (
-        diagnose_rail_daemon, query_last_heartbeat_iso,
+        diagnose_rail_daemon, query_last_heartbeat_iso, read_crash_loop_state,
     )
 
     cfg = load_config(config_path)
     pid_path = cli_mod._rail_daemon_pid_path()
     last_tick_iso = query_last_heartbeat_iso(cfg.project.state_db)
+    crash_loop = read_crash_loop_state(pid_path)
     decision = diagnose_rail_daemon(
         pid_path=pid_path, last_tick_iso=last_tick_iso,
     )
@@ -487,6 +488,18 @@ def heartbeat_status(
             "last_tick_age_seconds": decision.last_tick_age_seconds,
             "reason": decision.reason,
             "needs_revival": decision.needs_revival,
+            "crash_loop": (
+                {
+                    "failure_count": crash_loop.failure_count,
+                    "threshold": crash_loop.threshold,
+                    "suppressed": crash_loop.suppressed,
+                    "first_failure_at": crash_loop.first_failure_at,
+                    "last_failure_at": crash_loop.last_failure_at,
+                    "reason": crash_loop.reason,
+                }
+                if crash_loop is not None
+                else None
+            ),
         })
         return
     label = "alive" if decision.state == "alive" else "DEGRADED"
@@ -495,6 +508,13 @@ def heartbeat_status(
     if decision.last_tick_age_seconds is not None:
         typer.echo(f"  last tick: {decision.last_tick_age_seconds:.0f}s ago")
     typer.echo(f"  {decision.reason}")
+    if crash_loop is not None and crash_loop.suppressed:
+        typer.echo(
+            "  crash loop: suppressed after "
+            f"{crash_loop.failure_count} failed starts"
+        )
+        if crash_loop.reason:
+            typer.echo(f"  last failure: {crash_loop.reason}")
 
 
 @heartbeat_app.command(

--- a/src/pollypm/defaults/docs/reference/operator-runbook.md
+++ b/src/pollypm/defaults/docs/reference/operator-runbook.md
@@ -375,6 +375,21 @@ What an operator sees:
 - Log rotation does not emit an audit-log event today. Inspect archive
   files and the live log size when investigating rotation behavior.
 
+### Rail Daemon Startup Failures
+
+On startup, `rail_daemon` holds its single-instance lock before opening
+the workspace store. If the installed code has pending workspace schema
+migrations, the daemon applies them before booting the heartbeat rail;
+failed migrations still stop startup and leave the structured migration
+message in `~/.pollypm/rail_daemon.log`.
+
+If the supervisor repeatedly spawns the daemon and no child claims
+`~/.pollypm/rail_daemon.pid`, the supervisor writes
+`~/.pollypm/rail_daemon.crash_loop.json`, stops further respawns for
+that failure window, and upserts a user-facing inbox alert. `pm doctor`
+also reports this as an error. After fixing the startup cause, run
+`pm up`; a healthy daemon clears the sentinel.
+
 ### Cockpit Socket Reaper
 
 What runs:

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -1153,6 +1153,41 @@ def check_rail_daemon_alive() -> CheckResult:
     import os as _os
 
     pid_path = _pollypm_home() / "rail_daemon.pid"
+    try:
+        from pollypm.rail_daemon_supervisor import read_crash_loop_state
+
+        crash_loop = read_crash_loop_state(pid_path)
+    except Exception:  # noqa: BLE001
+        crash_loop = None
+    if crash_loop is not None and crash_loop.suppressed:
+        details = crash_loop.reason or "the daemon did not claim its PID file"
+        return _fail(
+            (
+                "rail daemon crash-loop suppressed after "
+                f"{crash_loop.failure_count} failed starts"
+            ),
+            why=(
+                "The outer supervisor repeatedly spawned rail_daemon, "
+                "but no healthy daemon registered. Further respawns are "
+                "suppressed to avoid a silent log-flood loop."
+            ),
+            fix=(
+                "Inspect the startup log and fix the underlying error:\n"
+                "  tail -n 120 ~/.pollypm/rail_daemon.log\n"
+                "Then run:\n"
+                "  pm up\n"
+                "Recheck: pm doctor"
+            ),
+            severity="error",
+            fixable=False,
+            data={
+                "failure_count": crash_loop.failure_count,
+                "threshold": crash_loop.threshold,
+                "first_failure_at": crash_loop.first_failure_at,
+                "last_failure_at": crash_loop.last_failure_at,
+                "reason": details,
+            },
+        )
     if not pid_path.exists():
         return _fail(
             "rail daemon is not running",

--- a/src/pollypm/rail_daemon.py
+++ b/src/pollypm/rail_daemon.py
@@ -59,6 +59,10 @@ def _lock_file(home: Path) -> Path:
     return home / "rail_daemon.lock"
 
 
+def _crash_loop_file(home: Path) -> Path:
+    return home / "rail_daemon.crash_loop.json"
+
+
 def _acquire_lifetime_lock(lock_path: Path) -> int | None:
     """Acquire the lifetime ``flock`` and return the open fd, or ``None``.
 
@@ -145,11 +149,20 @@ def _claim_pid_file(pid_path: Path) -> bool:
     Returns True on successful claim, False when a live daemon
     already owns the slot.
     """
-    if pid_path.exists():
+    def _read_existing_pid() -> int:
         try:
-            existing = int(pid_path.read_text().strip())
+            return int(pid_path.read_text().strip())
         except (ValueError, OSError):
-            existing = 0
+            return 0
+
+    if pid_path.exists():
+        existing = _read_existing_pid()
+        if existing <= 0:
+            # Another daemon may have won O_EXCL and not written its PID
+            # bytes yet. Give that tiny critical section a chance to
+            # finish before treating garbage/empty contents as stale.
+            time.sleep(0.05)
+            existing = _read_existing_pid()
         if existing > 0 and _pid_alive(existing):
             return False
         # Stale file — clear it so our O_EXCL create below can succeed.
@@ -200,6 +213,49 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
+def _apply_pending_migrations_for_startup(db_path: Path) -> int:
+    """Apply pending workspace migrations before the daemon opens services.
+
+    The rail daemon is the long-lived process that owns heartbeat/job
+    draining. After an upgrade, launchd or ``pm rail-daemon`` may start
+    it directly before the operator has run ``pm migrate --apply``. At
+    this point the daemon has not opened the store yet; applying the
+    append-only workspace migrations here avoids a silent restart loop
+    while preserving the refuse-start gate for failed migrations.
+
+    Returns the number of migrations applied.
+    """
+    from pollypm.store import migrations as _migrations
+
+    if _migrations.bypass_env_is_set():
+        return 0
+    try:
+        status = _migrations.inspect(db_path)
+    except _migrations.UnusableDatabaseError as exc:
+        _migrations.exit_unusable_database(exc)
+    if status.up_to_date:
+        return 0
+    logger.warning(
+        "rail_daemon: applying %d pending schema migration(s) before startup",
+        len(status.pending),
+    )
+    try:
+        outcome = _migrations.apply(db_path)
+    except _migrations.UnusableDatabaseError as exc:
+        _migrations.exit_unusable_database(exc)
+    except Exception:  # noqa: BLE001
+        logger.exception("rail_daemon: startup migration apply failed")
+        _migrations.require_no_pending_or_exit(db_path)
+        return 0
+    applied = len(outcome.applied)
+    logger.warning(
+        "rail_daemon: applied %d schema migration(s) before startup",
+        applied,
+    )
+    _migrations.require_no_pending_or_exit(db_path)
+    return applied
+
+
 def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
     """Run the daemon loop. Blocks until signalled.
 
@@ -208,13 +264,8 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
     """
     from pollypm.config import load_config, DEFAULT_CONFIG_PATH
     from pollypm.service_api import PollyPMService
-    from pollypm.store import migrations as _migrations
 
     cfg = load_config(config_path)
-    # Refuse-start gate (#717): the daemon opens the state store and
-    # would silently run migrations otherwise. Exit loudly so the
-    # operator runs ``pm migrate --apply`` from a terminal instead.
-    _migrations.require_no_pending_or_exit(cfg.project.state_db)
     pollypm_home = Path(DEFAULT_CONFIG_PATH).parent
     pid_path = _pid_file(pollypm_home)
     lock_path = _lock_file(pollypm_home)
@@ -239,6 +290,16 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
         )
         return 1
     _LIFETIME_LOCK_FD = lock_fd
+
+    try:
+        _apply_pending_migrations_for_startup(cfg.project.state_db)
+    except BaseException:
+        try:
+            os.close(lock_fd)
+        except OSError:
+            pass
+        _LIFETIME_LOCK_FD = None
+        raise
 
     if not _claim_pid_file(pid_path):
         # Lock was acquired but PID file is held by a still-live process.
@@ -365,6 +426,7 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
         logger.exception("rail_daemon: core_rail.start() failed")
         _cleanup()
         return 3
+    _crash_loop_file(pollypm_home).unlink(missing_ok=True)
 
     logger.info(
         "rail_daemon: started (pid=%d, poll=%.1fs) — heartbeat rail live",

--- a/src/pollypm/rail_daemon_supervisor.py
+++ b/src/pollypm/rail_daemon_supervisor.py
@@ -84,6 +84,7 @@ daemon directly on machine boot) is a separate opt-in surface — see
 from __future__ import annotations
 
 import logging
+import json
 import os
 import shlex
 import signal
@@ -104,8 +105,12 @@ __all__ = [
     "DEFAULT_STALE_TICK_SECONDS",
     "DEFAULT_REVIVAL_THROTTLE_SECONDS",
     "DEFAULT_SIGTERM_GRACE_SECONDS",
+    "DEFAULT_IMMEDIATE_EXIT_THRESHOLD",
+    "CrashLoopState",
     "check_and_revive_rail_daemon",
+    "crash_loop_state_path",
     "diagnose_rail_daemon",
+    "read_crash_loop_state",
     "should_revive",
 ]
 
@@ -137,6 +142,21 @@ DEFAULT_SIGTERM_GRACE_SECONDS = 3.0
 #: latency on the slowest field machines we've measured (~1-2s) without
 #: making cron callers block longer than their tick budget.
 DEFAULT_CHILD_PID_WAIT_SECONDS = 5.0
+
+#: Consecutive spawn attempts that return without a live matching PID
+#: before the supervisor suppresses further respawns and surfaces a
+#: durable operator alert. This is intentionally small: a daemon that
+#: cannot write a PID after five supervised starts is not recovering
+#: through repetition.
+DEFAULT_IMMEDIATE_EXIT_THRESHOLD = 5
+
+#: Stale crash-loop state expires after this window so an old sentinel
+#: cannot suppress a future unrelated recovery attempt forever.
+DEFAULT_CRASH_LOOP_WINDOW_SECONDS = 60 * 60
+
+_CRASH_LOOP_STATE_NAME = "rail_daemon.crash_loop.json"
+_RAIL_DAEMON_LOG_NAME = "rail_daemon.log"
+_CRASH_LOOP_ALERT_SENDER = "rail_daemon_crash_loop"
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +195,23 @@ class RevivalResult:
     spawn_error: str | None
     killed_pid: int | None
     kill_signal: str | None  # ``"SIGTERM"`` / ``"SIGKILL"`` / ``"already_gone"`` / ``None``
+
+
+@dataclass(frozen=True, slots=True)
+class CrashLoopState:
+    """Persisted supervisor state for daemon starts that die before PID claim."""
+
+    failure_count: int
+    threshold: int
+    first_failure_at: str
+    last_failure_at: str
+    reason: str
+    log_excerpt: str
+    alerted: bool = False
+
+    @property
+    def suppressed(self) -> bool:
+        return self.failure_count >= self.threshold
 
 
 # ---------------------------------------------------------------------------
@@ -793,6 +830,215 @@ def _emit_revival_audit(
         )
 
 
+def crash_loop_state_path(pid_path: Path) -> Path:
+    """Return the durable crash-loop sentinel path beside ``rail_daemon.pid``."""
+    return pid_path.with_name(_CRASH_LOOP_STATE_NAME)
+
+
+def _rail_daemon_log_path(pid_path: Path) -> Path:
+    return pid_path.with_name(_RAIL_DAEMON_LOG_NAME)
+
+
+def _parse_crash_loop_state(payload: dict[str, Any]) -> CrashLoopState | None:
+    try:
+        count = int(payload.get("failure_count") or 0)
+        threshold = int(payload.get("threshold") or DEFAULT_IMMEDIATE_EXIT_THRESHOLD)
+    except (TypeError, ValueError):
+        return None
+    if count <= 0:
+        return None
+    first = str(payload.get("first_failure_at") or "")
+    last = str(payload.get("last_failure_at") or first)
+    if not first or not last:
+        return None
+    return CrashLoopState(
+        failure_count=count,
+        threshold=max(1, threshold),
+        first_failure_at=first,
+        last_failure_at=last,
+        reason=str(payload.get("reason") or ""),
+        log_excerpt=str(payload.get("log_excerpt") or ""),
+        alerted=bool(payload.get("alerted")),
+    )
+
+
+def read_crash_loop_state(pid_path: Path) -> CrashLoopState | None:
+    """Read the crash-loop sentinel, returning ``None`` when absent/invalid."""
+    path = crash_loop_state_path(pid_path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return _parse_crash_loop_state(payload)
+
+
+def _write_crash_loop_state(pid_path: Path, state: CrashLoopState) -> None:
+    path = crash_loop_state_path(pid_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "failure_count": state.failure_count,
+        "threshold": state.threshold,
+        "first_failure_at": state.first_failure_at,
+        "last_failure_at": state.last_failure_at,
+        "reason": state.reason,
+        "log_excerpt": state.log_excerpt,
+        "alerted": state.alerted,
+    }
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _clear_crash_loop_state(pid_path: Path) -> None:
+    crash_loop_state_path(pid_path).unlink(missing_ok=True)
+
+
+def _last_failure_recent(
+    state: CrashLoopState | None,
+    *,
+    now: datetime,
+    window_seconds: float,
+) -> bool:
+    if state is None:
+        return False
+    try:
+        last_seen = datetime.fromisoformat(state.last_failure_at)
+    except ValueError:
+        return False
+    if last_seen.tzinfo is None:
+        last_seen = last_seen.replace(tzinfo=UTC)
+    return (now - last_seen).total_seconds() <= window_seconds
+
+
+def _read_log_tail(log_path: Path, *, max_bytes: int = 8192) -> str:
+    try:
+        with log_path.open("rb") as fh:
+            try:
+                fh.seek(0, os.SEEK_END)
+                size = fh.tell()
+                fh.seek(max(0, size - max_bytes), os.SEEK_SET)
+            except OSError:
+                fh.seek(0)
+            data = fh.read(max_bytes)
+    except OSError:
+        return ""
+    return data.decode("utf-8", "replace").strip()
+
+
+def _emit_crash_loop_alert(
+    *,
+    config_path: Path,
+    state: CrashLoopState,
+) -> bool:
+    """Best-effort operator alert for a suppressed rail-daemon crash loop."""
+    try:
+        from pollypm.config import load_config
+        from pollypm.inbox.kind import InboxItemKind
+        from pollypm.store import get_store
+
+        config = load_config(config_path)
+        store = get_store(config)
+        excerpt = state.log_excerpt.strip()
+        body_parts = [
+            (
+                "The rail daemon failed to start repeatedly and the "
+                "supervisor has stopped respawning it until the next "
+                "healthy start clears the sentinel."
+            ),
+            f"Failures: {state.failure_count}",
+            f"Last diagnosis: {state.reason or 'unknown'}",
+            "Next: inspect ~/.pollypm/rail_daemon.log, fix the startup error, then run pm up.",
+        ]
+        if excerpt:
+            body_parts.extend(["", "Recent rail_daemon.log:", excerpt])
+        store.upsert_message(
+            type="alert",
+            tier="immediate",
+            recipient="user",
+            sender=_CRASH_LOOP_ALERT_SENDER,
+            subject="Rail daemon crash loop suppressed",
+            body="\n".join(body_parts),
+            scope="inbox",
+            labels=["watchdog", "rail_daemon", "crash_loop"],
+            payload={
+                "failure_count": state.failure_count,
+                "threshold": state.threshold,
+                "first_failure_at": state.first_failure_at,
+                "last_failure_at": state.last_failure_at,
+                "reason": state.reason,
+                "log_excerpt": excerpt,
+            },
+            kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "rail_daemon_supervisor: crash-loop alert emit failed",
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+def _record_crash_loop_failure(
+    *,
+    pid_path: Path,
+    config_path: Path,
+    decision: RevivalDecision,
+    now: datetime,
+    threshold: int,
+    window_seconds: float,
+    emit_operator_alert: bool,
+) -> CrashLoopState:
+    existing = read_crash_loop_state(pid_path)
+    if _last_failure_recent(existing, now=now, window_seconds=window_seconds):
+        count = (existing.failure_count if existing is not None else 0) + 1
+        first = existing.first_failure_at if existing is not None else now.isoformat()
+        alerted = existing.alerted if existing is not None else False
+    else:
+        count = 1
+        first = now.isoformat()
+        alerted = False
+
+    state = CrashLoopState(
+        failure_count=count,
+        threshold=max(1, threshold),
+        first_failure_at=first,
+        last_failure_at=now.isoformat(),
+        reason=decision.reason,
+        log_excerpt=_read_log_tail(_rail_daemon_log_path(pid_path)),
+        alerted=alerted,
+    )
+    if state.suppressed and emit_operator_alert and not state.alerted:
+        state = CrashLoopState(
+            failure_count=state.failure_count,
+            threshold=state.threshold,
+            first_failure_at=state.first_failure_at,
+            last_failure_at=state.last_failure_at,
+            reason=state.reason,
+            log_excerpt=state.log_excerpt,
+            alerted=_emit_crash_loop_alert(config_path=config_path, state=state),
+        )
+    _write_crash_loop_state(pid_path, state)
+    return state
+
+
+def _suppressed_crash_loop(
+    *,
+    pid_path: Path,
+    now: datetime,
+    window_seconds: float,
+) -> CrashLoopState | None:
+    state = read_crash_loop_state(pid_path)
+    if state is None or not state.suppressed:
+        return None
+    if not _last_failure_recent(state, now=now, window_seconds=window_seconds):
+        _clear_crash_loop_state(pid_path)
+        return None
+    return state
+
+
 def _wait_for_child_pid(
     pid_path: Path,
     config_path: Path | None,
@@ -1035,15 +1281,17 @@ def _spawn_and_wait_for_child(
     pid_path: Path,
     child_wait_seconds: float,
     sleep_fn: Callable[[float], None],
-) -> str | None:
+) -> tuple[str | None, int | None]:
     """Spawn the new daemon and wait for it to register a PID file.
 
-    Returns ``spawn_error`` (None on success). Spawn-success but
-    pid-file-timeout produces a warning, not an error: the caller
-    still records ``revived=True`` because the spawn returned ok.
+    Returns ``(spawn_error, confirmed_pid)``. Spawn-success but
+    pid-file-timeout produces a warning and ``confirmed_pid=None``:
+    the caller records the failed confirmation separately so repeated
+    immediate exits can be suppressed.
     """
     spawner = spawn_fn or _default_spawn_fn()
     spawn_error: str | None = None
+    confirmed_pid: int | None = None
     try:
         spawner(config_path)
     except Exception as exc:  # noqa: BLE001
@@ -1081,7 +1329,7 @@ def _spawn_and_wait_for_child(
                 "but next cycle may re-spawn",
                 pid_path, child_wait_seconds,
             )
-    return spawn_error
+    return spawn_error, confirmed_pid
 
 
 def check_and_revive_rail_daemon(
@@ -1099,6 +1347,9 @@ def check_and_revive_rail_daemon(
     cron: bool = False,
     lock_timeout_seconds: float = 5.0,
     child_wait_seconds: float = DEFAULT_CHILD_PID_WAIT_SECONDS,
+    immediate_exit_threshold: int = DEFAULT_IMMEDIATE_EXIT_THRESHOLD,
+    crash_loop_window_seconds: float = DEFAULT_CRASH_LOOP_WINDOW_SECONDS,
+    emit_operator_alert: bool = True,
 ) -> RevivalResult:
     """Diagnose the rail daemon and respawn it if it's dead / stuck.
 
@@ -1151,16 +1402,27 @@ def check_and_revive_rail_daemon(
             :data:`DEFAULT_CHILD_PID_WAIT_SECONDS` (5s). On timeout
             we log + release anyway so a buggy spawner can never
             deadlock the supervisor.
+        immediate_exit_threshold: consecutive failed child PID
+            confirmations before suppressing further respawns and
+            surfacing a crash-loop alert.
+        crash_loop_window_seconds: age after which the crash-loop
+            sentinel is treated as stale and cleared.
+        emit_operator_alert: when ``False``, skip inbox alert writes
+            for tests or read-only probes while still recording the
+            crash-loop sentinel.
 
     Returns:
         :class:`RevivalResult` carrying the diagnosis, whether a spawn
         was attempted, and any signal / spawn error details.
     """
+    reference = now or datetime.now(UTC)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=UTC)
     decision = diagnose_rail_daemon(
         pid_path=pid_path,
         last_tick_iso=last_tick_iso,
         last_revival_at=last_revival_at,
-        now=now,
+        now=reference,
         stale_tick_seconds=stale_tick_seconds,
         throttle_seconds=throttle_seconds,
         config_path=config_path,
@@ -1168,6 +1430,8 @@ def check_and_revive_rail_daemon(
 
     short_circuit = _short_circuit_for_diagnosis(decision, cron=cron)
     if short_circuit is not None:
+        if decision.state == "alive":
+            _clear_crash_loop_state(pid_path)
         return short_circuit
 
     logger.warning(
@@ -1209,12 +1473,14 @@ def check_and_revive_rail_daemon(
             # reflects current process state without re-applying the
             # caller's throttle window.
             last_revival_at=None,
-            now=now,
+            now=reference,
             stale_tick_seconds=stale_tick_seconds,
             throttle_seconds=throttle_seconds,
             config_path=config_path,
         )
         if not recheck.needs_revival:
+            if recheck.state == "alive":
+                _clear_crash_loop_state(pid_path)
             logger.info(
                 "rail_daemon_supervisor: post-lock recheck shows %s — "
                 "another supervisor must have already revived; standing down",
@@ -1231,6 +1497,42 @@ def check_and_revive_rail_daemon(
         # Use the recheck's PID (which reflects current state) for any
         # signaling — the original ``decision.pid`` may be stale.
         diagnosed_pid = recheck.pid
+
+        if recheck.state in {"missing_pid", "dead_process"}:
+            suppressed = _suppressed_crash_loop(
+                pid_path=pid_path,
+                now=reference,
+                window_seconds=crash_loop_window_seconds,
+            )
+            if suppressed is not None:
+                if emit_operator_alert and not suppressed.alerted:
+                    alerted = _emit_crash_loop_alert(
+                        config_path=config_path, state=suppressed,
+                    )
+                    if alerted:
+                        suppressed = CrashLoopState(
+                            failure_count=suppressed.failure_count,
+                            threshold=suppressed.threshold,
+                            first_failure_at=suppressed.first_failure_at,
+                            last_failure_at=suppressed.last_failure_at,
+                            reason=suppressed.reason,
+                            log_excerpt=suppressed.log_excerpt,
+                            alerted=True,
+                        )
+                        _write_crash_loop_state(pid_path, suppressed)
+                logger.error(
+                    "rail_daemon_supervisor: suppressing daemon respawn "
+                    "after %d failed starts — %s",
+                    suppressed.failure_count,
+                    suppressed.reason,
+                )
+                return RevivalResult(
+                    decision=recheck,
+                    revived=False,
+                    spawn_error="crash_loop_suppressed",
+                    killed_pid=None,
+                    kill_signal=None,
+                )
 
         # Step 1: clean up the dead/stuck process. ``stuck_no_tick``
         # means the PID is alive but unresponsive; SIGTERM it so the
@@ -1265,13 +1567,33 @@ def check_and_revive_rail_daemon(
 
         # Step 3 + 4: spawn the new daemon and wait for it to claim
         # the PID file.
-        spawn_error = _spawn_and_wait_for_child(
+        spawn_error, confirmed_pid = _spawn_and_wait_for_child(
             spawn_fn=spawn_fn,
             config_path=config_path,
             pid_path=pid_path,
             child_wait_seconds=child_wait_seconds,
             sleep_fn=sleep_fn,
         )
+        if spawn_error is None and confirmed_pid is not None:
+            _clear_crash_loop_state(pid_path)
+        else:
+            if spawn_error is None:
+                spawn_error = "child_pid_timeout"
+            crash_state = _record_crash_loop_failure(
+                pid_path=pid_path,
+                config_path=config_path,
+                decision=recheck,
+                now=reference,
+                threshold=immediate_exit_threshold,
+                window_seconds=crash_loop_window_seconds,
+                emit_operator_alert=emit_operator_alert,
+            )
+            if crash_state.suppressed:
+                logger.error(
+                    "rail_daemon_supervisor: daemon start failed %d "
+                    "times; future respawns suppressed until recovery",
+                    crash_state.failure_count,
+                )
 
         revived = spawn_error is None
         result = RevivalResult(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -44,6 +44,30 @@ def test_run_cmd_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "timed out" in out
 
 
+def test_check_rail_daemon_alive_reports_crash_loop_sentinel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor, "_pollypm_home", lambda: tmp_path)
+    (tmp_path / "rail_daemon.crash_loop.json").write_text(json.dumps({
+        "failure_count": 5,
+        "threshold": 5,
+        "first_failure_at": "2026-05-25T00:00:00+00:00",
+        "last_failure_at": "2026-05-25T00:05:00+00:00",
+        "reason": "no rail_daemon.pid file",
+        "log_excerpt": "Cannot start — pending migration",
+        "alerted": True,
+    }))
+
+    result = doctor.check_rail_daemon_alive()
+
+    assert result.passed is False
+    assert result.severity == "error"
+    assert "crash-loop suppressed" in result.status
+    assert result.data["failure_count"] == 5
+    assert "tail -n 120" in result.fix
+
+
 # --------------------------------------------------------------------- #
 # System prerequisites
 # --------------------------------------------------------------------- #

--- a/tests/test_migrate_gate_regression_2194.py
+++ b/tests/test_migrate_gate_regression_2194.py
@@ -169,3 +169,19 @@ def test_apply_then_inspect_reports_up_to_date(
         "v11 migration claims success but claimed_by_session column "
         "was never added to work_tasks"
     )
+
+
+def test_rail_daemon_startup_auto_applies_pending_work_migration(
+    stale_state_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A direct rail-daemon restart after upgrade must not crash-loop on v11."""
+    from pollypm.rail_daemon import _apply_pending_migrations_for_startup
+
+    monkeypatch.delenv("POLLYPM_SKIP_MIGRATION_GATE", raising=False)
+    applied = _apply_pending_migrations_for_startup(stale_state_db)
+
+    assert applied >= 1
+    status_after = _migrations.inspect(stale_state_db)
+    assert status_after.up_to_date
+    _migrations.require_no_pending_or_exit(stale_state_db)

--- a/tests/test_rail_daemon_supervisor.py
+++ b/tests/test_rail_daemon_supervisor.py
@@ -37,7 +37,9 @@ from pollypm.rail_daemon_supervisor import (
     DEFAULT_STALE_TICK_SECONDS,
     RevivalDecision,
     check_and_revive_rail_daemon,
+    crash_loop_state_path,
     diagnose_rail_daemon,
+    read_crash_loop_state,
     should_revive,
 )
 
@@ -372,6 +374,7 @@ def test_revive_unlinks_stale_pid_file(tmp_path: Path):
     # We call _terminate_with_grace via the supervisor; intercept the
     # os.kill so we don't actually signal pytest.
     real_kill = _mod.os.kill
+
     def fake_kill(pid: int, sig: int) -> None:
         # Pretend SIGTERM took: subsequent ``os.kill(pid, 0)`` should
         # raise ProcessLookupError. Easiest way: track that we sent
@@ -383,7 +386,7 @@ def test_revive_unlinks_stale_pid_file(tmp_path: Path):
 
     _mod.os.kill = fake_kill
     try:
-        result = check_and_revive_rail_daemon(
+        check_and_revive_rail_daemon(
             config_path=config_path,
             pid_path=pid_path,
             last_tick_iso=stale_tick,
@@ -507,7 +510,6 @@ def test_revive_skips_signaling_when_pid_identity_mismatches(
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"
     pid_path.write_text(str(os.getpid()))
-    spawner = _SpawnRecorder(pid_path=pid_path)
 
     # Force the classifier to say "stuck_no_tick" even though the PID
     # isn't our daemon. The terminate helper must still refuse to kill.
@@ -850,10 +852,9 @@ def test_concurrent_revive_when_spawner_returns_without_writing_pid(
     spawner = _SpawnRecorder(pid_path=pid_path, write_pid=False)
 
     # Single-thread scenario first: even when the child never writes,
-    # the supervisor must surface this as a warning + revived=True
-    # (the spawn itself succeeded), and on retry NOT re-spawn while
-    # we're still inside the wait window. We bound the wait to keep
-    # the test fast.
+    # the supervisor must surface this as a warning + unconfirmed
+    # revival, and on retry NOT re-spawn while we're still inside the
+    # wait window. We bound the wait to keep the test fast.
     result = check_and_revive_rail_daemon(
         config_path=config_path,
         pid_path=pid_path,
@@ -865,10 +866,12 @@ def test_concurrent_revive_when_spawner_returns_without_writing_pid(
         child_wait_seconds=0.2,  # short: we just want to verify the
                                   # lock is held for SOME bounded time
     )
-    # The first call records exactly one spawn — the wait timed out
-    # but the spawn itself was attempted, so revived=True.
+    # The first call records exactly one spawn. Because the child never
+    # wrote a matching PID, the supervisor reports the revival as
+    # unconfirmed instead of treating a bare Popen return as healthy.
     assert spawner.calls == [config_path]
-    assert result.revived is True
+    assert result.revived is False
+    assert result.spawn_error == "child_pid_timeout"
 
     # Now the racy window: a SECOND concurrent caller (modeled here
     # as a thread that fires while the first is mid-wait). To exercise
@@ -934,6 +937,92 @@ def test_concurrent_revive_when_spawner_returns_without_writing_pid(
     # B reported lock_busy.
     assert results[1] is not None
     assert results[1].spawn_error == "lock_busy"
+
+
+def test_immediate_exit_crash_loop_suppresses_future_respawns(tmp_path: Path):
+    """Repeated starts with no child PID eventually stop respawning.
+
+    This is the daemon-level analogue of the session crash-loop guard:
+    a child that exits before claiming ``rail_daemon.pid`` should not
+    be spawned forever with only log-file evidence.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    (tmp_path / "rail_daemon.log").write_text("pending migration\n")
+    spawner = _SpawnRecorder(pid_path=pid_path, write_pid=False)
+
+    first = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        sleep_fn=lambda _s: None,
+        emit_audit=False,
+        emit_operator_alert=False,
+        child_wait_seconds=0.01,
+        immediate_exit_threshold=2,
+    )
+    second = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        sleep_fn=lambda _s: None,
+        emit_audit=False,
+        emit_operator_alert=False,
+        child_wait_seconds=0.01,
+        immediate_exit_threshold=2,
+    )
+    third = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        sleep_fn=lambda _s: None,
+        emit_audit=False,
+        emit_operator_alert=False,
+        child_wait_seconds=0.01,
+        immediate_exit_threshold=2,
+    )
+
+    assert first.spawn_error == "child_pid_timeout"
+    assert second.spawn_error == "child_pid_timeout"
+    assert third.spawn_error == "crash_loop_suppressed"
+    assert spawner.calls == [config_path, config_path]
+    state = read_crash_loop_state(pid_path)
+    assert state is not None
+    assert state.suppressed is True
+    assert state.failure_count == 2
+    assert "pending migration" in state.log_excerpt
+
+
+def test_crash_loop_state_clears_after_confirmed_child_pid(tmp_path: Path):
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    crash_loop_state_path(pid_path).write_text(
+        '{"failure_count": 1, "threshold": 5, '
+        '"first_failure_at": "2026-05-25T00:00:00+00:00", '
+        '"last_failure_at": "2026-05-25T00:00:00+00:00", '
+        '"reason": "missing", "log_excerpt": "", "alerted": false}'
+    )
+    spawner = _SpawnRecorder(pid_path=pid_path, write_pid=True)
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+        emit_operator_alert=False,
+    )
+
+    assert result.revived is True
+    assert result.spawn_error is None
+    assert read_crash_loop_state(pid_path) is None
 
 
 def test_daemon_pid_claim_is_atomic(tmp_path: Path):


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Apply pending workspace schema migrations during rail_daemon startup while holding the daemon lifetime lock, so direct daemon restarts after upgrades do not crash-loop on the migration gate.
- Track repeated supervised starts where no child claims rail_daemon.pid, suppress further respawns after the threshold, persist ~/.pollypm/rail_daemon.crash_loop.json, and upsert a user-facing alert.
- Surface crash-loop suppression in pm doctor and pm heartbeat status, clear the sentinel after a healthy daemon start, and document the operator recovery path.
- Harden the PID-claim race where a concurrent loser could read an empty just-created PID file and unlink the winner's claim.

Closes #2326.
Closes #2327.

## Verification
- PASS: uv run --extra test pytest tests/test_rail_daemon.py tests/test_rail_daemon_supervisor.py tests/test_migrate_gate_regression_2194.py tests/test_doctor.py::test_check_rail_daemon_alive_reports_crash_loop_sentinel -q
- PASS: uv run --extra dev ruff check --ignore E402 src/pollypm/rail_daemon.py src/pollypm/rail_daemon_supervisor.py src/pollypm/doctor.py src/pollypm/cli_features/alerts.py tests/test_rail_daemon_supervisor.py tests/test_migrate_gate_regression_2194.py tests/test_doctor.py
- PASS: git diff --check
- NOTE: a broader run including all of tests/test_doctor.py still fails two pre-existing pg-migration expectation tests: test_state_migrations_detects_drift and test_work_migrations_detects_missing_table.
