### PR TITLE
fix: fail closed on unknown task reassignment sessions

### DIFF
--- a/src/pollypm/storage/pg_sessions.py
+++ b/src/pollypm/storage/pg_sessions.py
@@ -24,6 +24,7 @@ Sessions:
   StateStore's compound prune (see #1528 + #232 for the alert/memory
   carve-outs preserved here)
 * :func:`get_session_window` — SELECT window_name FROM sessions WHERE name=…
+* :func:`session_exists` — true when a sessions-row exists for a name
 
 Events (backed by ``messages`` with ``type='event'``):
 
@@ -57,7 +58,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pollypm.storage.records import EventRecord, SessionRecord, SessionRuntimeRecord
 
@@ -280,6 +281,29 @@ def get_session_window(
     if row is None:
         return None
     return str(row[0])
+
+
+def session_exists(
+    session_name: str,
+    *,
+    cur: Any | None = None,
+    pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
+) -> bool:
+    """Return True when ``session_name`` exists in the sessions registry.
+
+    ``cur`` lets callers validate inside an existing transaction without
+    borrowing another pool connection while holding locks.
+    """
+    if cur is not None:
+        cur.execute(
+            "SELECT 1 FROM sessions WHERE name = %s",
+            (session_name,),
+        )
+        return cur.fetchone() is not None
+    return get_session_window(
+        session_name, pool=pool, config=config
+    ) is not None
 
 
 # --------------------------------------------------------------------- #
@@ -610,6 +634,7 @@ __all__ = [
     "prune_sessions",
     "recent_events",
     "record_event",
+    "session_exists",
     "upsert_session",
     "upsert_session_runtime",
 ]

--- a/src/pollypm/work/mock_service.py
+++ b/src/pollypm/work/mock_service.py
@@ -7,8 +7,9 @@ consumer tests, and proving the protocol is sufficient.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from collections.abc import Iterable
 from copy import deepcopy
+from datetime import datetime, timezone
 
 from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
 from pollypm.work.flow_engine import resolve_flow
@@ -85,7 +86,12 @@ class MockWorkService:
     Flow templates are resolved from the filesystem (same as SQLite service).
     """
 
-    def __init__(self, project_path: str | None = None) -> None:
+    def __init__(
+        self,
+        project_path: str | None = None,
+        *,
+        session_names: Iterable[str] | None = None,
+    ) -> None:
         self._tasks: dict[str, Task] = {}
         self._counter: dict[str, int] = {}  # per-project task number counters
         self._flows: dict[str, FlowTemplate] = {}
@@ -98,6 +104,29 @@ class MockWorkService:
         # Keyed by (project, task_number). Stored as plain dicts so tests
         # can inspect / mutate the row shape directly.
         self._worker_sessions: dict[tuple[str, int], dict] = {}
+        self._session_names: set[str] = {
+            name for name in (session_names or []) if name
+        }
+
+    def register_session(self, session_name: str) -> None:
+        """Register a valid target session for in-memory reassignment tests."""
+        if session_name:
+            self._session_names.add(session_name)
+
+    def _validate_reassign_target_session(self, session_name: str) -> None:
+        target = session_name.strip()
+        if not target or target != session_name:
+            raise ValidationError(
+                "Cannot reassign task: target assignee must be a "
+                "non-empty registered session name with no surrounding "
+                "whitespace."
+            )
+        if target not in self._session_names:
+            raise ValidationError(
+                f"Cannot reassign task to unknown session "
+                f"{target!r}. Create or register the session before "
+                f"handing off work to it."
+            )
 
     # ------------------------------------------------------------------
     # Flow resolution
@@ -508,6 +537,7 @@ class MockWorkService:
                 f"(spec §P-9); it refuses draft (queue + claim first) "
                 f"and terminal (done / cancelled) tasks."
             )
+        self._validate_reassign_target_session(new_assignee)
         old_assignee = task.assignee
         task.assignee = new_assignee
         task.updated_at = _now()

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -471,6 +471,32 @@ class PgWorkService:
             (f"work_tasks.worker_cap:{project}",),
         )
 
+    def _validate_reassign_target_session(
+        self, session_name: str, *, cur: Any | None = None
+    ) -> None:
+        """Fail closed unless ``session_name`` exists in the session registry."""
+        target = session_name.strip()
+        if not target or target != session_name:
+            raise ValidationError(
+                "Cannot reassign task: target assignee must be a "
+                "non-empty registered session name with no surrounding "
+                "whitespace."
+            )
+        from pollypm.storage.pg_sessions import session_exists
+
+        exists = session_exists(
+            target,
+            cur=cur,
+            pool=self._ro_pool or self._pool,
+            config=self._config,
+        )
+        if not exists:
+            raise ValidationError(
+                f"Cannot reassign task to unknown session "
+                f"{target!r}. Create or register the session before "
+                f"handing off work to it."
+            )
+
     def _count_capacity_consuming_tasks_locked(
         self,
         cur,
@@ -2572,6 +2598,7 @@ class PgWorkService:
                         f"`pm task next`, or queue + claim this one "
                         f"if it is still draft."
                     )
+                self._validate_reassign_target_session(new_assignee, cur=cur)
                 # Column write — same SQL shape as update(assignee=...)
                 # but inline so the context-log INSERT lands in the
                 # same transaction.

--- a/tests/test_pg_sessions.py
+++ b/tests/test_pg_sessions.py
@@ -35,11 +35,13 @@ def test_pg_sessions_upsert_list_roundtrip(pg_schema_pool):
     from pollypm.storage.pg_sessions import (
         get_session_window,
         list_sessions,
+        session_exists,
         upsert_session,
     )
 
     assert list_sessions(pool=pg_schema_pool) == []
     assert get_session_window("nope", pool=pg_schema_pool) is None
+    assert session_exists("nope", pool=pg_schema_pool) is False
 
     upsert_session(
         name="worker-alpha",
@@ -57,6 +59,10 @@ def test_pg_sessions_upsert_list_roundtrip(pg_schema_pool):
     assert rows[0].project == "alpha"
     assert rows[0].window_name == "alpha-1"
     assert get_session_window("worker-alpha", pool=pg_schema_pool) == "alpha-1"
+    assert session_exists("worker-alpha", pool=pg_schema_pool) is True
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        assert session_exists("worker-alpha", cur=cur) is True
+        assert session_exists("missing", cur=cur) is False
 
     # Re-upserting the same name overwrites (no duplicate row).
     upsert_session(

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -28,8 +28,22 @@ import pytest
 @pytest.fixture()
 def pg_service(pg_schema_pool):
     from pollypm.work.pg_service import PgWorkService
+    from pollypm.storage.pg_sessions import upsert_session
 
-    return PgWorkService(pool=pg_schema_pool, ro_pool=None)
+    service = PgWorkService(pool=pg_schema_pool, ro_pool=None)
+    for name in ("alice", "bob", "pete", "nora", "olga"):
+        upsert_session(
+            name=name,
+            role="worker",
+            project="demo",
+            provider="codex",
+            account="test",
+            cwd="/tmp/demo",
+            window_name=name,
+            pool=pg_schema_pool,
+        )
+
+    return service
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +281,29 @@ def test_reassign_task_optional_reason_lands_in_breadcrumb(pg_service):
     )
     assert len(entries) == 1
     assert "pete went offline" in entries[0].text
+
+
+def test_reassign_task_rejects_unknown_target_session(pg_service):
+    """Unknown assignee strings must not strand active tasks (#2370)."""
+    from pollypm.work.service_support import ValidationError
+
+    task = _make_draft(
+        pg_service, roles={"worker": "pete", "reviewer": "bob"}
+    )
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="pete")
+
+    with pytest.raises(ValidationError, match="unknown session"):
+        pg_service.reassign_task(
+            task.task_id, new_assignee="ghost-session", actor="api"
+        )
+
+    refetched = pg_service.get(task.task_id)
+    assert refetched.assignee == "pete"
+    entries = pg_service.get_context(
+        task.task_id, entry_type="reassignment"
+    )
+    assert entries == []
 
 
 def test_reassign_task_missing_task_raises(pg_service):

--- a/tests/test_tasks_writes_endpoint.py
+++ b/tests/test_tasks_writes_endpoint.py
@@ -38,6 +38,7 @@ from pollypm.config import (
     PollyPMConfig,
     PollyPMSettings,
     ProjectSettings,
+    SessionConfig,
 )
 from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
 from pollypm.web_api import create_app, ensure_token
@@ -155,9 +156,15 @@ class FakeWorkService:
     transition.
     """
 
-    def __init__(self, store: dict[str, FakeTask]):
+    def __init__(
+        self,
+        store: dict[str, FakeTask],
+        *,
+        session_names: set[str] | None = None,
+    ) -> None:
         self._store = store
         self._lock = threading.Lock()
+        self._session_names = set(session_names or set())
 
     # The context-manager protocol — ``create_work_service`` returns
     # something usable as ``with create_work_service(...) as svc:``.
@@ -172,6 +179,19 @@ class FakeWorkService:
         if task is None:
             raise TaskNotFoundError(f"Task '{task_id}' not found.")
         return task
+
+    def _validate_reassign_target_session(self, session_name: str) -> None:
+        target = session_name.strip()
+        if not target or target != session_name:
+            raise WorkValidationError(
+                "Cannot reassign task: target assignee must be a "
+                "non-empty registered session name with no surrounding "
+                "whitespace."
+            )
+        if target not in self._session_names:
+            raise WorkValidationError(
+                f"Cannot reassign task to unknown session {target!r}."
+            )
 
     def queue(self, task_id: str, actor: str) -> FakeTask:  # noqa: ARG002
         task = self.get(task_id)
@@ -290,6 +310,7 @@ class FakeWorkService:
                     f"Cannot reassign task in "
                     f"'{task.work_status.value}' state."
                 )
+            self._validate_reassign_target_session(new_assignee)
             old_assignee = task.assignee
             task.assignee = new_assignee
             task.updated_at = datetime.now(timezone.utc)
@@ -362,7 +383,18 @@ def api_config(project_root: Path, workspace_root: Path) -> PollyPMConfig:
                 home=base_dir / "homes" / "codex_primary",
             ),
         },
-        sessions={},
+        sessions={
+            name: SessionConfig(
+                name=name,
+                role="worker",
+                provider=ProviderKind.CODEX,
+                account="codex_primary",
+                cwd=project_root,
+                project="myproj",
+                window_name=name,
+            )
+            for name in {"bob", "carol", "nora"}
+        },
         projects={
             "myproj": KnownProject(
                 key="myproj",
@@ -411,8 +443,10 @@ def patched_work_service(
     from pollypm.work import factory as work_factory
     from pollypm.work import service_factory as work_service_factory
 
-    def _fake_factory(**_kwargs: object) -> FakeWorkService:
-        return FakeWorkService(task_store)
+    def _fake_factory(**kwargs: object) -> FakeWorkService:
+        config = kwargs.get("config")
+        sessions = getattr(config, "sessions", {}) if config is not None else {}
+        return FakeWorkService(task_store, session_names=set(sessions))
 
     monkeypatch.setattr(work_factory, "create_work_service", _fake_factory)
     # #2064 round-9 blocker #2: the API claim helper now routes
@@ -1246,6 +1280,27 @@ def test_reassign_rejects_unknown_field(client, auth_headers, task_store) -> Non
         f"reassign with unknown field must NOT record a breadcrumb; "
         f"got {seeded.context!r}"
     )
+
+
+def test_reassign_unknown_session_returns_422(
+    client, auth_headers, task_store,
+) -> None:
+    """Unknown target sessions fail closed before assignee/context writes."""
+    seeded = _seed(
+        task_store, n=53,
+        work_status=WorkStatus.IN_PROGRESS, assignee="bob",
+    )
+    response = client.post(
+        "/api/v1/tasks/myproj/53/reassign",
+        headers=auth_headers,
+        json={"actor": "ghost-session"},
+    )
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+    assert "unknown session" in body["error"]["message"].lower()
+    assert seeded.assignee == "bob"
+    assert seeded.context == []
 
 
 def test_reassign_records_context_log_breadcrumb(

--- a/tests/test_work_service_protocol_conformance.py
+++ b/tests/test_work_service_protocol_conformance.py
@@ -17,7 +17,10 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from pollypm.work.mock_service import MockWorkService
+from pollypm.work.mock_service import (
+    MockWorkService,
+    ValidationError as MockValidationError,
+)
 from pollypm.work.pg_service import PgWorkService
 from pollypm.work.service import WorkService
 
@@ -119,6 +122,38 @@ def test_mock_update_allows_assignee_and_external_refs(tmp_path) -> None:
     )
     assert updated.assignee == "olga"
     assert updated.external_refs == {"slack": "thread/abc"}
+
+
+def test_mock_reassign_requires_registered_target_session(tmp_path) -> None:
+    """MockWorkService mirrors pg fail-closed reassignment (#2370)."""
+    svc = MockWorkService(project_path=tmp_path, session_names=["nora"])
+    task = svc.create(
+        title="handoff-target",
+        type="task",
+        project="demo",
+        flow_template="standard",
+        roles={"worker": "pete", "reviewer": "bob"},
+        description="has body",
+    )
+    svc.queue(task.task_id, actor="user")
+    svc.claim(task.task_id, actor="pete")
+
+    with pytest.raises(MockValidationError, match="unknown session"):
+        svc.reassign_task(
+            task.task_id, new_assignee="ghost-session", actor="api"
+        )
+
+    refetched = svc.get(task.task_id)
+    assert refetched.assignee == "pete"
+    assert svc.get_context(task.task_id, entry_type="reassignment") == []
+
+    updated = svc.reassign_task(
+        task.task_id, new_assignee="nora", actor="api"
+    )
+    assert updated.assignee == "nora"
+    entries = svc.get_context(task.task_id, entry_type="reassignment")
+    assert len(entries) == 1
+    assert "pete" in entries[0].text and "nora" in entries[0].text
 
 
 def _create_mock_task(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Validates `POST /api/v1/tasks/{project}/{number}/reassign` targets against the session registry before changing assignee or writing reassignment context.
- Keeps the PG validation inside the task-row transaction and exposes a small `session_exists` facade helper so storage rules remain in the session module.
- Mirrors the fail-closed contract in `MockWorkService` and API tests.

## Issue
- Fixes #2370

## Tests
- `uv run --extra test pytest --noconftest tests/test_tasks_writes_endpoint.py tests/test_work_service_protocol_conformance.py -q` (`94 passed`)
- `uv run --extra test pytest tests/test_pg_sessions.py::test_pg_sessions_upsert_list_roundtrip tests/test_pg_work_service_full.py::test_reassign_task_appends_context_log_breadcrumb tests/test_pg_work_service_full.py::test_reassign_task_optional_reason_lands_in_breadcrumb tests/test_pg_work_service_full.py::test_reassign_task_rejects_unknown_target_session tests/test_pg_work_service_full.py::test_concurrent_reassign_serializes_breadcrumbs -q` (`5 passed`)
- `uv run --extra dev ruff check src/pollypm/storage/pg_sessions.py src/pollypm/work/mock_service.py src/pollypm/work/pg_service.py tests/test_pg_sessions.py tests/test_pg_work_service_full.py tests/test_tasks_writes_endpoint.py tests/test_work_service_protocol_conformance.py` (`passed`)
- `git diff --check origin/main...HEAD` (`passed`)
