### PR TITLE
fix: wire watchdog heartbeat and cancellation self-heal

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -108,6 +108,7 @@ The current event families are:
 | `work_db.opened` | `PgWorkService.__init__` | `had_messages_table_pre_open`, `tables_created`, `project_path` |
 | `work_table.cleared` | Reserved for future wholesale work-table reset paths | reset reason and affected scope |
 | `heartbeat.tick` | audit watchdog cadence | cadence metadata |
+| `worker.heartbeat` | heartbeat supervisor when a worker has fresh transcript output | `task_id`, `session_name`, `window_name`, `snapshot_hash`, `log_bytes`, `delta_bytes` |
 | `heartbeat.missing` | supervisor recovery detection | `session`, `window_name`, `tmux_session`, `failure_type`, `failure_message` |
 | `session.spawn` | supervisor recovery relaunch | `session`, `window_name`, `tmux_session`, `failure_type`, `account`, `provider` |
 | `audit.finding` | audit watchdog findings | `rule`, `message`, `recommendation`, plus rule-specific data |
@@ -142,7 +143,7 @@ an alert keyed by `(rule, project, subject)`.
 | `orphan_marker` | `marker.created` without matching `marker.released` and without a terminal task transition. | `window_seconds=1800` | Inspect the worker pane; resume it or transition/cancel the task so cleanup can release the marker. |
 | `marker_leaked` | Any `marker.leaked` event in the window. | `window_seconds=1800` | Investigate identity/persona guard failures and session-name collisions. |
 | `stuck_draft` | A draft task that has not moved to queued, in progress, review, blocked, rework, or a terminal state. | `stuck_draft_seconds=300` | Queue the task with `pm task queue <project/N>` or cancel it if it is stale. |
-| `cancellation_no_promotion` | A task was cancelled and no later `task.created` event appeared for the same project within the grace window. | `cancel_grace_seconds=300` | Nudge or restart planning so a replacement task is created, or confirm cancellation was intentional. |
+| `cancellation_no_promotion` | A task was cancelled and no later `task.created` event appeared for the same project within the grace window. | `cancel_grace_seconds=300` | Routed to the architect self-heal tier to queue replacement work or make the parked state intentional. |
 | `task_review_stale` | A task has stayed at `status=review` too long. | `review_stale_seconds=1800` | Spawn a reviewer or complete/reject the task manually. |
 | `task_on_hold_stale` | A task has stayed at `status=on_hold` too long. | `on_hold_stale_seconds=900` | Let the architect reassess. Use an on-hold reason starting with `human-needed` only when a real human decision is required. |
 | `role_session_missing` | A queued, in-progress, or review task needs a role window that is absent from the storage closet. | No time threshold; depends on live task state and tmux windows. | Spawn the expected role session or reassign the task. |

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -92,6 +92,7 @@ EVENT_WORK_DB_OPENED = "work_db.opened"
 # the fleet quantify whether the fix is holding without grepping
 # ``errors.log``.
 EVENT_WORKER_THREAD_LEAKED = "worker.thread_leaked"
+EVENT_WORKER_HEARTBEAT = "worker.heartbeat"
 # #1368 — emitted by ``cockpit_socket_reaper`` when it unlinks a stale
 # ``cockpit-<pid>.sock`` whose owning PID is no longer alive. Lets
 # operators forensically count leak rates without scraping logs.
