### PR TITLE
fix(api): stop terminal task dwell ticking

### DIFF
--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -42,7 +42,12 @@ from pollypm.work.inbox_view import (
     is_inbox_task,
     is_inbox_task_identity,
 )
-from pollypm.work.models import TaskSummaryCursorError, TaskSummaryProjection
+from pollypm.task_invariants import metadata_for
+from pollypm.work.models import (
+    TaskSummaryCursorError,
+    TaskSummaryProjection,
+    WorkStatus,
+)
 from pollypm.web_api.errors import (
     APIError,
     not_found,
@@ -3701,7 +3706,7 @@ def _task_summary_projection_to_api(row: TaskSummaryProjection) -> APITaskSummar
         plan_version=row.plan_version,
         created_at=created_at,
         state_entered_at=state_entered_at,
-        dwell_seconds=_elapsed_seconds(state_entered_at, now),
+        dwell_seconds=_dwell_seconds(row.work_status, state_entered_at, now),
         age_seconds=_elapsed_seconds(created_at, now),
         updated_at=_as_aware_datetime(row.updated_at),
     )
@@ -3711,7 +3716,9 @@ def _task_timing_fields(task) -> dict[str, datetime | int | None]:
     created_at = _as_aware_datetime(getattr(task, "created_at", None))
     state_entered_at = _state_entered_at(task)
     now = datetime.now(timezone.utc)
-    dwell_seconds = _elapsed_seconds(state_entered_at, now)
+    dwell_seconds = _dwell_seconds(
+        _enum_value(getattr(task, "work_status", "")), state_entered_at, now
+    )
     age_seconds = _elapsed_seconds(created_at, now)
     return {
         "created_at": created_at,
@@ -3730,6 +3737,22 @@ def _state_entered_at(task) -> datetime | None:
             if entered is not None:
                 return entered
     return _as_aware_datetime(getattr(task, "created_at", None))
+
+
+def _dwell_seconds(
+    work_status: object, state_entered_at: datetime | None, now: datetime
+) -> int | None:
+    if _is_terminal_work_status(work_status):
+        return None
+    return _elapsed_seconds(state_entered_at, now)
+
+
+def _is_terminal_work_status(work_status: object) -> bool:
+    value = _enum_value(work_status)
+    try:
+        return metadata_for(WorkStatus(value)).is_terminal
+    except ValueError:
+        return False
 
 
 def _as_aware_datetime(value: Any) -> datetime | None:

--- a/tests/web_api/test_endpoints.py
+++ b/tests/web_api/test_endpoints.py
@@ -222,6 +222,26 @@ def test_get_task_detail_renders_full_record(api_config, client, auth_headers, p
     assert "relationships" in body
 
 
+def test_get_task_detail_terminal_dwell_is_stable_null(
+    api_config, client, auth_headers, project_root
+) -> None:
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        task = make_task(svc, project="myproj", title="Done detail")
+        done = svc.mark_done(task.task_id, actor="tester")
+
+    response = client.get(
+        f"/api/v1/tasks/myproj/{done.task_number}", headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["work_status"] == "done"
+    assert body["state_entered_at"] is not None
+    assert body["dwell_seconds"] is None
+    assert isinstance(body["age_seconds"], int)
+
+
 def test_get_task_detail_404_for_unknown_task(client, auth_headers) -> None:
     response = client.get("/api/v1/tasks/myproj/9999", headers=auth_headers)
     assert response.status_code == 404

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -172,6 +172,24 @@ def test_list_tasks_timing_uses_latest_transition(
     assert item["age_seconds"] > item["dwell_seconds"]
 
 
+def test_list_tasks_terminal_dwell_is_stable_null(
+    api_config, client, auth_headers, project_root
+) -> None:
+    db_path = api_config.project.state_db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with create_work_service(db_path=db_path, project_path=project_root) as svc:
+        task = make_task(svc, project="myproj", title="Completed")
+        svc.mark_done(task.task_id, actor="tester")
+
+    response = client.get("/api/v1/tasks?project=myproj", headers=auth_headers)
+    assert response.status_code == 200, response.text
+    [item] = response.json()["items"]
+    assert item["work_status"] == "done"
+    assert item["state_entered_at"] is not None
+    assert item["dwell_seconds"] is None
+    assert isinstance(item["age_seconds"], int)
+
+
 def test_list_all_tasks_uses_list_rows_without_per_item_refetch(
     api_config, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Return `dwell_seconds: null` for terminal work statuses using the canonical task invariant metadata.
- Apply the same terminal guard to hydrated task details and summary-projection list rows.
- Add REST regressions for terminal task detail and flat task list responses.

## Tests
- `uv run --extra test pytest tests/web_api/test_endpoints.py::test_get_task_detail_renders_full_record tests/web_api/test_endpoints.py::test_get_task_detail_terminal_dwell_is_stable_null tests/web_api/test_tasks_list_endpoint.py::test_list_tasks_timing_uses_latest_transition tests/web_api/test_tasks_list_endpoint.py::test_list_tasks_terminal_dwell_is_stable_null -q`
- `uv run --extra test pytest tests/web_api/test_endpoints.py::test_get_task_detail_terminal_dwell_is_stable_null tests/web_api/test_tasks_list_endpoint.py::test_list_tasks_terminal_dwell_is_stable_null -q`

Closes #2339