### PR TITLE
fix: expose rich task fields and reachable task rail states

### DIFF
--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -1246,8 +1246,9 @@ def list_project_tasks(
             next_cursor: str | None = None
             if len(tasks) > limit and page:
                 next_cursor = str(getattr(page[-1], "task_number", 0))
+            project_paused = not getattr(project, "tracked", True)
             return [
-                _task_to_summary(t) for t in page
+                _task_to_summary(t, project_paused=project_paused) for t in page
             ], next_cursor, total
     except _BACKING_STORE_ERRORS as exc:
         logger.warning(
@@ -1349,7 +1350,14 @@ def list_all_tasks(
                 since=since,
             ):
                 continue
-            summaries.append(_task_to_summary(task))
+            summaries.append(
+                _task_to_summary(
+                    task,
+                    project_paused=_project_paused_for_key(
+                        config, str(getattr(task, "project", ""))
+                    ),
+                )
+            )
         return _page_task_summaries(
             summaries, limit=limit, cursor=cursor, warnings=warnings
         )
@@ -1391,7 +1399,7 @@ def list_all_tasks(
                 since=since,
             ):
                 continue
-            summaries.append(_task_to_summary(task))
+            summaries.append(_task_to_summary(task, project_paused=False))
 
     try:
         dropped_count = _count_untracked_matches(
@@ -1501,7 +1509,15 @@ def _list_all_tasks_summary_page(
                         }
                     )
             return (
-                [_task_summary_projection_to_api(row) for row in rows],
+                [
+                    _task_summary_projection_to_api(
+                        row,
+                        project_paused=_project_paused_for_key(
+                            config, row.project
+                        ),
+                    )
+                    for row in rows
+                ],
                 next_cursor,
                 warnings,
                 total,
@@ -1526,6 +1542,13 @@ def _workspace_root_path(config: PollyPMConfig) -> Path:
         or getattr(config.project, "root_dir", None)
         or Path.cwd()
     )
+
+
+def _project_paused_for_key(config: PollyPMConfig, project_key: str) -> bool:
+    project = config.projects.get(project_key)
+    if project is None:
+        return True
+    return not getattr(project, "tracked", True)
 
 
 def _task_for_summary(svc, task):
@@ -3688,7 +3711,11 @@ def _task_to_summary(task, *, project_paused: bool | None = None) -> APITaskSumm
     )
 
 
-def _task_summary_projection_to_api(row: TaskSummaryProjection) -> APITaskSummary:
+def _task_summary_projection_to_api(
+    row: TaskSummaryProjection,
+    *,
+    project_paused: bool | None = None,
+) -> APITaskSummary:
     created_at = _as_aware_datetime(row.created_at)
     state_entered_at = _as_aware_datetime(row.state_entered_at) or created_at
     now = datetime.now(timezone.utc)
@@ -3709,6 +3736,7 @@ def _task_summary_projection_to_api(row: TaskSummaryProjection) -> APITaskSummar
         dwell_seconds=_dwell_seconds(row.work_status, state_entered_at, now),
         age_seconds=_elapsed_seconds(created_at, now),
         updated_at=_as_aware_datetime(row.updated_at),
+        project_paused=project_paused,
     )
 
 

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -27,6 +27,14 @@
   const SESSION_EXPIRY_WARNING_MS = 6 * 24 * 60 * 60 * 1000;
   const TASK_RAIL_LIMIT = 200;
   const TASK_RENDER_LIMIT = 80;
+  const TASK_STATUS_GROUPS = {
+    attention: ["review", "queued", "rework", "blocked", "on_hold"],
+    active: ["in_progress", "rework"],
+    blocked: ["blocked", "on_hold"],
+    review: ["review"],
+    done: ["done"],
+    cancelled: ["cancelled"],
+  };
   const AUDIT_LIMIT = 25;
   const ACTIVITY_LIMIT = 40;
   const ACTIVITY_DEFAULT_SINCE = "2d";
@@ -56,6 +64,7 @@
     taskLoadError: null,
     surfaceLoading: false,
     taskLoading: false,
