### PR TITLE
Surface plan-review handoff trace

### DIFF
--- a/docs/test-plan/01-task-lifecycle.md
+++ b/docs/test-plan/01-task-lifecycle.md
@@ -353,17 +353,19 @@ curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/jso
 sleep 60
 
 # Verify the inbox item exists
-pm inbox list --label plan-review
+pm inbox --json | jq '.tasks[] | select(.kind=="plan_review_pending")'
 # Or via REST:
-curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/inbox?label=plan-review" | jq
+curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/inbox?type=plan_review&state=open" | jq
 
 # Verify audit trail
-grep -E 'plan_review_emit|inbox.message_created' ~/.pollypm/audit/pollypm.jsonl | tail -5
+grep -E '"event":"plan_review\.handoff_created"' ~/.pollypm/audit/pollypm.jsonl | tail -5
 ```
 
 **Pass:**
 - Plan-review item appears in inbox within 30s of architect emission.
 - Inbox item references the source session (`architect_pollypm`) and the plan content.
+- The inbox item metadata/labels include stable `handoff_id` and `correlation_id`
+  values, and the audit row references the same IDs.
 - Operator can act on it (approve, reject, comment) — see §3.4 for UI verification.
 
 **If no inbox item appears:** the emit path is broken. Check `src/pollypm/work/plan_review_emit.py` for the emit site and the audit log for failures. File `bug:plan-review-emit`.

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -124,6 +124,7 @@ EVENT_DAEMON_SERVE_RESPAWN = "daemon.serve.respawn"
 # render plan-history breadcrumbs without scanning task content.
 EVENT_PLAN_VERSION_INCREMENTED = "plan.version_incremented"
 EVENT_PLAN_SUCCESSOR_CREATED = "plan.successor_created"
+EVENT_PLAN_REVIEW_HANDOFF_CREATED = "plan_review.handoff_created"
 # #1414 — auto-unstick infrastructure. ``worker.session_reaped`` fires
 # whenever the worker-marker reaper unlinks an orphan marker (one event
 # per reaped marker); the watchdog's dead-loop detector counts these
@@ -1206,6 +1207,7 @@ __all__ = [
     "EVENT_SOCKET_REAPED",
     "EVENT_PLAN_VERSION_INCREMENTED",
     "EVENT_PLAN_SUCCESSOR_CREATED",
+    "EVENT_PLAN_REVIEW_HANDOFF_CREATED",
     "EVENT_WORKER_SESSION_REAPED",
     "EVENT_WATCHDOG_ESCALATION_DISPATCHED",
     "EVENT_WATCHDOG_OPERATOR_DISPATCHED",

--- a/src/pollypm/notify_task.py
+++ b/src/pollypm/notify_task.py
@@ -32,8 +32,11 @@ Contract:
 
 from __future__ import annotations
 
+from pollypm.inbox.kind import InboxItemKind, coerce_kind
+
 
 NOTIFY_LABEL = "notify"
+PLAN_REVIEW_LABEL = "plan_review"
 
 
 # Title prefixes used by historical notification writers. Kept as a
@@ -89,6 +92,17 @@ def _coerce_roles(value: object) -> dict[str, str]:
         if isinstance(parsed, dict):
             return {str(k): str(v) for k, v in parsed.items()}
     return {}
+
+
+def _labels(value: object) -> set[str]:
+    raw = getattr(value, "labels", None) or []
+    return {str(label) for label in raw}
+
+
+def _is_plan_review_pending_entry(item) -> bool:
+    if coerce_kind(getattr(item, "kind", None)) is InboxItemKind.PLAN_REVIEW_PENDING:
+        return True
+    return PLAN_REVIEW_LABEL in _labels(item)
 
 
 def is_notify_inbox_task(task) -> bool:
@@ -154,8 +168,14 @@ def is_notify_only_inbox_entry(item) -> bool:
     Anything else — work-service tasks, ``alert``-type messages,
     ``inbox_task``-type messages — is treated as actionable and stays
     visible by default.
+
+    Plan-review rows are the exception to the notify-stub rule: they
+    are notify-shaped so the Tasks view hides them, but they are still
+    actionable inbox decisions and must remain visible in inbox lenses.
     """
     source = getattr(item, "source", "task")
+    if _is_plan_review_pending_entry(item):
+        return False
     if source == "message":
         message_type = (getattr(item, "message_type", None) or "").lower()
         # Only the bare ``notify`` type is hidden by default; alerts and

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -4414,6 +4414,14 @@ def _task_to_inbox_item(
     }
     if is_plan_review:
         metadata["judgment_calls"] = _extract_judgment_calls(body)
+    for key in ("handoff_id", "correlation_id"):
+        prefix = f"{key}:"
+        value = next(
+            (label[len(prefix):] for label in labels if label.startswith(prefix)),
+            None,
+        )
+        if value:
+            metadata[key] = value
     return APIInboxItem(
         id=task.task_id,
         project=task.project,

--- a/src/pollypm/work/plan_review_emit.py
+++ b/src/pollypm/work/plan_review_emit.py
@@ -49,6 +49,7 @@ run ``pm notify`` perfectly.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -141,6 +142,13 @@ def task_is_pending_plan_approval(task: Any) -> bool:
 
 def _plan_task_label(task_id: str) -> str:
     return f"plan_task:{task_id}"
+
+
+def _plan_review_handoff_ids(plan_task_id: str) -> tuple[str, str]:
+    digest = hashlib.sha256(
+        f"plan_review:{plan_task_id}".encode("utf-8"),
+    ).hexdigest()[:16]
+    return f"plan-review-{digest}", f"plan-review:{plan_task_id}"
 
 
 def already_has_plan_review_message(
@@ -267,6 +275,49 @@ def _build_plan_review_user_prompt(plan_task_id: str) -> dict[str, Any]:
     }
 
 
+def _emit_plan_review_handoff_audit(
+    *,
+    project: str,
+    plan_task_id: str,
+    inbox_task_id: str,
+    message_id: int | None,
+    handoff_id: str,
+    correlation_id: str,
+    actor: str,
+    requester: str,
+    source: str,
+    project_path: Path | str | None,
+) -> None:
+    try:
+        from pollypm.audit.log import (
+            EVENT_PLAN_REVIEW_HANDOFF_CREATED,
+            emit as _audit_emit,
+        )
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        _audit_emit(
+            event=EVENT_PLAN_REVIEW_HANDOFF_CREATED,
+            project=project,
+            subject=plan_task_id,
+            actor=actor or "audit_watchdog",
+            status="ok",
+            metadata={
+                "handoff_id": handoff_id,
+                "correlation_id": correlation_id,
+                "plan_task_id": plan_task_id,
+                "inbox_task_id": inbox_task_id,
+                "message_id": message_id,
+                "source": source,
+                "requester": requester,
+                "kind": InboxItemKind.PLAN_REVIEW_PENDING.value,
+            },
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        return
+
+
 def emit_plan_review_for_task(
     *,
     svc: Any,
@@ -308,10 +359,13 @@ def emit_plan_review_for_task(
     subject = f"Plan ready for review: {project}"
     body = _build_plan_review_body(plan_task_id, source=source)
     target_label = _plan_task_label(plan_task_id)
+    handoff_id, correlation_id = _plan_review_handoff_ids(plan_task_id)
     labels = [
         PLAN_REVIEW_LABEL,
         f"project:{project}",
         target_label,
+        f"handoff_id:{handoff_id}",
+        f"correlation_id:{correlation_id}",
     ]
     user_prompt = _build_plan_review_user_prompt(plan_task_id)
 
@@ -354,6 +408,8 @@ def emit_plan_review_for_task(
                 "requester": requester,
                 "user_prompt": user_prompt,
                 "plan_task_id": plan_task_id,
+                "handoff_id": handoff_id,
+                "correlation_id": correlation_id,
                 "backstop_source": source,
             },
             state="closed",  # mirrors session_runtime.notify for immediate tier
@@ -424,6 +480,8 @@ def emit_plan_review_for_task(
                     "user_prompt": user_prompt,
                     "plan_task_id": plan_task_id,
                     "task_id": inbox_task_id,
+                    "handoff_id": handoff_id,
+                    "correlation_id": correlation_id,
                     "backstop_source": source,
                 },
             )
@@ -432,6 +490,18 @@ def emit_plan_review_for_task(
                 "plan_review_emit: update_message failed for %s",
                 plan_task_id, exc_info=True,
             )
+    _emit_plan_review_handoff_audit(
+        project=project,
+        plan_task_id=plan_task_id,
+        inbox_task_id=inbox_task_id,
+        message_id=message_id,
+        handoff_id=handoff_id,
+        correlation_id=correlation_id,
+        actor=actor or "audit_watchdog",
+        requester=requester,
+        source=source,
+        project_path=getattr(svc, "_project_path", None),
+    )
     return inbox_task_id
 
 

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -2296,6 +2296,45 @@ def test_list_inbox_type_filter_matches_structured_kind(
     assert svc.candidate_calls[0]["type_filter"] == "approval_request"
 
 
+def test_list_inbox_default_keeps_plan_review_notify_stub(
+    client, auth_headers, monkeypatch,
+) -> None:
+    from pollypm.inbox.kind import InboxItemKind
+
+    svc = _ReadInboxSvc([
+        _ReadInboxTask(
+            1,
+            title="Plan ready for review: myproj",
+            kind=InboxItemKind.PLAN_REVIEW_PENDING,
+            labels=[
+                "plan_review",
+                "project:myproj",
+                "plan_task:myproj/7",
+                "handoff_id:plan-review-abc123",
+                "correlation_id:plan-review:myproj/7",
+                "notify",
+            ],
+        ),
+        _ReadInboxTask(2, title="Draft notify", labels=["notify"]),
+    ])
+    _install_read_inbox_svc(monkeypatch, svc)
+
+    response = client.get(
+        "/api/v1/inbox?project=myproj&type=plan_review",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [item["id"] for item in body["items"]] == ["myproj/1"]
+    item = body["items"][0]
+    assert item["type"] == "plan_review"
+    assert item["metadata"]["kind"] == "plan_review_pending"
+    assert item["metadata"]["handoff_id"] == "plan-review-abc123"
+    assert item["metadata"]["correlation_id"] == "plan-review:myproj/7"
+    assert svc.candidate_calls[0]["type_filter"] == "plan_review"
+
+
 def test_list_inbox_includes_priority(
     client, auth_headers, monkeypatch,
 ) -> None:

--- a/tests/test_notify_task.py
+++ b/tests/test_notify_task.py
@@ -9,6 +9,7 @@ from pollypm.notify_task import (
     is_notify_inbox_task,
     is_notify_only_inbox_entry,
 )
+from pollypm.inbox.kind import InboxItemKind
 from pollypm.work.models import Priority, Task, TaskType, WorkStatus
 
 
@@ -291,3 +292,22 @@ class TestIsNotifyOnlyInboxEntry:
         """Notify-stub tasks (label / title) defer to is_notify_inbox_task."""
         task = _make_task(labels=[NOTIFY_LABEL])
         assert is_notify_only_inbox_entry(task) is True
+
+    def test_plan_review_notify_stub_stays_visible(self) -> None:
+        """Plan-review handoffs are actionable even though they are notify-shaped."""
+        task = _make_task(
+            labels=[
+                "plan_review",
+                "project:demo",
+                "plan_task:demo/1",
+                NOTIFY_LABEL,
+            ],
+        )
+        task.kind = InboxItemKind.PLAN_REVIEW_PENDING
+        assert is_notify_inbox_task(task) is True
+        assert is_notify_only_inbox_entry(task) is False
+
+    def test_legacy_plan_review_label_stays_visible(self) -> None:
+        """Older plan-review rows may have the label before kind backfill."""
+        task = _make_task(labels=["plan_review", NOTIFY_LABEL])
+        assert is_notify_only_inbox_entry(task) is False

--- a/tests/test_plan_review_emit.py
+++ b/tests/test_plan_review_emit.py
@@ -248,8 +248,18 @@ def test_pending_plan_approval_requires_plan_project_user_node() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_emit_creates_message_and_task(db_path: Path) -> None:
+def test_emit_creates_message_and_task(
+    db_path: Path,
+    fake_message_store: _MemoryMessageStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """First emit writes both the messages row and the inbox task."""
+    audit_events: list[dict[str, Any]] = []
+
+    def fake_audit_emit(**kwargs: Any) -> None:
+        audit_events.append(kwargs)
+
+    monkeypatch.setattr("pollypm.audit.log.emit", fake_audit_emit)
     task = _FakeTask(
         project="coffeeboardnm",
         task_number=1,
@@ -276,6 +286,14 @@ def test_emit_creates_message_and_task(db_path: Path) -> None:
     assert "plan_task:coffeeboardnm/1" in labels
     assert "project:coffeeboardnm" in labels
     assert "notify" in labels
+    handoff_labels = [label for label in labels if label.startswith("handoff_id:")]
+    correlation_labels = [
+        label for label in labels if label.startswith("correlation_id:")
+    ]
+    assert len(handoff_labels) == 1
+    assert len(correlation_labels) == 1
+    handoff_id = handoff_labels[0].split(":", 1)[1]
+    correlation_id = correlation_labels[0].split(":", 1)[1]
 
     # And a plan_review message lives in the messages table now.
     assert already_has_plan_review_message(
@@ -283,6 +301,22 @@ def test_emit_creates_message_and_task(db_path: Path) -> None:
         project="coffeeboardnm",
         plan_task_id="coffeeboardnm/1",
     )
+    [message] = fake_message_store._messages
+    assert message["payload"]["task_id"] == inbox_task_id
+    assert message["payload"]["handoff_id"] == handoff_id
+    assert message["payload"]["correlation_id"] == correlation_id
+
+    assert len(audit_events) == 1
+    audit = audit_events[0]
+    assert audit["event"] == "plan_review.handoff_created"
+    assert audit["project"] == "coffeeboardnm"
+    assert audit["subject"] == "coffeeboardnm/1"
+    assert audit["metadata"]["handoff_id"] == handoff_id
+    assert audit["metadata"]["correlation_id"] == correlation_id
+    assert audit["metadata"]["plan_task_id"] == "coffeeboardnm/1"
+    assert audit["metadata"]["inbox_task_id"] == inbox_task_id
+    assert audit["metadata"]["message_id"] == message["id"]
+    assert audit["metadata"]["kind"] == "plan_review_pending"
 
 
 def test_emit_does_not_require_legacy_db_path(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Keep `plan_review` / `plan_review_pending` inbox rows visible in the default inbox lens even when they are notify-shaped task stubs.
- Persist deterministic `handoff_id` and `correlation_id` values in plan-review message payloads, task labels, and API inbox metadata.
- Emit `plan_review.handoff_created` audit events after the message + inbox task are created.
- Update §1.4.4 test-plan commands to use the real `pm inbox --json` and REST `type=plan_review` surfaces.

## Verification
- `uv run --extra test pytest tests/test_plan_review_emit.py tests/test_notify_task.py tests/test_inbox_writes_endpoint.py -q` (`102 passed in 730.39s`)
- `uv run --extra test pytest tests/test_plan_review_emit.py tests/test_notify_task.py -q` (`38 passed in 88.36s`, after rebase onto current `origin/main`)

Closes #2333
