### PR TITLE
fix: audit session pause and resume actions

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -116,6 +116,9 @@ The current event families are:
 | `worker.session_reaped` | worker marker reaper | `window_name`, `marker_path`, `reason` |
 | `watchdog.escalation_dispatched` | auto-unstick dispatch path | `finding_type`, `subject`, `brief` |
 | `session.provisioned` | reviewer/role recovery provisioning | `role`, `project`, `reason` |
+| `session.paused` | sessions-admin pause route | `session_name`, `actor`, `reason`, `paused_count_after` |
+| `session.resumed` | sessions-admin resume route | `session_name`, `actor`, `reason`, `paused_count_after` |
+| `session.pause.refused` | sessions-admin pause/resume unreadable-marker 503 path | `session_name`, `actor`, `reason`, `paused_count_after`, `refused_reason` |
 | `session.pause.marker_unreadable` | pause-marker reader | `path`, `reason`, `last_readable_paused_names` |
 | `session.pause.marker_restored` | pause-marker reader | `path`, `restored_size_bytes`, `restored_mtime`, `paused_state_diff` |
 | `worker.thread_leaked` | job worker shutdown leak detector | worker/thread diagnostic metadata |

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -254,6 +254,14 @@ EVENT_COCKPIT_SESSION_PARKED = "cockpit.session_parked"
 EVENT_COCKPIT_SESSION_RESPAWNED = "cockpit.session_respawned"
 EVENT_COCKPIT_DUPLICATE_WINDOW_KILLED = "cockpit.duplicate_window_killed"
 EVENT_COCKPIT_PARK_SKIPPED_EXISTING = "cockpit.park_skipped_existing"
+# #2372 — operator pause/resume route audit events. The daemon-loop
+# ``session.pause.skip`` event is throttled in ``pollypm.session_paused``
+# because sweep ticks can fire repeatedly. These operator-request events
+# are not throttled: every successful API action, including idempotent
+# pause/resume requests, is a distinct audit breadcrumb.
+EVENT_SESSION_PAUSE_PAUSED = "session.paused"
+EVENT_SESSION_PAUSE_RESUMED = "session.resumed"
+EVENT_SESSION_PAUSE_REFUSED = "session.pause.refused"
 # #1570 — emitted once per row that ``pm inbox backfill-kinds --commit``
 # reclassifies from ``kind='legacy'`` to a real
 # :class:`pollypm.inbox.kind.InboxItemKind`. Carries ``msg_id``,

--- a/src/pollypm/session_paused.py
+++ b/src/pollypm/session_paused.py
@@ -134,6 +134,8 @@ PAUSE_SKIP_EVENT_TYPE = "session.pause.skip"
 PAUSE_MARKER_UNREADABLE_EVENT_TYPE = "session.pause.marker_unreadable"
 PAUSE_MARKER_RESTORED_EVENT_TYPE = "session.pause.marker_restored"
 UNREADABLE_PAUSED_REASON = "marker_unreadable"
+PAUSE_OPERATOR_DEFAULT_ACTOR = "operator"
+PAUSE_OPERATOR_DEFAULT_REASON = "operator_request"
 
 
 # --- Marker state ---------------------------------------------------
@@ -359,6 +361,59 @@ def save_paused_names(config: Any, names: set[str] | list[str]) -> None:
     payload = sorted(set(names))
     tmp.write_text(json.dumps(payload, indent=2) + "\n")
     tmp.replace(path)
