### PR TITLE
fix(ui): cap chat history rendering

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -22,6 +22,7 @@
   const PUSH_REFRESH_DEBOUNCE_MS = 150;
   const FETCH_RETRY_MS = 3000;
   const MAX_MESSAGES = 50;
+  const HISTORY_RENDER_LIMIT = MAX_MESSAGES;
   const SESSION_ISSUED_COOKIE = "pollypm-session-issued-at";
   const SESSION_EXPIRY_WARNING_MS = 6 * 24 * 60 * 60 * 1000;
   const TASK_RAIL_LIMIT = 200;
@@ -70,6 +71,7 @@
     dashboardRefreshQueued: false,
     historyInFlight: {},
     historyRefreshQueued: {},
+    historyRenderSignatures: {},
     fetchStates: {},
     sseFailures: 0,
     sseRetryTimer: null,
@@ -129,6 +131,11 @@
       }
     }
     return node;
+  }
+
+  function clearMessageList(list) {
+    list.innerHTML = "";
+    delete list.dataset.historySession;
   }
 
   function setStatus(level, label) {
@@ -1022,7 +1029,7 @@
     $("send-input").disabled = true;
     $("send-button").disabled = true;
     const list = $("message-list");
-    list.innerHTML = "";
+    clearMessageList(list);
     list.appendChild(el("div", {
       class: "message-empty",
       text: "No surface selected.",
@@ -1093,7 +1100,7 @@
       pollDashboard();
     });
     const list = $("message-list");
-    list.innerHTML = "";
+    clearMessageList(list);
     list.appendChild(el("div", { class: "empty-state" }, [
       el("div", { class: "empty-title", text: "No surface selected" }),
       el("div", {
@@ -1147,7 +1154,7 @@
   function renderTaskSummary(task, detail) {
     const data = detail || task;
     const list = $("message-list");
-    list.innerHTML = "";
+    clearMessageList(list);
     const status = data.work_status;
     const isTerminal = TERMINAL_TASK_STATES.has(status);
     // §1.4.5 (#2336): dwell row when non-terminal — surfaces "stuck
@@ -1600,6 +1607,53 @@
     renderLocalEchoes(name);
   }
 
+  function historyMessageSignature(message, index) {
+    const m = message || {};
+    return JSON.stringify([
+      m.id == null ? "index:" + index : "id:" + String(m.id),
+      String(m.ts || ""),
+      String(m.role || ""),
+      String(m.actor || ""),
+      String(m.type || ""),
+      String(m.text || ""),
+    ]);
+  }
+
+  function historyRenderSignature(data, messages) {
+    return JSON.stringify([
+      String(data.session_name || ""),
+      String(data.surface_type || ""),
+      String(data.transcript_source || ""),
+      String(messages.length),
+      messages.map(historyMessageSignature),
+    ]);
+  }
+
+  function shouldSkipHistoryRender(list, sessionName, signature) {
+    return (
+      list.dataset.historySession === sessionName
+      && state.historyRenderSignatures[sessionName] === signature
+    );
+  }
+
+  function markHistoryRendered(list, sessionName, signature) {
+    state.historyRenderSignatures[sessionName] = signature;
+    list.dataset.historySession = sessionName;
+  }
+
+  function historyMessageNode(message) {
+    const m = message || {};
+    const roleClass = "message message-role-" + (m.role || "system");
+    return el("div", { class: roleClass }, [
+      el("div", { class: "message-head" }, [
+        el("span", { class: "message-actor", text: m.actor || m.role || "?" }),
+        el("span", { class: "message-ts", text: m.ts || "" }),
+        el("span", { class: "message-type", text: m.type || "" }),
+      ]),
+      el("div", { class: "message-text", text: m.text || "" }),
+    ]);
+  }
+
   async function loadHistory(name, opts) {
     if (!name) return;
     const force = opts && opts.force;
@@ -1652,7 +1706,7 @@
 
   function renderHistoryLoading(fetchName) {
     const list = $("message-list");
-    list.innerHTML = "";
+    clearMessageList(list);
     list.appendChild(
       fetchAffordance(fetchName, "div", "message-empty", "loading history..."),
     );
@@ -1661,17 +1715,24 @@
 
   function renderHistory(data) {
     const list = $("message-list");
-    list.innerHTML = "";
     const meta = [];
     if (data.surface_type) meta.push(data.surface_type);
     if (data.transcript_source) meta.push("src=" + data.transcript_source);
     $("pane-meta").textContent = meta.join(" · ");
-    const msgs = Array.isArray(data.messages) ? data.messages.slice() : [];
+    const rawMessages = Array.isArray(data.messages) ? data.messages : [];
+    const msgs = rawMessages.slice(0, HISTORY_RENDER_LIMIT);
     const pending = reconcilePendingMessages(data.session_name, msgs);
     state.surfaceMidStream[data.session_name] = (
       msgs.length > 0 && messageLooksMidStream(msgs[0])
     );
     updateStopAgentButton();
+    const signature = historyRenderSignature(data, msgs);
+    if (shouldSkipHistoryRender(list, data.session_name, signature)) {
+      renderLocalEchoes(data.session_name);
+      return;
+    }
+    clearMessageList(list);
+    markHistoryRendered(list, data.session_name, signature);
     if (msgs.length === 0 && pending.length === 0) {
       list.appendChild(
         el("div", { class: "message-empty", text: "no messages yet" }),
@@ -1681,20 +1742,11 @@
     }
     // API returned newest-first; render oldest-first so the latest is
     // at the bottom (chat convention).
-    msgs.reverse();
-    for (const m of msgs) {
-      const roleClass = "message message-role-" + (m.role || "system");
-      list.appendChild(
-        el("div", { class: roleClass }, [
-          el("div", { class: "message-head" }, [
-            el("span", { class: "message-actor", text: m.actor || m.role || "?" }),
-            el("span", { class: "message-ts", text: m.ts || "" }),
-            el("span", { class: "message-type", text: m.type || "" }),
-          ]),
-          el("div", { class: "message-text", text: m.text || "" }),
-        ]),
-      );
+    const fragment = document.createDocumentFragment();
+    for (let i = msgs.length - 1; i >= 0; i -= 1) {
+      fragment.appendChild(historyMessageNode(msgs[i]));
     }
+    list.appendChild(fragment);
     renderLocalEchoes(data.session_name);
     list.scrollTop = list.scrollHeight;
     renderAuditPanel(data.session_name);
@@ -1702,7 +1754,7 @@
 
   function renderHistoryError(err) {
     const list = $("message-list");
-    list.innerHTML = "";
+    clearMessageList(list);
     list.appendChild(
       el("div", { class: "error-banner", text: "history error: " + err.message }),
     );
@@ -2126,7 +2178,7 @@
       + (state.inbox.nextCursor ? " · more available" : "")
     );
     const list = $("message-list");
-    list.innerHTML = "";
+    clearMessageList(list);
     list.appendChild(el("div", { class: "inbox-view" }, [
       renderInboxFilters(),
       el("div", { class: "inbox-content" }, [
@@ -2308,7 +2360,7 @@
     $("send-button").disabled = true;
     updateStopAgentButton();
     const list = $("message-list");
-    list.innerHTML = "";
+    clearMessageList(list);
     const rows = [
       ["Metric", card.label],
       ["Value", card.value],

--- a/tests/playwright/tests/render_history_perf.spec.ts
+++ b/tests/playwright/tests/render_history_perf.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const APP_JS = path.resolve(
+  __dirname,
+  "../../../src/pollypm/web_api/ui/app.js",
+);
+
+type HistoryMessage = {
+  id: string;
+  ts: string;
+  role: string;
+  actor: string;
+  type: string;
+  text: string;
+};
+
+function messages(count: number): HistoryMessage[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: "msg-" + index,
+    ts: "2026-05-23T00:00:" + String(index % 60).padStart(2, "0") + "Z",
+    role: index % 2 === 0 ? "assistant" : "user",
+    actor: index % 2 === 0 ? "codex" : "operator",
+    type: "message",
+    text: "message " + index,
+  }));
+}
+
+async function mountUiHarness(
+  page: import("@playwright/test").Page,
+  history: HistoryMessage[],
+) {
+  await page.setContent(`
+    <!doctype html>
+    <html>
+    <body>
+      <div id="conn-status" class="conn-status">
+        <span class="conn-dot"></span>
+        <span class="conn-label"></span>
+      </div>
+      <input id="project-filter" />
+      <select id="project-sort"><option value="urgency">Urgency</option></select>
+      <input id="surface-filter" />
+      <ul id="project-list"></ul>
+      <ul id="surface-list"></ul>
+      <h2 id="pane-title"></h2>
+      <span id="pane-meta"></span>
+      <div id="message-list"></div>
+      <form id="send-form">
+        <input id="send-input" />
+        <button id="stop-agent-button" type="button"></button>
+        <button id="send-button" type="submit"></button>
+      </form>
+      <select id="activity-since"><option value="2d">2d</option></select>
+      <button id="activity-refresh" type="button"></button>
+      <div id="dashboard-rollups"></div>
+      <div id="activity-summary"></div>
+      <div id="activity-feed"></div>
+    </body>
+    </html>
+  `);
+
+  await page.evaluate((seedHistory) => {
+    (window as any).__messageRequests = 0;
+    (window as any).__seedHistory = seedHistory;
+
+    class MockEventSource {
+      static OPEN = 1;
+
+      readyState = MockEventSource.OPEN;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor() {
+        setTimeout(() => {
+          if (this.onopen) this.onopen(new Event("open"));
+        }, 0);
+      }
+
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+    }
+
+    (window as any).EventSource = MockEventSource as any;
+    window.fetch = async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      let body: unknown = {};
+
+      if (url.includes("/api/v1/chat/operator/messages")) {
+        (window as any).__messageRequests += 1;
+        body = {
+          session_name: "operator",
+          surface_type: "operator",
+          transcript_source: "jsonl",
+          messages: (window as any).__seedHistory,
+        };
+      } else if (url.includes("/api/v1/chat/sessions")) {
+        body = {
+          sessions: [{
+            session_name: "operator",
+            surface_type: "operator",
+            persona: "polly",
+            project: "pollypm",
+            window: { present: true, pane_dead: false },
+          }],
+        };
+      } else if (url.includes("/api/v1/tasks")) {
+        body = { items: [] };
+      } else if (url.includes("/api/v1/projects")) {
+        body = { items: [] };
+      } else if (url.includes("/api/v1/dashboard")) {
+        body = {
+          rollups: {},
+          daemon_status: "up",
+          active_sessions: [],
+          recent_messages: [],
+          projects: [],
+          generated_at: "2026-05-23T00:00:00Z",
+          scoped_fields: [],
+        };
+      } else if (url.includes("/api/v1/audit/stats")) {
+        body = { total: 0, by_event: {}, by_severity: {}, since: null };
+      } else if (url.includes("/api/v1/audit/grep")) {
+        body = { events: [], next_cursor: null };
+      }
+
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+  }, history);
+
+  await page.addScriptTag({ path: APP_JS });
+  await page.waitForFunction(() => Boolean((window as any).PollyPM));
+}
+
+test.describe("history renderer performance", () => {
+  test("caps large history payloads and skips unchanged windows", async ({ page }) => {
+    await mountUiHarness(page, messages(5000));
+
+    await page.evaluate(() => (window as any).PollyPM.selectSurface("operator"));
+
+    await expect(page.locator("#message-list .message")).toHaveCount(50);
+    await expect(page.locator("#message-list .message-text").first()).toHaveText(
+      "message 49",
+    );
+    await expect(page.locator("#message-list .message-text").last()).toHaveText(
+      "message 0",
+    );
+
+    await page.locator("#message-list .message").first().evaluate((node) => {
+      node.setAttribute("data-retained", "yes");
+    });
+    const requestsBefore = await page.evaluate(
+      () => (window as any).__messageRequests,
+    );
+
+    await page.evaluate(async () => {
+      await (window as any).PollyPM.loadHistory("operator", { force: true });
+    });
+
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__messageRequests))
+      .toBe(requestsBefore + 1);
+    await expect(page.locator("#message-list .message")).toHaveCount(50);
+    await expect(
+      page.locator("#message-list .message[data-retained='yes']"),
+    ).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## Agent Identity

- Agent: Codex
- Worktree: `/Users/sam/dev/pollypm/.codex/watch-worktrees/20260525-233544/.codex/worktrees/issue-2352`
- Branch: `codex/2352-render-history-window`
- Commit: `a7f655086d1019e36d08ac23900e2668b4558635`

## Summary

- Caps chat history DOM rendering to the latest visible window.
- Builds message nodes in a `DocumentFragment` and skips unchanged history windows.
- Adds a Playwright regression with a 5000-message payload.

Closes #2352.

## Verification

- `npm test -- tests/render_history_perf.spec.ts` -> 2 passed after rebase.
- `git diff --check origin/main...HEAD` -> passed.