### PR TITLE
fix(smoke): warm up dashboard/sessions before timing assertion

### DIFF
--- a/docs/test-plan/07-quick-smoke.md
+++ b/docs/test-plan/07-quick-smoke.md
@@ -35,7 +35,7 @@ If §07 is green, you can ship a small change. If §07 is red, **do not ship** �
 
 When you have 5 minutes (e.g., post-merge sanity, mid-incident):
 
-1. **REST liveness** (1 min) — `/health`, `/dashboard`, `/chat/sessions` all 200 + sub-second.
+1. **REST liveness** (1 min) — `/health` 200; `/dashboard` and `/chat/sessions` 200 with **warm** response sub-second (see warmup-then-measure note in REST liveness section — first hit may be cold).
 2. **Web UI load + 3 clicks** (2 min) — open `/ui/`, click 3 surfaces, verify each <1s.
 3. **Send-receive round-trip** (2 min) — Web → tmux (<1s), tmux → Web (<5s).
 
@@ -64,8 +64,16 @@ export TOKEN=$(cat ~/.pollypm/api-token)
 
 ### REST liveness (1 min)
 
+**Warmup-then-measure contract.** `scripts/smoke.py` discards a first request to `/dashboard` and `/chat/sessions` (cold hit; cache population is expected to take up to ~1.2s on a freshly-restarted `pm serve`) and asserts the **second** (warm) request is under 1.0s. This matches §06.4 separating cold vs. warm budgets. `/health` has no warmup and no timing assertion.
+
+If you're running curl manually rather than `scripts/smoke.py`, run each command **twice** and check the second timing — or open the Web UI first, wait ~5 seconds for caches to warm, then time the requests below.
+
 ```bash
 curl -sS $BASE/api/v1/health
+# Warmup hit (discard timing — cold cache):
+curl -sS -o /dev/null -H "Authorization: Bearer $TOKEN" $BASE/api/v1/dashboard
+curl -sS -o /dev/null -H "Authorization: Bearer $TOKEN" $BASE/api/v1/chat/sessions
+# Measured hit (warm — this is what the smoke contract asserts):
 curl -sS -o /dev/null -w "dashboard %{http_code} %{time_total}s\n" -H "Authorization: Bearer $TOKEN" $BASE/api/v1/dashboard
 curl -sS -o /dev/null -w "sessions %{http_code} %{time_total}s\n" -H "Authorization: Bearer $TOKEN" $BASE/api/v1/chat/sessions
 curl -sS -H "Authorization: Bearer $TOKEN" $BASE/api/v1/dashboard | jq '.daemon_status'
@@ -75,7 +83,7 @@ curl -sS -H "Authorization: Bearer $TOKEN" $BASE/api/v1/chat/sessions | jq '.ses
 - ☐ `/health` returns `{"status":"ok",...}` 200.
 - ☐ `/dashboard` returns JSON with `daemon_status` present, 200.
 - ☐ `/chat/sessions` returns a list of >0 sessions.
-- ☐ Single-shot `/dashboard` and `/chat/sessions` are both comfortably under 1s. If not, run §06.
+- ☐ **Warm** `/dashboard` and `/chat/sessions` (second request) are both under 1.0s. A cold first-hit above 1s is **by design** (cache warmup). A **warmed** request exceeding 1.0s is a real failure — red the smoke and run §06.
 
 ### Web UI (3 min)
 

--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -180,6 +180,14 @@ def get_json(url: str, *, token: str | None, timeout_seconds: float = 5.0) -> tu
         return response.status, json.loads(body)
 
 
+# Endpoints whose timing is asserted against the §07 sub-second contract.
+# These get a discarded warmup hit before the measured request so a cold-cache
+# first-hit (e.g. 1.2s on a fresh `pm serve`) does not red the smoke when the
+# steady-state response is well under budget (§06.4 dashboard warm p95 < 150ms).
+WARMUP_REST_CHECKS: frozenset[str] = frozenset({"dashboard", "sessions"})
+WARM_RESPONSE_BUDGET_SECONDS: float = 1.0
+
+
 def run_rest_check(
     name: str,
     url: str,
@@ -193,6 +201,17 @@ def run_rest_check(
     if dry_run:
         auth = " with bearer token" if token else ""
         return CheckResult(name, True, f"DRY RUN GET {url}{auth}", skipped=True)
+
+    # Discard a warmup hit so the measured request reflects steady-state
+    # response time, not cold-start cache population. See §07 "comfortably
+    # under 1s" + §06.4 warm budgets.
+    if name in WARMUP_REST_CHECKS:
+        try:
+            get_json(url, token=token)
+        except Exception:
+            # Surface the real error on the measured attempt below; if the
+            # warmup hit is genuinely broken the measured call will fail too.
+            pass
 
     started = time.monotonic()
     try:
@@ -222,7 +241,7 @@ def run_rest_check(
         sessions = payload.get("sessions")
         if not isinstance(sessions, list) or not sessions:
             return CheckResult(name, False, "expected non-empty sessions list", elapsed)
-    if elapsed > 1.0 and name in {"dashboard", "sessions"}:
+    if elapsed > WARM_RESPONSE_BUDGET_SECONDS and name in WARMUP_REST_CHECKS:
         return CheckResult(name, False, f"slow response {elapsed:.3f}s", elapsed)
     return CheckResult(name, True, f"HTTP 200 in {elapsed:.3f}s", elapsed)
 

--- a/tests/test_smoke_script.py
+++ b/tests/test_smoke_script.py
@@ -111,6 +111,78 @@ def test_run_smoke_exits_nonzero_when_slow_rest_check_fails(monkeypatch, capsys)
     assert "Failed checks: dashboard" in output
 
 
+def test_run_rest_check_discards_cold_first_hit_for_dashboard(monkeypatch) -> None:
+    """Dashboard/sessions get a discarded warmup hit; measurement reflects the
+    second (warm) request. A cold-hit-then-warm pattern must pass even though
+    the cold hit alone would have exceeded the 1s smoke threshold."""
+    calls: list[str] = []
+
+    def fake_get_json(url: str, *, token: str | None, timeout_seconds: float = 5.0):
+        calls.append(url)
+        return 200, {"daemon_status": "ok"}
+
+    # run_rest_check calls time.monotonic() exactly twice on the measured
+    # request (start + end). The warmup hit doesn't time itself.
+    timings = iter([0.000, 0.050])
+    monkeypatch.setattr(smoke, "get_json", fake_get_json)
+    monkeypatch.setattr(smoke.time, "monotonic", lambda: next(timings))
+
+    result = smoke.run_rest_check(
+        "dashboard",
+        "http://127.0.0.1:8765/api/v1/dashboard",
+        token="t",
+        required_key="daemon_status",
+    )
+
+    # Two HTTP hits: one warmup, one measured.
+    assert len(calls) == 2
+    assert result.ok
+    assert result.elapsed_seconds == 0.050
+    assert "HTTP 200 in 0.050s" == result.detail
+
+
+def test_run_rest_check_health_does_not_warmup(monkeypatch) -> None:
+    """Endpoints outside WARMUP_REST_CHECKS get a single request only."""
+    calls: list[str] = []
+
+    def fake_get_json(url: str, *, token: str | None, timeout_seconds: float = 5.0):
+        calls.append(url)
+        return 200, {"status": "ok"}
+
+    monkeypatch.setattr(smoke, "get_json", fake_get_json)
+
+    result = smoke.run_rest_check(
+        "health",
+        "http://127.0.0.1:8765/api/v1/health",
+        token=None,
+        expected_value=("status", "ok"),
+    )
+
+    assert len(calls) == 1
+    assert result.ok
+
+
+def test_run_rest_check_fails_when_warm_response_exceeds_budget(monkeypatch) -> None:
+    """After warmup, a still-slow measured response (>1s) must still fail."""
+
+    def fake_get_json(url: str, *, token: str | None, timeout_seconds: float = 5.0):
+        return 200, {"daemon_status": "ok"}
+
+    monkeypatch.setattr(smoke, "get_json", fake_get_json)
+    timings = iter([0.000, 1.500])
+    monkeypatch.setattr(smoke.time, "monotonic", lambda: next(timings))
+
+    result = smoke.run_rest_check(
+        "dashboard",
+        "http://127.0.0.1:8765/api/v1/dashboard",
+        token="t",
+        required_key="daemon_status",
+    )
+
+    assert not result.ok
+    assert "slow response 1.500s" == result.detail
+
+
 def test_dry_run_avoids_command_execution() -> None:
     result, stdout = smoke.run_command(
         smoke.CommandSpec("doctor", ("pm", "doctor")),


### PR DESCRIPTION
## Summary
- `scripts/smoke.py` red-flagged any single-shot `/dashboard` or `/chat/sessions` response above 1.0s. Observed against a fresh `pm serve`: dashboard cold-hit is **1.215s**, warm is **87ms** — the warm path is comfortably inside the §06.4 dashboard warm budget (p95 < 150ms). The 1s gate was catching cold-cache start, not real slowness.
- Per §07 the smoke checks "comfortably under 1s" against steady state. This patch makes that explicit: `dashboard` and `sessions` get a discarded warmup hit, then the second (warm) request is what we measure and assert.
- `health` is unchanged (no warmup, no timing assertion). Source change is ~20 LOC.

## Why this approach
§06.4 documents separate cold/warm budgets (cold p95 < 300ms M-scale; warm p95 < 150ms). The §07 single-shot smoke probe is by definition a cold hit on a freshly-restarted `pm serve` — so asserting the warm budget against the cold request is a category error. Approach (a) from the bug brief: warmup-then-measure, applied only to the two endpoints that already had the 1s gate.

## Context
- Observed during overnight engagement-loop runs; see `docs/test-plan/journals/2026-05-23-ship-readiness.md` (the most recent ship-readiness journal in tree).
- Unblocks stop-condition #3 of the engagement loop (smoke green on fresh `pm serve`).

## Test plan
- [x] `uv run --extra test pytest tests/test_smoke_script.py -x --no-header -q` — 11 passed
- [x] Existing `test_run_smoke_exits_nonzero_when_slow_rest_check_fails` still pins the failure path (post-warmup slow → red).
- [x] New tests:
  - `test_run_rest_check_discards_cold_first_hit_for_dashboard` — two HTTP hits, only the second is timed.
  - `test_run_rest_check_health_does_not_warmup` — endpoints outside `WARMUP_REST_CHECKS` get one hit.
  - `test_run_rest_check_fails_when_warm_response_exceeds_budget` — a still-slow warm response (>1s) still fails.
- [ ] Manual: re-run `scripts/smoke.py` against a fresh `pm serve` and confirm dashboard/sessions pass without retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)