+
+
+def emit_pause_operator_action(
+    config: Any,
+    *,
+    event: str,
+    session_name: str,
+    actor: str | None = None,
+    reason: str | None = None,
+    paused_count_after: int | None,
+    status: str = "ok",
+    extra_metadata: dict[str, Any] | None = None,
+) -> None:
+    """Best-effort audit emit for operator pause/resume route actions.
+
+    Unlike ``session.pause.skip`` sweep breadcrumbs, these API actions
+    are intentionally not throttled. A repeated pause/resume request is
+    still a human/operator action worth preserving in the durable log.
+    """
+    try:
+        from pollypm.audit.log import emit as _audit_emit
+    except Exception:  # noqa: BLE001
+        logger.debug("session pause operator audit import failed", exc_info=True)
+        return
+
+    clean_actor = str(actor or "").strip() or PAUSE_OPERATOR_DEFAULT_ACTOR
+    clean_reason = str(reason or "").strip() or PAUSE_OPERATOR_DEFAULT_REASON
+    metadata: dict[str, Any] = {
+        "session_name": session_name,
+        "actor": clean_actor,
+        "reason": clean_reason,
+        "paused_count_after": paused_count_after,
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    project_key, project_path = _project_audit_context(config)
+    try:
+        _audit_emit(
+            event=event,
+            project=project_key,
+            subject=session_name,
+            actor=clean_actor,
+            status=status,
+            metadata=metadata,
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "session pause operator audit emit failed for %s/%s",
+            event,
+            session_name,
+            exc_info=True,
+        )
 
 
 @contextmanager
@@ -1014,9 +1069,12 @@ __all__ = [
     "PAUSE_MARKER_RESTORED_EVENT_TYPE",
     "PAUSE_MARKER_UNREADABLE_EVENT_TYPE",
     "PAUSE_MARKER_UNREADABLE_THROTTLE_SECONDS",
+    "PAUSE_OPERATOR_DEFAULT_ACTOR",
+    "PAUSE_OPERATOR_DEFAULT_REASON",
     "PAUSE_SKIP_EVENT_TYPE",
     "PAUSE_SKIP_THROTTLE_SECONDS",
     "UNREADABLE_PAUSED_REASON",
+    "emit_pause_operator_action",
     "is_paused",
     "load_paused_names",
     "load_paused_state",

--- a/src/pollypm/web_api/routes/sessions_admin.py
+++ b/src/pollypm/web_api/routes/sessions_admin.py
@@ -129,6 +129,14 @@ from pollypm.session_health import (
 from pollypm.session_health import (
     storage_session_name as _shared_storage_session_name,
 )
+from pollypm.audit.log import (
+    EVENT_SESSION_PAUSE_PAUSED,
+    EVENT_SESSION_PAUSE_REFUSED,
+    EVENT_SESSION_PAUSE_RESUMED,
+)
+from pollypm.session_paused import (
+    emit_pause_operator_action as _emit_pause_operator_action,
+)
 from pollypm.session_paused import (
     load_paused_state as _load_paused_state,
 )
@@ -261,6 +269,19 @@ class RestartSessionRequest(BaseModel):
             "Bypass a human-held session lease. This does not bypass the "
             "mid-turn safety probe; use safety=force for that."
         ),
+    )
+
+
+class SessionPauseMutationRequest(BaseModel):
+    """Optional operator context for pause/resume audit rows."""
+
+    actor: str = Field(
+        default="operator",
+        description="Operator identity to stamp into the audit event.",
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Operator-supplied reason for the pause/resume action.",
     )
 
 
@@ -452,6 +473,14 @@ _PAUSE_PARTIAL_ENFORCEMENT_NOTE = (
     "not yet treated as daemon-loop dispatch. The marker is visible via "
     "GET /api/v1/sessions on the separate `paused` field."
 )
+
+
+def _pause_mutation_actor_reason(
+    body: SessionPauseMutationRequest | None,
+) -> tuple[str, str | None]:
+    if body is None:
+        return "operator", None
+    return body.actor, body.reason
 
 
 # ---------------------------------------------------------------------------
@@ -1250,7 +1279,11 @@ def interrupt_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
         },
     },
 )
-def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
+def pause_session_endpoint(
+    name: str,
+    config: ConfigDep,
+    body: SessionPauseMutationRequest | None = None,
+) -> ActionResult:
     """POST /api/v1/sessions/{name}/pause — write the pause marker.
 
     **Partial enforcement.** The pause marker is HONORED by the
@@ -1274,6 +1307,7 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
     session returns 200 with no state change.
     """
     _find_session(config, name)  # 404 if unknown
+    actor, reason = _pause_mutation_actor_reason(body)
     try:
         with _pause_marker_lock(config):
             # PR #2081 round 3 finding 2 — go through the discriminated
@@ -1291,6 +1325,21 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
                     if getattr(config.project, "base_dir", None) is not None
                     else "<unknown>"
                 )
+                _emit_pause_operator_action(
+                    config,
+                    event=EVENT_SESSION_PAUSE_REFUSED,
+                    session_name=name,
+                    actor=actor,
+                    reason=reason,
+                    paused_count_after=None,
+                    status="warn",
+                    extra_metadata={
+                        "operation": "pause",
+                        "refused_reason": "marker_unreadable",
+                        "marker_path": str(marker_path),
+                        "marker_reason": state.reason,
+                    },
+                )
                 raise _marker_unreadable(
                     name, str(marker_path), state.reason,
                 )
@@ -1299,6 +1348,14 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
             # working set.
             names = set(state.names)
             if name in names:
