### PR TITLE
fix(chat): restore transcript fidelity and speed sends

### DIFF
--- a/docs/test-plan/02-translation-layer.md
+++ b/docs/test-plan/02-translation-layer.md
@@ -265,6 +265,16 @@ curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application
 
 **Expected:** 200, message lands even mid-stream. Confirms force bypass works.
 
+Then verify the audit trail:
+```bash
+tail -20 ~/.pollypm/audit/pollypm.jsonl | \
+  jq 'select(.event == "chat.send.force_bypass") | {event, status, subject, metadata}'
+```
+
+**Pass:** a `chat.send.force_bypass` event exists with `status: "warn"`,
+the target session in `subject`, a `metadata.bypassed_gates` array naming the
+skipped safety gates, and no injected message text in metadata.
+
 ### 2.4.4 Dead session
 
 ```bash

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -212,6 +212,7 @@ EVENT_TIER4_ACTION = "audit.tier4_action"
 EVENT_TIER4_GLOBAL_ACTION = "audit.tier4_global_action"
 EVENT_TIER4_DEMOTED = "audit.tier4_demoted"
 EVENT_TIER4_BUDGET_EXHAUSTED = "audit.tier4_budget_exhausted"
+EVENT_CHAT_SEND_FORCE_BYPASS = "chat.send.force_bypass"
 # #1413 — emitted whenever the supervisor / on-demand path provisions a
 # project-scoped role session (e.g. reviewer-<project>) that did not
 # previously exist. The watchdog (#1414) reads this stream to surface

--- a/src/pollypm/tmux/client.py
+++ b/src/pollypm/tmux/client.py
@@ -577,6 +577,65 @@ class TmuxClient:
             )
         return windows
 
+    def get_window(
+        self, target: str, *, timeout: int | None = None,
+    ) -> TmuxWindow | None:
+        """Return one tmux window by target without listing the session."""
+        fmt = (
+            "#{session_name}\t#{window_index}\t#{window_name}\t#{window_active}\t#{pane_id}\t"
+            "#{pane_current_command}\t#{pane_current_path}\t#{pane_dead}\t#{pane_pid}"
+        )
+        result = self.run(
+            "display-message",
+            "-t",
+            self._exact_target(target),
+            "-p",
+            fmt,
+            check=False,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            if result.returncode == 124:
+                raise subprocess.TimeoutExpired(
+                    cmd=["tmux", "display-message", "-t", target],
+                    timeout=timeout or self._DEFAULT_TIMEOUT,
+                )
+            return None
+        line = result.stdout.strip()
+        if not line:
+            return None
+        parts = line.split("\t", 8)
+        if len(parts) < 8:
+            return None
+        (
+            session,
+            index,
+            window_name,
+            active,
+            pane_id,
+            pane_current_command,
+            pane_current_path,
+            pane_dead,
+            *rest,
+        ) = parts
+        pane_pid: int | None = None
+        if rest:
+            try:
+                pane_pid = int(rest[0])
+            except ValueError:
+                pane_pid = None
+        return TmuxWindow(
+            session=session,
+            index=int(index),
+            name=window_name,
+            active=active == "1",
+            pane_id=pane_id,
+            pane_current_command=pane_current_command,
+            pane_current_path=pane_current_path,
+            pane_dead=pane_dead == "1",
+            pane_pid=pane_pid,
+        )
+
     def list_all_windows(self) -> list[TmuxWindow]:
         """List windows across ALL tmux sessions in a single subprocess call."""
         fmt = (
@@ -681,7 +740,14 @@ class TmuxClient:
         result = self.run("capture-pane", "-p", "-S", f"-{lines}", "-t", self._exact_target(target))
         return result.stdout
 
-    def send_keys(self, target: str, text: str, press_enter: bool = True) -> None:
+    def send_keys(
+        self,
+        target: str,
+        text: str,
+        press_enter: bool = True,
+        *,
+        enter_delay_seconds: float = 0.5,
+    ) -> None:
         """Send keys to a pane. Raises DeadPaneError if the target pane is dead."""
         import time
         resolved = self._exact_target(target)
@@ -735,7 +801,8 @@ class TmuxClient:
             self.run("send-keys", "-l", "-t", resolved, text)
         if press_enter:
             # Delay to let the terminal process pasted text before Enter.
-            time.sleep(0.5)
+            if enter_delay_seconds > 0:
+                time.sleep(enter_delay_seconds)
             self.run("send-keys", "-t", resolved, "Enter")
 
     def attach_session(self, name: str) -> int:

--- a/src/pollypm/transcript_ingest.py
+++ b/src/pollypm/transcript_ingest.py
@@ -89,6 +89,74 @@ def _extract_text(value: Any) -> str:
     return ""
 
 
+def _json_object_from_string(value: Any) -> dict[str, Any]:
+    if not isinstance(value, str) or not value.strip():
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return {"value": value}
+    return parsed if isinstance(parsed, dict) else {"value": parsed}
+
+
+def _codex_reasoning_text(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary")
+    if not isinstance(summary, list):
+        return ""
+    parts: list[str] = []
+    for item in summary:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if isinstance(text, str) and text:
+            parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def _codex_tool_call_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    payload_type = str(payload.get("type") or "tool_call")
+    call_id = str(payload.get("call_id") or payload.get("id") or "")
+    tool_name = str(
+        payload.get("name")
+        or payload.get("tool_name")
+        or payload.get("tool")
+        or payload_type
+    )
+    raw_input = (
+        payload.get("arguments")
+        if "arguments" in payload
+        else payload.get("input")
+    )
+    tool_input = raw_input if isinstance(raw_input, dict) else _json_object_from_string(raw_input)
+    out = dict(payload)
+    if call_id:
+        out["id"] = call_id
+    out["name"] = tool_name
+    out["input"] = tool_input
+    return out
+
+
+def _codex_tool_result_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    call_id = str(
+        payload.get("call_id")
+        or payload.get("id")
+        or payload.get("tool_use_id")
+        or ""
+    )
+    content = (
+        payload.get("output")
+        if "output" in payload
+        else payload.get("content", payload.get("text"))
+    )
+    out = dict(payload)
+    if call_id:
+        out["tool_use_id"] = call_id
+    if content is not None:
+        out["content"] = content
+        out["output"] = content
+    return out
+
+
 def _project_key_for_cwd(config, cwd: str | None) -> str:
     if not cwd:
         return config.project.name
@@ -483,7 +551,7 @@ def _normalize_codex_line(
             cursor.model_name = model_name
         return events
 
-    if entry_type != "event_msg":
+    if entry_type not in {"event_msg", "response_item"}:
         return events
 
     session_id = cursor.session_id or source_path.stem
@@ -491,6 +559,70 @@ def _normalize_codex_line(
     project_key = _project_key_for_cwd(config, cwd)
     model_name = cursor.model_name
     payload_type = payload.get("type")
+
+    if entry_type == "response_item":
+        common = {
+            "session_id": session_id,
+            "account_name": account_name,
+            "provider": account.provider.value,
+            "project_key": project_key,
+            "timestamp": timestamp,
+            "source_path": source_path,
+            "source_offset": source_offset,
+            "cwd": cwd,
+            "model_name": model_name,
+        }
+        if payload_type == "message":
+            text = _extract_text(
+                payload.get("content")
+                or payload.get("text")
+                or payload.get("message")
+                or payload
+            )
+            if text:
+                role = str(payload.get("role") or "assistant")
+                event_type = "user_turn" if role == "user" else "assistant_turn"
+                events.append(_event_base(
+                    event_type=event_type,
+                    payload={"text": text},
+                    **common,
+                ))
+        elif payload_type in {
+            "function_call",
+            "custom_tool_call",
+            "tool_search_call",
+        }:
+            events.append(_event_base(
+                event_type="tool_call",
+                payload=_codex_tool_call_payload(payload),
+                **common,
+            ))
+        elif payload_type in {
+            "function_call_output",
+            "custom_tool_call_output",
+            "tool_search_output",
+        }:
+            events.append(_event_base(
+                event_type="tool_result",
+                payload=_codex_tool_result_payload(payload),
+                **common,
+            ))
+        elif payload_type == "reasoning":
+            text = _codex_reasoning_text(payload)
+            if text:
+                events.append(_event_base(
+                    event_type="thinking",
+                    payload={
+                        "text": text,
+                        "signature": "",
+                        "raw": {
+                            "type": "reasoning",
+                            "summary": payload.get("summary"),
+                        },
+                    },
+                    **common,
+                ))
+        return events
 
     if payload_type == "token_count":
         info = payload.get("info") if isinstance(payload.get("info"), dict) else {}
@@ -536,7 +668,7 @@ def _normalize_codex_line(
                     payload={"text": text},
                 )
             )
-    elif payload_type == "assistant_message":
+    elif payload_type in {"assistant_message", "agent_message"}:
         text = _extract_text(payload.get("text") or payload.get("message") or payload)
         if text:
             events.append(
@@ -567,7 +699,7 @@ def _normalize_codex_line(
                 source_offset=source_offset,
                 cwd=cwd,
                 model_name=model_name,
-                payload=payload,
+                payload=_codex_tool_call_payload(payload),
             )
         )
     elif payload_type == "tool_result":
@@ -583,7 +715,7 @@ def _normalize_codex_line(
                 source_offset=source_offset,
                 cwd=cwd,
                 model_name=model_name,
-                payload=payload,
+                payload=_codex_tool_result_payload(payload),
             )
         )
     elif payload_type == "turn_end":
@@ -602,12 +734,31 @@ def _normalize_codex_line(
                 payload=payload,
             )
         )
-    # TODO(#2048): Codex rollouts do not currently surface a ``reasoning``
-    # ``event_msg`` payload type — only ``reasoning_output_tokens`` is
-    # exposed via the ``token_count`` info blob (see line ~413). Wire a
-    # ``thinking`` branch here if/when Codex starts emitting reasoning
-    # content blocks; until then leaving this absent so the parser
-    # contract stays Claude-only for the THINKING envelope.
+    elif payload_type == "reasoning":
+        text = _codex_reasoning_text(payload)
+        if text:
+            events.append(
+                _event_base(
+                    event_type="thinking",
+                    session_id=session_id,
+                    account_name=account_name,
+                    provider=account.provider.value,
+                    project_key=project_key,
+                    timestamp=timestamp,
+                    source_path=source_path,
+                    source_offset=source_offset,
+                    cwd=cwd,
+                    model_name=model_name,
+                    payload={
+                        "text": text,
+                        "signature": "",
+                        "raw": {
+                            "type": "reasoning",
+                            "summary": payload.get("summary"),
+                        },
+                    },
+                )
+            )
     elif payload_type == "error":
         events.append(
             _event_base(

--- a/src/pollypm/web_api/chat/registry.py
+++ b/src/pollypm/web_api/chat/registry.py
@@ -317,6 +317,7 @@ def find_chat_surface(
     *,
     work_service: Any | None = None,
     tmux_client: Any | None = None,
+    include_transcripts: bool = True,
 ) -> ChatSurface | None:
     """Resolve one chat surface without enumerating the whole workspace.
 
@@ -339,7 +340,7 @@ def find_chat_surface(
             tmux_session=storage_session_name(config.project.tmux_session),
             tmux_state_cache=tmux_state_cache,
             session_index_cache=session_index_cache,
-            include_transcripts=True,
+            include_transcripts=include_transcripts,
         )
 
     parsed = parse_task_window_name(session_name)
@@ -368,7 +369,7 @@ def find_chat_surface(
                 tmux_session=storage_session_name(config.project.tmux_session),
                 tmux_state_cache=tmux_state_cache,
                 session_index_cache=session_index_cache,
-                include_transcripts=True,
+                include_transcripts=include_transcripts,
             )
     return None
 

--- a/src/pollypm/web_api/chat/transcripts.py
+++ b/src/pollypm/web_api/chat/transcripts.py
@@ -210,8 +210,10 @@ def lookup_transcript_path(
     Matching is fingerprint-based, NOT "freshest under the project":
 
     1. ``cwd`` must match the surface's cwd (resolved). Required.
-    2. When ``account_name`` is given, entries with a different
-       ``account_name`` are filtered out.
+    2. When ``account_name`` is given, matching entries are preferred.
+       If the configured account points at a stale abandoned archive,
+       a fresher same-cwd/provider sibling may win so account binding
+       renames do not pin the surface to dead transcripts.
     3. When ``provider`` is given, entries with a different
        ``provider`` are filtered out.
     4. If multiple entries remain (e.g. a restarted session left two
@@ -225,16 +227,31 @@ def lookup_transcript_path(
         return None
     normalized = _normalize_cwd(cwd)
     best: _SessionIndexEntry | None = None
+    best_any_account: _SessionIndexEntry | None = None
     for entry in index:
         entry_cwd = entry.cwd_normalized or _normalize_cwd(entry.cwd)
         if entry_cwd != normalized:
             continue
-        if account_name and entry.account_name and entry.account_name != account_name:
-            continue
         if provider and entry.provider and entry.provider != provider:
+            continue
+        if best_any_account is None or entry.mtime > best_any_account.mtime:
+            best_any_account = entry
+        if account_name and entry.account_name and entry.account_name != account_name:
             continue
         if best is None or entry.mtime > best.mtime:
             best = entry
+    if best is not None:
+        if (
+            account_name
+            and best_any_account is not None
+            and best_any_account.path != best.path
+            and best_any_account.mtime > best.mtime
+            and (time.time() - best.mtime) > STALE_THRESHOLD_SECONDS
+        ):
+            return best_any_account.path
+        return best.path
+    if account_name and best_any_account is not None:
+        return best_any_account.path
     return best.path if best is not None else None
 
 
@@ -470,7 +487,8 @@ def parse_events_jsonl(
             "chat.transcripts: read failed for %s: %s",
             events_path, exc,
         )
-        return envelopes
+        return _dedupe_envelopes_by_id(envelopes)
+    envelopes = _dedupe_envelopes_by_id(envelopes)
     if cache_eligible and cached_mtime is not None:
         # Evict oldest insertion before storing the new entry. Python
         # dicts preserve insertion order so ``next(iter(...))`` gives
@@ -615,6 +633,7 @@ def parse_events_jsonl_tail(
                 actor_fallback=actor_fallback,
                 include_thinking=include_thinking,
             )[-limit:]
+        envelopes = _dedupe_envelopes_by_id(envelopes)
         if len(envelopes) >= limit:
             return envelopes[-limit:]
         if chunk_size >= file_size:
@@ -630,6 +649,17 @@ def parse_events_jsonl_tail(
         actor_fallback=actor_fallback,
         include_thinking=include_thinking,
     )[-limit:]
+
+
+def _dedupe_envelopes_by_id(envelopes: list[MessageEnvelope]) -> list[MessageEnvelope]:
+    seen: set[str] = set()
+    out: list[MessageEnvelope] = []
+    for envelope in envelopes:
+        if envelope.id in seen:
+            continue
+        seen.add(envelope.id)
+        out.append(envelope)
+    return out
 
 
 def _parse_tail_chunk(
@@ -1016,6 +1046,7 @@ def _envelope_tool_result(
     summary = _extract_text_from_blocks(
         payload.get("output") or payload.get("text") or payload.get("content"),
     )
+    tool_use_id = str(payload.get("tool_use_id") or payload.get("call_id") or "")
     return [MessageEnvelope(
         id=msg_id,
         ts=timestamp,
@@ -1023,7 +1054,11 @@ def _envelope_tool_result(
         actor="tool",
         type=MessageType.TOOL_RESULT,
         text=summary,
-        metadata={"tool_use_id": "", "is_error": False, "content": payload},
+        metadata={
+            "tool_use_id": tool_use_id,
+            "is_error": bool(payload.get("is_error", False)),
+            "content": payload,
+        },
     )]
 
 
@@ -1325,6 +1360,7 @@ def parse_raw_subagent_jsonl(
     *,
     actor_fallback: str = "subagent",
     limit: int | None = None,
+    include_thinking: bool = False,
 ) -> list[MessageEnvelope]:
     """Parse a raw Claude subagent JSONL into :class:`MessageEnvelope` rows.
 
@@ -1346,10 +1382,10 @@ def parse_raw_subagent_jsonl(
           }
         }
 
-    Each ``user`` / ``assistant`` line becomes one envelope; ``error``
-    lines become ``system_event`` envelopes with ``subtype=error``.
-    Anything else (``summary``, telemetry-only lines, malformed JSON)
-    is skipped.
+    ``user`` / ``assistant`` lines are expanded by content block so
+    tool-only turns do not become blank text envelopes. ``error`` lines
+    become ``system_event`` envelopes with ``subtype=error``. Anything
+    else (``summary``, telemetry-only lines, malformed JSON) is skipped.
 
     ``limit`` (optional): cap on emitted envelopes. ``None`` returns
     every envelope. The caller (the chat-messages route) sets a small
@@ -1385,13 +1421,16 @@ def parse_raw_subagent_jsonl(
                     continue
                 if not isinstance(obj, dict):
                     continue
-                envelope = _raw_subagent_line_to_envelope(
+                line_envelopes = _raw_subagent_line_to_envelopes(
                     obj,
                     index=index,
                     source_key=source_key,
                     actor_fallback=actor_fallback,
+                    include_thinking=include_thinking,
                 )
-                if envelope is not None:
+                for envelope in line_envelopes:
+                    if limit is not None and len(envelopes) >= limit:
+                        break
                     envelopes.append(envelope)
     except OSError as exc:
         logger.warning(
@@ -1401,78 +1440,213 @@ def parse_raw_subagent_jsonl(
     return envelopes
 
 
-def _raw_subagent_line_to_envelope(
+def _raw_subagent_line_to_envelopes(
     obj: dict[str, Any],
     *,
     index: int,
     source_key: str,
     actor_fallback: str,
-) -> MessageEnvelope | None:
-    """Map one raw Claude JSONL line to a :class:`MessageEnvelope`.
+    include_thinking: bool,
+) -> list[MessageEnvelope]:
+    """Map one raw Claude JSONL line to zero or more envelopes.
 
-    Returns ``None`` for line types we don't surface (``summary``,
+    Returns ``[]`` for line types we don't surface (``summary``,
     ``session_state``, malformed shapes). The id is deterministic per
-    ``(file, line index)`` so a repeated parse yields stable ids.
+    ``(file, line index, block index)`` so repeated parses are stable.
     """
     line_type = obj.get("type")
     timestamp = str(obj.get("timestamp") or "")
     msg_id = f"sub_{source_key}_{index:06d}"
     message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
     content = message.get("content") if isinstance(message, dict) else None
+    session_id = str(obj.get("sessionId") or "")
 
-    if line_type in _RAW_USER_TYPES:
-        text = _extract_text_from_blocks(content) or _extract_text_from_blocks(message)
+    def _base_metadata(model: str = "") -> dict[str, Any]:
+        metadata = {
+            "provider": "claude",
+            "source": "subagent_jsonl",
+            "session_id": session_id,
+        }
+        if model:
+            metadata["model"] = model
+        return metadata
+
+    def _text_envelope(
+        *,
+        block_id: str,
+        role: MessageRole,
+        actor: str,
+        text: str,
+        model: str = "",
+    ) -> MessageEnvelope | None:
+        if not text:
+            return None
         return MessageEnvelope(
-            id=msg_id,
+            id=block_id,
             ts=timestamp,
-            role=MessageRole.USER,
-            actor="user",
+            role=role,
+            actor=actor,
             type=MessageType.TEXT,
             text=text,
-            metadata={
-                "provider": "claude",
-                "source": "subagent_jsonl",
-                "session_id": str(obj.get("sessionId") or ""),
-            },
+            metadata=_base_metadata(model),
+        )
+
+    def _block_id(block_index: int) -> str:
+        return msg_id if block_index == 0 else f"{msg_id}_{block_index:02d}"
+
+    if line_type in _RAW_USER_TYPES:
+        return _raw_subagent_content_to_envelopes(
+            content if content is not None else message,
+            timestamp=timestamp,
+            block_id=_block_id,
+            role=MessageRole.USER,
+            actor="user",
+            actor_fallback=actor_fallback,
+            model="",
+            base_metadata=_base_metadata,
+            text_envelope=_text_envelope,
+            include_thinking=include_thinking,
         )
     if line_type in _RAW_ASSISTANT_TYPES:
-        text = _extract_text_from_blocks(content) or _extract_text_from_blocks(message)
         model_name = ""
         if isinstance(message, dict):
             raw_model = message.get("model")
             if isinstance(raw_model, str):
                 model_name = raw_model
-        return MessageEnvelope(
-            id=msg_id,
-            ts=timestamp,
+        return _raw_subagent_content_to_envelopes(
+            content if content is not None else message,
+            timestamp=timestamp,
+            block_id=_block_id,
             role=MessageRole.ASSISTANT,
             actor=actor_fallback,
-            type=MessageType.TEXT,
-            text=text,
-            metadata={
-                "provider": "claude",
-                "source": "subagent_jsonl",
-                "session_id": str(obj.get("sessionId") or ""),
-                "model": model_name,
-            },
+            actor_fallback=actor_fallback,
+            model=model_name,
+            base_metadata=_base_metadata,
+            text_envelope=_text_envelope,
+            include_thinking=include_thinking,
         )
     if line_type == "error":
         # Surface subagent errors as system_event so the caller's UI
         # doesn't lose them in the inlined stream.
-        return MessageEnvelope(
-            id=msg_id,
-            ts=timestamp,
-            role=MessageRole.SYSTEM,
-            actor="system",
-            type=MessageType.SYSTEM_EVENT,
-            text=_extract_text_from_blocks(obj.get("error")) or "(subagent error)",
-            metadata={
-                "subtype": "error",
-                "provider": "claude",
-                "source": "subagent_jsonl",
-            },
+        return [
+            MessageEnvelope(
+                id=msg_id,
+                ts=timestamp,
+                role=MessageRole.SYSTEM,
+                actor="system",
+                type=MessageType.SYSTEM_EVENT,
+                text=_extract_text_from_blocks(obj.get("error")) or "(subagent error)",
+                metadata={
+                    "subtype": "error",
+                    "provider": "claude",
+                    "source": "subagent_jsonl",
+                },
+            )
+        ]
+    return []
+
+
+def _raw_subagent_content_to_envelopes(
+    content: Any,
+    *,
+    timestamp: str,
+    block_id: Any,
+    role: MessageRole,
+    actor: str,
+    actor_fallback: str,
+    model: str,
+    base_metadata: Any,
+    text_envelope: Any,
+    include_thinking: bool,
+) -> list[MessageEnvelope]:
+    if not isinstance(content, list):
+        env = text_envelope(
+            block_id=block_id(0),
+            role=role,
+            actor=actor,
+            text=_extract_text_from_blocks(content),
+            model=model,
         )
-    return None
+        return [env] if env is not None else []
+
+    envelopes: list[MessageEnvelope] = []
+    for idx, block in enumerate(content):
+        current_id = block_id(idx)
+        if not isinstance(block, dict):
+            env = text_envelope(
+                block_id=current_id,
+                role=role,
+                actor=actor,
+                text=_extract_text_from_blocks(block),
+                model=model,
+            )
+            if env is not None:
+                envelopes.append(env)
+            continue
+        block_type = str(block.get("type") or "")
+        if block_type == "text":
+            env = text_envelope(
+                block_id=current_id,
+                role=role,
+                actor=actor,
+                text=str(block.get("text") or ""),
+                model=model,
+            )
+            if env is not None:
+                envelopes.append(env)
+        elif block_type == "tool_use":
+            tool_name = str(block.get("name") or "")
+            raw_input = block.get("input")
+            tool_input = raw_input if isinstance(raw_input, dict) else {}
+            tool_use_id = str(block.get("id") or current_id)
+            envelopes.append(MessageEnvelope(
+                id=current_id,
+                ts=timestamp,
+                role=MessageRole.ASSISTANT,
+                actor=actor_fallback,
+                type=MessageType.TOOL_USE,
+                text=_format_tool_use_summary(tool_name, tool_input),
+                metadata={
+                    **base_metadata(model),
+                    "tool_use_id": tool_use_id,
+                    "tool_name": tool_name,
+                    "tool_input": tool_input,
+                },
+            ))
+        elif block_type == "tool_result":
+            tool_use_id = str(block.get("tool_use_id") or "")
+            content_blocks = block.get("content") or []
+            envelopes.append(MessageEnvelope(
+                id=current_id,
+                ts=timestamp,
+                role=MessageRole.TOOL,
+                actor="tool",
+                type=MessageType.TOOL_RESULT,
+                text=_extract_text_from_blocks(content_blocks),
+                metadata={
+                    **base_metadata(model),
+                    "tool_use_id": tool_use_id,
+                    "is_error": bool(block.get("is_error", False)),
+                    "content": content_blocks,
+                },
+            ))
+        elif block_type == "thinking" and include_thinking:
+            text = str(block.get("thinking") or block.get("text") or "")
+            if not text:
+                continue
+            envelopes.append(MessageEnvelope(
+                id=current_id,
+                ts=timestamp,
+                role=MessageRole.ASSISTANT,
+                actor=actor_fallback,
+                type=MessageType.THINKING,
+                text=text,
+                metadata={
+                    **base_metadata(model),
+                    "signature": str(block.get("signature") or ""),
+                },
+            ))
+    return envelopes
 
 
 __all__ = [

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -827,6 +827,7 @@ def _apply_filters_and_paginate(
             if ts < since_aware:
                 continue
         filtered.append(envelope)
+    filtered = _dedupe_envelopes_by_id(filtered)
 
     # Stable sort by (ts, original position). Original position is
     # preserved because Python's sort is stable, but we've already
@@ -865,6 +866,17 @@ def _apply_filters_and_paginate(
         page = [post_process(env) for env in page]
 
     return [_envelope_to_wire(env) for env in page], has_more, next_cursor
+
+
+def _dedupe_envelopes_by_id(envelopes: list[MessageEnvelope]) -> list[MessageEnvelope]:
+    seen: set[str] = set()
+    out: list[MessageEnvelope] = []
+    for envelope in envelopes:
+        if envelope.id in seen:
+            continue
+        seen.add(envelope.id)
+        out.append(envelope)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -968,6 +980,7 @@ def _inline_subagent_transcript(
     *,
     allowed_roots: list[Path],
     actor_fallback: str,
+    include_thinking: bool = False,
 ) -> MessageEnvelope:
     """Enrich a ``subagent_result`` envelope with its subagent transcript.
 
@@ -1009,6 +1022,7 @@ def _inline_subagent_transcript(
             sub_path,
             actor_fallback=actor_fallback,
             limit=_SUBAGENT_INLINE_LIMIT,
+            include_thinking=include_thinking,
         )
     except Exception:  # noqa: BLE001
         logger.debug(
@@ -1203,6 +1217,7 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
                 env,
                 allowed_roots=allowed_roots,
                 actor_fallback=actor_fallback,
+                include_thinking=include_thinking,
             )
 
     rows, has_more, next_cursor = _apply_filters_and_paginate(

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -6,7 +6,7 @@ into the running CLI agent backing ``session_name`` via tmux.
 The router is a thin adapter over the P1 shared facade in
 :mod:`pollypm.web_api.chat`:
 
-- :func:`pollypm.web_api.chat.enumerate_chat_surfaces` resolves
+- :func:`pollypm.web_api.chat.find_chat_surface` resolves
   ``session_name`` → :class:`ChatSurface` (window, transcript, cwd).
   Workers are validated against the work-service's active
   :class:`WorkerSessionRecord` rows via the public service facade
@@ -81,10 +81,11 @@ from typing import Annotated, Any, Literal
 from fastapi import APIRouter, Query, Response
 from pydantic import BaseModel, Field
 
+from pollypm.audit.log import EVENT_CHAT_SEND_FORCE_BYPASS, emit as audit_emit
 from pollypm.tmux.client import DeadPaneError, TmuxClient
 from pollypm.web_api.chat import (
     ChatSurface,
-    enumerate_chat_surfaces,
+    find_chat_surface,
 )
 from pollypm.web_api.errors import APIError
 from pollypm.web_api.routes._deps import ConfigDep
@@ -497,7 +498,9 @@ def _list_worker_sessions(config: Any) -> list[Any]:
     return list(list_active_worker_sessions(config)) or []
 
 
-def _list_worker_sessions_strict(config: Any) -> list[Any]:
+def _list_worker_sessions_strict(
+    config: Any, *, project: str | None = None,
+) -> list[Any]:
     """Strict worker-lookup via the public service facade.
 
     Codex #2043 review v6 blocker 1 / v7 blocker 2: the *non-strict*
@@ -526,7 +529,7 @@ def _list_worker_sessions_strict(config: Any) -> list[Any]:
     raise, exercising the real public-facade-bypass path end-to-end.
     """
     try:
-        return list(list_active_worker_sessions_strict(config))
+        return list(list_active_worker_sessions_strict(config, project=project))
     except _WorkerFacadeUnavailable:
         raise
     except Exception as exc:  # noqa: BLE001
@@ -538,8 +541,13 @@ def _list_worker_sessions_strict(config: Any) -> list[Any]:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_surface(config: Any, session_name: str) -> ChatSurface:
-    """Resolve ``session_name`` → :class:`ChatSurface` via the P1 facade.
+def _resolve_surface(
+    config: Any,
+    session_name: str,
+    *,
+    include_transcripts: bool = True,
+) -> ChatSurface:
+    """Resolve ``session_name`` → one :class:`ChatSurface`.
 
     Configured operator/architect/advisor sessions come from
     ``config.sessions``. Per-task workers are looked up in the
@@ -563,13 +571,15 @@ def _resolve_surface(config: Any, session_name: str) -> ChatSurface:
     is_worker_pattern = _looks_like_worker_session(session_name)
     worker_records: list[Any]
     if is_worker_pattern:
-        # Strict path: bypass the public facade so open/list outages
-        # propagate as :class:`_WorkerFacadeUnavailable` and map to a
-        # typed 503 (Codex #2043 review v6 blocker 1). The public
-        # facade swallows those failures into ``[]``, which would
-        # collapse into ``404 session_unknown`` here.
+        parsed_worker = parse_task_window_name(session_name)
+        project_filter = parsed_worker[0] if parsed_worker else None
         try:
-            worker_records = _list_worker_sessions_strict(config)
+            try:
+                worker_records = _list_worker_sessions_strict(
+                    config, project=project_filter,
+                )
+            except TypeError:
+                worker_records = _list_worker_sessions_strict(config)
         except _WorkerFacadeUnavailable as exc:
             logger.debug(
                 "chat_send: worker session lookup failed for %r",
@@ -598,21 +608,30 @@ def _resolve_surface(config: Any, session_name: str) -> ChatSurface:
 
     class _Adapter:
         @staticmethod
-        def list_worker_sessions(*, active_only: bool = True) -> list[Any]:
+        def list_worker_sessions(
+            *, project: str | None = None, active_only: bool = True,
+        ) -> list[Any]:
+            records = worker_records
+            if project is not None:
+                records = [
+                    r for r in records
+                    if getattr(r, "task_project", "") == project
+                ]
             if not active_only:
-                return worker_records
+                return records
             return [
-                r for r in worker_records if getattr(r, "ended_at", None) is None
+                r for r in records if getattr(r, "ended_at", None) is None
             ]
 
-    surfaces = enumerate_chat_surfaces(
+    surface = find_chat_surface(
         config,
-        work_service=_Adapter,
+        session_name,
+        work_service=_Adapter if is_worker_pattern else None,
         tmux_client=None,
+        include_transcripts=include_transcripts,
     )
-    for surface in surfaces:
-        if surface.session_name == session_name:
-            return surface
+    if surface is not None:
+        return surface
     raise _session_unknown(session_name)
 
 
@@ -761,10 +780,10 @@ def _resolve_session_events(
     """Locate the exact events.jsonl for ``surface``.
 
     Trusts :attr:`ChatSurface.transcript_path` populated by P1's
-    :func:`enumerate_chat_surfaces` — that's the same fingerprint
-    mapping the read endpoints (P2) use, so the send path can never
-    disagree with the GET path on "which transcript is this
-    session's". P1's resolver returns ``None`` when no archive
+    single-surface resolver — that's the same fingerprint mapping the
+    read endpoints (P2) use, so the send path can never disagree with
+    the GET path on "which transcript is this session's". P1's
+    resolver returns ``None`` when no archive
     matches the surface's ``(cwd, account, provider)`` fingerprint;
     it never opportunistically picks the freshest.
 
@@ -810,12 +829,18 @@ def _last_assistant_open_tool_ids(
     any *other* open tool still blocks the send (Codex #2043 review
     v4 block 1).
     """
-    # Find the most-recent boundary (user_turn or assistant_turn).
+    # Find the most-recent boundary. ``turn_end`` / ``session_state``
+    # close stale orphaned tool calls left by a prior crashed turn.
     # Everything after that belongs to the current in-flight response.
     boundary = -1
     for idx in range(len(events) - 1, -1, -1):
         event_type = events[idx].get("event_type")
-        if event_type in ("user_turn", "assistant_turn"):
+        if event_type in (
+            "user_turn",
+            "assistant_turn",
+            "turn_end",
+            "session_state",
+        ):
             boundary = idx
             break
     # When no boundary exists in the tail we still scan: that's the
@@ -866,6 +891,75 @@ def _is_mid_tool(
     return bool(
         _last_assistant_open_tool_ids(events, exempt_tool_ids=exempt_tool_ids),
     )
+
+
+def _force_bypass_gates(
+    *,
+    events_path: Path | None,
+    resolution: _ResolutionQuality,
+    config: Any,
+    session_name: str,
+    exempt_tool_ids: set[str] | None,
+) -> list[str]:
+    """Best-effort list of gates ``safety=force`` bypassed.
+
+    This never blocks the send path. It only evaluates the same safety
+    signals for audit metadata so a later forensic read can distinguish
+    a routine force send from a force send during active streaming.
+    """
+    bypassed: list[str] = []
+    if resolution == "absent_but_others_exist":
+        bypassed.append("unsafe_mid_tool")
+    try:
+        if _is_mid_tool(events_path, exempt_tool_ids=exempt_tool_ids):
+            bypassed.append("unsafe_mid_tool")
+    except TranscriptUnavailable:
+        bypassed.append("unsafe_unavailable_transcript")
+    try:
+        age = _heartbeat_age_seconds(config, session_name)
+    except HeartbeatUnavailable:
+        bypassed.append("unsafe_unavailable_heartbeat")
+    else:
+        if age is not None and age < _MID_STREAM_WINDOW_SECONDS:
+            bypassed.append("unsafe_mid_stream")
+    return sorted(set(bypassed))
+
+
+def _emit_force_bypass_audit(
+    *,
+    config: Any,
+    project_key: str | None,
+    project_root: Path,
+    session_name: str,
+    target: str,
+    message_id: str,
+    text_to_send: str,
+    method: str,
+    press_enter: bool,
+    press_enter_at: str | None,
+    bypassed_gates: list[str],
+) -> None:
+    project = project_key or getattr(getattr(config, "project", None), "name", "")
+    try:
+        audit_emit(
+            event=EVENT_CHAT_SEND_FORCE_BYPASS,
+            project=str(project or ""),
+            subject=session_name,
+            actor="rest_client",
+            status="warn",
+            project_path=project_root,
+            metadata={
+                "message_id": message_id,
+                "window_target": target,
+                "characters_sent": len(text_to_send),
+                "method": method,
+                "press_enter": press_enter,
+                "press_enter_at": press_enter_at,
+                "bypassed_gates": list(bypassed_gates),
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("chat_send: force-bypass audit emit failed", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -1161,6 +1255,38 @@ def _resolve_pane_target(
     ``409 pane_invalid``) so the operator gets actionable typed
     errors instead of generic 500s (Codex #2043 review v4 block 3).
     """
+    window_target = f"{storage_session}:{window_name}"
+    if pane_index is None:
+        get_window = getattr(tmux, "get_window", None)
+        if callable(get_window):
+            try:
+                try:
+                    window = get_window(window_target, timeout=1)
+                except TypeError:
+                    window = get_window(window_target)
+            except FileNotFoundError as exc:
+                raise _tmux_unavailable(
+                    f"tmux binary not found: {exc}",
+                ) from exc
+            except subprocess.TimeoutExpired as exc:
+                raise _tmux_unavailable(
+                    f"tmux command timed out after {exc.timeout}s",
+                ) from exc
+            except subprocess.CalledProcessError:
+                logger.debug(
+                    "chat_send: get_window(%r) CalledProcessError",
+                    window_target,
+                    exc_info=True,
+                )
+                return window_target, False
+            except OSError as exc:
+                raise _tmux_unavailable(str(exc)) from exc
+            if window is None:
+                return window_target, False
+            if getattr(window, "pane_dead", False):
+                raise _pane_dead(window_target)
+            return window_target, True
+
     try:
         windows = tmux.list_windows(storage_session)
     except FileNotFoundError as exc:
@@ -1183,7 +1309,7 @@ def _resolve_pane_target(
             storage_session,
             exc_info=True,
         )
-        return f"{storage_session}:{window_name}", False
+        return window_target, False
     except OSError as exc:
         # Other subprocess plumbing errors (permission denied on
         # ``tmux`` binary, etc.) — treat as tmux_unavailable so the
@@ -1200,15 +1326,14 @@ def _resolve_pane_target(
     # signal here.
     if pane_index is None:
         if window.pane_dead:
-            raise _pane_dead(f"{storage_session}:{window_name}")
-        return f"{storage_session}:{window_name}", True
+            raise _pane_dead(window_target)
+        return window_target, True
     # Specific pane requested (including 0). Pane indexes must be
     # >= 0 and the pane has to exist on the window AND be alive.
     # Without this gate a negative or out-of-range index slips
     # through to ``send_keys`` and surfaces as a 500 — and explicit
     # ``pane=0`` would silently go to tmux's active pane, which is
     # not guaranteed to be pane 0.
-    window_target = f"{storage_session}:{window_name}"
     if pane_index < 0:
         raise _pane_invalid(pane_index, window_target)
     try:
@@ -1276,10 +1401,16 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
 ) -> ChatSendResponse:
     """POST /api/v1/chat/{session_name}/send — push text into a tmux pane."""
     safety_mode = safety or body.safety
+    needs_transcript = safety_mode != "force" or body.answer_to is not None
 
-    # 1. Resolve session via the P1 facade (validates workers against
-    # the work-service — see Codex review block 2).
-    surface = _resolve_surface(config, session_name)
+    # 1. Resolve the one target surface. Plain force sends do not need
+    # a transcript before touching tmux, so keep the latency-critical
+    # path out of the session-index filesystem walk.
+    surface = _resolve_surface(
+        config,
+        session_name,
+        include_transcripts=needs_transcript,
+    )
     # ``surface.project`` is intentionally ``None`` for operators in P1
     # (the operator is workspace-wide). The send path still needs a
     # concrete project_key for storage-closet naming and transcripts
@@ -1319,7 +1450,10 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
     # the failure entirely. We track the helper's outcome rather than
     # short-circuiting on the first call so the warning header lands
     # even when the answer_to lookup is what raised.
-    events_path, resolution = _resolve_session_events(surface, project_root)
+    events_path: Path | None = None
+    resolution: _ResolutionQuality = "absent_clean"
+    if needs_transcript:
+        events_path, resolution = _resolve_session_events(surface, project_root)
     ask_envelope: dict[str, Any] | None = None
     ask_exempt_ids: set[str] = set()
     transcript_unavailable_detail: str | None = None
@@ -1349,7 +1483,18 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
 
     # 3. Safety gates (§4.1, §4.3) — use the exact session transcript
     # (Codex review block 3).
-    if safety_mode != "force":
+    force_bypassed_gates: list[str] = []
+    force_gate_audit_deferred = safety_mode == "force" and not needs_transcript
+    if safety_mode == "force":
+        if not force_gate_audit_deferred:
+            force_bypassed_gates = _force_bypass_gates(
+                events_path=events_path,
+                resolution=resolution,
+                config=config,
+                session_name=session_name,
+                exempt_tool_ids=ask_exempt_ids,
+            )
+    else:
         if resolution == "absent_but_others_exist":
             # Strict and loose both require an exact transcript
             # mapping. Other transcripts exist for the project but
@@ -1430,9 +1575,16 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
     method: Literal["send_keys", "paste_buffer"] = (
         "paste_buffer" if len(text_to_send) > 100 else "send_keys"
     )
+    message_id = f"msg_{uuid.uuid4().hex}"
     press_enter_at: str | None = None
+    enter_delay_seconds = 0.0 if method == "send_keys" else 0.5
     try:
-        tmux.send_keys(target, text_to_send, press_enter=body.press_enter)
+        tmux.send_keys(
+            target,
+            text_to_send,
+            press_enter=body.press_enter,
+            enter_delay_seconds=enter_delay_seconds,
+        )
     except DeadPaneError as exc:
         # Pane died between validation and send. Already mapped to a
         # typed 409 before this refactor — keep that shape.
@@ -1471,10 +1623,39 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
         raise _send_failed(target, str(exc)) from exc
     if body.press_enter:
         press_enter_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    if safety_mode == "force":
+        if force_gate_audit_deferred:
+            try:
+                force_bypassed_gates = _force_bypass_gates(
+                    events_path=None,
+                    resolution="absent_clean",
+                    config=config,
+                    session_name=session_name,
+                    exempt_tool_ids=ask_exempt_ids,
+                )
+            except Exception:  # noqa: BLE001
+                force_bypassed_gates = []
+                logger.debug(
+                    "chat_send: force-bypass gate audit failed",
+                    exc_info=True,
+                )
+        _emit_force_bypass_audit(
+            config=config,
+            project_key=project_key,
+            project_root=project_root,
+            session_name=session_name,
+            target=target,
+            message_id=message_id,
+            text_to_send=text_to_send,
+            method=method,
+            press_enter=body.press_enter,
+            press_enter_at=press_enter_at,
+            bypassed_gates=force_bypassed_gates,
+        )
 
     return ChatSendResponse(
         ok=True,
-        message_id=f"msg_{uuid.uuid4().hex}",
+        message_id=message_id,
         session_name=session_name,
         window_target=target,
         characters_sent=len(text_to_send),

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -826,6 +826,36 @@ def test_messages_endpoint_respects_limit(
     assert body["next_cursor"] == "msg_009"
 
 
+def test_messages_endpoint_dedupes_duplicate_ids_before_pagination(
+    client, auth_headers, patch_registry, patch_parser, tmp_path,
+):
+    archive = tmp_path / "events.jsonl"
+    archive.write_text("x")
+    envelopes = [
+        _env("dup", ts="2026-05-21T10:00:00Z", text="first"),
+        _env("dup", ts="2026-05-21T10:00:00Z", text="first"),
+        _env("unique", ts="2026-05-21T10:01:00Z", text="second"),
+    ]
+    patch_registry([_surface(
+        "operator", SurfaceType.OPERATOR, persona="Polly",
+        transcript_path=archive,
+    )])
+    patch_parser({archive: envelopes})
+
+    first = client.get(
+        "/api/v1/chat/operator/messages?direction=asc&limit=1",
+        headers=auth_headers,
+    ).json()
+    assert [m["id"] for m in first["messages"]] == ["dup"]
+    assert first["has_more"] is True
+    second = client.get(
+        f"/api/v1/chat/operator/messages?direction=asc&limit=1&since_id={first['next_cursor']}",
+        headers=auth_headers,
+    ).json()
+    assert [m["id"] for m in second["messages"]] == ["unique"]
+    assert second["has_more"] is False
+
+
 def test_messages_endpoint_since_id_walks_cursor(
     client, auth_headers, patch_registry, patch_parser, tmp_path,
 ):
@@ -1696,6 +1726,38 @@ def test_messages_endpoint_include_subagents_inlines_with_real_parser(
                     "content": [{"type": "text", "text": "subagent reply"}],
                 },
             }),
+            json.dumps({
+                "type": "assistant",
+                "sessionId": "child-1",
+                "cwd": str(project_root),
+                "timestamp": "2026-05-21T10:00:06Z",
+                "message": {
+                    "model": "claude-opus-4-7",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_child",
+                            "name": "Bash",
+                            "input": {"command": "pwd"},
+                        }
+                    ],
+                },
+            }),
+            json.dumps({
+                "type": "user",
+                "sessionId": "child-1",
+                "cwd": str(project_root),
+                "timestamp": "2026-05-21T10:00:07Z",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_child",
+                            "content": [{"type": "text", "text": str(project_root)}],
+                        }
+                    ],
+                },
+            }),
         ]) + "\n"
     )
 
@@ -1778,15 +1840,19 @@ def test_messages_endpoint_include_subagents_inlines_with_real_parser(
     assert metadata["output_file"] == str(child_jsonl)
     transcript = metadata.get("subagent_transcript")
     assert isinstance(transcript, list)
-    assert len(transcript) == 2
+    assert len(transcript) == 4
     # First child envelope: user turn with "kick off" text; second:
-    # assistant turn with the reply.
+    # assistant turn with the reply; final two preserve child tool use.
     assert transcript[0]["role"] == "user"
     assert transcript[0]["type"] == "text"
     assert "kick off" in transcript[0]["text"]
     assert transcript[1]["role"] == "assistant"
     assert transcript[1]["type"] == "text"
     assert transcript[1]["text"] == "subagent reply"
+    assert transcript[2]["type"] == "tool_use"
+    assert transcript[2]["metadata"]["tool_use_id"] == "toolu_child"
+    assert transcript[3]["type"] == "tool_result"
+    assert transcript[3]["metadata"]["tool_use_id"] == "toolu_child"
     # Provenance marker so downstream consumers can distinguish
     # inlined-from-raw envelopes from the normalized stream.
     assert transcript[0]["metadata"]["source"] == "subagent_jsonl"

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -76,6 +76,7 @@ class FakeTmuxClient:
     panes_by_target: dict[str, list[FakePane]] = {}
     send_side_effect: Exception | None = None
     send_calls: list[tuple[str, str, bool]] = []
+    send_enter_delays: list[float] = []
     list_panes_side_effect: Exception | None = None
     list_windows_side_effect: Exception | None = None
 
@@ -91,10 +92,18 @@ class FakeTmuxClient:
         # or session, depending on the call shape; check both.
         return list(self.panes_by_target.get(target, []))
 
-    def send_keys(self, target: str, text: str, press_enter: bool = True) -> None:
+    def send_keys(
+        self,
+        target: str,
+        text: str,
+        press_enter: bool = True,
+        *,
+        enter_delay_seconds: float = 0.5,
+    ) -> None:
         if self.send_side_effect is not None:
             raise self.send_side_effect
         self.send_calls.append((target, text, press_enter))
+        self.send_enter_delays.append(enter_delay_seconds)
 
 
 @pytest.fixture(autouse=True)
@@ -103,6 +112,7 @@ def _reset_fake_tmux():
     FakeTmuxClient.panes_by_target = {}
     FakeTmuxClient.send_side_effect = None
     FakeTmuxClient.send_calls = []
+    FakeTmuxClient.send_enter_delays = []
     FakeTmuxClient.list_panes_side_effect = None
     FakeTmuxClient.list_windows_side_effect = None
     yield
@@ -396,6 +406,7 @@ def test_happy_path_text_send(
     assert patched_tmux.send_calls == [
         ("pollypm-test-storage-closet:pm-operator", "hello operator", True),
     ]
+    assert patched_tmux.send_enter_delays == [0.0]
 
 
 def test_happy_path_long_text_uses_paste_buffer(
@@ -416,6 +427,34 @@ def test_happy_path_long_text_uses_paste_buffer(
     body = response.json()
     assert body["method"] == "paste_buffer"
     assert body["characters_sent"] == 250
+    assert patched_tmux.send_enter_delays == [0.5]
+
+
+def test_force_text_send_skips_transcript_resolution(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    monkeypatch.setattr(chat_send_routes, "audit_emit", lambda **kwargs: None)
+
+    def _should_not_resolve(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        raise AssertionError("force text send should not resolve transcripts")
+
+    monkeypatch.setattr(
+        chat_send_routes, "_resolve_session_events", _should_not_resolve,
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send?safety=force",
+        json={"text": "fast force"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert patched_tmux.send_calls == [
+        ("pollypm-test-storage-closet:pm-operator", "fast force", True),
+    ]
 
 
 def test_happy_path_architect_session(
@@ -812,7 +851,64 @@ def test_closed_tool_allows_send(
     assert response.status_code == 200
 
 
-def test_safety_force_bypasses_mid_tool(
+def test_safety_force_audit_does_not_log_message_text(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_audit: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        chat_send_routes,
+        "audit_emit",
+        lambda **kwargs: captured_audit.append(kwargs),
+    )
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, 0.5)  # also fresh heartbeat
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "force"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert len(captured_audit) == 1
+    event = captured_audit[0]
+    assert event["event"] == "chat.send.force_bypass"
+    assert event["subject"] == "operator"
+    assert event["actor"] == "rest_client"
+    assert event["status"] == "warn"
+    assert event["metadata"]["message_id"] == body["message_id"]
+    assert event["metadata"]["window_target"] == "pollypm-test-storage-closet:pm-operator"
+    assert event["metadata"]["characters_sent"] == len("hello")
+    assert event["metadata"]["press_enter"] is True
+    assert set(event["metadata"]["bypassed_gates"]) == {
+        "unsafe_mid_stream",
+    }
+    assert "hello" not in json.dumps(event["metadata"])
+
+
+def test_force_bypass_gate_helper_detects_mid_tool(
+    api_config: PollyPMConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    _patch_heartbeat_age(monkeypatch, None)
+    events_path = _write_events_jsonl(
+        project_root, "session-open", _assistant_with_open_tool(),
+        cwd=workspace_root,
+    )
+    assert chat_send_routes._force_bypass_gates(
+        events_path=events_path,
+        resolution="exact",
+        config=api_config,
+        session_name="operator",
+        exempt_tool_ids=set(),
+    ) == ["unsafe_mid_tool"]
+
+
+def test_strict_mid_tool_does_not_emit_force_audit(
     client: TestClient,
     auth_headers: dict[str, str],
     patched_tmux: type[FakeTmuxClient],
@@ -820,18 +916,26 @@ def test_safety_force_bypasses_mid_tool(
     project_root: Path,
     workspace_root: Path,
 ) -> None:
+    captured_audit: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        chat_send_routes,
+        "audit_emit",
+        lambda **kwargs: captured_audit.append(kwargs),
+    )
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
-    _patch_heartbeat_age(monkeypatch, 0.5)  # also fresh heartbeat
+    _patch_heartbeat_age(monkeypatch, None)
     _write_events_jsonl(
         project_root, "session-open", _assistant_with_open_tool(),
         cwd=workspace_root,
     )
     response = client.post(
         "/api/v1/chat/operator/send",
-        json={"text": "hello", "safety": "force"},
+        json={"text": "hello"},
         headers=auth_headers,
     )
-    assert response.status_code == 200
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "unsafe_mid_tool"
+    assert captured_audit == []
 
 
 def test_safety_force_query_param_bypasses_mid_tool(
@@ -1778,6 +1882,22 @@ def test_open_tool_ids_helper_resets_per_assistant_turn() -> None:
         {"event_type": "assistant_turn", "payload": {"text": "first"}},
         {"event_type": "tool_call", "payload": {"id": "stale_open"}},
         {"event_type": "assistant_turn", "payload": {"text": "second"}},
+    ]
+    assert chat_send_routes._last_assistant_open_tool_ids(events) == set()
+
+
+def test_open_tool_ids_helper_turn_end_closes_orphaned_tool() -> None:
+    events = [
+        {"event_type": "tool_call", "payload": {"id": "stale_open"}},
+        {"event_type": "turn_end", "payload": {"reason": "done"}},
+    ]
+    assert chat_send_routes._last_assistant_open_tool_ids(events) == set()
+
+
+def test_open_tool_ids_helper_session_state_closes_previous_run() -> None:
+    events = [
+        {"event_type": "tool_call", "payload": {"id": "stale_open"}},
+        {"event_type": "session_state", "payload": {"state": "started"}},
     ]
     assert chat_send_routes._last_assistant_open_tool_ids(events) == set()
 

--- a/tests/test_chat_transcripts.py
+++ b/tests/test_chat_transcripts.py
@@ -35,6 +35,7 @@ from pollypm.web_api.chat import (
     is_archive_stale,
     parse_events_jsonl,
     parse_events_jsonl_tail,
+    parse_raw_subagent_jsonl,
     resolve_transcript_path,
 )
 from pollypm.web_api.chat import transcripts as transcripts_module
@@ -609,6 +610,100 @@ def test_looks_like_subagent_result_detects_task_notification_block() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Raw Claude subagent JSONL parser
+# ---------------------------------------------------------------------------
+
+
+def test_raw_subagent_jsonl_emits_tool_blocks_and_skips_blank_text(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "agent.jsonl"
+    path.write_text(
+        "\n".join([
+            json.dumps({
+                "type": "assistant",
+                "sessionId": "agent-1",
+                "timestamp": "2026-05-21T20:48:11Z",
+                "message": {
+                    "model": "claude-opus-4-7",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_raw",
+                            "name": "Bash",
+                            "input": {"command": "pwd"},
+                        }
+                    ],
+                },
+            }),
+            json.dumps({
+                "type": "user",
+                "sessionId": "agent-1",
+                "timestamp": "2026-05-21T20:48:12Z",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_raw",
+                            "content": [{"type": "text", "text": "/tmp/repo"}],
+                        }
+                    ],
+                },
+            }),
+        ])
+        + "\n"
+    )
+
+    envelopes = parse_raw_subagent_jsonl(path, actor_fallback="child")
+
+    assert [env.type for env in envelopes] == [
+        MessageType.TOOL_USE,
+        MessageType.TOOL_RESULT,
+    ]
+    assert envelopes[0].text == "[Bash] pwd"
+    assert envelopes[0].metadata["tool_use_id"] == "toolu_raw"
+    assert envelopes[0].metadata["tool_name"] == "Bash"
+    assert envelopes[1].text == "/tmp/repo"
+    assert envelopes[1].metadata["tool_use_id"] == "toolu_raw"
+    assert all(env.text for env in envelopes)
+
+
+def test_raw_subagent_jsonl_thinking_is_opt_in(tmp_path: Path) -> None:
+    path = tmp_path / "agent-thinking.jsonl"
+    path.write_text(json.dumps({
+        "type": "assistant",
+        "sessionId": "agent-1",
+        "timestamp": "2026-05-21T20:48:11Z",
+        "message": {
+            "model": "claude-opus-4-7",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "private child reasoning",
+                    "signature": "sig-child",
+                },
+                {"type": "text", "text": "visible child reply"},
+            ],
+        },
+    }) + "\n")
+
+    default_envs = parse_raw_subagent_jsonl(path, actor_fallback="child")
+    assert [env.type for env in default_envs] == [MessageType.TEXT]
+
+    thinking_envs = parse_raw_subagent_jsonl(
+        path,
+        actor_fallback="child",
+        include_thinking=True,
+    )
+    assert [env.type for env in thinking_envs] == [
+        MessageType.THINKING,
+        MessageType.TEXT,
+    ]
+    assert thinking_envs[0].text == "private child reasoning"
+    assert thinking_envs[0].metadata["signature"] == "sig-child"
+
+
+# ---------------------------------------------------------------------------
 # AskUserQuestion
 # ---------------------------------------------------------------------------
 
@@ -781,11 +876,28 @@ def test_codex_tool_result_extracts_output_text(tmp_path: Path) -> None:
     _write_events(events_path, [_codex_event(
         "tool_result",
         type="local_shell_result",
+        tool_use_id="call_1",
         output="file1\nfile2",
     )])
     envelopes = parse_events_jsonl(events_path)
     assert envelopes[0].type == MessageType.TOOL_RESULT
     assert envelopes[0].text == "file1\nfile2"
+    assert envelopes[0].metadata["tool_use_id"] == "call_1"
+
+
+def test_codex_reasoning_surfaces_as_thinking_when_opted_in(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [_codex_event(
+        "thinking",
+        text="Summarized reasoning.",
+        raw={"type": "reasoning", "summary": [{"text": "Summarized reasoning."}]},
+    )])
+
+    assert parse_events_jsonl(events_path) == []
+    envelopes = parse_events_jsonl(events_path, include_thinking=True)
+    assert envelopes[0].type == MessageType.THINKING
+    assert envelopes[0].text == "Summarized reasoning."
+    assert envelopes[0].metadata["provider"] == "codex"
 
 
 # ---------------------------------------------------------------------------
@@ -1373,6 +1485,45 @@ def test_resolve_transcript_filters_by_account_name(tmp_path: Path) -> None:
     assert alt_resolved.parent.name == "session-alt"
 
 
+def test_lookup_falls_back_to_fresh_same_cwd_provider_when_account_stale(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    project_root = tmp_path / "proj"
+    transcripts = project_root / ".pollypm" / "transcripts"
+    shared_cwd = str(tmp_path / "shared")
+    Path(shared_cwd).mkdir()
+    stale_event = _claude_event("user_turn", text="old")
+    stale_event["account_name"] = "claude_old"
+    stale_event["cwd"] = shared_cwd
+    (transcripts / "session-old").mkdir(parents=True)
+    old_path = transcripts / "session-old" / "events.jsonl"
+    old_path.write_text(json.dumps(stale_event) + "\n")
+    old_mtime = old_path.stat().st_mtime
+    time.sleep(0.05)
+    fresh_event = _claude_event("user_turn", text="new")
+    fresh_event["account_name"] = "claude_new"
+    fresh_event["cwd"] = shared_cwd
+    (transcripts / "session-new").mkdir(parents=True)
+    new_path = transcripts / "session-new" / "events.jsonl"
+    new_path.write_text(json.dumps(fresh_event) + "\n")
+    monkeypatch.setattr(
+        transcripts_module.time,
+        "time",
+        lambda: old_mtime + STALE_THRESHOLD_SECONDS + 5,
+    )
+
+    index = build_session_index(transcripts)
+    resolved = lookup_transcript_path(
+        index,
+        cwd=shared_cwd,
+        account_name="claude_old",
+        provider="claude",
+    )
+
+    assert resolved is not None
+    assert resolved.parent.name == "session-new"
+
+
 def test_build_session_index_skips_unreadable_events(tmp_path: Path) -> None:
     project_root = tmp_path / "proj"
     transcripts = project_root / ".pollypm" / "transcripts"
@@ -1495,6 +1646,30 @@ def test_envelope_ids_are_unique_within_file(tmp_path: Path) -> None:
     envelopes = parse_events_jsonl(events_path)
     ids = [e.id for e in envelopes]
     assert len(set(ids)) == len(ids)
+
+
+def test_parse_events_jsonl_dedupes_repeated_envelope_ids(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    _write_events(events_path, [
+        _claude_event(
+            "tool_call",
+            type="tool_use",
+            id="toolu_duplicate",
+            name="Bash",
+            input={"command": "pwd"},
+        ),
+        _claude_event(
+            "tool_call",
+            type="tool_use",
+            id="toolu_duplicate",
+            name="Bash",
+            input={"command": "pwd"},
+        ),
+    ])
+
+    envelopes = parse_events_jsonl(events_path)
+
+    assert [env.id for env in envelopes] == ["msg_toolu_duplicate"]
 
 
 def test_tool_call_envelope_id_uses_tool_use_id(tmp_path: Path) -> None:

--- a/tests/test_tmux_hardening.py
+++ b/tests/test_tmux_hardening.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -163,6 +162,61 @@ class TestSendKeysDeadPane:
 
         client.send_keys("%42", "hello")
         assert len(calls) == 2  # send-keys text + send-keys Enter
+
+    def test_send_keys_can_skip_enter_delay(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        client = TmuxClient()
+        calls: list[tuple[str, ...]] = []
+        sleeps: list[float] = []
+        monkeypatch.setattr(client, "is_pane_alive", lambda pane_id: True)
+        monkeypatch.setattr(
+            client,
+            "run",
+            lambda *args, **kwargs: (calls.append(args), _ok())[1],
+        )
+        monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
+
+        client.send_keys(
+            "%42", "hello", press_enter=True, enter_delay_seconds=0.0,
+        )
+
+        assert len(calls) == 2
+        assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# Single-window probe
+# ---------------------------------------------------------------------------
+
+class TestGetWindow:
+    def test_get_window_parses_display_message(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        client = TmuxClient()
+        stdout = "s\t2\tmain\t1\t%7\tbash\t/tmp\t0\t1234\n"
+        monkeypatch.setattr(client, "run", lambda *args, **kwargs: _ok(stdout))
+
+        window = client.get_window("s:main")
+
+        assert window is not None
+        assert window.session == "s"
+        assert window.index == 2
+        assert window.name == "main"
+        assert window.pane_id == "%7"
+        assert window.pane_dead is False
+        assert window.pane_pid == 1234
+
+    def test_get_window_returns_none_on_missing_target(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        client = TmuxClient()
+        monkeypatch.setattr(client, "run", lambda *args, **kwargs: _fail())
+
+        assert client.get_window("s:missing") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transcript_ingest.py
+++ b/tests/test_transcript_ingest.py
@@ -148,6 +148,105 @@ def test_sync_transcripts_once_normalizes_claude_and_codex_events(tmp_path: Path
     # See transcript_ingest.py:154.
 
 
+def test_sync_transcripts_once_normalizes_codex_response_items(tmp_path: Path) -> None:
+    config, _config_path = _config(tmp_path)
+    codex_file = (
+        config.accounts["codex_main"].home
+        / ".codex/sessions/2026/05/25/rollout-response-items.jsonl"
+    )
+    codex_file.parent.mkdir(parents=True, exist_ok=True)
+    codex_file.write_text(
+        "\n".join([
+            json.dumps({
+                "timestamp": "2026-05-25T00:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "session-response-items",
+                    "cwd": str(config.project.root_dir),
+                },
+            }),
+            json.dumps({
+                "timestamp": "2026-05-25T00:00:01Z",
+                "type": "turn_context",
+                "payload": {"cwd": str(config.project.root_dir), "model": "gpt-5.4"},
+            }),
+            json.dumps({
+                "timestamp": "2026-05-25T00:00:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Codex reply."}],
+                },
+            }),
+            json.dumps({
+                "timestamp": "2026-05-25T00:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "call_id": "call_shell",
+                    "name": "shell",
+                    "arguments": "{\"command\":\"pwd\"}",
+                },
+            }),
+            json.dumps({
+                "timestamp": "2026-05-25T00:00:04Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call_shell",
+                    "output": "/tmp/repo",
+                },
+            }),
+            json.dumps({
+                "timestamp": "2026-05-25T00:00:05Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "reasoning",
+                    "summary": [
+                        {"type": "summary_text", "text": "Visible reasoning."}
+                    ],
+                    "encrypted_content": "do-not-copy",
+                },
+            }),
+            json.dumps({
+                "timestamp": "2026-05-25T00:00:06Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "Agent alias."},
+            }),
+        ])
+        + "\n"
+    )
+
+    sync_transcripts_once(config)
+
+    events = [
+        json.loads(line)
+        for line in (
+            config.project.root_dir
+            / ".pollypm/transcripts/session-response-items/events.jsonl"
+        ).read_text().splitlines()
+    ]
+
+    assert [event["event_type"] for event in events] == [
+        "session_state",
+        "assistant_turn",
+        "tool_call",
+        "tool_result",
+        "thinking",
+        "assistant_turn",
+    ]
+    assert events[1]["payload"]["text"] == "Codex reply."
+    assert events[2]["payload"]["id"] == "call_shell"
+    assert events[2]["payload"]["name"] == "shell"
+    assert events[2]["payload"]["input"] == {"command": "pwd"}
+    assert events[3]["payload"]["tool_use_id"] == "call_shell"
+    assert events[3]["payload"]["content"] == "/tmp/repo"
+    assert events[4]["payload"]["text"] == "Visible reasoning."
+    assert "encrypted_content" not in events[4]["payload"]["raw"]
+    assert events[5]["payload"]["text"] == "Agent alias."
+
+
 def test_sync_transcripts_once_skips_non_dict_json_lines(tmp_path: Path, caplog) -> None:
     config, _config_path = _config(tmp_path)
     claude_file = config.accounts["claude_main"].home / ".claude/projects/demo/session-a.jsonl"


### PR DESCRIPTION
## Agent Identity

- Agent: Codex
- Worktree: `/Users/sam/dev/pollypm/.codex/watch-worktrees/20260525-233544/.codex/worktrees/chat-transcripts`
- Branch: `codex/2341-2347-chat-transcripts`
- Commit: `a9d1343eeb01078330432b1788fcfa070051fb49`

## Summary

- Audits `safety=force` chat sends without logging message text.
- Restores raw subagent tool blocks, Codex response_item ingestion, opt-in thinking, and REST id de-duplication.
- Fixes stale Codex mid_tool false positives and speeds short send-to-pane by avoiding full surface/transcript walks and the 500 ms Enter delay.

## Issues

Closes #2341.
Closes #2342.
Closes #2343.
Closes #2344.
Closes #2345.
Closes #2346.
Closes #2347.
Closes #2356.

## Verification

- 237 passed: `uv run --extra test pytest tests/test_chat_send_endpoint.py tests/test_chat_transcripts.py tests/test_transcript_ingest.py tests/test_chat_messages_endpoint.py -q` before the #2356 extension.
- 18 passed after rebase: focused chat/transcript/tmux regression selection covering this PR.
- Ruff passed on changed Python files.
- `git diff --check origin/main...HEAD` passed.