### PR TITLE
perf(web): coalesce dashboard and inbox poll work

### DIFF
--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -29,6 +29,8 @@ from datetime import datetime
 import json
 import logging
 from pathlib import Path
+import threading
+import time
 
 from pollypm.accounts import (
     AccountStatus,
@@ -78,6 +80,13 @@ from pollypm.workers import (
 
 
 logger = logging.getLogger(__name__)
+
+
+_READONLY_LAUNCHES_TTL_SECONDS = 5.0
+_READONLY_LAUNCHES_LOCK = threading.Lock()
+_READONLY_LAUNCHES_CACHE: dict[
+    tuple[int, int], tuple[float, tuple[SessionLaunchSpec, ...]]
+] = {}
 
 
 def _parse_task_window_name(name: str) -> tuple[str, int] | None:
@@ -1055,6 +1064,38 @@ def plan_launches_readonly(config, store) -> list:
     objects. Avoids a second StateStore open by injecting the caller's
     store into a minimal Supervisor shell.
     """
+    cache_key = (id(config), id(store))
+    now = time.monotonic()
+    cached = _READONLY_LAUNCHES_CACHE.get(cache_key)
+    if (
+        cached is not None
+        and now - cached[0] < _READONLY_LAUNCHES_TTL_SECONDS
+    ):
+        return list(cached[1])
+
+    with _READONLY_LAUNCHES_LOCK:
+        now = time.monotonic()
+        cached = _READONLY_LAUNCHES_CACHE.get(cache_key)
+        if (
+            cached is not None
+            and now - cached[0] < _READONLY_LAUNCHES_TTL_SECONDS
+        ):
+            return list(cached[1])
+
+        launches = _plan_launches_readonly_uncached(config, store)
+        completed_at = time.monotonic()
+        if len(_READONLY_LAUNCHES_CACHE) > 8:
+            for stale_key in [
+                k for k, (ts, _v) in _READONLY_LAUNCHES_CACHE.items()
+                if completed_at - ts >= _READONLY_LAUNCHES_TTL_SECONDS
+            ]:
+                _READONLY_LAUNCHES_CACHE.pop(stale_key, None)
+        _READONLY_LAUNCHES_CACHE[cache_key] = (completed_at, tuple(launches))
+        return list(launches)
+
+
+def _plan_launches_readonly_uncached(config, store) -> list:
+    """Build a read-only launch plan without consulting the burst cache."""
     from pollypm.session_services import create_tmux_client
 
     supervisor = Supervisor.__new__(Supervisor)

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -3953,6 +3953,17 @@ def _collect_inbox_items(
     entry; ``id`` is the task_id so later detail / reply paths can
     address it.
     """
+    if project is None:
+        workspace = _collect_inbox_items_workspace_pg(
+            config,
+            type_filter=type_filter,
+            state_filter=state_filter,
+            include_drafts=include_drafts,
+            limit=limit,
+        )
+        if workspace is not None:
+            return workspace
+
     out: list[APIInboxItem] = []
     unread_count = 0
     complete = True
@@ -3979,53 +3990,17 @@ def _collect_inbox_items(
                 )
                 if limit is not None and len(tasks) >= limit:
                     complete = False
-                read_marker_numbers = _task_numbers_with_context_entry(
-                    svc, project=key, entry_type="read", tasks=tasks,
+                items, unread = _materialize_inbox_items(
+                    svc,
+                    tasks,
+                    type_filter=type_filter,
+                    state_filter=state_filter,
+                    include_drafts=include_drafts,
+                    include_closed=include_closed,
+                    now=now,
                 )
-                # Snooze visibility (#2060): the snooze write helper
-                # persists ``entry_type='snooze'`` rows whose text
-                # encodes the wake-up time. Items whose latest snooze
-                # is still in the future must NOT appear in the
-                # default inbox view (otherwise the endpoint returns
-                # 200 while the row stays actionable). We compute the
-                # active-snooze set once per project — the same
-                # readonly service handle stays open so we don't
-                # double-pay for connection setup.
-                snoozed_ids = _active_snoozed_ids(svc, tasks, now=now)
-                # Iterate inside the ``with`` block so the canonical
-                # inbox predicate (Codex round-5 on #2060) can call
-                # ``svc.get_flow(...)`` for its current-node-human
-                # branch while the readonly handle is still open.
-                #
-                # One shared ``flow_cache`` per project scan: the
-                # canonical predicate falls back to ``svc.get_flow``
-                # for the current-node-human branch, and a page of N
-                # tasks on the same flow would otherwise pay N
-                # lookups. Matches the cockpit / rail / dashboard
-                # path in :func:`pollypm.work.inbox_view.inbox_tasks`
-                # (one cache, threaded through every call). Codex
-                # round-6 blocker 2 on PR #2060.
-                flow_cache: dict = {}
-                for task in tasks:
-                    if task.task_id in snoozed_ids:
-                        continue
-                    if not include_drafts and is_notify_only_inbox_entry(task):
-                        continue
-                    if not inbox_task_matches_type(task, type_filter):
-                        continue
-                    entry = _task_to_inbox_item(
-                        task,
-                        svc,
-                        flow_cache=flow_cache,
-                        include_closed=include_closed,
-                    )
-                    if entry is None:
-                        continue
-                    if not _inbox_item_matches_state(entry, state_filter):
-                        continue
-                    out.append(entry)
-                    if _task_number(task) not in read_marker_numbers:
-                        unread_count += 1
+                out.extend(items)
+                unread_count += unread
         except _BACKING_STORE_ERRORS as exc:
             # Backing-store failure on a single project: log loudly,
             # skip that project but keep building the aggregate. We
@@ -4043,6 +4018,132 @@ def _collect_inbox_items(
     return out, unread_count, complete
 
 
+def _collect_inbox_items_workspace_pg(
+    config: PollyPMConfig,
+    *,
+    type_filter: str | None,
+    state_filter: str | None,
+    include_drafts: bool,
+    limit: int | None,
+) -> tuple[list[APIInboxItem], int, bool] | None:
+    """Load the workspace inbox with one pg-backed candidate query."""
+    try:
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
+        if not is_pg_backend(config):
+            return None
+    except Exception:  # noqa: BLE001
+        return None
+
+    project_items = list(config.projects.items())
+    if not project_items:
+        return [], 0, True
+
+    first_key, first_project = project_items[0]
+    known_projects = tuple(key for key, _project in project_items)
+    now = datetime.now(timezone.utc)
+    include_closed = _state_filter_requests_closed(state_filter)
+    try:
+        with _open_work_service_readonly(
+            config=config,
+            project_key=first_key,
+            project_path=first_project.path,
+        ) as svc:
+            raw_tasks = _list_inbox_candidate_tasks(
+                svc,
+                project=None,
+                projects=known_projects,
+                type_filter=type_filter,
+                state_filter=state_filter,
+                limit=limit,
+            )
+            known_project_set = set(known_projects)
+            tasks = [
+                task for task in raw_tasks
+                if str(getattr(task, "project", "") or "") in known_project_set
+            ]
+            complete = not (limit is not None and len(raw_tasks) >= limit)
+            items, unread_count = _materialize_inbox_items(
+                svc,
+                tasks,
+                type_filter=type_filter,
+                state_filter=state_filter,
+                include_drafts=include_drafts,
+                include_closed=include_closed,
+                now=now,
+            )
+            return items, unread_count, complete
+    except _BACKING_STORE_ERRORS as exc:
+        logger.warning(
+            "inbox: workspace pg candidate scan failed; skipping: %s",
+            exc,
+            exc_info=True,
+        )
+        return [], 0, True
+
+
+def _materialize_inbox_items(
+    svc,
+    tasks,
+    *,
+    type_filter: str | None,
+    state_filter: str | None,
+    include_drafts: bool,
+    include_closed: bool,
+    now: datetime,
+) -> tuple[list[APIInboxItem], int]:
+    task_list = list(tasks or [])
+    tasks_by_project: dict[str, list] = {}
+    for task in task_list:
+        project_key = str(getattr(task, "project", "") or "")
+        tasks_by_project.setdefault(project_key, []).append(task)
+
+    read_marker_numbers_by_project: dict[str, set[int]] = {}
+    for project_key, project_tasks in tasks_by_project.items():
+        read_marker_numbers_by_project[project_key] = (
+            _task_numbers_with_context_entry(
+                svc,
+                project=project_key,
+                entry_type="read",
+                tasks=project_tasks,
+            )
+        )
+
+    # Snooze visibility (#2060): the snooze write helper persists
+    # ``entry_type='snooze'`` rows whose text encodes the wake-up time.
+    # Items whose latest snooze is still in the future must NOT appear
+    # in the default inbox view. Compute the set once for the candidate
+    # batch so the pg implementation can use one bulk lookup.
+    snoozed_ids = _active_snoozed_ids(svc, task_list, now=now)
+
+    items: list[APIInboxItem] = []
+    unread_count = 0
+    flow_cache: dict = {}
+    for task in task_list:
+        if task.task_id in snoozed_ids:
+            continue
+        if not include_drafts and is_notify_only_inbox_entry(task):
+            continue
+        if not inbox_task_matches_type(task, type_filter):
+            continue
+        entry = _task_to_inbox_item(
+            task,
+            svc,
+            flow_cache=flow_cache,
+            include_closed=include_closed,
+        )
+        if entry is None:
+            continue
+        if not _inbox_item_matches_state(entry, state_filter):
+            continue
+        items.append(entry)
+        project_key = str(getattr(task, "project", "") or "")
+        read_marker_numbers = read_marker_numbers_by_project.get(project_key, set())
+        if _task_number(task) not in read_marker_numbers:
+            unread_count += 1
+    return items, unread_count
+
+
 def _task_number(task) -> int:
     value = getattr(task, "task_number", None)
     if value is not None:
@@ -4053,7 +4154,7 @@ def _task_number(task) -> int:
 def _task_numbers_with_context_entry(
     svc,
     *,
-    project: str,
+    project: str | None,
     entry_type: str,
     tasks,
 ) -> set[int]:
@@ -4105,7 +4206,8 @@ def _inbox_item_matches_state(
 def _list_inbox_candidate_tasks(
     svc,
     *,
-    project: str,
+    project: str | None,
+    projects: Iterable[str] | None = None,
     type_filter: str | None,
     state_filter: str | None,
     limit: int | None,
@@ -4120,6 +4222,7 @@ def _list_inbox_candidate_tasks(
     if callable(optimized):
         return optimized(
             project=project,
+            projects=projects,
             type_filter=type_filter,
             state_filter=state_filter,
             limit=limit,

--- a/src/pollypm/work/mock_service.py
+++ b/src/pollypm/work/mock_service.py
@@ -298,6 +298,7 @@ class MockWorkService:
         self,
         *,
         project: str | None = None,
+        projects: tuple[str, ...] | list[str] | None = None,
         type_filter: str | None = None,
         state_filter: str | None = None,
         limit: int | None = None,
@@ -312,6 +313,9 @@ class MockWorkService:
         tasks = list(self._tasks.values())
         if project is not None:
             tasks = [t for t in tasks if t.project == project]
+        elif projects is not None:
+            allowed = {str(value) for value in projects}
+            tasks = [t for t in tasks if t.project in allowed]
 
         state = (state_filter or "").strip().lower()
         if state in {"closed", "resolved", "archived"}:

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -762,6 +762,7 @@ class PgWorkService:
         self,
         *,
         project: str | None = None,
+        projects: tuple[str, ...] | list[str] | None = None,
         type_filter: str | None = None,
         state_filter: str | None = None,
         limit: int | None = None,
@@ -780,6 +781,13 @@ class PgWorkService:
         if project is not None:
             where.append("project = %s")
             params.append(project)
+        elif projects is not None:
+            allowed = [str(value) for value in projects]
+            if allowed:
+                where.append("project = ANY(%s)")
+                params.append(allowed)
+            else:
+                where.append("FALSE")
 
         state = (state_filter or "").strip().lower()
         terminal_values = sorted(s.value for s in TERMINAL_STATUSES)

--- a/src/pollypm/work/service.py
+++ b/src/pollypm/work/service.py
@@ -111,6 +111,7 @@ class WorkService(Protocol):
         self,
         *,
         project: str | None = None,
+        projects: tuple[str, ...] | list[str] | None = None,
         type_filter: str | None = None,
         state_filter: str | None = None,
         limit: int | None = None,
@@ -120,8 +121,11 @@ class WorkService(Protocol):
 
         Implementations should push cheap state/type/limit predicates into
         storage, then callers run the canonical inbox-view predicate before
-        exposing rows. This keeps API pagination from full-scanning the work
-        table while preserving service ownership of storage rules.
+        exposing rows. ``projects`` is the all-project workspace filter used
+        by the API inbox; implementations should apply either ``project`` or
+        ``projects`` when provided. This keeps API pagination from
+        full-scanning the work table while preserving service ownership of
+        storage rules.
         """
         ...
 

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -2120,6 +2120,7 @@ class _ReadInboxTask:
         self,
         n: int,
         *,
+        project: str = "myproj",
         title: str | None = None,
         status=None,
         kind=None,
@@ -2130,8 +2131,8 @@ class _ReadInboxTask:
         from pollypm.inbox.kind import InboxItemKind
         from pollypm.work.models import Priority, WorkStatus
 
-        self.task_id = f"myproj/{n}"
-        self.project = "myproj"
+        self.task_id = f"{project}/{n}"
+        self.project = project
         self.task_number = n
         self.title = title or f"inbox {n}"
         self.description = f"body {n}"
@@ -2164,6 +2165,13 @@ class _ReadInboxSvc:
         self.candidate_calls.append(dict(kwargs))
         limit = kwargs.get("limit")
         rows = list(self.tasks)
+        project = kwargs.get("project")
+        if project is not None:
+            rows = [task for task in rows if task.project == project]
+        projects = kwargs.get("projects")
+        if projects is not None:
+            allowed = {str(value) for value in projects}
+            rows = [task for task in rows if task.project in allowed]
         if limit is not None:
             rows = rows[: int(limit)]
         return rows
@@ -2221,6 +2229,45 @@ def test_list_inbox_state_closed_returns_archived_task(
     assert [item["id"] for item in body["items"]] == ["myproj/1"]
     assert body["items"][0]["state"] == "closed"
     assert svc.candidate_calls[0]["state_filter"] == "closed"
+
+
+def test_workspace_inbox_uses_one_pg_candidate_scan(
+    client, auth_headers, monkeypatch, config, tmp_path: Path,
+) -> None:
+    """All-project inbox reads should not open/query one service per project."""
+    other_root = tmp_path / "otherproj"
+    other_root.mkdir()
+    (other_root / ".pollypm").mkdir()
+    config.projects["otherproj"] = KnownProject(
+        key="otherproj",
+        path=other_root,
+        name="Other Project",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+
+    svc = _ReadInboxSvc([
+        _ReadInboxTask(1, project="myproj", title="my project item"),
+        _ReadInboxTask(2, project="otherproj", title="other project item"),
+        _ReadInboxTask(3, project="staleproj", title="stale project item"),
+    ])
+    _install_read_inbox_svc(monkeypatch, svc)
+    monkeypatch.setattr(
+        "pollypm.storage._backend_dispatch.is_pg_backend",
+        lambda _config: True,
+    )
+
+    response = client.get("/api/v1/inbox", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert {item["id"] for item in body["items"]} == {
+        "myproj/1",
+        "otherproj/2",
+    }
+    assert len(svc.candidate_calls) == 1
+    assert svc.candidate_calls[0]["project"] is None
+    assert set(svc.candidate_calls[0]["projects"]) == {"myproj", "otherproj"}
 
 
 def test_list_inbox_type_filter_matches_structured_kind(

--- a/tests/test_launch_planner.py
+++ b/tests/test_launch_planner.py
@@ -11,6 +11,7 @@ import base64
 import json
 from pathlib import Path
 import shlex
+from types import SimpleNamespace
 
 from pollypm.launch_planner import LaunchPlanner, get_launch_planner
 from pollypm.models import (
@@ -549,3 +550,39 @@ def test_planner_handles_none_store_for_architect_session(
     plan = planner.plan_launches()
     architect = next(item for item in plan if item.session.name == "architect")
     assert architect.session.provider is ProviderKind.CLAUDE
+
+
+def test_plan_launches_readonly_coalesces_burst_calls(monkeypatch) -> None:
+    """Read-only dashboard callers should share a short-lived launch plan."""
+    from pollypm.service_api import v1 as service_v1
+
+    service_v1._READONLY_LAUNCHES_CACHE.clear()
+    plan_calls = 0
+
+    class FakeSupervisor:
+        def invalidate_launch_cache(self) -> None:
+            pass
+
+        def plan_launches(self):
+            nonlocal plan_calls
+            plan_calls += 1
+            return [SimpleNamespace(session=SimpleNamespace(name="operator"))]
+
+    monkeypatch.setattr(service_v1, "Supervisor", FakeSupervisor)
+    monkeypatch.setattr(
+        "pollypm.session_services.create_tmux_client",
+        lambda: object(),
+    )
+
+    config = SimpleNamespace()
+    store = object()
+
+    try:
+        first = service_v1.plan_launches_readonly(config, store)
+        second = service_v1.plan_launches_readonly(config, store)
+
+        assert plan_calls == 1
+        assert first == second
+        assert first is not second
+    finally:
+        service_v1._READONLY_LAUNCHES_CACHE.clear()


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a short-lived singleflight cache around `plan_launches_readonly()` so dashboard poll bursts do not rebuild launch specs for every client.
- Route workspace-wide `GET /api/v1/inbox` through one pg-backed candidate scan filtered to registered projects, then share the existing materialization logic for read markers, snoozes, type/state filters, and flow-cache membership.
- Extend the work-service inbox-candidate contract with an optional `projects` filter and cover both hot-path changes with regressions.

## Verification
- `uv run --extra test pytest tests/test_launch_planner.py -q`
- `uv run --extra test pytest --noconftest tests/test_inbox_writes_endpoint.py -q`
- `uv run --extra test pytest --noconftest tests/test_dashboard_endpoint.py::test_list_projects_uses_pg_bulk_task_snapshot -q`
- `uv run --extra test python -m py_compile src/pollypm/service_api/v1.py src/pollypm/web_api/service.py src/pollypm/work/pg_service.py src/pollypm/work/service.py src/pollypm/work/mock_service.py tests/test_inbox_writes_endpoint.py tests/test_launch_planner.py`
- `git diff --check`

## Notes
- Refs #2308 and #2310.
- I did not rerun the live M-scale 10-client/60s perf harness in this worktree; this PR removes the identified repeated launch-plan rebuild and per-project inbox scan sources so the next §06 wave can measure the live delta.