+    taskStatusFilter: "",
     selectedKind: null,
     selectedSurface: null,
     selectedTaskKey: null,
@@ -532,7 +541,7 @@
     const tasksPromise = railJsonWithTimeout(
       "tasks",
       (opts) => apiJsonOptional(
-        API + "/tasks?limit=" + TASK_RAIL_LIMIT,
+        taskListPath(),
         opts,
       ),
       { signal: request.signal },
@@ -616,7 +625,26 @@
       priority: task.priority || "",
       assignee: task.assignee || "",
       updated_at: task.updated_at || "",
+      project_paused: Boolean(task.project_paused),
       duplicate_count: task.duplicate_count || 1,
+    };
+  }
+
+  function taskListPath() {
+    const params = new URLSearchParams();
+    params.set("limit", String(TASK_RAIL_LIMIT));
+    const statuses = TASK_STATUS_GROUPS[state.taskStatusFilter] || [];
+    for (const status of statuses) params.append("status", status);
+    return API + "/tasks?" + params.toString();
+  }
+
+  function parseTaskKey(value) {
+    const match = String(value || "").trim().match(/^([^/\s]+)\/([0-9]+)$/);
+    if (!match) return null;
+    return {
+      key: match[1] + "/" + match[2],
+      project: match[1],
+      task_number: match[2],
     };
   }
 
@@ -899,6 +927,30 @@
     list.appendChild(li);
   }
 
+  function renderDirectTaskOpenItem(list, parsed) {
+    const active = state.selectedKind === "task"
+      && state.selectedTaskKey === parsed.key;
+    const li = el(
+      "li",
+      {
+        "data-task": parsed.key,
+        "class": ("task-surface direct-task" + (active ? " active" : "")),
+      },
+      [
+        el("span", { class: "surface-name" }, [
+          el("span", { class: "surface-dot waiting" }),
+          document.createTextNode("Open " + parsed.key),
+        ]),
+        el("span", {
+          class: "surface-meta",
+          text: "fetch task detail",
+        }),
+      ],
+    );
+    li.addEventListener("click", () => selectTask(parsed.key));
+    list.appendChild(li);
+  }
+
   function selectedProjectMatches(project) {
     return !state.selectedProject || project === state.selectedProject;
   }
@@ -936,11 +988,18 @@
       selectedProjectMatches(task.project || "")
       && taskMatchesFilter(task, filter)
     ));
+    const directTask = parseTaskKey(filter);
+    const directTaskVisible = Boolean(
+      directTask
+      && selectedProjectMatches(directTask.project)
+      && !taskSurfaces.some((task) => task.key === directTask.key)
+    );
     const hasRegistered = (
       state.surfaces.length > 0
       || state.taskSurfaces.length > 0
       || state.surfaceLoadError
       || state.taskLoadError
+      || directTaskVisible
     );
     const isLoading = state.surfaceLoading || state.taskLoading;
     const allSectionsPending = state.surfaceLoading && state.taskLoading;
@@ -964,6 +1023,7 @@
       && taskSurfaces.length === 0
       && !state.surfaceLoadError
       && !state.taskLoadError
+      && !directTaskVisible
     ) {
       list.appendChild(
         el("li", { class: "surface-empty", text: "no matching surfaces" }),
@@ -986,8 +1046,9 @@
         text: "loading chat surfaces...",
       }));
     }
