### PR TITLE
Fix doctor API query-string fix runs

### DIFF
--- a/docs/test-plan/01-task-lifecycle.md
+++ b/docs/test-plan/01-task-lifecycle.md
@@ -297,7 +297,10 @@ Find or create two open inbox items. Hit `archive` on both in parallel. Both sho
  wait)
 ```
 
-**Expected:** one 200, one 409 `busy` (single-flight per the doctor contract).
+**Expected:** one 200, one 409 `in_progress` (single-flight per the doctor contract).
+The 409 envelope includes `retry_after_seconds=5`.
+Each API attempt should emit `pm.doctor_run` in `~/.pollypm/audit/_workspace.jsonl`,
+including the rejected 409 path.
 
 ---
 

--- a/src/pollypm/web_api/routes/doctor.py
+++ b/src/pollypm/web_api/routes/doctor.py
@@ -446,6 +446,84 @@ def _fix_busy_error() -> APIError:
     )
 
 
+def _merge_run_request(
+    body: DoctorRunRequest | None,
+    *,
+    query_fix: bool | None,
+) -> DoctorRunRequest:
+    """Return the effective doctor run payload.
+
+    ``fix`` is accepted both in the JSON body and as a query parameter
+    because the public test plan historically used
+    ``POST /doctor/run?fix=true``. FastAPI does not merge query strings
+    into body models, so the route has to bind it explicitly.
+    """
+    payload = body or DoctorRunRequest()
+    if query_fix is None:
+        return payload
+    return DoctorRunRequest(check=payload.check, fix=query_fix)
+
+
+def _emit_doctor_run_audit(
+    *,
+    payload: DoctorRunRequest,
+    timeout_seconds: float,
+    status: str,
+    outcome: str,
+    query_fix: bool | None,
+    report: DoctorReport | None = None,
+    fixes_applied: list[dict[str, Any]] | None = None,
+    error_code: str | None = None,
+) -> None:
+    """Best-effort audit parity for API doctor runs.
+
+    Mirrors the CLI's ``pm.doctor_run`` event without coupling the
+    route to audit failures. The doctor endpoint is a mutation surface
+    when ``fix=true``; even rejected single-flight attempts should be
+    visible in the audit tail.
+    """
+    try:
+        from pollypm.audit import emit as _audit_emit
+    except Exception:  # noqa: BLE001
+        return
+
+    metadata: dict[str, Any] = {
+        "source": "web_api",
+        "route": "POST /api/v1/doctor/run",
+        "check": payload.check,
+        "timeout_seconds": round(float(timeout_seconds), 3),
+        "fix_requested": bool(payload.fix),
+        "fix_query_param": query_fix,
+        "outcome": outcome,
+    }
+    if report is not None:
+        metadata.update({
+            "findings_total": len(report.errors) + len(report.warnings),
+            "errors": len(report.errors),
+            "warnings": len(report.warnings),
+            "checks_total": len(report.results),
+            "passed": report.passed_count,
+            "skipped": report.skipped_count,
+            "duration_seconds": round(report.duration_seconds, 3),
+        })
+    if fixes_applied is not None:
+        metadata["fixes_applied_count"] = len(fixes_applied)
+    if error_code:
+        metadata["error_code"] = error_code
+
+    try:
+        _audit_emit(
+            event="pm.doctor_run",
+            project="_workspace",
+            subject="POST /api/v1/doctor/run",
+            actor="api",
+            status=status,
+            metadata=metadata,
+        )
+    except Exception:  # noqa: BLE001
+        return
+
+
 def _reject_non_default_config(config: Any) -> None:
     """Refuse to run doctor against a non-default config path.
 
@@ -756,6 +834,15 @@ def run_doctor_endpoint(
     config: ConfigDep,
     request: Request,
     body: DoctorRunRequest | None = None,
+    fix: Annotated[
+        bool | None,
+        Query(
+            description=(
+                "Compatibility alias for the JSON body field. When set, "
+                "this query parameter is used as the effective fix flag."
+            ),
+        ),
+    ] = None,
     timeout_seconds: Annotated[
         float,
         Query(
@@ -790,70 +877,90 @@ def run_doctor_endpoint(
     owned by the FastAPI lifespan (Codex round-5 on PR #2058).
     """
     _reject_non_default_config(config)
-    payload = body or DoctorRunRequest()
-
-    selected = _select_checks(payload.check)
-    executor = _get_executor(request)
+    payload = _merge_run_request(body, query_fix=fix)
 
     fixes_applied: list[dict[str, Any]] = []
-    if payload.fix:
-        fix_lock = _get_fix_lock(request)
-        # Single-flight gate for ``fix=true``. Acquire non-blocking so a
-        # second concurrent caller returns 409 immediately rather than
-        # queueing behind the in-flight fix. ``fix=false`` is read-only
-        # for our purposes (each check has its own internal locks) and
-        # is allowed to overlap.
-        if not fix_lock.acquire(blocking=False):
-            raise _fix_busy_error()
+    try:
+        selected = _select_checks(payload.check)
+        executor = _get_executor(request)
+        if payload.fix:
+            fix_lock = _get_fix_lock(request)
+            # Single-flight gate for ``fix=true``. Acquire non-blocking so a
+            # second concurrent caller returns 409 immediately rather than
+            # queueing behind the in-flight fix. ``fix=false`` is read-only
+            # for our purposes (each check has its own internal locks) and
+            # is allowed to overlap.
+            if not fix_lock.acquire(blocking=False):
+                raise _fix_busy_error()
 
-        # Round-4 (Codex on PR #2058): the lock MUST be held until the
-        # worker thread truly terminates, not just until the HTTP request
-        # returns. The prior implementation released in a ``finally``
-        # block, which ran on the 504 timeout path even though the worker
-        # thread was still alive inside ``apply_fixes`` mutating shared
-        # state. A retry within seconds of the 504 would acquire the lock
-        # and start a *second* concurrent fix.
-        #
-        # The fix: submit the work ourselves, attach an
-        # ``add_done_callback`` that releases the lock when the worker
-        # really finishes, and DO NOT release the lock on any code path
-        # in this function — the callback owns the release.
-        #
-        # ``add_done_callback`` runs synchronously if the future is
-        # already done at registration time; otherwise it runs in the
-        # worker thread once the result is set. Either way, the lock is
-        # released exactly once when the work is truly complete.
-        #
-        # Round-5 (Codex on PR #2058): the callback also logs the
-        # eventual outcome (success / exception / cancel) so a
-        # timed-out fix that finishes late is observable in the
-        # server log rather than disappearing silently.
-        future = _submit_doctor_work(
-            executor, _run_full_fix_under_budget, selected,
+            # Round-4 (Codex on PR #2058): the lock MUST be held until the
+            # worker thread truly terminates, not just until the HTTP request
+            # returns. The prior implementation released in a ``finally``
+            # block, which ran on the 504 timeout path even though the worker
+            # thread was still alive inside ``apply_fixes`` mutating shared
+            # state. A retry within seconds of the 504 would acquire the lock
+            # and start a *second* concurrent fix.
+            #
+            # The fix: submit the work ourselves, attach an
+            # ``add_done_callback`` that releases the lock when the worker
+            # really finishes, and DO NOT release the lock on any code path
+            # in this function — the callback owns the release.
+            #
+            # ``add_done_callback`` runs synchronously if the future is
+            # already done at registration time; otherwise it runs in the
+            # worker thread once the result is set. Either way, the lock is
+            # released exactly once when the work is truly complete.
+            #
+            # Round-5 (Codex on PR #2058): the callback also logs the
+            # eventual outcome (success / exception / cancel) so a
+            # timed-out fix that finishes late is observable in the
+            # server log rather than disappearing silently.
+            future = _submit_doctor_work(
+                executor, _run_full_fix_under_budget, selected,
+            )
+            future.add_done_callback(_release_fix_lock_factory(fix_lock))
+            # Round-3 (Codex on PR #2058): the entire run+apply+verify
+            # sequence is wrapped in one budget so a hanging
+            # ``apply_fixes`` can't escape the timeout contract. The
+            # post-fix verify rerun shares the same wall-clock budget;
+            # if apply_fixes itself consumes the budget, the future
+            # times out before verify even starts and we surface 504.
+            report, fixes_applied = _await_with_budget(
+                future,
+                budget_s=timeout_seconds,
+                name=payload.check,
+            )
+        else:
+            report = _run_with_budget(
+                executor,
+                run_checks,
+                selected,
+                budget_s=timeout_seconds,
+                name=payload.check,
+            )
+    except APIError as exc:
+        _emit_doctor_run_audit(
+            payload=payload,
+            timeout_seconds=timeout_seconds,
+            status="error" if exc.status_code >= 500 else "warn",
+            outcome="rejected" if exc.status_code == 409 else "failed",
+            query_fix=fix,
+            fixes_applied=fixes_applied,
+            error_code=exc.code,
         )
-        future.add_done_callback(_release_fix_lock_factory(fix_lock))
-        # Round-3 (Codex on PR #2058): the entire run+apply+verify
-        # sequence is wrapped in one budget so a hanging
-        # ``apply_fixes`` can't escape the timeout contract. The
-        # post-fix verify rerun shares the same wall-clock budget;
-        # if apply_fixes itself consumes the budget, the future
-        # times out before verify even starts and we surface 504.
-        report, fixes_applied = _await_with_budget(
-            future,
-            budget_s=timeout_seconds,
-            name=payload.check,
-        )
-    else:
-        report = _run_with_budget(
-            executor,
-            run_checks,
-            selected,
-            budget_s=timeout_seconds,
-            name=payload.check,
-        )
+        raise
 
     generated_at = _record_last_report(request, report)
     base = _build_report_response(report, generated_at=generated_at)
+    _emit_doctor_run_audit(
+        payload=payload,
+        timeout_seconds=timeout_seconds,
+        status="ok" if report.ok else "warn",
+        outcome="completed",
+        query_fix=fix,
+        report=report,
+        fixes_applied=fixes_applied,
+    )
     return DoctorRunResponse(
         generated_at=base.generated_at,
         duration_seconds=base.duration_seconds,

--- a/tests/test_doctor_endpoint.py
+++ b/tests/test_doctor_endpoint.py
@@ -15,6 +15,7 @@ registry / runner so the suite never touches the user's real machine
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -353,6 +354,91 @@ def test_run_with_fix_invokes_fix_fn(client, auth_headers, patch_registry, monke
     # Post-fix re-run replaced the failing result with a passing one.
     [row] = body["checks"]
     assert row["passed"] is True
+
+
+def test_run_query_fix_true_invokes_fix_fn(client, auth_headers, patch_registry):
+    """``POST /doctor/run?fix=true`` reaches the same path as body fix=true."""
+    counter = {"n": 0}
+
+    def stateful_run() -> CheckResult:
+        counter["n"] += 1
+        if counter["n"] == 1:
+            return _fail("alpha", fixable=True)
+        return _ok("alpha")
+
+    check = Check(name="alpha", run=stateful_run, category="test", severity="error")
+    patch_registry([check])
+    response = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        params={"fix": "true", "check": "ignored-by-route"},
+        json={"check": "alpha"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["fixes_applied"] == [
+        {"name": "alpha", "ok": True, "message": "applied fix for alpha"},
+    ]
+    assert body["checks"][0]["passed"] is True
+
+
+def test_api_doctor_run_audit_covers_query_fix_and_busy_rejection(
+    client, app, auth_headers, patch_registry, monkeypatch, tmp_path: Path,
+) -> None:
+    """API doctor runs emit ``pm.doctor_run`` audit rows, including 409."""
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit"))
+    patch_registry([_check("alpha", _ok("alpha"))])
+
+    completed = client.post(
+        "/api/v1/doctor/run",
+        headers=auth_headers,
+        params={"fix": "true"},
+        json={"check": "alpha"},
+    )
+    assert completed.status_code == 200, completed.json()
+
+    fix_lock = app.state.doctor_fix_lock
+    assert fix_lock.acquire(blocking=False)
+    try:
+        rejected = client.post(
+            "/api/v1/doctor/run",
+            headers=auth_headers,
+            params={"fix": "true"},
+            json={"check": "alpha"},
+        )
+    finally:
+        fix_lock.release()
+
+    assert rejected.status_code == 409, rejected.json()
+    assert rejected.json()["error"]["code"] == "in_progress"
+
+    central = tmp_path / "audit" / "_workspace.jsonl"
+    assert central.exists(), f"audit log not written at {central}"
+    events = [
+        json.loads(line)
+        for line in central.read_text().splitlines()
+        if line.strip()
+    ]
+    doctor_events = [
+        event for event in events if event.get("event") == "pm.doctor_run"
+    ]
+    assert len(doctor_events) == 2
+    completed_event = next(
+        event for event in doctor_events
+        if event["metadata"]["outcome"] == "completed"
+    )
+    rejected_event = next(
+        event for event in doctor_events
+        if event["metadata"]["outcome"] == "rejected"
+    )
+    assert completed_event["actor"] == "api"
+    assert completed_event["status"] == "ok"
+    assert completed_event["metadata"]["source"] == "web_api"
+    assert completed_event["metadata"]["fix_requested"] is True
+    assert completed_event["metadata"]["fix_query_param"] is True
+    assert rejected_event["status"] == "warn"
+    assert rejected_event["metadata"]["error_code"] == "in_progress"
 
 
 def test_run_with_fix_false_does_not_invoke_fixes(client, auth_headers, patch_registry):


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Bind `POST /api/v1/doctor/run?fix=true` as the effective doctor fix flag instead of silently ignoring it.
- Emit `pm.doctor_run` audit rows from API doctor runs, including rejected single-flight `409 in_progress` attempts.
- Update the lifecycle test plan to document the API audit breadcrumb and `in_progress` envelope.

## Verification
- `uv run --extra test pytest tests/test_doctor_endpoint.py -q` (`25 passed in 251.14s`)

Closes #2334