@@ -1220,6 +1221,7 @@ __all__ = [
     "EVENT_WORK_TABLE_CLEARED",
     "EVENT_WORK_DB_OPENED",
     "EVENT_WORKER_THREAD_LEAKED",
+    "EVENT_WORKER_HEARTBEAT",
     "EVENT_SOCKET_REAPED",
     "EVENT_PLAN_VERSION_INCREMENTED",
     "EVENT_PLAN_SUCCESSOR_CREATED",

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -75,6 +75,7 @@ from pollypm.audit.log import (
     EVENT_WATCHDOG_ESCALATION_DISPATCHED,
     EVENT_WATCHDOG_OPERATOR_DISPATCHED,
     EVENT_WORKER_SESSION_REAPED,
+    EVENT_WORKER_HEARTBEAT,
     AuditEvent,
 )
 
@@ -262,8 +263,8 @@ QUEUE_WITHOUT_MOTION_SUPPRESSED_PROJECTS: frozenset[str] = frozenset({
 #   issues; today no rule emits at this tier.
 # * ``TIER_TERMINAL`` — observe-only. The rule produces a finding for
 #   forensic / alerting purposes but no automated action follows. Used
-#   for orphan_marker, marker_leaked, cancellation_no_promotion,
-#   plan_missing_alert_churn (canary detectors).
+#   for orphan_marker, marker_leaked, plan_missing_alert_churn
+#   (canary detectors).
 TIER_1 = "1"
 TIER_2 = "2"
 TIER_3 = "3"
@@ -856,7 +857,7 @@ def _detect_cancellation_no_promotion(
             continue
         findings.append(Finding(
             rule=RULE_CANCEL_NO_PROMOTION,
-            tier=TIER_TERMINAL,
+            tier=TIER_2,
             project=ev.project,
             subject=ev.subject,
             message=(
@@ -874,6 +875,17 @@ def _detect_cancellation_no_promotion(
                 "cancelled_at": ev.ts,
                 "actor": ev.actor,
                 "from": (ev.metadata or {}).get("from"),
+                "detected_via": "event",
+            },
+            evidence={
+                "cancelled_task_id": ev.subject,
+                "cancelled_at": ev.ts,
+                "from": (ev.metadata or {}).get("from"),
+                "actor": ev.actor,
+                "replacement_task_created": False,
+                "required_decision": (
+                    "queue_replacement_or_mark_project_intentionally_parked"
+                ),
             },
         ))
     return findings
@@ -1217,7 +1229,7 @@ def _latest_worker_heartbeat_time(
     """Return the latest ``worker.heartbeat`` timestamp for ``subject``."""
     latest: datetime | None = None
     for ev in events:
-        if ev.event != "worker.heartbeat":
+        if ev.event != EVENT_WORKER_HEARTBEAT:
             continue
         meta = ev.metadata or {}
         event_subjects = {
@@ -1295,7 +1307,7 @@ def _detect_task_progress_stale(
             )
             if heartbeat_ts is not None and heartbeat_ts > last_activity:
                 last_activity = heartbeat_ts
-                last_activity_kind = "worker.heartbeat"
+                last_activity_kind = EVENT_WORKER_HEARTBEAT
             context_ts, context_kind = _latest_task_context_time(
                 task, since=entry_ts,
             )
@@ -1369,7 +1381,7 @@ def _detect_task_progress_stale(
         )
         if heartbeat_ts is not None and heartbeat_ts > last_activity:
             last_activity = heartbeat_ts
-            last_activity_kind = "worker.heartbeat"
+            last_activity_kind = EVENT_WORKER_HEARTBEAT
         if last_activity > cutoff:
             continue
         stuck_minutes = max(
@@ -2548,7 +2560,7 @@ _QUEUE_MOTION_EVENTS: frozenset[str] = frozenset({
     "task.claimed",
     "execution.advanced",
     "execution.completed",
-    "worker.heartbeat",
+    EVENT_WORKER_HEARTBEAT,
 })
 
 
@@ -3699,6 +3711,45 @@ def _brief_task_progress_stale(
     return lines
 
 
+def _brief_cancellation_no_promotion(
+    finding: Finding,
+    subject: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``cancellation_no_promotion``."""
+    cancelled_at = meta.get("cancelled_at")
+    from_state = meta.get("from") or "<unknown>"
+    actor = meta.get("actor") or "<unknown>"
+    lines: list[str] = []
+    lines.append("Stuck for: cancellation grace window elapsed")
+    lines.append("Observed evidence:")
+    if cancelled_at:
+        lines.append(
+            f"- Task transitioned {from_state} -> cancelled at {cancelled_at}"
+        )
+    else:
+        lines.append("- Task transitioned to cancelled; timestamp unavailable")
+    lines.append(f"- Cancellation actor: {actor}")
+    lines.append(
+        "- No later task.created event for this project was observed "
+        "inside the scan window."
+    )
+    lines.append("")
+    lines.append(
+        "Your job: decide whether this cancellation ended the project "
+        "intentionally or left replacement work unqueued. Do not reply "
+        "with analysis alone; make the queue state explicit."
+    )
+    lines.append(
+        f"Cli levers available: create and queue replacement work with "
+        f"`pm task create ...` then `pm task queue <replacement-task-id>`, "
+        f"or intentionally park the abandoned thread with "
+        f"`pm task context {subject} \"parked intentionally: <why>\"` "
+        f"plus cancel/hold for any remaining scoped task."
+    )
+    return lines
+
+
 def _brief_role_session_missing(
     finding: Finding,
     project: str,
@@ -3978,6 +4029,8 @@ def format_unstick_brief(
         lines.extend(_brief_task_review_stale(finding, subject, meta))
     elif finding.rule == RULE_TASK_PROGRESS_STALE:
         lines.extend(_brief_task_progress_stale(finding, subject, meta))
+    elif finding.rule == RULE_CANCEL_NO_PROMOTION:
+        lines.extend(_brief_cancellation_no_promotion(finding, subject, meta))
     elif finding.rule == RULE_ROLE_SESSION_MISSING:
         lines.extend(_brief_role_session_missing(finding, project, meta))
     elif finding.rule == RULE_PLAN_REVIEW_MISSING:

--- a/src/pollypm/heartbeats/api.py
+++ b/src/pollypm/heartbeats/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -10,6 +11,9 @@ from pollypm.atomic_io import atomic_write_json
 from pollypm.checkpoints import record_checkpoint, snapshot_hash, write_mechanical_checkpoint
 from pollypm.heartbeats.base import HeartbeatCursor, HeartbeatSessionContext, HeartbeatUnmanagedWindow
 from pollypm.heartbeats.types import Alert
+
+
+logger = logging.getLogger(__name__)
 
 
 class _SupervisorHost(Protocol):
@@ -168,6 +172,61 @@ class SupervisorHeartbeatAPI:
             snapshot_path=context.snapshot_path,
             snapshot_hash=context.snapshot_hash,
         )
+
+    def record_worker_heartbeat(
+        self,
+        context: HeartbeatSessionContext,
+        *,
+        task_id: str | None = None,
+    ) -> None:
+        """Emit the audit progress signal for fresh worker transcript output.
+
+        The local heartbeat backend decides whether a session produced
+        fresh transcript output this tick; this facade owns the audit
+        write so the event uses the configured project/audit path and
+        stays best-effort like the rest of the heartbeat observation
+        path.
+        """
+        if context.role != "worker":
+            return
+        if not (context.transcript_delta or "").strip():
+            return
+        project = context.project_key or ""
+        if not project:
+            return
+        subject = task_id or context.session_name
+        project_path: Path | None = None
+        try:
+            project_cfg = self.supervisor.config.projects.get(project)
+            if project_cfg is not None:
+                project_path = Path(project_cfg.path)
+        except Exception:  # noqa: BLE001
+            project_path = None
+
+        try:
+            from pollypm.audit.log import (
+                EVENT_WORKER_HEARTBEAT,
+                emit as audit_emit,
+            )
+
+            delta = context.transcript_delta or ""
+            audit_emit(
+                event=EVENT_WORKER_HEARTBEAT,
+                project=project,
+                subject=subject,
+                actor=context.session_name,
+                metadata={
+                    "task_id": task_id or "",
+                    "session_name": context.session_name,
+                    "window_name": context.window_name,
+                    "snapshot_hash": context.snapshot_hash,
+                    "log_bytes": context.source_bytes,
+                    "delta_bytes": len(delta.encode("utf-8")),
+                },
+                project_path=project_path,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("record_worker_heartbeat failed", exc_info=True)
 
     def record_checkpoint(self, context: HeartbeatSessionContext, *, alerts: list[str]) -> None:
         if not context.window_present or context.snapshot_path is None:

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -828,6 +828,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             return
 
         api.record_observation(context)
+        self._record_worker_progress_heartbeat(api, context)
         api.clear_alert(context.session_name, "missing_window")
 
         stopped_reason = "Pane process is stopped (SIGSTOP)"
@@ -954,6 +955,34 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         # Use the structured classification engine for intervention decisions
         if not mechanical_only:
             self._dispatch_health_intervention(api, context)
+
+    def _record_worker_progress_heartbeat(
+        self, api, context: HeartbeatSessionContext
+    ) -> None:
+        """Record a task-scoped audit heartbeat for fresh worker output."""
+        recorder = getattr(api, "record_worker_heartbeat", None)
+        if recorder is None or context.role != "worker":
+            return
+        if not (context.transcript_delta or "").strip():
+            return
+        task_id: str | None = None
+        try:
+            work_signals = _collect_work_service_signals(api, context)
+            candidate = work_signals.get("active_claim_task_id")
+            if isinstance(candidate, str) and candidate:
+                task_id = candidate
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "worker progress heartbeat task lookup failed for %s",
+                context.session_name, exc_info=True,
+            )
+        try:
+            recorder(context, task_id=task_id)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "worker progress heartbeat emit failed for %s",
+                context.session_name, exc_info=True,
+            )
 
     def _dispatch_health_intervention(
         self, api, context: HeartbeatSessionContext

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -39,6 +39,7 @@ from pollypm.audit.watchdog import (
     ESCALATION_THROTTLE_SECONDS,
     OPERATOR_DISPATCH_THROTTLE_SECONDS,
     Finding,
+    RULE_CANCEL_NO_PROMOTION,
     RULE_DUPLICATE_ADVISOR_TASKS,
     RULE_LEGACY_DB_SHADOW,
     RULE_PLAN_MISSING_ALERT_CHURN,
@@ -145,6 +146,7 @@ _DISPATCHABLE_RULES: frozenset[str] = frozenset({
     # alone leaves them parked forever; dispatch the architect to queue,
     # cancel, or rewrite them.
     RULE_STUCK_DRAFT,
+    RULE_CANCEL_NO_PROMOTION,
     RULE_TASK_REVIEW_STALE,
     RULE_TASK_PROGRESS_STALE,
     RULE_WORKER_SESSION_DEAD_LOOP,

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -31,6 +31,7 @@ from pollypm.audit.watchdog import (
     RULE_ORPHAN_MARKER,
     RULE_STUCK_DRAFT,
     RULE_TASK_PROGRESS_STALE,
+    TIER_2,
     Finding,
     WatchdogConfig,
     emit_finding,
@@ -395,6 +396,12 @@ def test_cancel_without_replacement_fires(now: datetime) -> None:
     ]
     assert len(findings) == 1
     assert findings[0].subject == "demo/1"
+    assert findings[0].tier == TIER_2
+    assert findings[0].evidence["cancelled_task_id"] == "demo/1"
+    assert (
+        findings[0].evidence["required_decision"]
+        == "queue_replacement_or_mark_project_intentionally_parked"
+    )
 
 
 def test_cancel_with_followup_create_silenced(now: datetime) -> None:
@@ -415,6 +422,32 @@ def test_cancel_with_followup_create_silenced(now: datetime) -> None:
         if f.rule == RULE_CANCEL_NO_PROMOTION
     ]
     assert findings == []
+
+
+def test_format_unstick_brief_cancellation_no_promotion_is_decisive() -> None:
+    from pollypm.audit.watchdog import format_unstick_brief
+
+    finding = Finding(
+        rule=RULE_CANCEL_NO_PROMOTION,
+        project="demo",
+        subject="demo/1",
+        message="Task demo/1 was cancelled but no replacement was queued.",
+        metadata={
+            "cancelled_at": "2026-05-06T16:45:00+00:00",
+            "from": "in_progress",
+            "actor": "worker",
+        },
+        tier=TIER_2,
+    )
+
+    brief = format_unstick_brief(finding)
+
+    assert "Finding: cancellation_no_promotion" in brief
+    assert "in_progress -> cancelled" in brief
+    assert "No later task.created" in brief
+    assert "queue replacement work" in brief
+    assert "intentionally park" in brief
+    assert "Do not reply with analysis alone" in brief
 
 
 def test_cancel_within_grace_window_silenced(now: datetime) -> None:
@@ -1213,6 +1246,75 @@ def test_cadence_handler_dispatches_stuck_draft(
     ]
     assert len(dispatch_rows) == 1
     assert dispatch_rows[0]["metadata"]["finding_type"] == RULE_STUCK_DRAFT
+
+
+def test_cadence_handler_dispatches_cancellation_no_promotion(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel-without-replacement is tier-2 self-heal via architect dispatch."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    central = central_log_path("savethenovel")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    central.write_text(
+        json.dumps({
+            "schema": 1,
+            "ts": (now - timedelta(minutes=15)).isoformat(),
+            "project": "savethenovel",
+            "event": EVENT_TASK_STATUS_CHANGED,
+            "subject": "savethenovel/1",
+            "actor": "worker",
+            "status": "ok",
+            "metadata": {"from": "in_progress", "to": "cancelled"},
+        }) + "\n",
+        encoding="utf-8",
+    )
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        lambda target, brief: sent.append((target, brief)) or True,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [],
+    )
+
+    store = _RecordingStore()
+    counters = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert counters["findings"] == 1
+    assert counters["dispatches_sent"] == 1
+    assert len(sent) == 1
+    target, brief = sent[0]
+    assert target == "pollypm-storage-closet:architect-savethenovel"
+    assert RULE_CANCEL_NO_PROMOTION in brief
+    assert "queue replacement work" in brief
+    assert "intentionally park" in brief
+
+    rows = [
+        json.loads(line)
+        for line in central.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    dispatch_rows = [
+        r for r in rows if r["event"] == "watchdog.escalation_dispatched"
+    ]
+    assert len(dispatch_rows) == 1
+    assert dispatch_rows[0]["metadata"]["finding_type"] == RULE_CANCEL_NO_PROMOTION
 
 
 def test_cadence_handler_throttles_repeat_dispatch(

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -114,6 +114,7 @@ class FakeHeartbeatAPI:
         self.events: list[tuple[str, str, str]] = []
         self.observations: list[str] = []
         self.checkpoints: list[tuple[str, list[str]]] = []
+        self.worker_heartbeats: list[tuple[str, str | None]] = []
         self.recoveries: list[tuple[str, str, str]] = []
         self.account_marks: list[tuple[str, str, str]] = []
         self.messages: list[tuple[str, str, str]] = []
@@ -147,6 +148,14 @@ class FakeHeartbeatAPI:
 
     def record_checkpoint(self, context: HeartbeatSessionContext, *, alerts: list[str]) -> None:
         self.checkpoints.append((context.session_name, alerts))
+
+    def record_worker_heartbeat(
+        self,
+        context: HeartbeatSessionContext,
+        *,
+        task_id: str | None = None,
+    ) -> None:
+        self.worker_heartbeats.append((context.session_name, task_id))
 
     def record_event(self, session_name: str, event_type: str, message: str) -> None:
         self.events.append((session_name, event_type, message))
@@ -663,6 +672,40 @@ def test_supervisor_heartbeat_api_records_observation_via_supervisor_facade() ->
     assert calls[0]["snapshot_hash"] == "hash-1"
 
 
+def test_supervisor_heartbeat_api_emits_worker_heartbeat_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.audit.log import EVENT_WORKER_HEARTBEAT, read_events
+
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    supervisor = SimpleNamespace(config=_config(tmp_path))
+    api = SupervisorHeartbeatAPI.__new__(SupervisorHeartbeatAPI)
+    api.supervisor = supervisor
+
+    api.record_worker_heartbeat(
+        _context(
+            session_name="worker_pollypm",
+            role="worker",
+            project_key="pollypm",
+            transcript_delta="Implemented the parser.\n",
+            source_bytes=128,
+        ),
+        task_id="pollypm/9",
+    )
+
+    rows = read_events(
+        "pollypm",
+        event=EVENT_WORKER_HEARTBEAT,
+        project_path=tmp_path,
+    )
+    assert len(rows) == 1
+    assert rows[0].subject == "pollypm/9"
+    assert rows[0].actor == "worker_pollypm"
+    assert rows[0].metadata["task_id"] == "pollypm/9"
+    assert rows[0].metadata["delta_bytes"] == len("Implemented the parser.\n")
+
+
 def test_supervisor_heartbeat_api_deduplicates_snapshot_learnings(tmp_path: Path, monkeypatch) -> None:
     supervisor = Supervisor(_config(tmp_path))
     supervisor.ensure_layout()
@@ -1147,6 +1190,38 @@ def test_local_heartbeat_backend_uses_mechanical_checks_only_for_heartbeat_super
     assert ("heartbeat", "needs_followup") not in api.alerts
     assert ("heartbeat", "idle_output") not in api.alerts
     assert ("heartbeat", "suspected_loop") not in api.alerts
+
+
+def test_local_heartbeat_backend_records_worker_heartbeat_for_fresh_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "pollypm.heartbeats.local._collect_work_service_signals",
+        lambda _api, _context: {"active_claim_task_id": "pollypm/42"},
+    )
+    api = FakeHeartbeatAPI([
+        _context(transcript_delta="Implemented the change.\n"),
+    ])
+
+    LocalHeartbeatBackend().run(api)
+
+    assert api.worker_heartbeats == [("worker_pollypm", "pollypm/42")]
+
+
+def test_local_heartbeat_backend_skips_worker_heartbeat_without_fresh_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "pollypm.heartbeats.local._collect_work_service_signals",
+        lambda _api, _context: {"active_claim_task_id": "pollypm/42"},
+    )
+    api = FakeHeartbeatAPI([
+        _context(transcript_delta=""),
+    ])
+
+    LocalHeartbeatBackend().run(api)
+
+    assert api.worker_heartbeats == []
 
 
 def test_local_heartbeat_backend_alerts_on_unmanaged_window_once() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- emit durable `worker.heartbeat` audit events from worker heartbeat updates that include fresh transcript deltas
- connect local heartbeat collection to active task signals so `task_progress_stale` has a real worker-progress source
- promote `cancellation_no_promotion` to the self-heal tier with structured evidence, architect brief text, dispatchability, docs, and regression tests

Fixes #2367
Fixes #2369

## Verification
- `uv run --extra test python -m pytest tests/test_audit_watchdog.py -q` -> 112 passed
- `uv run --extra test python -m pytest tests/test_audit_log_docs.py -q` -> 2 passed
- `uv run --extra test python -m pytest tests/test_heartbeat_plugin_api.py -q -k "worker_heartbeat or emits_worker_heartbeat_audit"` -> 3 passed, 39 deselected
- `uv run --extra test python -m py_compile src/pollypm/audit/log.py src/pollypm/audit/watchdog.py src/pollypm/heartbeats/api.py src/pollypm/heartbeats/local.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py tests/test_audit_watchdog.py tests/test_heartbeat_plugin_api.py`
- `git diff --check origin/main...HEAD`

## Notes
- `uv run --extra dev ruff check docs/audit-log.md src/pollypm/audit/log.py src/pollypm/audit/watchdog.py src/pollypm/heartbeats/api.py src/pollypm/heartbeats/local.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py tests/test_audit_watchdog.py tests/test_heartbeat_plugin_api.py` still reports pre-existing full-file issues in `src/pollypm/heartbeats/local.py` and `tests/test_heartbeat_plugin_api.py` unrelated to this change.
