### PR TITLE
Audit account failover transitions

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -111,6 +111,10 @@ The current event families are:
 | `worker.heartbeat` | heartbeat supervisor when a worker has fresh transcript output | `task_id`, `session_name`, `window_name`, `snapshot_hash`, `log_bytes`, `delta_bytes` |
 | `heartbeat.missing` | supervisor recovery detection | `session`, `window_name`, `tmux_session`, `failure_type`, `failure_message` |
 | `session.spawn` | supervisor recovery relaunch | `session`, `window_name`, `tmux_session`, `failure_type`, `account`, `provider` |
+| `account.failover.proactive` | account usage refresh soft controller failover | `from`, `to`, `reason`, `threshold`, `current` |
+| `account.failover.engaged` | supervisor hard recovery failover after account failure | `session`, `failure_type`, `from`, `to`, `account`, `provider` |
+| `account.failover.blocked` | supervisor hard recovery when no viable failover account exists | `session`, `failure_type`, `from`, `reason` |
+| `account.failover.failed` | supervisor hard recovery when every failover candidate fails launch | `session`, `failure_type`, `from`, `reason`, `last_error` |
 | `audit.finding` | audit watchdog findings | `rule`, `message`, `recommendation`, plus rule-specific data |
 | `agent.injection.flagged` | `pm audit agent-refusal` / auth-marker refusal contract | `reason`, `source`, `paired_event` |
 | `agent.refusal` | `pm audit agent-refusal` / auth-marker refusal contract | `reason`, `source`, `paired_event` |

--- a/docs/v1/02-configuration-accounts-and-isolation.md
+++ b/docs/v1/02-configuration-accounts-and-isolation.md
@@ -341,6 +341,14 @@ If every failover account is also at or above the threshold, the sweep raises a
 `account.failover.proactive` event with `reason =
 "no_failover_account_below_threshold"` instead of failing silently.
 
+Hard account failures use the same ordered failover list. When supervisor
+recovery moves a session because the active account is `auth_broken`,
+`capacity_exhausted`, or `capacity_low`, it emits
+`account.failover.engaged` to the JSONL audit log with the source and target
+accounts. If no viable account exists, or every candidate fails to launch, the
+audit log records `account.failover.blocked` or `account.failover.failed`
+instead of leaving only the recovery alert.
+
 ### Failure Classification
 
 When an account fails, PollyPM classifies the failure to determine the correct response.

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -293,6 +293,10 @@ EVENT_HEARTBEAT_MISSING = "heartbeat.missing"
 EVENT_RECOVERY_SPAWN = "recovery.spawn"
 EVENT_SESSION_SPAWN = "session.spawn"
 EVENT_TASK_RECLAIMED = "task.reclaimed"
+EVENT_ACCOUNT_FAILOVER_PROACTIVE = "account.failover.proactive"
+EVENT_ACCOUNT_FAILOVER_ENGAGED = "account.failover.engaged"
+EVENT_ACCOUNT_FAILOVER_BLOCKED = "account.failover.blocked"
+EVENT_ACCOUNT_FAILOVER_FAILED = "account.failover.failed"
 # #2296 — public agent-side refusal observability. Agents use the
 # narrow ``pm audit agent-refusal`` command when they refuse a message
 # claiming PollyPM authority but missing/failing the auth marker.

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -171,11 +171,13 @@ def _apply_proactive_controller_failover(
         )
         _append_proactive_failover_event(
             msg_store,
+            config=config,
             from_account=decision.primary_account,
             to_account=None,
             reason=decision.reason,
             threshold=decision.threshold_pct,
             current_account=decision.current_account,
+            status="warn",
         )
         return summary
 
