### PR TITLE
fix: stabilize chat surface parity tests

### DIFF
--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -814,6 +814,7 @@ because typing curl with bearer-token plumbing every time gets old.
 
 ```
 pm chat list [--json]
+pm chat sessions [--json]
 pm chat history <session_name> [--limit N] [--since ISO]
                                 [--since-id MSG_ID]
                                 [--direction desc|asc]
@@ -829,8 +830,11 @@ pm chat send <session_name> <text> [--no-enter]
                                    [--json]
 ```
 
-- `pm chat list` → `GET /api/v1/chat/sessions`. Renders a fixed-column
-  table by default; `--json` emits the raw response envelope.
+- `pm chat list` / `pm chat sessions` → `GET /api/v1/chat/sessions`.
+  Renders a fixed-column table by default; `--json` emits the raw
+  response envelope. Use these commands for chat-surface parity checks;
+  root `pm sessions` is the configured-session admin-health view and
+  mirrors `GET /api/v1/sessions`.
 - `pm chat history` → `GET /api/v1/chat/<session>/messages`. Forwards
   every flag as the matching query param. `--since-id` is cursor
   pagination (pass the previous response's `next_cursor`). `--pane` is

--- a/docs/test-plan/03-web-ui-richness.md
+++ b/docs/test-plan/03-web-ui-richness.md
@@ -27,7 +27,7 @@ export TOKEN=$(cat ~/.pollypm/api-token)
 - Polling cadence:
   - Dashboard: 15s
   - Messages (selected surface): 5s
-  - Surfaces list: 30s
+  - Surfaces list: SSE push refresh plus fallback polling
 - TUI: `pm cockpit` — for direct comparison.
 
 ### What the Web UI currently has (per #2065)
@@ -38,16 +38,15 @@ export TOKEN=$(cat ~/.pollypm/api-token)
 - Center: selected surface transcript with send box.
 - Cookie auth (HttpOnly, 7-day Max-Age).
 
-### What it does NOT have yet (known gaps to verify)
+### Known gaps to verify
 
-- WebSocket / SSE — all updates poll.
-- Surface filter / search.
-- "Stop the agent" (Ctrl-C / Esc) affordance.
-- Audit log panel.
-- Task surfaces (tasks aren't in the rail; only sessions).
-- Cookie expiry banner.
+This list is no longer a static "missing features" checklist. Verify
+the current UI before filing: SSE refresh, surface filtering, stop-agent
+affordance, audit panel, task rail, and cookie-expiry surfacing have all
+shipped in at least a baseline form.
 
-Document these as known gaps and decide which become this-sprint vs. next-sprint.
+Document any remaining gaps and decide which become this-sprint vs.
+next-sprint.
 
 ---
 
@@ -99,16 +98,21 @@ Repeat 3.1.1 at M-scale from `06-performance-budgets.md`:
 ```bash
 # TUI surface list (from cockpit)
 pm cockpit  # then visually count or use a CLI proxy:
-pm sessions list --json | jq '.[].name' | sort > /tmp/tui-sessions.txt
+pm chat sessions --json | jq -r '.sessions[].session_name' | sort > /tmp/tui-sessions.txt
 
 # Web surface list
 curl -sS -H "Authorization: Bearer $TOKEN" $BASE/api/v1/chat/sessions | \
-  jq -r '.sessions[].name' | sort > /tmp/web-sessions.txt
+  jq -r '.sessions[].session_name' | sort > /tmp/web-sessions.txt
 
 diff /tmp/tui-sessions.txt /tmp/web-sessions.txt
 ```
 
 **Pass:** no diff. Any session in one and not the other is a `bug:surface-enum`.
+
+`pm sessions --json` is intentionally not this proxy: it is the
+admin-health contract for configured sessions and mirrors
+`GET /api/v1/sessions`, so it includes non-chat sessions such as
+heartbeat/reviewer and omits work-service task chat surfaces.
 
 ---
 

--- a/docs/test-plan/06-performance-budgets.md
+++ b/docs/test-plan/06-performance-budgets.md
@@ -44,7 +44,9 @@ Each scale has a defined fixture. Codex lane E builds the seed scripts under `sc
 4. Ensure one designated surface has the >1MB (M) or >10MB (L) transcript file.
 5. Verify the resulting state matches the table below; exit non-zero on mismatch.
 
-**Pre-§06 requirement:** before running §06, execute the appropriate seed script and verify with `pm sessions list --json | jq 'length'` and `pm task list --project pollypm --status all --json | jq 'length'`.
+**Pre-§06 requirement:** before running §06, execute the appropriate
+seed script and verify with `pm chat sessions --json | jq '.sessions | length'`
+and `pm task list --project pollypm --status all --json | jq 'length'`.
 
 If `scripts/perf/seed_mscale.sh` does not exist, file `bug:perf-seed-missing` against lane E and either:
 - Run §06 at S-scale only (smoke coverage), OR

--- a/src/pollypm/cli_features/chat.py
+++ b/src/pollypm/cli_features/chat.py
@@ -276,6 +276,15 @@ def chat_list(
         typer.echo(line)
 
 
+chat_app.command(
+    "sessions",
+    help=(
+        "Alias for `pm chat list`. Lists the same chat-surface envelope "
+        "as GET /api/v1/chat/sessions; use `pm sessions` for admin health."
+    ),
+)(chat_list)
+
+
 # ---------------------------------------------------------------------------
 # `pm chat history <session_name>`
 # ---------------------------------------------------------------------------

--- a/tests/playwright/tests/auth.spec.ts
+++ b/tests/playwright/tests/auth.spec.ts
@@ -135,7 +135,9 @@ test.describe("auth", () => {
     // own APIRequestContext, which shares the cookie jar) succeed.
     // This proves the JS app's `credentials: "include"` model works.
     await page.goto("/ui/");
-    const resp = await page.request.get("/api/v1/chat/sessions");
+    const resp = await page.request.get(
+      "/api/v1/chat/sessions?include_transcripts=false",
+    );
     expect(resp.status(), "status with cookie").toBe(200);
     const body = await resp.json();
     expect(body).toHaveProperty("sessions");

--- a/tests/playwright/tests/dashboard_rail.spec.ts
+++ b/tests/playwright/tests/dashboard_rail.spec.ts
@@ -9,7 +9,7 @@ const FAKE_SURFACE = {
 };
 
 async function stubSurfaces(page: import("@playwright/test").Page) {
-  await page.route("**/api/v1/chat/sessions", (route) =>
+  await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -113,8 +113,8 @@ test.describe("dashboard rail", () => {
     );
 
     const expected: Array<[RegExp, string]> = [
-      [/inbox/i, "operator"],
-      [/plan reviews/i, "Dashboard: plan reviews"],
+      [/inbox/i, "Inbox"],
+      [/plan reviews/i, "Inbox"],
       [/alerts/i, "Dashboard: alerts"],
       [/activity/i, "operator"],
       [/daemon/i, "Dashboard: daemon"],

--- a/tests/playwright/tests/edge_cases.spec.ts
+++ b/tests/playwright/tests/edge_cases.spec.ts
@@ -5,6 +5,7 @@ import { test, expect } from "@playwright/test";
  *
  * The UI surfaces errors via two channels:
  *   - history errors land in #message-list as `.error-banner`
+ *   - send failures stay attached to the local echo as `.message-error`
  *   - the connection badge (#conn-status) flips to conn-warn / conn-error
  */
 
@@ -17,7 +18,7 @@ const FAKE_SURFACE = {
 };
 
 async function stubSurfaces(page: import("@playwright/test").Page) {
-  await page.route("**/api/v1/chat/sessions", (route) =>
+  await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -92,9 +93,9 @@ test.describe("edge cases", () => {
     await page.locator("#send-input").fill("oops");
     await page.locator("#send-button").click();
 
-    const banner = page.locator("#message-list .error-banner");
-    await expect(banner).toBeVisible();
-    await expect(banner).toContainText(/mid-tool|unsafe_mid_tool/i);
+    const inlineError = page.locator("#message-list .message-error");
+    await expect(inlineError).toBeVisible();
+    await expect(inlineError).toContainText(/mid-tool|unsafe_mid_tool/i);
   });
 
   test("503 service_unavailable surfaces in UI", async ({ page }) => {
@@ -118,7 +119,7 @@ test.describe("edge cases", () => {
   });
 
   test("empty session list shows empty-state in left rail", async ({ page }) => {
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -132,7 +133,7 @@ test.describe("edge cases", () => {
   });
 
   test("sessions endpoint 500 shows error in left rail", async ({ page }) => {
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 500,
         contentType: "application/json",
@@ -155,7 +156,7 @@ test.describe("edge cases", () => {
     // win the race and flip the badge back to conn-ok. To assert the
     // failure-surfacing contract deterministically, override BOTH read
     // endpoints to fail in this specific test.
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 500,
         contentType: "application/json",

--- a/tests/playwright/tests/inbox.spec.ts
+++ b/tests/playwright/tests/inbox.spec.ts
@@ -24,7 +24,7 @@ const SECOND_ITEM = {
 };
 
 async function stubChrome(page: import("@playwright/test").Page) {
-  await page.route("**/api/v1/chat/sessions", (route) =>
+  await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -199,11 +199,22 @@ test.describe("inbox panel", () => {
 
     await page.goto("/ui/");
     await page.locator(".rollup-card[title='Open inbox']").click();
+    await expect(page.locator("[data-inbox-id='demo/1']")).toBeVisible();
     await page.locator(".inbox-filter-input").fill("demo");
     await page.locator(".inbox-filter-select").first().selectOption("waiting-on-pm");
     await page.locator(".inbox-filter-select").nth(1).selectOption("plan_review");
+    const filteredResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return (
+        url.pathname === "/api/v1/inbox"
+        && url.searchParams.get("project") === "demo"
+        && url.searchParams.get("state") === "waiting-on-pm"
+        && url.searchParams.get("type") === "plan_review"
+      );
+    });
     await page.locator(".inbox-filter-button.primary").click();
-    await expect.poll(() => filteredRequestSeen).toBe(true);
+    await filteredResponse;
+    expect(filteredRequestSeen).toBe(true);
 
     await page.locator("[data-inbox-id='demo/1']").click();
     await page.locator(".inbox-action", { hasText: "Mark read" }).click();

--- a/tests/playwright/tests/keyboard.spec.ts
+++ b/tests/playwright/tests/keyboard.spec.ts
@@ -19,7 +19,7 @@ const FAKE_SURFACE = {
 };
 
 async function stubBasics(page: import("@playwright/test").Page) {
-  await page.route("**/api/v1/chat/sessions", (route) =>
+  await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/tests/playwright/tests/mobile_viewport.spec.ts
+++ b/tests/playwright/tests/mobile_viewport.spec.ts
@@ -58,7 +58,7 @@ test.describe("mobile viewport", () => {
         }),
       }),
     );
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/tests/playwright/tests/send_message.spec.ts
+++ b/tests/playwright/tests/send_message.spec.ts
@@ -16,7 +16,7 @@ const FAKE_SURFACE = {
 };
 
 async function stubSurfaces(page: import("@playwright/test").Page) {
-  await page.route("**/api/v1/chat/sessions", (route) =>
+  await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -26,14 +26,15 @@ test.describe("surfaces", () => {
           "#surface-list li[data-task]",
         ).length;
         if (items > 0 || tasks > 0) return true;
-        const empty = document.querySelector(
+        const empties = Array.from(document.querySelectorAll(
           "#surface-list .surface-empty",
-        ) as HTMLElement | null;
-        if (!empty) return false;
-        const text = (empty.textContent ?? "").trim();
-        return (
-          text.includes("no surfaces registered") || text.startsWith("error:")
-        );
+        )) as HTMLElement[];
+        return empties.some((empty) => {
+          const text = (empty.textContent ?? "").trim();
+          return (
+            text.includes("no surfaces registered") || text.startsWith("error:")
+          );
+        });
       },
       undefined,
       { timeout: 10_000 },
@@ -176,7 +177,7 @@ test.describe("surfaces", () => {
   }
 
   async function stubEmptySessions(page: import("@playwright/test").Page) {
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -278,7 +279,7 @@ test.describe("surfaces", () => {
       }),
     );
     // Stub the sessions endpoint to ensure at least one selectable surface.
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -334,7 +335,7 @@ test.describe("surfaces", () => {
         }),
       });
     });
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -547,7 +548,7 @@ test.describe("surfaces", () => {
     const firstRequestGate = new Promise<void>((resolve) => {
       releaseFirst = resolve;
     });
-    await page.route("**/api/v1/chat/sessions", async (route) => {
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, async (route) => {
       sessionRequests += 1;
       if (sessionRequests === 1) {
         await firstRequestGate;
@@ -593,7 +594,7 @@ test.describe("surfaces", () => {
     let taskRequests = 0;
     let projectRequests = 0;
 
-    await page.route("**/api/v1/chat/sessions", async (route) => {
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, async (route) => {
       sessionRequests += 1;
       await sessionsGate;
       return route.fulfill({
@@ -647,7 +648,7 @@ test.describe("surfaces", () => {
       releaseTasks = resolve;
     });
 
-    await page.route("**/api/v1/chat/sessions", async (route) => {
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, async (route) => {
       await sessionsGate;
       return route.fulfill({
         status: 200,
@@ -720,7 +721,7 @@ test.describe("surfaces", () => {
       }).catch(() => undefined);
     }
 
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       slowJson(route, { sessions: [] }),
     );
     await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
@@ -770,7 +771,7 @@ test.describe("surfaces", () => {
       releaseSecond = resolve;
     });
 
-    await page.route("**/api/v1/chat/sessions", async (route) => {
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, async (route) => {
       sessionRequests += 1;
       if (sessionRequests === 1) {
         await firstRequestGate;
@@ -824,7 +825,7 @@ test.describe("surfaces", () => {
   test("task surfaces render in a separate rail group", async ({ page }) => {
     await stubEmptyProjects(page);
     await stubEmptyActivity(page);
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -890,7 +891,7 @@ test.describe("surfaces", () => {
     let claimActor = "";
     await stubEmptyProjects(page);
     await stubEmptyActivity(page);
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -1035,7 +1036,7 @@ test.describe("surfaces", () => {
         }),
       }),
     );
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -1211,7 +1212,7 @@ test.describe("surfaces", () => {
         }),
       }),
     );
-    await page.route("**/api/v1/chat/sessions", (route) =>
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/tests/test_pm_chat_cli.py
+++ b/tests/test_pm_chat_cli.py
@@ -192,6 +192,29 @@ class TestChatList:
         decoded = json.loads(result.output)
         assert decoded == payload
 
+    def test_sessions_alias_uses_chat_sessions_endpoint(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _install_token(monkeypatch, tmp_path)
+        payload = {
+            "sessions": [
+                {
+                    "session_name": "operator",
+                    "surface_type": "operator",
+                    "persona": "Polly",
+                    "project": None,
+                    "window": {"present": True},
+                }
+            ]
+        }
+        capture = _install_response(monkeypatch, json_payload=payload)
+
+        result = runner.invoke(_build_cli_app(), ["chat", "sessions", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == payload
+        assert capture.method == "GET"
+        assert capture.url.endswith("/api/v1/chat/sessions")
+
     def test_empty_sessions_list_friendly_message(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Stabilizes chat surface Playwright stubs so `/api/v1/chat/sessions?include_transcripts=false` is intercepted consistently.
- Updates stale rail/detail assertions for current UI behavior and hardens surface-empty polling.
- Adds `pm chat sessions` as an alias for the chat surface enumeration endpoint and documents the distinction from root `pm sessions` admin-health output.

## Issues
- Fixes #2362
- Addresses #2363

## Tests
- `uv run --extra test pytest tests/test_pm_chat_cli.py tests/test_chat_registry.py tests/test_chat_messages_endpoint.py -q` (`112 passed`)
- `uv run --extra test pytest tests/test_pm_chat_cli.py -q` (`25 passed`)
- `uv run pm chat sessions --help`
- `npx playwright test tests/dashboard_rail.spec.ts tests/edge_cases.spec.ts --project=chromium --project=mobile-chrome --reporter=line` (`16 passed`)
- `npx playwright test tests/surfaces.spec.ts -g "clicking a surface populates" --project=chromium --project=mobile-chrome --reporter=line` (`2 passed`)
- `npx playwright test tests/surfaces.spec.ts tests/edge_cases.spec.ts tests/mobile_viewport.spec.ts tests/send_message.spec.ts tests/dashboard_rail.spec.ts tests/keyboard.spec.ts --project=chromium --project=mobile-chrome --reporter=line` (`80 passed, 4 skipped`)
- `npx playwright test --project=chromium --project=mobile-chrome --reporter=line` (`104 passed, 4 skipped`)

Note: `npx tsc --noEmit` was attempted from `tests/playwright`, but this package does not install TypeScript as a dependency; the Playwright suite above provided the TypeScript/transpile verification path available in-tree.
