### PR TITLE
fix(audit): recover after truncated log tails

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -686,7 +686,7 @@ def _append_line(path: Path, line: str) -> None:
     append fires unconditionally so a housekeeping bug can never
     cause audit data loss.
 
-    Uses POSIX append-mode (``"a"``) so concurrent writers from
+    Uses POSIX append-mode (``"a+b"``) so concurrent writers from
     multiple processes interleave at the line level — provided the
     line is under PIPE_BUF (4096 bytes), which our records always
     are. We open + write + close on every call rather than holding
@@ -706,11 +706,26 @@ def _append_line(path: Path, line: str) -> None:
             "audit.log: _maybe_rotate raised unexpectedly for %s",
             path, exc_info=True,
         )
-    # Newline added here so the encoded record stays a single
-    # JSON object on its own line.
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write(line)
-        fh.write("\n")
+    encoded = line.encode("utf-8")
+    try:
+        with open(path, "a+b") as fh:
+            leading_newline = b""
+            fh.seek(0, os.SEEK_END)
+            if fh.tell() > 0:
+                fh.seek(-1, os.SEEK_END)
+                if fh.read(1) != b"\n":
+                    leading_newline = b"\n"
+            # Newline added here so the encoded record stays a single
+            # JSON object on its own line. If a prior crash left a
+            # partial tail without "\n", start the new record on a
+            # fresh line so it remains recoverable by the JSONL reader.
+            fh.write(leading_newline + encoded + b"\n")
+    except OSError:
+        logger.debug(
+            "audit.log: append failed for %s",
+            path, exc_info=True,
+        )
+        raise
 
 
 def emit(

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -301,6 +301,57 @@ def test_read_events_skips_truncated_tail_lines(tmp_path: Path) -> None:
     assert events[0].subject == "trunc/1"
 
 
+def test_emit_recovers_after_truncated_central_tail(tmp_path: Path) -> None:
+    """A fresh append after a corrupt tail must not get joined onto
+    the partial JSON line and disappear from readers."""
+    emit(event=EVENT_TASK_CREATED, project="recover", subject="recover/1")
+    central = central_log_path("recover")
+    with open(central, "a", encoding="utf-8") as fh:
+        fh.write('{"ts": "2026-05-06T00:00:00+00:00", "event": "task.cre')
+
+    emit(event=EVENT_TASK_CREATED, project="recover", subject="recover/2")
+
+    lines = central.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    assert json.loads(lines[-1])["subject"] == "recover/2"
+    events = read_events("recover")
+    assert [event.subject for event in events] == ["recover/1", "recover/2"]
+
+
+def test_emit_recovers_after_truncated_per_project_tail(tmp_path: Path) -> None:
+    """The per-project audit log is the source of truth, so tail
+    recovery must work there too."""
+    project_root = tmp_path / "recover-project"
+    (project_root / ".pollypm").mkdir(parents=True)
+
+    emit(
+        event=EVENT_TASK_CREATED,
+        project="recoverproj",
+        subject="recoverproj/1",
+        project_path=project_root,
+    )
+    per_project = project_log_path(project_root)
+    assert per_project is not None
+    with open(per_project, "a", encoding="utf-8") as fh:
+        fh.write('{"ts": "2026-05-06T00:00:00+00:00", "event": "task.cre')
+
+    emit(
+        event=EVENT_TASK_CREATED,
+        project="recoverproj",
+        subject="recoverproj/2",
+        project_path=project_root,
+    )
+
+    lines = per_project.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    assert json.loads(lines[-1])["subject"] == "recoverproj/2"
+    events = read_events("recoverproj", project_path=project_root)
+    assert [event.subject for event in events] == [
+        "recoverproj/1",
+        "recoverproj/2",
+    ]
+
+
 def test_read_events_empty_when_no_log_exists(tmp_path: Path) -> None:
     assert read_events("never-emitted") == []
 


### PR DESCRIPTION
## Agent Identity

- Agent: Codex
- Worktree: `/Users/sam/dev/pollypm/.codex/watch-worktrees/20260525-233544/.codex/worktrees/issue-2353`
- Branch: `codex/2353-audit-tail`
- Commit: `027381a23d25079ef94a34bbf7a48f5300da6705`

## Summary

- Heals audit JSONL append boundaries when an existing log tail lacks a newline.
- Keeps the next valid audit event recoverable after a crash/truncated write.
- Adds central-tail and per-project regression coverage.

Closes #2353.

## Verification

- `uv run --extra test pytest tests/test_audit_log.py -q` -> 26 passed before rebase.
- `uv run --extra test pytest tests/test_audit_log.py::test_emit_recovers_after_truncated_central_tail tests/test_audit_log.py::test_emit_recovers_after_truncated_per_project_tail tests/test_audit_log.py::test_read_events_skips_truncated_tail_lines -q` -> 3 passed after rebase.
- `uv run --extra dev ruff check src/pollypm/audit/log.py` -> passed.
- `git diff --check origin/main...HEAD` -> passed.