-    if (taskSurfaces.length > 0 || state.taskLoadError) {
+    if (taskSurfaces.length > 0 || state.taskLoadError || directTaskVisible) {
       appendRailGroup(list, "Tasks");
+      if (directTaskVisible) renderDirectTaskOpenItem(list, directTask);
       const visibleTasks = taskSurfaces.slice(0, TASK_RENDER_LIMIT);
       for (const task of visibleTasks) renderTaskSurfaceItem(list, task);
       if (taskSurfaces.length > visibleTasks.length) {
@@ -1046,7 +1107,14 @@
       const task = state.taskSurfaces.find((item) => (
         item.key === state.selectedTaskKey
       ));
-      if (!task || task.project !== state.selectedProject) clearSelection();
+      const parsed = parseTaskKey(state.selectedTaskKey);
+      if (
+        task
+        ? task.project !== state.selectedProject
+        : (!parsed || parsed.project !== state.selectedProject)
+      ) {
+        clearSelection();
+      }
     }
   }
 
@@ -1113,8 +1181,23 @@
   }
 
   function selectTask(key) {
-    const task = state.taskSurfaces.find((item) => item.key === key);
-    if (!task) return;
+    let task = state.taskSurfaces.find((item) => item.key === key);
+    if (!task) {
+      const parsed = parseTaskKey(key);
+      if (!parsed) return;
+      task = {
+        key: parsed.key,
+        task_id: parsed.key,
+        project: parsed.project,
+        task_number: parsed.task_number,
+        title: parsed.key,
+        work_status: "",
+        type: "",
+        priority: "",
+        assignee: "",
+        updated_at: "",
+      };
+    }
     state.selectedKind = "task";
     state.selectedSurface = null;
     state.selectedTaskKey = key;
@@ -1160,14 +1243,25 @@
     // §1.4.5 (#2336): dwell row when non-terminal — surfaces "stuck
     // for X" right next to Status.
     const dwellStr = !isTerminal ? formatDwell(data.dwell_seconds) : null;
-    const rows = [
+    const rows = [];
+    if (data.type && data.type !== "task") rows.push(["Type", data.type]);
+    rows.push(
       ["Status", status],
       ["Project", data.project],
       ["Task", data.task_number],
       ["Assignee", data.assignee],
       ["Priority", data.priority],
       ["Updated", data.updated_at],
-    ];
+    );
+    if (Array.isArray(data.labels) && data.labels.length > 0) {
+      rows.push(["Labels", data.labels.join(", ")]);
+    }
+    if (data.requires_human_review != null) {
+      rows.push([
+        "Human review",
+        data.requires_human_review ? "required" : "not required",
+      ]);
+    }
     if (dwellStr) {
       rows.push(["Dwell", dwellStr + " in " + status]);
     }
@@ -1217,24 +1311,18 @@
           + "likely stale state, run `pm doctor`.",
       }));
     }
-    if (data.description) {
-      children.push(el("div", {
-        class: "task-detail-description",
-        text: data.description,
-      }));
-    }
+    appendTaskDetailSection(children, "Description", data.description);
     for (const row of filteredRows) {
       children.push(el("div", { class: "task-detail-row" }, [
         el("span", { class: "task-detail-label", text: row[0] }),
         el("span", { class: "task-detail-value", text: String(row[1]) }),
       ]));
     }