+                _emit_pause_operator_action(
+                    config,
+                    event=EVENT_SESSION_PAUSE_PAUSED,
+                    session_name=name,
+                    actor=actor,
+                    reason=reason,
+                    paused_count_after=len(names),
+                )
                 return ActionResult(
                     ok=True,
                     message=(
@@ -1308,6 +1365,7 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
                 )
             names.add(name)
             _save_paused_names(config, names)
+            paused_count_after = len(names)
     except APIError:
         raise
     except RuntimeError as exc:
@@ -1323,6 +1381,14 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
             f"Cannot write pause marker for {name!r}: {exc!s}",
             hint="Check filesystem permissions on ~/.pollypm.",
         ) from exc
+    _emit_pause_operator_action(
+        config,
+        event=EVENT_SESSION_PAUSE_PAUSED,
+        session_name=name,
+        actor=actor,
+        reason=reason,
+        paused_count_after=paused_count_after,
+    )
     return ActionResult(
         ok=True,
         message=f"tagged {name} paused — {_PAUSE_PARTIAL_ENFORCEMENT_NOTE}",
@@ -1353,7 +1419,11 @@ def pause_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
         },
     },
 )
-def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
+def resume_session_endpoint(
+    name: str,
+    config: ConfigDep,
+    body: SessionPauseMutationRequest | None = None,
+) -> ActionResult:
     """POST /api/v1/sessions/{name}/resume — clear the pause marker.
 
     Idempotent inverse of :func:`pause_session_endpoint`. The same
@@ -1363,6 +1433,7 @@ def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
     operator actions.
     """
     _find_session(config, name)  # 404 if unknown
+    actor, reason = _pause_mutation_actor_reason(body)
     try:
         with _pause_marker_lock(config):
             # PR #2081 round 3 finding 2 — same discriminated-reader
@@ -1379,11 +1450,34 @@ def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
                     if getattr(config.project, "base_dir", None) is not None
                     else "<unknown>"
                 )
+                _emit_pause_operator_action(
+                    config,
+                    event=EVENT_SESSION_PAUSE_REFUSED,
+                    session_name=name,
+                    actor=actor,
+                    reason=reason,
+                    paused_count_after=None,
+                    status="warn",
+                    extra_metadata={
+                        "operation": "resume",
+                        "refused_reason": "marker_unreadable",
+                        "marker_path": str(marker_path),
+                        "marker_reason": state.reason,
+                    },
+                )
                 raise _marker_unreadable(
                     name, str(marker_path), state.reason,
                 )
             names = set(state.names)
             if name not in names:
+                _emit_pause_operator_action(
+                    config,
+                    event=EVENT_SESSION_PAUSE_RESUMED,
+                    session_name=name,
+                    actor=actor,
+                    reason=reason,
+                    paused_count_after=len(names),
+                )
                 return ActionResult(
                     ok=True,
                     message=(
@@ -1393,6 +1487,7 @@ def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
                 )
             names.discard(name)
             _save_paused_names(config, names)
+            paused_count_after = len(names)
     except APIError:
         raise
     except RuntimeError as exc:
@@ -1404,6 +1499,14 @@ def resume_session_endpoint(name: str, config: ConfigDep) -> ActionResult:
             f"Cannot write pause marker for {name!r}: {exc!s}",
             hint="Check filesystem permissions on ~/.pollypm.",
         ) from exc
