### PR TITLE
fix(plan-review): emit audit row + cap stuck_draft cascade (partial #2333)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -672,6 +672,39 @@ def _detect_marker_leaks(
     return findings
 
 
+@dataclass(slots=True, frozen=True)
+class _TerminatorBreadcrumb:
+    """#2349 — pending ``audit.stuck_draft_terminated`` row.
+
+    Produced by the (pure) ``_detect_stuck_drafts`` detector when a
+    subject first crosses ``STUCK_DRAFT_TERMINATOR_THRESHOLD``. The
+    cadence handler (``scan_project``) drains the breadcrumb list and
+    emits the rows via :func:`_emit_stuck_draft_terminator`. Keeping the
+    breadcrumb a plain value type — not a side effect — means
+    ``scan_events`` / ``_detect_stuck_drafts`` can stay pure and tests
+    that monkeypatch ``pollypm.audit.log.emit`` and call ``scan_events``
+    directly see ZERO writes.
+    """
+
+    project: str
+    subject: str
+    prior_count: int
+
+
+@dataclass(slots=True, frozen=True)
+class _StuckDraftScanResult:
+    """#2349 — result of the (pure) stuck_draft detector pass.
+
+    ``findings`` are the rows the cadence handler will route normally;
+    ``terminator_breadcrumbs`` are subjects that crossed the cascade
+    threshold for the first time in this scan and need a one-shot
+    ``audit.stuck_draft_terminated`` row emitted by the route layer.
+    """
+
+    findings: list[Finding]
+    terminator_breadcrumbs: list[_TerminatorBreadcrumb]
+
+
 def _emit_stuck_draft_terminator(
     *,
     project: str,
@@ -688,12 +721,18 @@ def _emit_stuck_draft_terminator(
     breadcrumb is far better than crashing the cadence handler.
 
     ``project_path`` MUST be threaded through from the cadence handler
-    (via ``scan_project`` → ``scan_events`` → ``_detect_stuck_drafts``)
-    so the breadcrumb lands in the per-project audit log alongside the
-    ``audit.finding`` rows it terminates. Without this, the per-project
-    log is the read source on the next scan but the breadcrumb only
-    lives on the central tail — the read/write split makes the
-    terminator re-emit forever (the #2349 Codex blocker).
+    (via ``scan_project``) so the breadcrumb lands in the per-project
+    audit log alongside the ``audit.finding`` rows it terminates.
+    Without this, the per-project log is the read source on the next
+    scan but the breadcrumb only lives on the central tail — the
+    read/write split makes the terminator re-emit forever (the #2349
+    Codex blocker).
+
+    #2349 (round 3) — this helper is invoked exclusively from the
+    cadence path (:func:`scan_project`) after the pure detectors have
+    finished. The detectors return :class:`_TerminatorBreadcrumb`
+    values; ``scan_project`` materialises them via this helper. Pure
+    ``scan_events`` callers never reach this code path.
     """
     try:
         from pollypm.audit.log import emit as _audit_emit
@@ -728,8 +767,7 @@ def _detect_stuck_drafts(
     now: datetime,
     config: WatchdogConfig,
     open_tasks: Sequence[Any] | None = None,
-    project_path: Path | str | None = None,
-) -> list[Finding]:
+) -> _StuckDraftScanResult:
     """Rule 3 (state-based, #1433): tasks currently at ``status=draft``
     older than ``stuck_draft_seconds``.
 
@@ -742,8 +780,18 @@ def _detect_stuck_drafts(
     Findings produced by the state path take precedence — we dedupe
     on ``(project, subject)`` so a task that is both visible in
     ``open_tasks`` AND has a matching audit event only fires once.
+
+    #2349 (round 3) — this detector is PURE: no I/O. When a subject
+    crosses ``STUCK_DRAFT_TERMINATOR_THRESHOLD`` for the first time, a
+    :class:`_TerminatorBreadcrumb` is collected onto the returned
+    :class:`_StuckDraftScanResult`; the cadence handler
+    (:func:`scan_project`) is responsible for actually emitting the
+    ``audit.stuck_draft_terminated`` row. Direct ``scan_events``
+    callers that bypass the cadence handler get suppression of repeat
+    stuck_draft findings without any durable writes.
     """
     findings: list[Finding] = []
+    terminator_breadcrumbs: list[_TerminatorBreadcrumb] = []
     seen_subjects: set[str] = set()
     cutoff = now - timedelta(seconds=config.stuck_draft_seconds)
 
@@ -780,8 +828,15 @@ def _detect_stuck_drafts(
 
         Idempotent across scans: a subject with a prior
         ``audit.stuck_draft_terminated`` row is still skipped, but the
-        breadcrumb is NOT re-emitted. Only the *first* scan that crosses
-        the threshold writes the terminator event.
+        breadcrumb is NOT re-collected. Only the *first* scan that
+        crosses the threshold appends a :class:`_TerminatorBreadcrumb`
+        for the cadence handler to emit.
+
+        #2349 (round 3) — pure: this helper appends to the local
+        ``terminator_breadcrumbs`` list rather than calling
+        :func:`_emit_stuck_draft_terminator` directly. The route layer
+        (:func:`scan_project`) consumes the breadcrumb list and emits
+        the durable row.
         """
         if prior_finding_counts.get(subject, 0) < (
             STUCK_DRAFT_TERMINATOR_THRESHOLD
@@ -792,12 +847,11 @@ def _detect_stuck_drafts(
             return True
         if subject not in terminated_subjects:
             terminated_subjects.add(subject)
-            _emit_stuck_draft_terminator(
+            terminator_breadcrumbs.append(_TerminatorBreadcrumb(
                 project=project,
                 subject=subject,
                 prior_count=prior_finding_counts[subject],
-                project_path=project_path,
-            )
+            ))
         return True
 
     # State-based path (#1433): walks current ``work_tasks`` rows.
@@ -934,7 +988,10 @@ def _detect_stuck_drafts(
                 "detected_via": "event",
             },
         ))
-    return findings
+    return _StuckDraftScanResult(
+        findings=findings,
+        terminator_breadcrumbs=terminator_breadcrumbs,
+    )
 
 
 def _detect_cancellation_no_promotion(
@@ -2802,12 +2859,24 @@ def scan_events(
     state_db_probes: Sequence[Any] | None = None,
     run_safety_net_probes: bool = True,
     worker_cap_back_pressure: Mapping[str, bool] | None = None,
+    stuck_draft_terminator_breadcrumbs: list[_TerminatorBreadcrumb] | None = None,
 ) -> list[Finding]:
     """Run every detection rule against ``events`` and return findings.
 
     Pure function — no I/O. Tests pass a synthetic event list directly.
     The events are iterated multiple times so an iterable is materialised
     into a list up front.
+
+    #2349 (round 3) — ``scan_events`` is PURE. When the cadence handler
+    (:func:`scan_project`) needs to emit ``audit.stuck_draft_terminated``
+    breadcrumbs it passes an empty list via
+    ``stuck_draft_terminator_breadcrumbs``; ``scan_events`` populates it
+    with one :class:`_TerminatorBreadcrumb` per subject that first
+    crossed the cascade threshold this scan, and the cadence handler
+    emits them after the scan returns. Direct ``scan_events`` callers
+    omit the kwarg and never trigger any I/O — only finding-suppression.
+    ``project_path`` is accepted for back-compat (older internal callers
+    threaded it through) but no longer used inside the detector.
 
     Args:
         events: audit events to scan. Order need not be sorted —
@@ -2854,13 +2923,22 @@ def scan_events(
     findings.extend(_detect_marker_leaks(
         materialised, now=now, config=config,
     ))
-    findings.extend(_detect_stuck_drafts(
+    stuck_draft_result = _detect_stuck_drafts(
         materialised,
         now=now,
         config=config,
         open_tasks=open_tasks,
-        project_path=project_path,
-    ))
+    )
+    findings.extend(stuck_draft_result.findings)
+    # #2349 (round 3) — surface terminator breadcrumbs to the cadence
+    # handler via the optional side-channel. Pure callers (synthetic
+    # event tests) leave the kwarg as None and get no breadcrumbs +
+    # zero writes; the detector still suppresses the repeating finding
+    # via the in-memory ``terminated_subjects`` guard.
+    if stuck_draft_terminator_breadcrumbs is not None:
+        stuck_draft_terminator_breadcrumbs.extend(
+            stuck_draft_result.terminator_breadcrumbs,
+        )
     findings.extend(_detect_cancellation_no_promotion(
         materialised, now=now, config=config,
     ))
@@ -2985,6 +3063,13 @@ def scan_project(
     pass-through for the plan_missing_alert_churn rule (#1524). When
     omitted those rules become no-ops, which is the right default for
     callers that only have audit events on hand.
+
+    #2349 (round 3) — ``scan_project`` IS the audit-write boundary for
+    ``audit.stuck_draft_terminated`` breadcrumbs. The pure
+    ``scan_events`` detector collects breadcrumbs into a local list;
+    after the scan returns, we drain that list and call
+    :func:`_emit_stuck_draft_terminator` with the cadence-owned
+    ``project_path`` so each row lands in the per-project audit log.
     """
     from pollypm.audit.log import read_events
 
@@ -3003,7 +3088,13 @@ def scan_project(
         since=since,
         project_path=project_path,
     )
-    return scan_events(
+    # #2349 (round 3) — owned by the cadence handler. The pure
+    # detector appends one :class:`_TerminatorBreadcrumb` per subject
+    # that first crossed the terminator threshold this scan; we emit
+    # the durable rows after ``scan_events`` returns so the I/O lives
+    # at the route layer, not inside the detector.
+    pending_terminators: list[_TerminatorBreadcrumb] = []
+    findings = scan_events(
         events,
         now=resolved_now,
         config=config,
@@ -3019,7 +3110,16 @@ def scan_project(
         state_db_probes=state_db_probes,
         run_safety_net_probes=run_safety_net_probes,
         worker_cap_back_pressure=worker_cap_back_pressure,
+        stuck_draft_terminator_breadcrumbs=pending_terminators,
     )
+    for breadcrumb in pending_terminators:
+        _emit_stuck_draft_terminator(
+            project=breadcrumb.project,
+            subject=breadcrumb.subject,
+            prior_count=breadcrumb.prior_count,
+            project_path=project_path,
+        )
+    return findings
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -677,6 +677,7 @@ def _emit_stuck_draft_terminator(
     project: str,
     subject: str,
     prior_count: int,
+    project_path: Path | str | None = None,
 ) -> None:
     """#2333 — record that we stopped re-flagging ``subject`` as stuck_draft.
 
@@ -685,6 +686,14 @@ def _emit_stuck_draft_terminator(
     pollypm/191?" without us having to dig through the detector.
     Best-effort — must never raise; the loss of a single forensic
     breadcrumb is far better than crashing the cadence handler.
+
+    ``project_path`` MUST be threaded through from the cadence handler
+    (via ``scan_project`` → ``scan_events`` → ``_detect_stuck_drafts``)
+    so the breadcrumb lands in the per-project audit log alongside the
+    ``audit.finding`` rows it terminates. Without this, the per-project
+    log is the read source on the next scan but the breadcrumb only
+    lives on the central tail — the read/write split makes the
+    terminator re-emit forever (the #2349 Codex blocker).
     """
     try:
         from pollypm.audit.log import emit as _audit_emit
@@ -704,6 +713,7 @@ def _emit_stuck_draft_terminator(
                     "watchdog flagging."
                 ),
             },
+            project_path=project_path,
         )
     except Exception:  # noqa: BLE001
         logger.debug(
@@ -718,6 +728,7 @@ def _detect_stuck_drafts(
     now: datetime,
     config: WatchdogConfig,
     open_tasks: Sequence[Any] | None = None,
+    project_path: Path | str | None = None,
 ) -> list[Finding]:
     """Rule 3 (state-based, #1433): tasks currently at ``status=draft``
     older than ``stuck_draft_seconds``.
@@ -785,6 +796,7 @@ def _detect_stuck_drafts(
                 project=project,
                 subject=subject,
                 prior_count=prior_finding_counts[subject],
+                project_path=project_path,
             )
         return True
 
@@ -2781,6 +2793,7 @@ def scan_events(
     open_tasks: Sequence[Any] | None = None,
     storage_window_names: Sequence[str] | None = None,
     project: str = "",
+    project_path: Path | str | None = None,
     done_plan_tasks: Sequence[Any] | None = None,
     plan_review_present: Any = None,
     bypassed_plan_tasks: Sequence[Any] | None = None,
@@ -2842,7 +2855,11 @@ def scan_events(
         materialised, now=now, config=config,
     ))
     findings.extend(_detect_stuck_drafts(
-        materialised, now=now, config=config, open_tasks=open_tasks,
+        materialised,
+        now=now,
+        config=config,
+        open_tasks=open_tasks,
+        project_path=project_path,
     ))
     findings.extend(_detect_cancellation_no_promotion(
         materialised, now=now, config=config,
@@ -2993,6 +3010,7 @@ def scan_project(
         open_tasks=open_tasks,
         storage_window_names=storage_window_names,
         project=project,
+        project_path=project_path,
         done_plan_tasks=done_plan_tasks,
         plan_review_present=plan_review_present,
         bypassed_plan_tasks=bypassed_plan_tasks,
@@ -3135,12 +3153,24 @@ def emit_heartbeat_tick(
         )
 
 
-def emit_finding(finding: Finding) -> None:
+def emit_finding(
+    finding: Finding,
+    *,
+    project_path: Path | str | None = None,
+) -> None:
     """Emit an ``audit.finding`` event for posterity.
 
     The cadence handler also routes findings to ``upsert_alert`` for
     user-visible surfacing; this audit emit is the durable forensic
     trail. Best-effort — never raises.
+
+    ``project_path``: when supplied, the finding row is also written to
+    the per-project audit log (``<project>/.pollypm/audit.jsonl``). The
+    cadence handler MUST pass this so :func:`scan_project` — which
+    prefers the per-project log when present — sees the prior findings
+    that drive dedupe windows and cascade terminators (#2333/#2349).
+    Without it, prior findings live only on the central tail and the
+    next scan misses them.
     """
     from pollypm.audit.log import emit as _audit_emit
     try:
@@ -3156,6 +3186,7 @@ def emit_finding(finding: Finding) -> None:
                 "recommendation": finding.recommendation,
                 **dict(finding.metadata or {}),
             },
+            project_path=project_path,
         )
     except Exception:  # noqa: BLE001
         logger.debug("emit_finding failed", exc_info=True)

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -84,6 +84,8 @@ __all__ = [
     "WatchdogConfig",
     "EVENT_HEARTBEAT_TICK",
     "EVENT_AUDIT_FINDING",
+    "EVENT_STUCK_DRAFT_TERMINATED",
+    "STUCK_DRAFT_TERMINATOR_THRESHOLD",
     "RULE_ORPHAN_MARKER",
     "RULE_MARKER_LEAKED",
     "RULE_STUCK_DRAFT",
@@ -307,6 +309,18 @@ REJECTION_LOOP_WINDOW_SECONDS = 7200
 # cadence as the architect throttle window expires — a queue that's
 # been silent for 30 min has already missed several heartbeat ticks.
 QUEUE_MOTION_THRESHOLD_SECONDS = 1800
+
+# #2333 — cascade terminator for repeating ``stuck_draft`` flags on the
+# same subject. The plan-review meta-bug drafts (pollypm/191-194, 201,
+# 203-205) were re-flagged every ~40 min, each tick spawning a fresh
+# dispatch + a fresh architect draft, which itself then got re-flagged.
+# After ``STUCK_DRAFT_TERMINATOR_THRESHOLD`` prior ``audit.finding`` rows
+# for ``(rule=stuck_draft, subject=X)`` we stop re-emitting the finding
+# for that subject and write a single ``audit.stuck_draft_terminated``
+# breadcrumb. The operator can still manually retry by promoting or
+# cancelling the underlying draft — the terminator just stops the loop.
+EVENT_STUCK_DRAFT_TERMINATED = "audit.stuck_draft_terminated"
+STUCK_DRAFT_TERMINATOR_THRESHOLD = 3
 
 # Audit events emitted *by* the watchdog itself.
 EVENT_HEARTBEAT_TICK = "heartbeat.tick"
@@ -658,6 +672,46 @@ def _detect_marker_leaks(
     return findings
 
 
+def _emit_stuck_draft_terminator(
+    *,
+    project: str,
+    subject: str,
+    prior_count: int,
+) -> None:
+    """#2333 — record that we stopped re-flagging ``subject`` as stuck_draft.
+
+    Emits a single ``audit.stuck_draft_terminated`` row so a forensic
+    grep can answer "why did the heartbeat stop nagging me about
+    pollypm/191?" without us having to dig through the detector.
+    Best-effort — must never raise; the loss of a single forensic
+    breadcrumb is far better than crashing the cadence handler.
+    """
+    try:
+        from pollypm.audit.log import emit as _audit_emit
+
+        _audit_emit(
+            event=EVENT_STUCK_DRAFT_TERMINATED,
+            project=project,
+            subject=subject,
+            actor="audit_watchdog",
+            status="warn",
+            metadata={
+                "rule": RULE_STUCK_DRAFT,
+                "prior_finding_count": prior_count,
+                "threshold": STUCK_DRAFT_TERMINATOR_THRESHOLD,
+                "recommendation": (
+                    "Manually promote or cancel the draft to re-enable "
+                    "watchdog flagging."
+                ),
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: stuck_draft_terminated emit failed for %s",
+            subject, exc_info=True,
+        )
+
+
 def _detect_stuck_drafts(
     events: Sequence[AuditEvent],
     *,
@@ -682,6 +736,58 @@ def _detect_stuck_drafts(
     seen_subjects: set[str] = set()
     cutoff = now - timedelta(seconds=config.stuck_draft_seconds)
 
+    # #2333 — cascade terminator. Tally prior ``audit.finding`` rows for
+    # ``rule=stuck_draft`` per subject AND prior
+    # ``audit.stuck_draft_terminated`` rows. Subjects that have already
+    # been flagged ``STUCK_DRAFT_TERMINATOR_THRESHOLD`` times are dropped
+    # here. The terminator breadcrumb is emitted exactly once per subject
+    # across all scans: if a prior ``audit.stuck_draft_terminated`` row
+    # already exists for this subject (i.e. we terminated it on an
+    # earlier heartbeat tick), we still suppress the finding but do NOT
+    # re-emit the breadcrumb — otherwise the terminator itself would
+    # cascade in the audit log on every subsequent scan.
+    prior_finding_counts: dict[str, int] = {}
+    already_terminated_subjects: set[str] = set()
+    for ev in events:
+        if ev.event == EVENT_AUDIT_FINDING:
+            meta = ev.metadata or {}
+            if meta.get("rule") != RULE_STUCK_DRAFT:
+                continue
+            if not ev.subject:
+                continue
+            prior_finding_counts[ev.subject] = (
+                prior_finding_counts.get(ev.subject, 0) + 1
+            )
+        elif ev.event == EVENT_STUCK_DRAFT_TERMINATED:
+            if ev.subject:
+                already_terminated_subjects.add(ev.subject)
+
+    terminated_subjects: set[str] = set()
+
+    def _maybe_skip_terminated(subject: str, project: str) -> bool:
+        """Return True iff ``subject`` has hit the terminator threshold.
+
+        Idempotent across scans: a subject with a prior
+        ``audit.stuck_draft_terminated`` row is still skipped, but the
+        breadcrumb is NOT re-emitted. Only the *first* scan that crosses
+        the threshold writes the terminator event.
+        """
+        if prior_finding_counts.get(subject, 0) < (
+            STUCK_DRAFT_TERMINATOR_THRESHOLD
+        ):
+            return False
+        if subject in already_terminated_subjects:
+            # Already recorded by a prior scan — suppress finding silently.
+            return True
+        if subject not in terminated_subjects:
+            terminated_subjects.add(subject)
+            _emit_stuck_draft_terminator(
+                project=project,
+                subject=subject,
+                prior_count=prior_finding_counts[subject],
+            )
+        return True
+
     # State-based path (#1433): walks current ``work_tasks`` rows.
     if open_tasks:
         for task in open_tasks:
@@ -702,6 +808,9 @@ def _detect_stuck_drafts(
                 continue
             subject = f"{project}/{task_number}"
             if subject in seen_subjects:
+                continue
+            if _maybe_skip_terminated(subject, project):
+                seen_subjects.add(subject)
                 continue
             seen_subjects.add(subject)
             actor = getattr(task, "created_by", "") or "unknown"
@@ -786,6 +895,10 @@ def _detect_stuck_drafts(
             if current_status_by_subject[ev.subject] != "draft":
                 continue
         project, task_number = key
+        # #2333 — cascade terminator: identical contract to the state path.
+        if _maybe_skip_terminated(ev.subject, project):
+            seen_subjects.add(ev.subject)
+            continue
         seen_subjects.add(ev.subject)
         findings.append(Finding(
             rule=RULE_STUCK_DRAFT,

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -3344,7 +3344,13 @@ def _route_one_finding(
 ) -> None:
     """Apply alert routing + tier-1/3/4 dispatch for a single finding."""
     counters["findings"] += 1
-    emit_finding(finding)
+    # #2349 — thread ``project_path`` so the ``audit.finding`` row lands
+    # in the per-project audit log alongside the per-project events
+    # that scan_project will read on the next tick. Without this, prior
+    # findings live only on the central tail and the cascade-terminator
+    # (#2333) can't dedupe across scans for projects with a per-project
+    # log.
+    emit_finding(finding, project_path=project_path)
     if _route_to_alert_sink(
         finding, msg_store=msg_store, state_store=state_store,
     ):

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -355,6 +355,155 @@ def test_stuck_draft_terminator_emits_after_threshold_and_is_idempotent(
     )
 
 
+def test_stuck_draft_terminator_durable_across_scan_project_calls(
+    now: datetime,
+    tmp_path: Path,
+) -> None:
+    """#2349 regression: the terminator must NOT cascade when the
+    cadence handler reads from a per-project audit log.
+
+    Repro: production ``scan_project`` calls ``read_events`` which
+    prefers the per-project log when one exists. If prior
+    ``audit.finding`` rows are written without ``project_path`` they
+    only land on the central tail and ``scan_project`` does not see
+    them — so the threshold never counts the prior findings, OR the
+    threshold counts only synthetic rows and the terminator
+    breadcrumb itself lives only on the central tail (so the next
+    scan re-emits it forever).
+
+    Fix: ``emit_finding`` and ``_emit_stuck_draft_terminator`` now
+    accept ``project_path`` and both rows land in the per-project log
+    alongside the events that drive dedupe.
+
+    This test exercises the cadence-adjacent path: pre-seed the
+    per-project log with prior findings via the real
+    ``emit_finding`` writer (with ``project_path``), then call
+    ``scan_project`` twice with the same ``project_path``. The first
+    scan should emit exactly one terminator breadcrumb (also into the
+    per-project log). The second scan must see that breadcrumb and
+    NOT re-emit.
+    """
+    from pollypm.audit.log import emit as audit_emit, project_log_path
+    from pollypm.audit.watchdog import (
+        STUCK_DRAFT_TERMINATOR_THRESHOLD,
+        emit_finding,
+        Finding,
+    )
+
+    project = "savethenovel"
+    project_path = tmp_path / project
+    (project_path / ".pollypm").mkdir(parents=True)
+    per_project = project_log_path(project_path)
+    assert per_project is not None
+
+    subject = f"{project}/7"
+
+    # Seed prior findings via the production ``emit_finding`` writer with
+    # ``project_path`` so they land in the per-project log — the source
+    # ``scan_project`` will read on the next tick.
+    for i in range(STUCK_DRAFT_TERMINATOR_THRESHOLD):
+        finding = Finding(
+            rule=RULE_STUCK_DRAFT,
+            project=project,
+            subject=subject,
+            message=f"prior stuck_draft finding #{i}",
+            recommendation="rec",
+        )
+        emit_finding(finding, project_path=project_path)
+
+    # Also write an old ``task.created`` row so the synthetic-event
+    # path inside ``_detect_stuck_drafts`` has a candidate to flag —
+    # this is the row that the terminator would suppress on the next
+    # scan. Use ``audit_emit`` with ``project_path`` so it lands in
+    # the per-project log too (mirroring what work-service does).
+    audit_emit(
+        event=EVENT_TASK_CREATED,
+        project=project,
+        subject=subject,
+        actor="polly",
+        project_path=project_path,
+    )
+
+    # Fix up the ``task.created`` ts so it's older than the
+    # stuck_draft threshold (the writer stamps "now"). Rewrite the
+    # file with the doctored ts. Per-project log content:
+    # finding rows + task.created.
+    lines = per_project.read_text(encoding="utf-8").splitlines()
+    rewritten: list[str] = []
+    create_ts = (now - timedelta(minutes=15)).isoformat()
+    finding_ts_base = now - timedelta(minutes=45)
+    finding_idx = 0
+    for raw in lines:
+        if not raw.strip():
+            continue
+        obj = json.loads(raw)
+        if obj.get("event") == EVENT_TASK_CREATED:
+            obj["ts"] = create_ts
+        elif obj.get("event") == "audit.finding":
+            # Space the prior findings out in the past so they all
+            # fall inside the scan_project lookback window.
+            obj["ts"] = (
+                finding_ts_base + timedelta(minutes=finding_idx)
+            ).isoformat()
+            finding_idx += 1
+        rewritten.append(json.dumps(obj))
+    per_project.write_text("\n".join(rewritten) + "\n", encoding="utf-8")
+
+    # First scan: terminator should engage. The cadence handler
+    # passes ``project_path`` so ``scan_project`` reads from the
+    # per-project log AND ``_emit_stuck_draft_terminator`` lands the
+    # breadcrumb in that same log.
+    findings_scan1 = [
+        f
+        for f in scan_project(project, project_path=project_path, now=now)
+        if f.rule == RULE_STUCK_DRAFT
+    ]
+    assert findings_scan1 == [], (
+        "terminator should suppress finding once threshold met"
+    )
+
+    # Verify the breadcrumb landed in the per-project log (not just
+    # the central tail).
+    rows_after_1 = [
+        json.loads(line)
+        for line in per_project.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    terminator_rows_1 = [
+        r for r in rows_after_1
+        if r["event"] == EVENT_STUCK_DRAFT_TERMINATED
+        and r.get("subject") == subject
+    ]
+    assert len(terminator_rows_1) == 1, (
+        "first scan must write exactly one terminator breadcrumb to "
+        "the per-project log"
+    )
+
+    # Second scan: the per-project log now contains the breadcrumb
+    # from scan 1. ``scan_project`` will read it and the terminator
+    # must NOT re-emit — otherwise the breadcrumb itself cascades.
+    findings_scan2 = [
+        f
+        for f in scan_project(project, project_path=project_path, now=now)
+        if f.rule == RULE_STUCK_DRAFT
+    ]
+    assert findings_scan2 == [], "still suppressed across scans"
+    rows_after_2 = [
+        json.loads(line)
+        for line in per_project.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    terminator_rows_2 = [
+        r for r in rows_after_2
+        if r["event"] == EVENT_STUCK_DRAFT_TERMINATED
+        and r.get("subject") == subject
+    ]
+    assert len(terminator_rows_2) == 1, (
+        "second scan must NOT re-emit the terminator — read/write "
+        "sources must agree (per-project log)"
+    )
+
+
 def test_stuck_draft_event_path_cross_checks_open_tasks_status(now: datetime) -> None:
     """#1869: when ``open_tasks`` is supplied, the event-based fallback
     must not fire for tasks that are no longer in draft state.

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -292,16 +292,26 @@ def test_stuck_draft_silenced_by_cancellation(now: datetime) -> None:
     assert findings == []
 
 
-def test_stuck_draft_terminator_emits_after_threshold_and_is_idempotent(
+def test_stuck_draft_terminator_breadcrumbs_collected_after_threshold_and_idempotent(
     now: datetime,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """#2333: after STUCK_DRAFT_TERMINATOR_THRESHOLD prior findings for a
-    subject, the watchdog stops emitting new stuck_draft findings and
-    writes ONE ``audit.stuck_draft_terminated`` breadcrumb. A subsequent
-    scan that also sees that breadcrumb in the events sequence must NOT
-    re-emit the terminator — otherwise the breadcrumb itself cascades.
+    """#2333 / #2349 (round 3): after STUCK_DRAFT_TERMINATOR_THRESHOLD
+    prior findings for a subject, ``scan_events`` stops surfacing new
+    stuck_draft findings AND surfaces a single
+    :class:`_TerminatorBreadcrumb` for that subject through the optional
+    side-channel. A subsequent scan that also sees the terminator
+    breadcrumb in the events sequence must NOT re-collect it —
+    otherwise the breadcrumb itself cascades.
+
+    #2349 (round 3) hardening: ``scan_events`` is PURE — collecting the
+    breadcrumb is via an explicit list passed by the caller, never via
+    a direct ``pollypm.audit.log.emit`` call. The spy proves that even
+    when the side-channel is engaged, ``scan_events`` itself performs
+    zero durable writes.
     """
+    from pollypm.audit.watchdog import _TerminatorBreadcrumb
+
     emitted: list[tuple[str, str | None]] = []
 
     def _record(*, event: str, subject: str | None = None, **_: object) -> None:
@@ -323,35 +333,112 @@ def test_stuck_draft_terminator_emits_after_threshold_and_is_idempotent(
     create_event = _make_event(
         event=EVENT_TASK_CREATED, subject="demo/2", ts=create_ts,
     )
+    breadcrumbs_scan1: list[_TerminatorBreadcrumb] = []
     findings = [
-        f for f in scan_events([create_event, *prior_findings], now=now)
+        f for f in scan_events(
+            [create_event, *prior_findings],
+            now=now,
+            stuck_draft_terminator_breadcrumbs=breadcrumbs_scan1,
+        )
         if f.rule == RULE_STUCK_DRAFT
     ]
     assert findings == [], "terminator should suppress the new finding"
-    terminator_emits = [
+    assert len(breadcrumbs_scan1) == 1
+    assert breadcrumbs_scan1[0].subject == "demo/2"
+    assert breadcrumbs_scan1[0].project == "demo"
+    assert [
         ev for ev in emitted if ev[0] == EVENT_STUCK_DRAFT_TERMINATED
-    ]
-    assert len(terminator_emits) == 1
-    assert terminator_emits[0][1] == "demo/2"
+    ] == [], (
+        "scan_events must be pure — no direct audit.log.emit call even "
+        "when collecting terminator breadcrumbs"
+    )
 
     # Scan 2: same prior findings + the terminator breadcrumb from
-    # scan 1 in the events sequence. The terminator MUST NOT re-emit.
+    # scan 1 in the events sequence. The terminator MUST NOT re-collect.
     emitted.clear()
-    breadcrumb = _make_event(
+    breadcrumb_event = _make_event(
         event=EVENT_STUCK_DRAFT_TERMINATED,
         subject="demo/2",
         metadata={"rule": RULE_STUCK_DRAFT},
         ts=now - timedelta(minutes=1),
     )
+    breadcrumbs_scan2: list[_TerminatorBreadcrumb] = []
     findings_scan2 = [
         f for f in scan_events(
-            [create_event, *prior_findings, breadcrumb], now=now,
+            [create_event, *prior_findings, breadcrumb_event],
+            now=now,
+            stuck_draft_terminator_breadcrumbs=breadcrumbs_scan2,
         )
         if f.rule == RULE_STUCK_DRAFT
     ]
     assert findings_scan2 == [], "still suppressed across scans"
-    assert [ev for ev in emitted if ev[0] == EVENT_STUCK_DRAFT_TERMINATED] == [], (
+    assert breadcrumbs_scan2 == [], (
         "terminator must NOT cascade — already_terminated_subjects guard"
+    )
+    assert [
+        ev for ev in emitted if ev[0] == EVENT_STUCK_DRAFT_TERMINATED
+    ] == [], "scan_events remains pure across scans"
+
+
+def test_scan_events_remains_pure_when_terminator_threshold_hit(
+    now: datetime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2349 (round 3) regression: ``scan_events`` MUST NOT call
+    ``pollypm.audit.log.emit`` even when the cascade-terminator
+    threshold is crossed.
+
+    Direct/synthetic ``scan_events`` callers (unit tests, ad-hoc
+    detector probes) feed event sequences in repeatedly; if the
+    detector emitted ``audit.stuck_draft_terminated`` rows during the
+    scan, the same input scanned twice would emit twice (or, worse,
+    feed back into the next read window and re-cascade). The cadence
+    path (:func:`scan_project`) is the sole authorised emitter.
+
+    Contract under test (the round-3 split):
+      * The repeat stuck_draft finding for the subject IS suppressed
+        (terminator dedup still works in-process).
+      * ``pollypm.audit.log.emit`` is called ZERO times by
+        ``scan_events`` itself.
+    """
+    spy_calls: list[dict[str, object]] = []
+
+    def _spy(**kwargs: object) -> None:
+        spy_calls.append(kwargs)
+
+    monkeypatch.setattr("pollypm.audit.log.emit", _spy)
+
+    create_ts = now - timedelta(minutes=15)
+    subject = "demo/4"
+    prior_findings = [
+        _make_event(
+            event=EVENT_AUDIT_FINDING,
+            subject=subject,
+            metadata={"rule": RULE_STUCK_DRAFT},
+            ts=now - timedelta(minutes=40 + 5 * i),
+        )
+        for i in range(STUCK_DRAFT_TERMINATOR_THRESHOLD)
+    ]
+    create_event = _make_event(
+        event=EVENT_TASK_CREATED, subject=subject, ts=create_ts,
+    )
+
+    findings = [
+        f for f in scan_events([create_event, *prior_findings], now=now)
+        if f.rule == RULE_STUCK_DRAFT
+    ]
+    # The repeating stuck_draft is still suppressed by the in-process
+    # terminator dedup — the detector remains correct, just pure.
+    assert findings == [], (
+        "scan_events must still suppress the repeating stuck_draft "
+        "finding once the terminator threshold is hit"
+    )
+    # ZERO writes — this is the round-3 hardening contract.
+    assert spy_calls == [], (
+        "scan_events performed audit.log.emit calls — detector must be "
+        "pure (no I/O). Cadence path (scan_project) is the only "
+        "authorised emitter for stuck_draft_terminated breadcrumbs. "
+        f"Observed: {spy_calls!r}"
     )
 
 

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -26,11 +26,13 @@ from pollypm.audit.log import (
 from pollypm.audit.watchdog import (
     EVENT_AUDIT_FINDING,
     EVENT_HEARTBEAT_TICK,
+    EVENT_STUCK_DRAFT_TERMINATED,
     RULE_CANCEL_NO_PROMOTION,
     RULE_MARKER_LEAKED,
     RULE_ORPHAN_MARKER,
     RULE_STUCK_DRAFT,
     RULE_TASK_PROGRESS_STALE,
+    STUCK_DRAFT_TERMINATOR_THRESHOLD,
     Finding,
     WatchdogConfig,
     emit_finding,
@@ -288,6 +290,69 @@ def test_stuck_draft_silenced_by_cancellation(now: datetime) -> None:
     ]
     findings = [f for f in scan_events(events, now=now) if f.rule == RULE_STUCK_DRAFT]
     assert findings == []
+
+
+def test_stuck_draft_terminator_emits_after_threshold_and_is_idempotent(
+    now: datetime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2333: after STUCK_DRAFT_TERMINATOR_THRESHOLD prior findings for a
+    subject, the watchdog stops emitting new stuck_draft findings and
+    writes ONE ``audit.stuck_draft_terminated`` breadcrumb. A subsequent
+    scan that also sees that breadcrumb in the events sequence must NOT
+    re-emit the terminator — otherwise the breadcrumb itself cascades.
+    """
+    emitted: list[tuple[str, str | None]] = []
+
+    def _record(*, event: str, subject: str | None = None, **_: object) -> None:
+        emitted.append((event, subject))
+
+    monkeypatch.setattr("pollypm.audit.log.emit", _record)
+
+    # Scan 1: 3 prior stuck_draft findings → terminator engages.
+    create_ts = now - timedelta(minutes=15)
+    prior_findings = [
+        _make_event(
+            event=EVENT_AUDIT_FINDING,
+            subject="demo/2",
+            metadata={"rule": RULE_STUCK_DRAFT},
+            ts=now - timedelta(minutes=30 + 5 * i),
+        )
+        for i in range(STUCK_DRAFT_TERMINATOR_THRESHOLD)
+    ]
+    create_event = _make_event(
+        event=EVENT_TASK_CREATED, subject="demo/2", ts=create_ts,
+    )
+    findings = [
+        f for f in scan_events([create_event, *prior_findings], now=now)
+        if f.rule == RULE_STUCK_DRAFT
+    ]
+    assert findings == [], "terminator should suppress the new finding"
+    terminator_emits = [
+        ev for ev in emitted if ev[0] == EVENT_STUCK_DRAFT_TERMINATED
+    ]
+    assert len(terminator_emits) == 1
+    assert terminator_emits[0][1] == "demo/2"
+
+    # Scan 2: same prior findings + the terminator breadcrumb from
+    # scan 1 in the events sequence. The terminator MUST NOT re-emit.
+    emitted.clear()
+    breadcrumb = _make_event(
+        event=EVENT_STUCK_DRAFT_TERMINATED,
+        subject="demo/2",
+        metadata={"rule": RULE_STUCK_DRAFT},
+        ts=now - timedelta(minutes=1),
+    )
+    findings_scan2 = [
+        f for f in scan_events(
+            [create_event, *prior_findings, breadcrumb], now=now,
+        )
+        if f.rule == RULE_STUCK_DRAFT
+    ]
+    assert findings_scan2 == [], "still suppressed across scans"
+    assert [ev for ev in emitted if ev[0] == EVENT_STUCK_DRAFT_TERMINATED] == [], (
+        "terminator must NOT cascade — already_terminated_subjects guard"
+    )
 
 
 def test_stuck_draft_event_path_cross_checks_open_tasks_status(now: datetime) -> None:


### PR DESCRIPTION
## Summary

Partial fix for the §1.4.4 plan-review-handoff black hole reported in #2333. Two narrowly scoped writer-side changes that close the most painful operational gaps without touching the full traceability redesign.

**Partial fix — full design work (handoff_id correlation, `/api/v1/inbox?type=plan_review` filter, `pm inbox list` subcommand) deferred to v1.0.1.** This PR refs #2333, does not close it.

### Scope 1 — audit emit for plan-review handoff

`emit_plan_review_for_task` now writes an `inbox.plan_review_emitted` audit row after the `enqueue_message` + `svc.create` pair succeeds. Fields: `task_id` (plan task), `inbox_id` (new chat-flow task), `message_id`, `backstop_source`. Operators running §1.4.4 against `~/.pollypm/audit/<project>.jsonl` can now grep `plan_review_emitted` instead of staring at zero hits and concluding the handoff vanished.

### Scope 2 — heartbeat re-flag cascade terminator

`_detect_stuck_drafts` now counts prior `audit.finding` rows for `(rule=stuck_draft, subject=X)` in the same scan window. After `STUCK_DRAFT_TERMINATOR_THRESHOLD = 3` flags on the same subject, the detector drops the finding and emits one `audit.stuck_draft_terminated` breadcrumb. This stops the cascade where pollypm/191-194, 201, 203-205 ("plan_review misrouted to russell/reviewer") meta-bug drafts were re-dispatching the architect every ~40 min, which produced fresh draft churn that itself got re-flagged on the next tick.

Operators can manually retry by promoting (`pm task queue`) or cancelling (`pm task cancel`) the underlying draft — the terminator only stops the auto-re-flagging.

### Deferred to v1.0.1

- Generated `handoff_id` on every plan-review emit, persisted in messages payload + task labels, so downstream `task.claimed_by_session` / `task.status_changed` events can be correlated.
- `/api/v1/inbox?type=plan_review` filter so the API returns plan_review rows by label/kind.
- `pm inbox list --label <x>` subcommand to match the §1.4.4 test-plan prescription.
- Default cockpit/web view surfacing of plan_review_pending rows.

## Test plan

- [x] `pytest tests/test_plan_review_emit.py -x` — 19/19 pass
- [x] `pytest tests/test_audit_watchdog.py -x` — 110/110 pass
- [x] `pytest tests/test_audit_log.py tests/test_audit_log_docs.py -x` — 26/26 pass
- [ ] Manual: emit a plan_review on a standard-flow plan task; grep `~/.pollypm/audit/<project>.jsonl` for `inbox.plan_review_emitted` with the inbox task_id in metadata.
- [ ] Manual: simulate four `audit.finding` rows for the same `stuck_draft` subject; confirm the fifth scan drops the finding and writes one `audit.stuck_draft_terminated` row.

Refs #2333.