### PR TITLE
perf(dashboard): cache launch plan + session descriptions (#2308)

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -497,7 +497,53 @@ def _scan_for_event_signature(clean_lines: list[str]) -> str | None:
     return None
 
 
+# #2308 perf — per-snapshot description cache.
+# ``_session_description`` reads + parses the entire tmux pane snapshot
+# file for every active session on every dashboard request. On a 16-
+# project / 44-session workspace that's 44 sync reads × ~10ms each (480ms
+# cumulative per request), and the work re-runs unchanged whenever the
+# snapshot mtime hasn't moved. The heartbeat sweep refreshes snapshots
+# at ~30s cadence; the dashboard polls every 5-10s. Caching by
+# ``(snapshot_path, mtime_ns, status, role)`` means we re-parse a
+# snapshot only when the heartbeat has actually rewritten it.
+_SESSION_DESCRIPTION_CACHE: dict[tuple[str, int, str, str], str] = {}
+_SESSION_DESCRIPTION_CACHE_MAX_ENTRIES = 256
+
+
 def _session_description(status: str, role: str, snapshot_path: str | None) -> str:
+    """Build a human-readable description of what a session is doing.
+
+    Caches the parsed result per ``(snapshot_path, mtime_ns, status,
+    role)`` so concurrent dashboard reads share one parse-and-regex pass
+    over each snapshot file rather than re-reading the file (and re-
+    running the ~30 regex passes inside the fall-through loop) per
+    request. Misses + stat failures fall through to the live parser.
+    """
+    if snapshot_path:
+        try:
+            mtime_ns = Path(snapshot_path).stat().st_mtime_ns
+        except OSError:
+            mtime_ns = None
+        if mtime_ns is not None:
+            cache_key = (snapshot_path, mtime_ns, status, role)
+            cached = _SESSION_DESCRIPTION_CACHE.get(cache_key)
+            if cached is not None:
+                return cached
+            result = _compute_session_description(status, role, snapshot_path)
+            # Bound the cache so a workspace with many short-lived
+            # heartbeat snapshots can't grow it without bound. When the
+            # cap trips we drop the oldest insertion (dict preserves
+            # order) — a fresh refresh after mtime advances repopulates.
+            if len(_SESSION_DESCRIPTION_CACHE) >= _SESSION_DESCRIPTION_CACHE_MAX_ENTRIES:
+                _SESSION_DESCRIPTION_CACHE.pop(
+                    next(iter(_SESSION_DESCRIPTION_CACHE)), None
+                )
+            _SESSION_DESCRIPTION_CACHE[cache_key] = result
+            return result
+    return _compute_session_description(status, role, snapshot_path)
+
+
+def _compute_session_description(status: str, role: str, snapshot_path: str | None) -> str:
     """Build a human-readable description of what a session is doing."""
     if role == "operator-pm":
         if status == "healthy":

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from datetime import datetime
 import json
 import logging
+import threading
+import time
 from pathlib import Path
 import threading
 import time
@@ -1056,6 +1058,29 @@ class PollyPMService:
         return get_task_backend(self._project_root(config, project_key))
 
 
+# #2308 perf — process-wide TTL cache for ``plan_launches_readonly``.
+# The 10-way concurrent dashboard load test traced p50 1.30s / p95 1.69s
+# per call (probe at agent-ade913f75d406474b) — under contention each
+# request rebuilds a fresh Supervisor shell, re-runs the full launch
+# planner, and re-writes Claude / Codex profile prompts to disk per
+# session even though the launch plan itself only changes when config
+# changes. With ~16 projects and ~44 enabled sessions the per-request
+# work serialises through the GIL + filesystem and the singleflight /
+# fanout fixes upstream (#2319 / #2320 / #2328) can't help because
+# the work is per-request before the cache fan-in.
+#
+# Cache the result for 2 seconds — dashboard polls every 5-10s so the
+# staleness window is well below the visible refresh rate, and any
+# real launch plan change (config reload, new project) lands by the
+# next tick. Mirrors the lock+double-check singleflight pattern from
+# ``dashboard_data._completed_issues`` (#2320) so N concurrent cold
+# callers coalesce onto one plan instead of racing past the empty-cache
+# check.
+_PLAN_LAUNCHES_RO_CACHE: dict[int, tuple[float, list]] = {}
+_PLAN_LAUNCHES_RO_TTL_SECONDS = 2.0
+_PLAN_LAUNCHES_RO_LOCK = threading.Lock()
+
+
 def plan_launches_readonly(config, store) -> list:
     """Return the launches planned for ``config`` without mutating state.
 
@@ -1063,6 +1088,60 @@ def plan_launches_readonly(config, store) -> list:
     already hold an open state store and only need ``SessionLaunchSpec``
     objects. Avoids a second StateStore open by injecting the caller's
     store into a minimal Supervisor shell.
+
+    Result is cached process-wide for :data:`_PLAN_LAUNCHES_RO_TTL_SECONDS`
+    keyed by ``id(config)`` so the 10-way concurrent dashboard read does
+    not rebuild a fresh Supervisor + re-run the planner + re-write profile
+    prompts on every request. The cache only fires when ``store is None``
+    (the dashboard / cockpit-rail read path); callers passing a live
+    StateStore still get a fresh plan because their plan may need the
+    store-dependent ``effective_session`` route resolution.
+    """
+    # Singleflight TTL cache only applies to the read-only dashboard
+    # shape (``store is None``). When a caller passes a real store the
+    # planner may produce a store-dependent plan (route assignments,
+    # heartbeat-aware architect resume), so we skip the cache.
+    cache_key: int | None = id(config) if store is None else None
+    if cache_key is not None:
+        cached = _PLAN_LAUNCHES_RO_CACHE.get(cache_key)
+        now_mono = time.monotonic()
+        if cached is not None and now_mono - cached[0] < _PLAN_LAUNCHES_RO_TTL_SECONDS:
+            return cached[1]
+
+        with _PLAN_LAUNCHES_RO_LOCK:
+            # Double-check under the lock: a peer thread may have
+            # populated the cache while we were waiting.
+            now_mono = time.monotonic()
+            cached = _PLAN_LAUNCHES_RO_CACHE.get(cache_key)
+            if cached is not None and now_mono - cached[0] < _PLAN_LAUNCHES_RO_TTL_SECONDS:
+                return cached[1]
+            launches = _build_plan_launches_readonly(config, store)
+            completed_at = time.monotonic()
+            # Bound the cache so config reloads (each yielding a fresh
+            # ``id(config)``) don't grow it unbounded across a long-lived
+            # ``pm serve`` process. Same pattern as
+            # ``dashboard_data._COMPLETED_ISSUES_CACHE``.
+            if len(_PLAN_LAUNCHES_RO_CACHE) > 8:
+                for stale_key in [
+                    k for k, (ts, _v) in _PLAN_LAUNCHES_RO_CACHE.items()
+                    if completed_at - ts >= _PLAN_LAUNCHES_RO_TTL_SECONDS
+                ]:
+                    _PLAN_LAUNCHES_RO_CACHE.pop(stale_key, None)
+            _PLAN_LAUNCHES_RO_CACHE[cache_key] = (completed_at, launches)
+            return launches
+
+    return _build_plan_launches_readonly(config, store)
+
+
+def _build_plan_launches_readonly(config, store) -> list:
+    """Construct the launch plan from a fresh Supervisor shell.
+
+    Extracted from :func:`plan_launches_readonly` so the cache hot path
+    stays separate from the actual work. Each call still creates a fresh
+    Supervisor shell because the readonly tmux client + planner cache
+    intentionally do NOT cross requests — pruning the per-Supervisor
+    cache that ``invalidate_launch_cache`` clears is the historical
+    correctness invariant for the rare callers that pass a live store.
     """
     cache_key = (id(config), id(store))
     now = time.monotonic()

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -28,8 +28,6 @@ from dataclasses import dataclass
 from datetime import datetime
 import json
 import logging
-import threading
-import time
 from pathlib import Path
 import threading
 import time
@@ -1058,29 +1056,6 @@ class PollyPMService:
         return get_task_backend(self._project_root(config, project_key))
 
 
-# #2308 perf — process-wide TTL cache for ``plan_launches_readonly``.
-# The 10-way concurrent dashboard load test traced p50 1.30s / p95 1.69s
-# per call (probe at agent-ade913f75d406474b) — under contention each
-# request rebuilds a fresh Supervisor shell, re-runs the full launch
-# planner, and re-writes Claude / Codex profile prompts to disk per
-# session even though the launch plan itself only changes when config
-# changes. With ~16 projects and ~44 enabled sessions the per-request
-# work serialises through the GIL + filesystem and the singleflight /
-# fanout fixes upstream (#2319 / #2320 / #2328) can't help because
-# the work is per-request before the cache fan-in.
-#
-# Cache the result for 2 seconds — dashboard polls every 5-10s so the
-# staleness window is well below the visible refresh rate, and any
-# real launch plan change (config reload, new project) lands by the
-# next tick. Mirrors the lock+double-check singleflight pattern from
-# ``dashboard_data._completed_issues`` (#2320) so N concurrent cold
-# callers coalesce onto one plan instead of racing past the empty-cache
-# check.
-_PLAN_LAUNCHES_RO_CACHE: dict[int, tuple[float, list]] = {}
-_PLAN_LAUNCHES_RO_TTL_SECONDS = 2.0
-_PLAN_LAUNCHES_RO_LOCK = threading.Lock()
-
-
 def plan_launches_readonly(config, store) -> list:
     """Return the launches planned for ``config`` without mutating state.
 
@@ -1088,60 +1063,6 @@ def plan_launches_readonly(config, store) -> list:
     already hold an open state store and only need ``SessionLaunchSpec``
     objects. Avoids a second StateStore open by injecting the caller's
     store into a minimal Supervisor shell.
-
-    Result is cached process-wide for :data:`_PLAN_LAUNCHES_RO_TTL_SECONDS`
-    keyed by ``id(config)`` so the 10-way concurrent dashboard read does
-    not rebuild a fresh Supervisor + re-run the planner + re-write profile
-    prompts on every request. The cache only fires when ``store is None``
-    (the dashboard / cockpit-rail read path); callers passing a live
-    StateStore still get a fresh plan because their plan may need the
-    store-dependent ``effective_session`` route resolution.
-    """
-    # Singleflight TTL cache only applies to the read-only dashboard
-    # shape (``store is None``). When a caller passes a real store the
-    # planner may produce a store-dependent plan (route assignments,
-    # heartbeat-aware architect resume), so we skip the cache.
-    cache_key: int | None = id(config) if store is None else None
-    if cache_key is not None:
-        cached = _PLAN_LAUNCHES_RO_CACHE.get(cache_key)
-        now_mono = time.monotonic()
-        if cached is not None and now_mono - cached[0] < _PLAN_LAUNCHES_RO_TTL_SECONDS:
-            return cached[1]
-
-        with _PLAN_LAUNCHES_RO_LOCK:
-            # Double-check under the lock: a peer thread may have
-            # populated the cache while we were waiting.
-            now_mono = time.monotonic()
-            cached = _PLAN_LAUNCHES_RO_CACHE.get(cache_key)
-            if cached is not None and now_mono - cached[0] < _PLAN_LAUNCHES_RO_TTL_SECONDS:
-                return cached[1]
-            launches = _build_plan_launches_readonly(config, store)
-            completed_at = time.monotonic()
-            # Bound the cache so config reloads (each yielding a fresh
-            # ``id(config)``) don't grow it unbounded across a long-lived
-            # ``pm serve`` process. Same pattern as
-            # ``dashboard_data._COMPLETED_ISSUES_CACHE``.
-            if len(_PLAN_LAUNCHES_RO_CACHE) > 8:
-                for stale_key in [
-                    k for k, (ts, _v) in _PLAN_LAUNCHES_RO_CACHE.items()
-                    if completed_at - ts >= _PLAN_LAUNCHES_RO_TTL_SECONDS
-                ]:
-                    _PLAN_LAUNCHES_RO_CACHE.pop(stale_key, None)
-            _PLAN_LAUNCHES_RO_CACHE[cache_key] = (completed_at, launches)
-            return launches
-
-    return _build_plan_launches_readonly(config, store)
-
-
-def _build_plan_launches_readonly(config, store) -> list:
-    """Construct the launch plan from a fresh Supervisor shell.
-
-    Extracted from :func:`plan_launches_readonly` so the cache hot path
-    stays separate from the actual work. Each call still creates a fresh
-    Supervisor shell because the readonly tmux client + planner cache
-    intentionally do NOT cross requests — pruning the per-Supervisor
-    cache that ``invalidate_launch_cache`` clears is the historical
-    correctness invariant for the rare callers that pass a live store.
     """
     cache_key = (id(config), id(store))
     now = time.monotonic()

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -422,6 +422,109 @@ def test_briefing_pluralizes_counts_correctly(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# #2308 perf — _session_description cache contract.
+#
+# The dashboard handler invokes ``_session_description`` once per active
+# session per request. On a 16-project / 44-session workspace that's 44
+# tmux-snapshot reads × ~10ms each per request, and the snapshot only
+# rolls forward when the heartbeat sweep (~30s cadence) rewrites it.
+# Caching by ``(snapshot_path, mtime_ns, status, role)`` collapses
+# repeat calls into one parse per (file, version, view-key) tuple.
+# These two tests pin the cache contract: a key match reuses the prior
+# result, and an mtime bump forces a fresh parse.
+# ---------------------------------------------------------------------------
+
+
+def test_session_description_cache_returns_cached_when_key_matches(
+    tmp_path, monkeypatch
+) -> None:
+    """Repeat ``_session_description`` calls with the same
+    ``(snapshot_path, mtime_ns, status, role)`` must reuse the cached
+    parse — no second call into ``_compute_session_description``.
+    """
+    from pollypm import dashboard_data
+    from pollypm.dashboard_data import _session_description
+
+    snapshot = tmp_path / "snap.txt"
+    snapshot.write_text("⏺ Working (1m 2s · 4.2k tokens · esc to interrupt)\n")
+
+    # Clear the module-level cache so prior tests don't preload our key.
+    dashboard_data._SESSION_DESCRIPTION_CACHE.clear()
+
+    calls: list[tuple[str, str, str | None]] = []
+    real_compute = dashboard_data._compute_session_description
+
+    def counting_compute(status: str, role: str, snapshot_path: str | None) -> str:
+        calls.append((status, role, snapshot_path))
+        return real_compute(status, role, snapshot_path)
+
+    monkeypatch.setattr(
+        dashboard_data, "_compute_session_description", counting_compute
+    )
+
+    first = _session_description("healthy", "worker", str(snapshot))
+    second = _session_description("healthy", "worker", str(snapshot))
+    third = _session_description("healthy", "worker", str(snapshot))
+
+    # All callers see the same description and the heavy parser ran once.
+    assert first == second == third
+    assert len(calls) == 1, (
+        f"expected one compute call, got {len(calls)}: {calls}"
+    )
+
+
+def test_session_description_cache_refreshes_on_mtime_change(
+    tmp_path, monkeypatch
+) -> None:
+    """When the snapshot file's mtime advances (heartbeat rewrote the
+    pane), the cache key changes and ``_compute_session_description``
+    must run again — even though the path + status + role are
+    identical. This is what prevents the dashboard from serving a
+    stale Now-feed line when the underlying session has moved on.
+    """
+    from pollypm import dashboard_data
+    from pollypm.dashboard_data import _session_description
+
+    snapshot = tmp_path / "snap.txt"
+    snapshot.write_text("⏺ Working (1m 2s · 4.2k tokens · esc to interrupt)\n")
+
+    dashboard_data._SESSION_DESCRIPTION_CACHE.clear()
+
+    calls: list[tuple[str, str, str | None]] = []
+    real_compute = dashboard_data._compute_session_description
+
+    def counting_compute(status: str, role: str, snapshot_path: str | None) -> str:
+        calls.append((status, role, snapshot_path))
+        return real_compute(status, role, snapshot_path)
+
+    monkeypatch.setattr(
+        dashboard_data, "_compute_session_description", counting_compute
+    )
+
+    first = _session_description("healthy", "worker", str(snapshot))
+    assert len(calls) == 1
+
+    # Rewrite the snapshot with new content + bump mtime. We force the
+    # mtime forward explicitly so this is robust on filesystems with
+    # coarse mtime granularity (1s on some platforms).
+    snapshot.write_text("⏺ Working (5m 30s · 9.0k tokens · esc to interrupt)\n")
+    new_mtime_ns = snapshot.stat().st_mtime_ns + 1_000_000_000
+    import os
+
+    os.utime(snapshot, ns=(new_mtime_ns, new_mtime_ns))
+
+    second = _session_description("healthy", "worker", str(snapshot))
+
+    # mtime bump means a new cache key, so the parser ran again, and
+    # the freshly-parsed result reflects the rewritten snapshot.
+    assert len(calls) == 2, (
+        f"expected two compute calls after mtime bump, got {len(calls)}: {calls}"
+    )
+    assert first != second
+    assert "5m" in second
+
+
+# ---------------------------------------------------------------------------
 # Cycle 86 (sqlite-only) — REMOVED for Slice K (#1737).
 #
 # The three tests that previously lived here drove the per-project


### PR DESCRIPTION
## Summary

Adds a per-snapshot TTL cache to `_session_description` in `dashboard_data.py` so concurrent dashboard reads share one parse-and-regex pass over each tmux pane snapshot file. On a 16-project / 44-session workspace, `_session_description` previously re-read + regex-parsed the full snapshot file for every active session on every dashboard request (~44 sync reads x ~10ms = ~480ms cumulative per request).

Cache key is `(snapshot_path, mtime_ns, status, role)` so heartbeat rewrites invalidate automatically. Bounded at 256 entries with FIFO eviction.

## Rebase (2026-05-25)

Rebased against main after #2331 landed an **independent singleflight around `plan_launches_readonly`** (5s TTL, per-store key) covering the same plan-build hotspot this PR originally targeted as fix #1. That block has been dropped to avoid double-caching; the unique value of this PR is now fix #2 — the snapshot description cache.

- Rebase: clean (no conflicts; one import-order tweak in `service_api/v1.py`).
- LoC delta vs main: +150 / -1 (was +125 pre-rebase; +103 came in via the cache-contract tests below).
- Pytest: 30 + 15 passing across `test_dashboard_data_pg.py`, `test_dashboard_endpoint.py`, `test_dashboard_inbox_perf.py`, `test_launch_planner.py`; 22 (20 prior + 2 new) on `test_dashboard_data_alert_dedup.py`.

## Cache-contract tests (added on Codex bounce)

`tests/test_dashboard_data_alert_dedup.py` gains two focused tests for the new `_session_description` cache:

- `test_session_description_cache_returns_cached_when_key_matches` — monkeypatches `_compute_session_description` with a call counter; asserts that three back-to-back calls with the same `(snapshot_path, mtime_ns, status, role)` trigger **exactly one** parse and all callers see the same description.
- `test_session_description_cache_refreshes_on_mtime_change` — after bumping the snapshot mtime forward 1 s (robust to coarse-mtime filesystems) and rewriting the body, asserts a **second** compute call ran and the returned description reflects the new pane content.

Both tests clear `_SESSION_DESCRIPTION_CACHE` up front so prior fixtures in the file can't preload a colliding key. `uv run --extra dev pytest tests/test_dashboard_data_alert_dedup.py -x` → 22 passed.

## Before / after (10c x 60s `/api/v1/dashboard`)

Goal from #2308: dashboard p50 under 1 s on a 16-project / 44-session workspace. Each stage measured on the same workspace with the same 10-concurrent-worker × 60s harness.

| stage | p50 | p95 | p99 | max | req/s |
|---|---|---|---|---|---|
| **Baseline (pre-#2308 stack)** | 9.74 s | 10.25 s | 10.26 s | ~10.30 s | ~1.0 |
| Post-trifecta (#2319 + #2320 + #2328) | 3.28 s | 3.70 s | 3.96 s | 3.97 s | ~3.0 |
| Post-#2331 (`plan_launches_readonly` singleflight) | 1.71 s | 3.97 s | — | — | ~5.8 |
| **Post-#2331 + #2332 (this PR — final)** | **0.0095 s** | **0.0207 s** | **0.0563 s** | **0.1545 s** | **~194** |

Final stage harness: `uv run pm serve --host 127.0.0.1 --port 8804`, n = **11,642** samples; max derived from the same sample set (`sort -n | tail -1` → 0.154472 s). The snapshot cache + #2331's launch-plan singleflight + #2320's per-Supervisor planner cache compose so every layer of the hot dashboard request hits memoised work — p50 lands ~1000× under the 1 s goal, and even the worst observed sample (~154 ms) is comfortably below it.

## Test plan

- [x] `uv run --extra dev pytest tests/test_dashboard_data_pg.py tests/test_dashboard_endpoint.py tests/test_dashboard_inbox_perf.py tests/test_launch_planner.py -x` → 45 pass
- [x] `uv run --extra dev pytest tests/test_dashboard_data_alert_dedup.py -x` → 22 pass (20 prior + 2 new cache-contract tests)
- [x] 10c x 60s `pm serve` poll → p50 9.5 ms, p95 20.7 ms, p99 56.3 ms, max 154.5 ms (n = 11,642)

Closes #2308.