+    _emit_pause_operator_action(
+        config,
+        event=EVENT_SESSION_PAUSE_RESUMED,
+        session_name=name,
+        actor=actor,
+        reason=reason,
+        paused_count_after=paused_count_after,
+    )
     return ActionResult(
         ok=True,
         message=f"cleared pause tag on {name} — {_PAUSE_PARTIAL_ENFORCEMENT_NOTE}",
@@ -1415,6 +1518,7 @@ __all__ = [
     "SessionDetail",
     "SessionHealthSnapshot",
     "SessionInfo",
+    "SessionPauseMutationRequest",
     "SessionsListResponse",
     "get_session_endpoint",
     "list_sessions_endpoint",

--- a/tests/web_api/test_sessions_admin_audit.py
+++ b/tests/web_api/test_sessions_admin_audit.py
@@ -1,0 +1,159 @@
+"""Audit coverage for session pause/resume admin routes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pollypm.audit.log import (
+    EVENT_SESSION_PAUSE_PAUSED,
+    EVENT_SESSION_PAUSE_REFUSED,
+    EVENT_SESSION_PAUSE_RESUMED,
+)
+from pollypm.models import ProviderKind, SessionConfig
+from pollypm.session_paused import _reset_skip_throttle_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _reset_pause_audit_state() -> None:
+    _reset_skip_throttle_for_tests()
+
+
+@pytest.fixture
+def configured_session(api_config, project_root: Path) -> str:
+    api_config.sessions["operator"] = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=project_root,
+        project="myproj",
+        window_name="operator",
+    )
+    return "operator"
+
+
+def _audit_records(audit_home: Path, project: str = "PollyPM") -> list[dict]:
+    path = audit_home / f"{project}.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def test_pause_session_emits_operator_audit_event_without_deduping(
+    client,
+    auth_headers,
+    audit_home,
+    configured_session: str,
+) -> None:
+    payload = {"actor": "sam", "reason": "maintenance window"}
+
+    first = client.post(
+        f"/api/v1/sessions/{configured_session}/pause",
+        headers=auth_headers,
+        json=payload,
+    )
+    second = client.post(
+        f"/api/v1/sessions/{configured_session}/pause",
+        headers=auth_headers,
+        json=payload,
+    )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    pause_events = [
+        row
+        for row in _audit_records(audit_home)
+        if row["event"] == EVENT_SESSION_PAUSE_PAUSED
+    ]
+    assert len(pause_events) == 2
+    assert [row["actor"] for row in pause_events] == ["sam", "sam"]
+    for row in pause_events:
+        assert row["subject"] == configured_session
+        assert row["status"] == "ok"
+        assert row["metadata"] == {
+            "session_name": configured_session,
+            "actor": "sam",
+            "reason": "maintenance window",
+            "paused_count_after": 1,
+        }
+
+
+def test_resume_session_emits_operator_audit_event(
+    client,
+    auth_headers,
+    audit_home,
+    configured_session: str,
+) -> None:
+    pause = client.post(
+        f"/api/v1/sessions/{configured_session}/pause",
+        headers=auth_headers,
+        json={"actor": "sam", "reason": "prepare resume test"},
+    )
+    assert pause.status_code == 200, pause.text
+
+    response = client.post(
+        f"/api/v1/sessions/{configured_session}/resume",
+        headers=auth_headers,
+        json={"actor": "sam", "reason": "work can continue"},
+    )
+
+    assert response.status_code == 200, response.text
+    resume_events = [
+        row
+        for row in _audit_records(audit_home)
+        if row["event"] == EVENT_SESSION_PAUSE_RESUMED
+    ]
+    assert len(resume_events) == 1
+    event = resume_events[0]
+    assert event["subject"] == configured_session
+    assert event["actor"] == "sam"
+    assert event["status"] == "ok"
+    assert event["metadata"] == {
+        "session_name": configured_session,
+        "actor": "sam",
+        "reason": "work can continue",
+        "paused_count_after": 0,
+    }
+
+
+def test_pause_session_emits_refused_audit_event_for_unreadable_marker(
+    api_config,
+    client,
+    auth_headers,
+    audit_home,
+    configured_session: str,
+) -> None:
+    marker = api_config.project.base_dir / "paused-sessions.json"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("{not json")
+
+    response = client.post(
+        f"/api/v1/sessions/{configured_session}/pause",
+        headers=auth_headers,
+        json={"actor": "sam", "reason": "operator requested pause"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "marker_unreadable"
+    refused_events = [
+        row
+        for row in _audit_records(audit_home)
+        if row["event"] == EVENT_SESSION_PAUSE_REFUSED
+    ]
+    assert len(refused_events) == 1
+    event = refused_events[0]
+    assert event["subject"] == configured_session
+    assert event["actor"] == "sam"
+    assert event["status"] == "warn"
+    metadata = event["metadata"]
+    assert metadata["session_name"] == configured_session
+    assert metadata["actor"] == "sam"
+    assert metadata["reason"] == "operator requested pause"
+    assert metadata["paused_count_after"] is None
+    assert metadata["operation"] == "pause"
+    assert metadata["refused_reason"] == "marker_unreadable"
+    assert metadata["marker_path"] == str(marker)
+    assert "malformed JSON" in metadata["marker_reason"]


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Emits durable audit events for successful `POST /api/v1/sessions/{name}/pause` and `/resume` actions, including idempotent operator requests.
- Emits `session.pause.refused` when unreadable pause markers cause the route to fail closed.
- Documents the new audit events and adds route-level regression coverage.

## Issue
- Fixes #2372

## Tests
- `uv run --extra test pytest tests/web_api/test_sessions_admin_audit.py tests/test_session_paused_marker_wiring.py tests/test_audit_log_docs.py -q` (`40 passed`)
- `uv run --extra dev ruff check docs/audit-log.md src/pollypm/audit/log.py src/pollypm/session_paused.py src/pollypm/web_api/routes/sessions_admin.py tests/web_api/test_sessions_admin_audit.py` (`passed`)
- `git diff --check origin/main...HEAD` (`passed`)
