### PR TITLE
Refresh stale architect worktrees before launch

### DIFF
--- a/docs/agent-handbook.md
+++ b/docs/agent-handbook.md
@@ -64,6 +64,13 @@ error message body, kept here for grep-ability):
 `architect`, `reviewer`, `worker`, `polly`, `russell`, `triage`. **Note**:
 `user` is **not** a role — the human is not an autonomous agent.
 
+Architect sessions run from persistent project worktrees. When PollyPM
+launches or relaunches an architect, it fast-forwards a clean architect
+worktree to local `main`/`master` when possible. If local changes or a
+divergent branch make that unsafe, PollyPM leaves the worktree untouched and
+writes `.pollypm/architect-worktree-status.md` inside it for the architect to
+surface before relying on repository state.
+
 ## 3. Canonical CLI commands
 
 All commands are invoked as `pm <verb>` (or `pollypm <verb>` — both

--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -42,10 +42,11 @@ Stage-0 (Research) additionally produces `docs/planning-context.md` via a ReAct 
 <kickoff>
 You are {persona_name}, the architect. On session start:
 
-1. Claim your work: run `pm task next` to find the highest-priority queued `plan_project` task routed to you. If nothing is queued yet, wait for a ping from the task-assignment bus — the sweeper will re-notify every few minutes.
-2. Walk the `plan_project` flow stages in order: research → discover → decompose → test_strategy → magic → critic_panel → synthesize → plan_review → user_approval → emit_backlog.
-3. At the end of EACH stage you MUST drive the node transition yourself — see `<stage_transitions>`. Writing the artifact is not enough; the task node stays where it is until you call `pm task done`.
-4. Stop at stage 7 (user_approval) and notify the user. Emission + worker delegation happens only after the user approves the plan.
+1. Check `.pollypm/architect-worktree-status.md` if it exists. If PollyPM says this checkout is stale relative to main, surface that before planning from repository state; do not reset or discard local work unless the operator explicitly approves it.
+2. Claim your work: run `pm task next` to find the highest-priority queued `plan_project` task routed to you. If nothing is queued yet, wait for a ping from the task-assignment bus — the sweeper will re-notify every few minutes.
+3. Walk the `plan_project` flow stages in order: research → discover → decompose → test_strategy → magic → critic_panel → synthesize → plan_review → user_approval → emit_backlog.
+4. At the end of EACH stage you MUST drive the node transition yourself — see `<stage_transitions>`. Writing the artifact is not enough; the task node stays where it is until you call `pm task done`.
+5. Stop at stage 7 (user_approval) and notify the user. Emission + worker delegation happens only after the user approves the plan.
 </kickoff>
 
 <stage_transitions>

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -1325,6 +1325,7 @@ class Supervisor:
                 # reviewer, workers) would otherwise never get registered.
                 self._record_launch(launch)
                 continue
+            self._refresh_architect_worktree_before_launch(launch)
             _status(f"Recreating {launch.session.name}...")
             if not self.session_service.tmux.has_session(storage_session):
                 self.session_service.tmux.create_session(storage_session, launch.window_name, launch.command)
@@ -1366,6 +1367,7 @@ class Supervisor:
         targets: list[tuple[SessionLaunchSpec, str]] = []
         if launches:
             first = launches[0]
+            self._refresh_architect_worktree_before_launch(first)
             if on_status:
                 on_status(f"Creating {first.session.name}...")
             first_pane_id = self.session_service.tmux.create_session(storage_session, first.window_name, first.command)
@@ -1378,6 +1380,7 @@ class Supervisor:
             pane_target = first_pane_id or window_target
             targets.append((first, pane_target))
             for launch in launches[1:]:
+                self._refresh_architect_worktree_before_launch(launch)
                 if on_status:
                     on_status(f"Creating {launch.session.name}...")
                 pane_id = self.session_service.tmux.create_window(storage_session, launch.window_name, launch.command, detached=True)
@@ -4258,6 +4261,74 @@ class Supervisor:
             self._stabilize_launch(launch, target, on_status=on_status)
         return launch
 
+    def _refresh_architect_worktree_before_launch(
+        self,
+        launch: SessionLaunchSpec,
+    ) -> None:
+        """Refresh architect role worktrees before spawning a new pane.
+
+        Runs only for architect launches whose window is absent. The
+        helper is deliberately non-destructive: clean branches may
+        fast-forward to local main/master, while dirty or divergent
+        checkouts get a status file the architect profile tells the
+        agent to inspect.
+        """
+        session = launch.session
+        if session.role != "architect" or not session.project:
+            return
+        project = self.config.projects.get(session.project)
+        if project is None:
+            return
+        try:
+            from pollypm.worktrees import refresh_architect_worktree
+
+            result = refresh_architect_worktree(project.path, session.cwd)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "architect worktree refresh failed for %s at %s: %s",
+                session.name,
+                session.cwd,
+                exc,
+            )
+            return
+        if result.status == "updated":
+            logger.info(
+                "architect worktree %s fast-forwarded to %s (%s)",
+                session.cwd,
+                result.base_ref,
+                result.base_head,
+            )
+        if result.status in {"current", "updated"}:
+            try:
+                self._msg_store.clear_alert(session.name, "architect_worktree_stale")
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "architect worktree stale-alert clear failed for %s",
+                    session.name,
+                    exc_info=True,
+                )
+        elif result.status == "stale":
+            marker = str(result.marker_path) if result.marker_path else ""
+            message = (
+                f"Architect worktree {session.cwd} is stale relative to "
+                f"{result.base_ref or 'project mainline'}; {result.reason}. "
+                f"Status file: {marker}"
+            )
+            logger.warning(message)
+            try:
+                self._msg_store.upsert_alert(
+                    session.name,
+                    "architect_worktree_stale",
+                    "warn",
+                    message,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "architect worktree stale-alert write failed for %s",
+                    session.name,
+                    exc_info=True,
+                )
+
     def create_session_window(
         self,
         session_name: str,
@@ -4284,6 +4355,7 @@ class Supervisor:
         # #1096 — scope existence-check to the launch's tmux_session.
         if (tmux_session, launch.window_name) in window_map:
             return launch, None
+        self._refresh_architect_worktree_before_launch(launch)
         existing_claude_ids: set[str] | None = None
         if (
             launch.session.provider is ProviderKind.CLAUDE

--- a/src/pollypm/worktrees.py
+++ b/src/pollypm/worktrees.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import re
 import subprocess
 from pathlib import Path
@@ -21,6 +22,20 @@ if TYPE_CHECKING:
     from pollypm.models import PollyPMConfig
 
 _SAFE_WORKTREE_KEY_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+ARCHITECT_WORKTREE_STATUS_PATH = Path(".pollypm") / "architect-worktree-status.md"
+
+
+@dataclass(slots=True)
+class ArchitectWorktreeRefreshResult:
+    """Outcome of the architect worktree freshness check."""
+
+    status: str
+    worktree_path: Path
+    base_ref: str | None = None
+    base_head: str | None = None
+    worktree_head: str | None = None
+    marker_path: Path | None = None
+    reason: str | None = None
 
 
 def _list_worktrees_for_backend(
@@ -82,6 +97,247 @@ def _validate_worktree_key(param_name: str, param_value: str) -> None:
         raise typer.BadParameter(f"{param_name} contains invalid characters: {param_value}")
 
 
+def _git(
+    cwd: Path,
+    *args: str,
+    timeout: int = 60,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+
+
+def _git_ref_exists(project_path: Path, ref: str) -> bool:
+    result = _git(project_path, "rev-parse", "--verify", "--quiet", ref)
+    return result.returncode == 0
+
+
+def _architect_base_ref(project_path: Path) -> str:
+    for ref in ("refs/heads/main", "refs/heads/master"):
+        if _git_ref_exists(project_path, ref):
+            return ref
+    return "HEAD"
+
+
+def _git_oid(path: Path, ref: str) -> str | None:
+    result = _git(path, "rev-parse", "--verify", ref)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _git_worktree_registered(project_path: Path, worktree_path: Path) -> bool:
+    result = _git(project_path, "worktree", "list", "--porcelain")
+    if result.returncode != 0:
+        return False
+    try:
+        target = worktree_path.resolve()
+    except OSError:
+        target = worktree_path
+    for line in result.stdout.splitlines():
+        if not line.startswith("worktree "):
+            continue
+        registered = Path(line[len("worktree "):].strip())
+        try:
+            registered = registered.resolve()
+        except OSError:
+            pass
+        if registered == target:
+            return True
+    return False
+
+
+def _base_is_ancestor(worktree_path: Path, base_head: str) -> bool:
+    result = _git(
+        worktree_path,
+        "merge-base",
+        "--is-ancestor",
+        base_head,
+        "HEAD",
+    )
+    return result.returncode == 0
+
+
+def _worktree_dirty(worktree_path: Path) -> bool:
+    result = _git(worktree_path, "status", "--porcelain")
+    if result.returncode != 0:
+        return True
+    return bool(result.stdout.strip())
+
+
+def _write_architect_stale_marker(
+    *,
+    worktree_path: Path,
+    base_ref: str | None,
+    base_head: str | None,
+    worktree_head: str | None,
+    reason: str,
+) -> Path:
+    marker_path = worktree_path / ARCHITECT_WORKTREE_STATUS_PATH
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text(
+        "\n".join(
+            [
+                "# Architect worktree freshness warning",
+                "",
+                "PollyPM could not fast-forward this architect worktree "
+                "to the current project mainline without risking local work.",
+                "",
+                f"- Base ref checked: `{base_ref or 'unknown'}`",
+                f"- Base HEAD: `{base_head or 'unknown'}`",
+                f"- Worktree HEAD: `{worktree_head or 'unknown'}`",
+                f"- Reason: {reason}",
+                "",
+                "Surface this before planning from repository state. Do not "
+                "reset, delete, or discard work in this checkout unless the "
+                "operator explicitly approves it.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return marker_path
+
+
+def _clear_architect_stale_marker(worktree_path: Path) -> Path:
+    marker_path = worktree_path / ARCHITECT_WORKTREE_STATUS_PATH
+    marker_path.unlink(missing_ok=True)
+    return marker_path
+
+
+def refresh_architect_worktree(
+    project_path: Path,
+    worktree_path: Path,
+) -> ArchitectWorktreeRefreshResult:
+    """Fast-forward an architect worktree to local main when safe.
+
+    This is intentionally conservative: it never resets, rebases,
+    deletes, or force-checkouts. If the checkout is dirty or divergent,
+    PollyPM writes a visible status file for the architect instead of
+    mutating the worktree.
+    """
+    marker_path = _clear_architect_stale_marker(worktree_path)
+    if not worktree_path.exists():
+        return ArchitectWorktreeRefreshResult(
+            status="missing",
+            worktree_path=worktree_path,
+            marker_path=marker_path,
+            reason="worktree path does not exist",
+        )
+    if not (project_path / ".git").exists():
+        return ArchitectWorktreeRefreshResult(
+            status="not_git",
+            worktree_path=worktree_path,
+            marker_path=marker_path,
+            reason="project path is not a git repository",
+        )
+    if not _git_worktree_registered(project_path, worktree_path):
+        reason = "worktree is not registered with git"
+        marker_path = _write_architect_stale_marker(
+            worktree_path=worktree_path,
+            base_ref=None,
+            base_head=None,
+            worktree_head=None,
+            reason=reason,
+        )
+        return ArchitectWorktreeRefreshResult(
+            status="stale",
+            worktree_path=worktree_path,
+            marker_path=marker_path,
+            reason=reason,
+        )
+
+    base_ref = _architect_base_ref(project_path)
+    base_head = _git_oid(project_path, base_ref)
+    worktree_head = _git_oid(worktree_path, "HEAD")
+    if base_head is None or worktree_head is None:
+        reason = "could not resolve git HEADs for freshness check"
+        marker_path = _write_architect_stale_marker(
+            worktree_path=worktree_path,
+            base_ref=base_ref,
+            base_head=base_head,
+            worktree_head=worktree_head,
+            reason=reason,
+        )
+        return ArchitectWorktreeRefreshResult(
+            status="stale",
+            worktree_path=worktree_path,
+            base_ref=base_ref,
+            base_head=base_head,
+            worktree_head=worktree_head,
+            marker_path=marker_path,
+            reason=reason,
+        )
+
+    if _base_is_ancestor(worktree_path, base_head):
+        return ArchitectWorktreeRefreshResult(
+            status="current",
+            worktree_path=worktree_path,
+            base_ref=base_ref,
+            base_head=base_head,
+            worktree_head=worktree_head,
+            marker_path=marker_path,
+        )
+
+    if _worktree_dirty(worktree_path):
+        reason = "worktree has uncommitted changes"
+        marker_path = _write_architect_stale_marker(
+            worktree_path=worktree_path,
+            base_ref=base_ref,
+            base_head=base_head,
+            worktree_head=worktree_head,
+            reason=reason,
+        )
+        return ArchitectWorktreeRefreshResult(
+            status="stale",
+            worktree_path=worktree_path,
+            base_ref=base_ref,
+            base_head=base_head,
+            worktree_head=worktree_head,
+            marker_path=marker_path,
+            reason=reason,
+        )
+
+    result = _git(worktree_path, "merge", "--ff-only", base_ref, timeout=300)
+    if result.returncode == 0:
+        refreshed_head = _git_oid(worktree_path, "HEAD")
+        if refreshed_head is not None and _base_is_ancestor(worktree_path, base_head):
+            return ArchitectWorktreeRefreshResult(
+                status="updated",
+                worktree_path=worktree_path,
+                base_ref=base_ref,
+                base_head=base_head,
+                worktree_head=refreshed_head,
+                marker_path=marker_path,
+            )
+
+    reason = (
+        result.stderr.strip()
+        or result.stdout.strip()
+        or "worktree branch cannot fast-forward to mainline"
+    )
+    marker_path = _write_architect_stale_marker(
+        worktree_path=worktree_path,
+        base_ref=base_ref,
+        base_head=base_head,
+        worktree_head=worktree_head,
+        reason=reason,
+    )
+    return ArchitectWorktreeRefreshResult(
+        status="stale",
+        worktree_path=worktree_path,
+        base_ref=base_ref,
+        base_head=base_head,
+        worktree_head=worktree_head,
+        marker_path=marker_path,
+        reason=reason,
+    )
+
+
 def ensure_worktree(
     config_path: Path,
     *,
@@ -113,6 +369,8 @@ def ensure_worktree(
 
     existing = _active_worktree(config, project_key, lane_kind, lane_key)
     if existing is not None and Path(existing.path).exists():
+        if lane_kind == "architect":
+            refresh_architect_worktree(project.path, Path(existing.path))
         return existing
 
     path = worktree_root / f"{project_key}-{lane_kind}-{lane_key}"
@@ -141,6 +399,8 @@ def ensure_worktree(
         branch=branch,
         status="active",
     )
+    if lane_kind == "architect":
+        refresh_architect_worktree(project.path, path)
     return _active_worktree(config, project_key, lane_kind, lane_key)
 
 

--- a/tests/test_project_planning_plugin.py
+++ b/tests/test_project_planning_plugin.py
@@ -586,6 +586,7 @@ def test_architect_profile_points_at_research_stage() -> None:
     text = root.read_text(encoding="utf-8")
     assert "planning-context.md" in text
     assert "research" in text.lower()
+    assert ".pollypm/architect-worktree-status.md" in text
 
 
 def _make_architect_context(tmp_path: Path, *, persona_name: str | None):

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -1,4 +1,5 @@
 import subprocess
+from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
@@ -14,8 +15,14 @@ from pollypm.models import (
     PollyPMSettings,
     ProviderKind,
 )
-from pollypm.storage.state import StateStore
-from pollypm.worktrees import cleanup_worktree, ensure_worktree, list_worktrees
+from pollypm.storage.records import WorktreeRecord
+from pollypm.worktrees import (
+    ARCHITECT_WORKTREE_STATUS_PATH,
+    cleanup_worktree,
+    ensure_worktree,
+    list_worktrees,
+    refresh_architect_worktree,
+)
 
 
 def _git_project(tmp_path: Path) -> Path:
@@ -55,11 +62,77 @@ def _config(tmp_path: Path, repo: Path, *, project_key: str = "demo") -> PollyPM
     )
 
 
-def test_worktree_lifecycle(tmp_path: Path) -> None:
+def _install_memory_worktree_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[WorktreeRecord]:
+    records: list[WorktreeRecord] = []
+
+    def list_records(_config, project_key):
+        if project_key is None:
+            return list(records)
+        return [record for record in records if record.project_key == project_key]
+
+    def upsert_record(_config, **kwargs):
+        for record in records:
+            if (
+                record.project_key == kwargs["project_key"]
+                and record.lane_kind == kwargs["lane_kind"]
+                and record.lane_key == kwargs["lane_key"]
+                and record.status == kwargs["status"]
+            ):
+                record.session_name = kwargs["session_name"]
+                record.issue_key = kwargs["issue_key"]
+                record.path = kwargs["path"]
+                record.branch = kwargs["branch"]
+                record.updated_at = "now"
+                return
+        records.append(
+            WorktreeRecord(
+                project_key=kwargs["project_key"],
+                lane_kind=kwargs["lane_kind"],
+                lane_key=kwargs["lane_key"],
+                session_name=kwargs["session_name"],
+                issue_key=kwargs["issue_key"],
+                path=kwargs["path"],
+                branch=kwargs["branch"],
+                status=kwargs["status"],
+                created_at="now",
+                updated_at="now",
+            )
+        )
+
+    def update_status(_config, project_key, lane_kind, lane_key, status):
+        for record in records:
+            if (
+                record.project_key == project_key
+                and record.lane_kind == lane_kind
+                and record.lane_key == lane_key
+                and record.status == "active"
+            ):
+                record.status = status
+                record.updated_at = "now"
+
+    monkeypatch.setattr(
+        "pollypm.worktrees._list_worktrees_for_backend",
+        list_records,
+    )
+    monkeypatch.setattr(
+        "pollypm.worktrees._upsert_worktree_for_backend",
+        upsert_record,
+    )
+    monkeypatch.setattr(
+        "pollypm.worktrees._update_worktree_status_for_backend",
+        update_status,
+    )
+    return records
+
+
+def test_worktree_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _git_project(tmp_path)
     config = _config(tmp_path, repo)
     config_path = tmp_path / "pollypm.toml"
     write_config(config, config_path, force=True)
+    _install_memory_worktree_backend(monkeypatch)
 
     worktree = ensure_worktree(
         config_path,
@@ -78,14 +151,147 @@ def test_worktree_lifecycle(tmp_path: Path) -> None:
     assert removed == Path(worktree.path)
 
 
+def test_refresh_architect_worktree_fast_forwards_clean_checkout(
+    tmp_path: Path,
+) -> None:
+    repo = _git_project(tmp_path)
+    subprocess.run(["git", "-C", str(repo), "branch", "-M", "main"], check=True)
+    worktree_path = tmp_path / "architect_demo"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "worktree",
+            "add",
+            "-B",
+            "pollypm/demo/architect/architect_demo",
+            "--",
+            str(worktree_path),
+            "HEAD",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    docs_dir = repo / "docs" / "test-plan"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "README.md").write_text("current plan\n")
+    subprocess.run(["git", "-C", str(repo), "add", "docs/test-plan/README.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "add test plan"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = refresh_architect_worktree(repo, worktree_path)
+
+    assert result.status == "updated"
+    assert (worktree_path / "docs" / "test-plan" / "README.md").read_text() == "current plan\n"
+    assert not (worktree_path / ARCHITECT_WORKTREE_STATUS_PATH).exists()
+
+
+def test_refresh_architect_worktree_surfaces_dirty_staleness(
+    tmp_path: Path,
+) -> None:
+    repo = _git_project(tmp_path)
+    subprocess.run(["git", "-C", str(repo), "branch", "-M", "main"], check=True)
+    worktree_path = tmp_path / "architect_demo"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "worktree",
+            "add",
+            "-B",
+            "pollypm/demo/architect/architect_demo",
+            "--",
+            str(worktree_path),
+            "HEAD",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (worktree_path / "local-notes.md").write_text("operator notes\n")
+
+    docs_dir = repo / "docs" / "test-plan"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "README.md").write_text("current plan\n")
+    subprocess.run(["git", "-C", str(repo), "add", "docs/test-plan/README.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "add test plan"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = refresh_architect_worktree(repo, worktree_path)
+
+    assert result.status == "stale"
+    assert result.reason == "worktree has uncommitted changes"
+    assert not (worktree_path / "docs" / "test-plan" / "README.md").exists()
+    assert (worktree_path / "local-notes.md").read_text() == "operator notes\n"
+    marker = worktree_path / ARCHITECT_WORKTREE_STATUS_PATH
+    assert marker.exists()
+    marker_text = marker.read_text(encoding="utf-8")
+    assert "worktree has uncommitted changes" in marker_text
+    assert "Do not reset, delete, or discard" in marker_text
+
+
+def test_ensure_worktree_refreshes_existing_architect_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _git_project(tmp_path)
+    subprocess.run(["git", "-C", str(repo), "branch", "-M", "main"], check=True)
+    config = _config(tmp_path, repo)
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+    _install_memory_worktree_backend(monkeypatch)
+
+    worktree = ensure_worktree(
+        config_path,
+        project_key="demo",
+        lane_kind="architect",
+        lane_key="architect_demo",
+        session_name="architect_demo",
+    )
+    assert worktree is not None
+    worktree_path = Path(worktree.path)
+
+    docs_dir = repo / "docs" / "test-plan"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "README.md").write_text("current plan\n")
+    subprocess.run(["git", "-C", str(repo), "add", "docs/test-plan/README.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "add test plan"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    reused = ensure_worktree(
+        config_path,
+        project_key="demo",
+        lane_kind="architect",
+        lane_key="architect_demo",
+        session_name="architect_demo",
+    )
+
+    assert reused is not None
+    assert Path(reused.path) == worktree_path
+    assert (worktree_path / "docs" / "test-plan" / "README.md").read_text() == "current plan\n"
+    assert not (worktree_path / ARCHITECT_WORKTREE_STATUS_PATH).exists()
+
+
 def test_ensure_worktree_rejects_invalid_project_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _git_project(tmp_path)
     config = _config(tmp_path, repo, project_key="demo/evil")
     monkeypatch.setattr("pollypm.worktrees.load_config", lambda _: config)
-    monkeypatch.setattr(
-        "pollypm.worktrees.subprocess.run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("git should not be called")),
-    )
 
     with pytest.raises(typer.BadParameter, match="project_key contains invalid characters"):
         ensure_worktree(
@@ -103,6 +309,7 @@ def test_ensure_worktree_adds_separator_before_path(
     repo = _git_project(tmp_path)
     config = _config(tmp_path, repo)
     commands: list[list[str]] = []
+    _install_memory_worktree_backend(monkeypatch)
 
     def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         if cmd[:3] == ["git", "-C", str(repo)] and cmd[3:5] == [
@@ -114,7 +321,10 @@ def test_ensure_worktree_adds_separator_before_path(
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
     monkeypatch.setattr("pollypm.worktrees.load_config", lambda _: config)
-    monkeypatch.setattr("pollypm.worktrees.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "pollypm.worktrees.subprocess",
+        SimpleNamespace(run=fake_run, CompletedProcess=subprocess.CompletedProcess),
+    )
 
     worktree = ensure_worktree(
         tmp_path / "pollypm.toml",
@@ -146,16 +356,20 @@ def test_cleanup_worktree_adds_separator_before_path(
     config = _config(tmp_path, repo)
     config_path = tmp_path / "pollypm.toml"
     worktree_path = tmp_path / "worker_demo" / "demo-pa-worker_demo"
-    store = StateStore(config.project.state_db)
-    store.upsert_worktree(
-        project_key="demo",
-        lane_kind="pa",
-        lane_key="worker_demo",
-        session_name="worker_demo",
-        issue_key=None,
-        path=str(worktree_path),
-        branch="pollypm/demo/pa/worker_demo",
-        status="active",
+    records = _install_memory_worktree_backend(monkeypatch)
+    records.append(
+        WorktreeRecord(
+            project_key="demo",
+            lane_kind="pa",
+            lane_key="worker_demo",
+            session_name="worker_demo",
+            issue_key=None,
+            path=str(worktree_path),
+            branch="pollypm/demo/pa/worker_demo",
+            status="active",
+            created_at="now",
+            updated_at="now",
+        )
     )
     commands: list[list[str]] = []
 
@@ -164,7 +378,10 @@ def test_cleanup_worktree_adds_separator_before_path(
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
     monkeypatch.setattr("pollypm.worktrees.load_config", lambda _: config)
-    monkeypatch.setattr("pollypm.worktrees.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "pollypm.worktrees.subprocess",
+        SimpleNamespace(run=fake_run, CompletedProcess=subprocess.CompletedProcess),
+    )
 
     removed = cleanup_worktree(
         config_path,


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Refresh persistent architect worktrees before creating/recreating architect panes and when reusing an architect worktree record.
- Fast-forward only clean architect checkouts to local `main`/`master`; dirty, divergent, missing, or unsafe states are left untouched.
- Surface unsafe stale states through `.pollypm/architect-worktree-status.md`, a supervisor alert, and architect-profile/docs guidance.

Fixes #2382

## Verification
- `uv run --extra test pytest --noconftest tests/test_worktrees.py tests/test_project_planning_plugin.py::test_architect_profile_points_at_research_stage -q`
- `uv run --extra test pytest --noconftest tests/test_launch_planner.py::test_planner_routes_architect_launch_to_project_override tests/test_launch_planner.py::test_planner_writes_claude_system_prompt_file_for_architect tests/test_launch_planner.py::test_planner_handles_none_store_for_architect_session -q`
- `uv run --extra dev ruff check src/pollypm/worktrees.py tests/test_worktrees.py`
- `python -m py_compile src/pollypm/worktrees.py src/pollypm/supervisor.py tests/test_worktrees.py tests/test_project_planning_plugin.py`
- `git diff --check`

## Notes
- A broader ruff run over all touched files still reports existing `E402` import-order findings in `src/pollypm/supervisor.py` and existing unused imports in `tests/test_project_planning_plugin.py`; this PR does not introduce or resolve that baseline.
- The refresh deliberately does not fetch remotes. It updates architect worktrees to the current local project `main`/`master`, and leaves already-running architect panes alone until the next launch/relaunch.