-    if (data.acceptance_criteria) {
-      children.push(el("div", {
-        class: "task-detail-description",
-        text: data.acceptance_criteria,
-      }));
-    }
+    appendTaskDetailSection(
+      children, "Acceptance criteria", data.acceptance_criteria,
+    );
+    appendTaskDetailSection(children, "Constraints", data.constraints);
+    appendTaskDetailList(children, "Relevant files", data.relevant_files);
     const actions = [];
     if (data.work_status === "queued" || data.work_status === "rework") {
       const claim = el("button", {
@@ -1266,6 +1354,24 @@
       children.push(el("div", { class: "task-detail-actions" }, actions));
     }
     list.appendChild(el("div", { class: "task-detail" }, children));
+  }
+
+  function appendTaskDetailSection(children, heading, text) {
+    if (text == null || text === "") return;
+    children.push(el("div", { class: "task-detail-section" }, [
+      el("h3", { class: "task-detail-heading", text: heading }),
+      el("div", { class: "task-detail-section-body", text: String(text) }),
+    ]));
+  }
+
+  function appendTaskDetailList(children, heading, items) {
+    if (!Array.isArray(items) || items.length === 0) return;
+    children.push(el("div", { class: "task-detail-section" }, [
+      el("h3", { class: "task-detail-heading", text: heading }),
+      el("ul", { class: "task-detail-list" }, items.map((item) => (
+        el("li", { text: String(item) })
+      ))),
+    ]));
   }
 
   async function claimTaskFromDetail(task) {
@@ -3003,11 +3109,20 @@
 
   function wireSurfaceFilter() {
     const input = $("surface-filter");
-    if (!input) return;
-    input.addEventListener("input", () => {
-      state.surfaceFilter = input.value || "";
-      renderSurfaces();
-    });
+    if (input) {
+      input.addEventListener("input", () => {
+        state.surfaceFilter = input.value || "";
+        renderSurfaces();
+      });
+    }
+    const status = $("task-status-filter");
+    if (status) {
+      status.value = state.taskStatusFilter;
+      status.addEventListener("change", () => {
+        state.taskStatusFilter = status.value || "";
+        loadSurfaces();
+      });
+    }
   }
 
   function wireProjectControls() {

--- a/src/pollypm/web_api/ui/index.html
+++ b/src/pollypm/web_api/ui/index.html
@@ -55,6 +55,19 @@
         aria-label="Filter surfaces"
         autocomplete="off"
       />
+      <select
+        id="task-status-filter"
+        class="rail-select task-status-filter"
+        aria-label="Filter tasks by status"
+      >
+        <option value="">Recent tasks</option>
+        <option value="attention">Needs attention</option>
+        <option value="active">Active work</option>
+        <option value="blocked">Blocked / held</option>
+        <option value="review">Review</option>
+        <option value="done">Done</option>
+        <option value="cancelled">Cancelled</option>
+      </select>
     </div>
     <ul id="surface-list" class="surface-list">
       <li class="surface-empty">loading…</li>

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -146,6 +146,9 @@ aside#dashboard-rail {
 }
 
 .surface-filter-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   padding: 0 12px 8px;
 }
 .rail-input,
@@ -169,6 +172,9 @@ aside#dashboard-rail {
 }
 .rail-select {
   flex: 0 0 86px;
+}
+.task-status-filter {
+  flex: 0 0 auto;
 }
 
 .project-list {
@@ -409,6 +415,32 @@ section#message-pane {
   font-size: 12.5px;
   margin: 8px 0;
   white-space: pre-wrap;
+}
+.task-detail-section {
+  margin: 10px 0;
+}
+.task-detail-heading {
+  color: var(--text-label);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 4px;
+  text-transform: uppercase;
+}
+.task-detail-section-body {
+  color: var(--text-body);
+  font-size: 12.5px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.task-detail-list {
+  margin: 0;
+  padding-left: 18px;
+}
+.task-detail-list li {
+  color: var(--text-body);
+  font-size: 12.5px;
+  overflow-wrap: anywhere;
 }
 .task-detail-row {
   display: grid;

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -167,7 +167,7 @@ test.describe("surfaces", () => {
   }
 
   async function stubEmptyTasks(page: import("@playwright/test").Page) {
-    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+    await page.route(/\/api\/v1\/tasks\?.*limit=200/, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -885,6 +885,91 @@ test.describe("surfaces", () => {
     await expect(page.locator("#message-list")).toContainText(
       "Visible task detail",
     );
+  });
+
+  test("task status selector reloads rail with status query params", async ({ page }) => {
+    const requestedStatuses: string[][] = [];
+    await stubEmptyProjects(page);
+    await stubEmptyActivity(page);
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      }),
+    );
+    await page.route(/\/api\/v1\/tasks\?.*limit=200/, (route) => {
+      const url = new URL(route.request().url());
+      requestedStatuses.push(url.searchParams.getAll("status"));
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator("#task-status-filter").selectOption("blocked");
+    await expect.poll(() => requestedStatuses.some((statuses) =>
+      statuses.includes("blocked") && statuses.includes("on_hold"),
+    )).toBe(true);
+  });
+
+  test("task search can open project slash number outside the loaded rail", async ({ page }) => {
+    await stubEmptyProjects(page);
+    await stubEmptyActivity(page);
+    await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [] }),
+      }),
+    );
+    await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      }),
+    );
+    await page.route("**/api/v1/tasks/demo/404", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          task_id: "demo/404",
+          project: "demo",
+          task_number: 404,
+          title: "Historical blocked task",
+          work_status: "blocked",
+          type: "bug",
+          priority: "high",
+          assignee: "",
+          updated_at: "2026-05-23T00:00:00Z",
+          description: "Loaded by direct detail lookup",
+          acceptance_criteria: "Direct lookup has labeled criteria.",
+          constraints: "Use REST detail only.",
+          labels: ["historical"],
+          relevant_files: ["src/pollypm/web_api/ui/app.js"],
+          requires_human_review: true,
+          relationships: {},
+          transitions: [],
+          executions: [],
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await page.locator("#surface-filter").fill("demo/404");
+    await page.locator("li[data-task='demo/404']").click();
+    await expect(page.locator("#pane-title")).toHaveText("demo/404");
+    await expect(page.locator("#message-list")).toContainText(
+      "Loaded by direct detail lookup",
+    );
+    await expect(page.locator("#message-list")).toContainText(
+      "Acceptance criteria",
+    );
+    await expect(page.locator("#message-list")).toContainText("Relevant files");
   });
 
   test("queued task detail Start posts to claim endpoint as worker", async ({ page }) => {

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -244,6 +244,7 @@ def test_list_all_tasks_uses_list_rows_without_per_item_refetch(
 
     assert [item.task_id for item in items] == ["myproj/1"]
     assert items[0].state_entered_at == now - timedelta(minutes=5)
+    assert items[0].project_paused is False
     assert next_cursor is None
     assert warnings == []
     assert total == 1
@@ -363,9 +364,71 @@ def test_list_tasks_include_untracked_returns_hidden_rows(
     )
     assert response.status_code == 200, response.text
     body = response.json()
-    titles = sorted(item["title"] for item in body["items"])
+    by_title = {item["title"]: item for item in body["items"]}
+    titles = sorted(by_title)
     assert titles == ["Hidden", "Visible"]
+    assert by_title["Hidden"]["project_paused"] is True
+    assert by_title["Visible"]["project_paused"] is False
     assert body.get("warnings") is None
+
+
+def test_list_tasks_include_untracked_summary_page_marks_paused_projects(
+    api_config, monkeypatch
+) -> None:
+    """Fast summary pages must carry the same paused flag as detail."""
+    from contextlib import contextmanager
+
+    from pollypm.models import KnownProject, ProjectKind
+    from pollypm.web_api import service as svc_mod
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    api_config.projects["paused"] = KnownProject(
+        key="paused",
+        path=api_config.project.root_dir / "paused",
+        name="Paused",
+        tracked=False,
+        kind=ProjectKind.GIT,
+    )
+
+    class FakeService:
+        def list_task_summary_page(self, **kwargs):
+            assert kwargs["projects"] is None
+            return (
+                [
+                    TaskSummaryProjection(
+                        task_id="paused/1",
+                        project="paused",
+                        task_number=1,
+                        title="Paused projected",
+                        work_status="queued",
+                        type="task",
+                        priority="normal",
+                        created_at=now - timedelta(hours=1),
+                        state_entered_at=now - timedelta(minutes=5),
+                        updated_at=now,
+                    )
+                ],
+                None,
+                1,
+            )
+
+        def count_task_summary_matches(self, **_kwargs):
+            return 0
+
+    @contextmanager
+    def fake_open(**_kwargs):
+        yield FakeService()
+
+    monkeypatch.setattr(svc_mod, "_open_work_service_readonly", fake_open)
+
+    items, _next_cursor, warnings, total = svc_mod.list_all_tasks(
+        api_config, include_untracked=True, limit=10
+    )
+
+    assert total == 1
+    assert warnings == []
+    assert items[0].task_id == "paused/1"
+    assert items[0].project_paused is True
 
 
 def test_list_tasks_project_filter_warns_for_unregistered_pg_rows(

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1366,14 +1366,15 @@ const path = process.argv[1];
 const payload = JSON.parse(process.argv[2]);
 
 function makeNode(tag) {
-  const node = {
-    tagName: (tag || "div").toUpperCase(),
-    children: [],
-    attrs: {},
-    className: "",
-    textContent: "",
-    disabled: false,
-  };
+    const node = {
+      tagName: (tag || "div").toUpperCase(),
+      children: [],
+      attrs: {},
+      className: "",
+      textContent: "",
+      dataset: {},
+      disabled: false,
+    };
   Object.defineProperty(node, "innerHTML", {
     get() {
       function render(n) {
@@ -1531,6 +1532,45 @@ def test_selecting_task_surface_disables_chat_send() -> None:
     assert "Historical fix" in rendered["messages"]
     assert rendered["sendInputDisabled"] is True
     assert rendered["sendButtonDisabled"] is True
+
+
+def test_task_detail_renders_labeled_api_fields() -> None:
+    rendered = _node_render_surface_rail({
+        "tasks": [
+            {
+                "key": "myproj/11",
+                "task_id": "myproj/11",
+                "project": "myproj",
+                "task_number": "11",
+                "title": "Spike contract",
+                "work_status": "queued",
+                "type": "spike",
+                "priority": "high",
+                "assignee": "",
+                "updated_at": "2026-05-23T00:00:00Z",
+                "description": "Investigate the API shape.",
+                "acceptance_criteria": "Acceptance stays visible.",
+                "constraints": "Do not bypass service facades.",
+                "labels": ["api", "web"],
+                "relevant_files": ["src/pollypm/web_api/service.py"],
+                "requires_human_review": True,
+            },
+        ],
+        "selectTask": "myproj/11",
+    })
+    messages = rendered["messages"]
+    assert "Type" in messages
+    assert "spike" in messages
+    assert "Labels" in messages
+    assert "api, web" in messages
+    assert "Human review" in messages
+    assert "required" in messages
+    assert "Acceptance criteria" in messages
+    assert "Acceptance stays visible." in messages
+    assert "Constraints" in messages
+    assert "Do not bypass service facades." in messages
+    assert "Relevant files" in messages
+    assert "src/pollypm/web_api/service.py" in messages
 
 
 def test_task_detail_surfaces_cancel_and_reopen_actions() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds web task-detail rendering for labels, constraints, relevant files, human-review requirement, non-default type, and labeled acceptance criteria.
- Adds a task status filter and direct `project/N` lookup affordance so the rail can reach older blocked/held/review/done/in-progress tasks outside the newest slice.
- Populates `project_paused` on task-list summaries consistently with task detail for paused/untracked projects.

## Issues
- Fixes #2364
- Fixes #2365
- Fixes #2366

## Tests
- `node --check src/pollypm/web_api/ui/app.js` (`passed`)
- `python -m py_compile src/pollypm/web_api/service.py` (`passed`)
- `uv run --extra test pytest -q tests/web_api/test_tasks_list_endpoint.py tests/web_api/test_task_detail_surfacing.py tests/web_api/test_web_ui.py::test_render_surface_rail_groups_chat_and_task_surfaces tests/web_api/test_web_ui.py::test_selecting_task_surface_disables_chat_send tests/web_api/test_web_ui.py::test_task_detail_renders_labeled_api_fields tests/web_api/test_web_ui.py::test_task_detail_surfaces_cancel_and_reopen_actions` (`34 passed`)
- `POLLYPM_BASE_URL=http://127.0.0.1:8876 npx playwright test tests/surfaces.spec.ts --project=chromium --grep "task surfaces render|task status selector|task search can open|queued task detail Start"` (`4 passed`)
- `git diff --check origin/main...HEAD` (`passed`)

Note: a first Playwright attempt against the default `127.0.0.1:8765` failed because that port was serving older UI assets. Re-run used a dedicated `pm serve --host 127.0.0.1 --port 8876` process started from this branch and stopped afterward.