@@ -183,6 +185,16 @@ def _apply_proactive_controller_failover(
     operator = _operator_session(config)
     if target is None or operator is None:
         summary["error"] = "No operator session or selected account available"
+        _emit_proactive_failover_audit(
+            config,
+            from_account=decision.current_account,
+            to_account=target,
+            reason=decision.reason,
+            threshold=decision.threshold_pct,
+            current_account=decision.current_account,
+            status="error",
+            error=summary["error"],
+        )
         _upsert_proactive_failover_failed_alert(msg_store, summary["error"])
         return summary
 
@@ -195,6 +207,16 @@ def _apply_proactive_controller_failover(
         )
     except Exception as exc:  # noqa: BLE001
         summary["error"] = str(exc)
+        _emit_proactive_failover_audit(
+            config,
+            from_account=decision.current_account,
+            to_account=target,
+            reason=decision.reason,
+            threshold=decision.threshold_pct,
+            current_account=decision.current_account,
+            status="error",
+            error=str(exc),
+        )
         _upsert_proactive_failover_failed_alert(
             msg_store,
             f"Proactive controller failover to {target} failed: {exc}",
@@ -217,6 +239,7 @@ def _apply_proactive_controller_failover(
         _upsert_proactive_failover_active_alert(msg_store, decision)
     _append_proactive_failover_event(
         msg_store,
+        config=config,
         from_account=(
             decision.primary_account
             if decision.action == "switch"
@@ -226,6 +249,7 @@ def _apply_proactive_controller_failover(
         reason=decision.reason,
         threshold=decision.threshold_pct,
         current_account=decision.current_account,
+        status="ok",
     )
     summary["applied"] = True
     return summary
@@ -249,12 +273,23 @@ def _switch_operator_account(
 def _append_proactive_failover_event(
     msg_store: Any | None,
     *,
+    config: Any,
     from_account: str,
     to_account: str | None,
     reason: str,
     threshold: int,
     current_account: str,
+    status: str,
 ) -> None:
+    _emit_proactive_failover_audit(
+        config,
+        from_account=from_account,
+        to_account=to_account,
+        reason=reason,
+        threshold=threshold,
+        current_account=current_account,
+        status=status,
+    )
     if msg_store is None:
         return
     try:
@@ -277,6 +312,49 @@ def _append_proactive_failover_event(
     except Exception:  # noqa: BLE001
         logger.warning(
             "account.usage_refresh: failed to append proactive failover event",
+            exc_info=True,
+        )
+
+
+def _emit_proactive_failover_audit(
+    config: Any,
+    *,
+    from_account: str,
+    to_account: str | None,
+    reason: str,
+    threshold: int,
+    current_account: str,
+    status: str,
+    error: str | None = None,
+) -> None:
+    try:
+        from pollypm.audit.log import (
+            EVENT_ACCOUNT_FAILOVER_PROACTIVE,
+            emit as _audit_emit,
+        )
+
+        project_root = getattr(getattr(config, "project", None), "root_dir", None)
+        metadata = {
+            "from": from_account,
+            "to": to_account,
+            "reason": reason,
+            "threshold": threshold,
+            "current": current_account,
+        }
+        if error:
+            metadata["error"] = error
+        _audit_emit(
+            event=EVENT_ACCOUNT_FAILOVER_PROACTIVE,
+            project="_workspace",
+            subject="operator",
+            actor="account.usage_refresh",
+            status=status,
+            metadata=metadata,
+            project_path=project_root,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "account.usage_refresh: failed to emit proactive failover audit",
             exc_info=True,
         )
 

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -2857,6 +2857,9 @@ class Supervisor:
     # Failure types where the session is gone — no live interaction to protect.
     _DEAD_SESSION_FAILURES = frozenset({"missing_window", "pane_dead", "shell_returned"})
     _AUDIT_MISSING_FAILURES = _DEAD_SESSION_FAILURES
+    _ACCOUNT_FAILOVER_FAILURES = frozenset(
+        {"auth_broken", "capacity_exhausted", "capacity_low"}
+    )
 
     # Map detected failure types to the raw signals the RecoveryPolicy
     # expects. Keeps the policy decoupled from Supervisor's vocabulary.
@@ -3834,6 +3837,24 @@ class Supervisor:
         }
         candidates = self._candidate_accounts(launch, allow_same=allow_same)
         if not candidates:
+            if failure_type in self._ACCOUNT_FAILOVER_FAILURES:
+                from pollypm.audit.log import EVENT_ACCOUNT_FAILOVER_BLOCKED
+
+                self._emit_session_recovery_audit(
+                    EVENT_ACCOUNT_FAILOVER_BLOCKED,
+                    launch,
+                    status="error",
+                    actor="supervisor",
+                    metadata={
+                        "failure_type": failure_type,
+                        "failure_message": failure_message,
+                        "from": launch.account.name,
+                        "to": None,
+                        "account": launch.account.name,
+                        "provider": launch.account.provider.value,
+                        "reason": "no_viable_account",
+                    },
+                )
             self._msg_store.upsert_alert(
                 launch.session.name,
                 "blocked_no_capacity",
@@ -3885,6 +3906,25 @@ class Supervisor:
             "error",
             f"Recovery failed for all viable accounts: {last_error or 'no candidate succeeded'}",
         )
+        if failure_type in self._ACCOUNT_FAILOVER_FAILURES:
+            from pollypm.audit.log import EVENT_ACCOUNT_FAILOVER_FAILED
+
+            self._emit_session_recovery_audit(
+                EVENT_ACCOUNT_FAILOVER_FAILED,
+                launch,
+                status="error",
+                actor="supervisor",
+                metadata={
+                    "failure_type": failure_type,
+                    "failure_message": failure_message,
+                    "from": launch.account.name,
+                    "to": None,
+                    "account": launch.account.name,
+                    "provider": launch.account.provider.value,
+                    "reason": "candidate_launch_failed",
+                    "last_error": last_error or "",
+                },
+            )
         self._upsert_session_runtime(
             session_name=launch.session.name,
             status="blocked",
@@ -3942,6 +3982,11 @@ class Supervisor:
         )
         tmux_session = self._tmux_session_for_launch(launch)
         previous_runtime = self._get_session_runtime(session_name)
+        previous_account = (
+            previous_runtime.effective_account
+            if previous_runtime is not None and previous_runtime.effective_account
+            else launch.account.name
+        )
         if self.session_service.tmux.has_session(tmux_session):
             window_map = self._window_map()
             # #1096 — key includes the tmux_session so we don't mistake
@@ -4015,6 +4060,27 @@ class Supervisor:
                     status="ok",
                     actor="supervisor",
                     metadata=recovery_metadata,
+                )
+            if (
+                failure_type in self._ACCOUNT_FAILOVER_FAILURES
+                and account_name != previous_account
+            ):
+                from pollypm.audit.log import EVENT_ACCOUNT_FAILOVER_ENGAGED
+
+                self._emit_session_recovery_audit(
+                    EVENT_ACCOUNT_FAILOVER_ENGAGED,
+                    launch,
+                    status="ok",
+                    actor="supervisor",
+                    metadata={
+                        "failure_type": failure_type,
+                        "from": previous_account,
+                        "to": account_name,
+                        "account": account_name,
+                        "provider": account.provider.value,
+                        "configured_account": getattr(launch.session, "account", ""),
+                        "reason": "recovery_failover",
+                    },
                 )
         # Inject recovery prompt so the agent knows what it was doing.
         # For role-scoped agents (reviewer / heartbeat) prepend an

--- a/tests/test_core_recurring_proactive_failover.py
+++ b/tests/test_core_recurring_proactive_failover.py
@@ -133,6 +133,49 @@ def test_proactive_failover_switches_operator_and_emits_audit_event(tmp_path: Pa
     ) in msg_store.cleared
 
 
+def test_proactive_failover_writes_jsonl_audit_event(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.audit.log import (
+        EVENT_ACCOUNT_FAILOVER_PROACTIVE,
+        read_events,
+    )
+
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    config = _config(tmp_path)
+
+    _apply_proactive_controller_failover(
+        tmp_path / "pollypm.toml",
+        config,
+        ProactiveFailoverDecision(
+            action="switch",
+            primary_account="claude_main",
+            current_account="claude_main",
+            selected_account="claude_backup",
+            reason="used_pct_threshold",
+            threshold_pct=85,
+            candidates_evaluated=1,
+        ),
+        msg_store=None,
+        switcher=lambda *_args: None,
+    )
+
+    events = read_events("_workspace", event=EVENT_ACCOUNT_FAILOVER_PROACTIVE)
+    assert len(events) == 1
+    event = events[0]
+    assert event.subject == "operator"
+    assert event.actor == "account.usage_refresh"
+    assert event.status == "ok"
+    assert event.metadata == {
+        "from": "claude_main",
+        "to": "claude_backup",
+        "reason": "used_pct_threshold",
+        "threshold": 85,
+        "current": "claude_main",
+    }
+
+
 def test_proactive_failover_alerts_when_no_account_is_under_threshold(tmp_path: Path) -> None:
     config = _config(tmp_path)
     msg_store = _MsgStore()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -108,6 +108,11 @@ def test_supervisor_failover_prefers_viable_backup(monkeypatch, tmp_path: Path) 
     monkeypatch.setattr(supervisor, "_account_is_viable", lambda name: name == "codex_backup")
     monkeypatch.setattr(
         supervisor,
+        "_record_recovery_attempt",
+        lambda *_args, **_kwargs: (True, 1),
+    )
+    monkeypatch.setattr(
+        supervisor,
         "_restart_session",
         lambda session_name, account_name, failure_type: restarted.update(
             {"session": session_name, "account": account_name, "failure": failure_type}
@@ -152,6 +157,11 @@ def test_supervisor_failover_skips_pg_exhausted_account(monkeypatch, tmp_path: P
         )
 
     monkeypatch.setattr("pollypm.capacity.probe_capacity", fake_probe_capacity)
+    monkeypatch.setattr(
+        supervisor,
+        "_record_recovery_attempt",
+        lambda *_args, **_kwargs: (True, 1),
+    )
     monkeypatch.setattr(
         supervisor,
         "_restart_session",
@@ -1590,6 +1600,112 @@ def test_restart_session_emits_session_spawn_audit(
     assert recovery_event.metadata["target_task"] == ""
     assert recovery_event.metadata["reason"] == "recovery_restart"
     assert recovery_event.metadata["failure_type"] == "missing_window"
+
+
+def test_restart_session_hard_failover_emits_account_failover_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.audit.log import (
+        EVENT_ACCOUNT_FAILOVER_ENGAGED,
+        read_events,
+    )
+
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = SessionLaunchSpec(
+        session=config.sessions["operator"],
+        account=config.accounts["claude_controller"],
+        window_name="pm-operator",
+        log_path=tmp_path / ".pollypm/logs/operator.log",
+        command="claude",
+    )
+
+    monkeypatch.setattr(
+        supervisor.session_service.tmux,
+        "has_session",
+        lambda _name: False,
+    )
+    monkeypatch.setattr(supervisor, "_get_session_runtime", lambda _name: None)
+    monkeypatch.setattr(supervisor, "_launch_by_session", lambda _name: launch)
+    monkeypatch.setattr(supervisor, "launch_session", lambda _name: launch)
+
+    supervisor.restart_session(
+        "operator",
+        "codex_backup",
+        failure_type="auth_broken",
+    )
+
+    events = read_events(
+        "pollypm",
+        project_path=tmp_path,
+        event=EVENT_ACCOUNT_FAILOVER_ENGAGED,
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event.subject == "operator"
+    assert event.actor == "supervisor"
+    assert event.status == "ok"
+    assert event.metadata["session"] == "operator"
+    assert event.metadata["failure_type"] == "auth_broken"
+    assert event.metadata["from"] == "claude_controller"
+    assert event.metadata["to"] == "codex_backup"
+    assert event.metadata["account"] == "codex_backup"
+    assert event.metadata["provider"] == "codex"
+    assert event.metadata["reason"] == "recovery_failover"
+    assert event.metadata["target_session"] == "operator"
+
+
+def test_auth_broken_without_candidate_emits_failover_blocked_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.audit.log import (
+        EVENT_ACCOUNT_FAILOVER_BLOCKED,
+        read_events,
+    )
+
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = SessionLaunchSpec(
+        session=config.sessions["operator"],
+        account=config.accounts["claude_controller"],
+        window_name="pm-operator",
+        log_path=tmp_path / ".pollypm/logs/operator.log",
+        command="claude",
+    )
+
+    monkeypatch.setattr(supervisor, "_policy_recommendation", lambda *_args: None)
+    monkeypatch.setattr(
+        supervisor,
+        "_record_recovery_attempt",
+        lambda *_args, **_kwargs: (True, 1),
+    )
+    monkeypatch.setattr(supervisor, "_candidate_accounts", lambda *_args, **_kwargs: [])
+
+    supervisor.maybe_recover_session(
+        launch,
+        failure_type="auth_broken",
+        failure_message="401",
+    )
+
+    events = read_events(
+        "pollypm",
+        project_path=tmp_path,
+        event=EVENT_ACCOUNT_FAILOVER_BLOCKED,
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "error"
+    assert event.metadata["failure_type"] == "auth_broken"
+    assert event.metadata["failure_message"] == "401"
+    assert event.metadata["from"] == "claude_controller"
+    assert event.metadata["to"] is None
+    assert event.metadata["reason"] == "no_viable_account"
 
 
 def test_supervisor_record_heartbeat_routes_through_pg_facade(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add JSONL audit events for proactive account failover, hard recovery failover success, blocked-no-candidate, and all-candidates-failed paths.
- Keep existing message-store alerts/events while making failover grep-visible in `~/.pollypm/audit/`.
- Document the new failover audit events and add regression tests for successful `auth_broken` failover plus the no-viable-account failure mode.

Fixes #2380.

## Tests
- `uv run --extra test pytest tests/test_core_recurring_proactive_failover.py tests/test_supervisor.py::test_supervisor_failover_prefers_viable_backup tests/test_supervisor.py::test_supervisor_failover_skips_pg_exhausted_account tests/test_supervisor.py::test_restart_session_emits_session_spawn_audit tests/test_supervisor.py::test_restart_session_hard_failover_emits_account_failover_audit tests/test_supervisor.py::test_auth_broken_without_candidate_emits_failover_blocked_audit`
- `uv run --extra test python -m py_compile src/pollypm/audit/log.py src/pollypm/plugins_builtin/core_recurring/maintenance.py src/pollypm/supervisor.py tests/test_core_recurring_proactive_failover.py tests/test_supervisor.py`

## Notes
- `uv run --extra dev ruff check ...` is not clean on the touched file set because existing `E402`/unused-import findings in `src/pollypm/supervisor.py` and `tests/test_supervisor.py` fire before this change's scope.
