### PR TITLE
Hydrate pg task executions and plan-review done backstop

### DIFF
--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -610,6 +610,7 @@ class PgWorkService:
         task = self._row_to_task(row, relationships=rels)
         task.transitions = self._load_transitions(project, task_number)
         task.context = self._load_context_entries(project, task_number)
+        task.executions = self.get_execution(task_id)
         return task
 
     def list_tasks(
@@ -1985,6 +1986,7 @@ class PgWorkService:
                 task_id,
                 exc_info=True,
             )
+        self._maybe_emit_plan_review_on_task_done(task_id, actor)
         return result
 
     def force_review(
@@ -3504,11 +3506,8 @@ class PgWorkService:
         a plain-language summary. Any failure is swallowed with a warning
         so the transition itself remains durable.
 
-        Note: pg's :meth:`get` does not yet hydrate ``executions`` /
-        ``context`` (Slice B carryover), so the summary helper would see
-        an empty work-output history if called against the raw ``get``
-        result. We hydrate those fields locally before invoking the
-        generator so the prompt has the worker's submission to summarise.
+        The helper still goes through a small hydration shim so older
+        call sites that hand in thin task doubles keep the same shape.
         """
         if task.work_status not in {WorkStatus.REVIEW, WorkStatus.ON_HOLD}:
             return
@@ -3686,6 +3685,7 @@ class PgWorkService:
                     task_id,
                     exc_info=True,
                 )
+            self._maybe_emit_plan_review_on_task_done(task_id, actor)
         # #1780: clear the per-task no_session alert after approve.
         # Mirrors the sqlite WorkTransitionManager._handle_approve_alert_cleanup
         # hook so the alert raised by the heartbeat sweep doesn't sit in
@@ -3699,6 +3699,24 @@ class PgWorkService:
                 exc_info=True,
             )
         return result
+
+    def _maybe_emit_plan_review_on_task_done(
+        self,
+        task_id: str,
+        actor: str,
+    ) -> None:
+        try:
+            from pollypm.work.plan_review_emit import (
+                maybe_emit_plan_review_on_task_done,
+            )
+
+            maybe_emit_plan_review_on_task_done(self, task_id, actor or "polly")
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "plan_review backstop emit skipped for %s",
+                task_id,
+                exc_info=True,
+            )
 
     def reject(self, task_id: str, actor: str, reason: str) -> Task:
         """Reject a review node and bounce the task to ``rework``."""

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -1496,6 +1496,77 @@ def test_node_done_advances_to_review(pg_service):
     assert done.work_status is WorkStatus.REVIEW
 
 
+def test_get_hydrates_executions_with_worker_output(pg_service):
+    task = _drive_to_review(pg_service)
+    pg_service.node_done(
+        task.task_id,
+        actor="alice",
+        work_output={
+            "type": "code_change",
+            "summary": "implemented X",
+            "artifacts": [
+                {"kind": "commit", "description": "impl", "ref": "HEAD"}
+            ],
+        },
+    )
+
+    fetched = pg_service.get(task.task_id)
+    outputs = [
+        execution.work_output
+        for execution in fetched.executions
+        if execution.work_output is not None
+    ]
+    assert [output.summary for output in outputs] == ["implemented X"]
+    assert outputs[0].artifacts[0].ref == "HEAD"
+
+
+def test_mark_done_invokes_plan_review_backstop(pg_service, monkeypatch):
+    calls: list[tuple[object, str, str]] = []
+
+    def _record(svc, task_id, actor):  # noqa: ANN001
+        calls.append((svc, task_id, actor))
+        return "plan-review-id"
+
+    monkeypatch.setattr(
+        "pollypm.work.plan_review_emit.maybe_emit_plan_review_on_task_done",
+        _record,
+    )
+    task = _make_draft(pg_service, labels=["poc-plan"])
+
+    pg_service.mark_done(task.task_id, actor="polly")
+
+    assert calls == [(pg_service, task.task_id, "polly")]
+
+
+def test_approve_done_invokes_plan_review_backstop(pg_service, monkeypatch):
+    calls: list[tuple[object, str, str]] = []
+
+    def _record(svc, task_id, actor):  # noqa: ANN001
+        calls.append((svc, task_id, actor))
+        return "plan-review-id"
+
+    monkeypatch.setattr(
+        "pollypm.work.plan_review_emit.maybe_emit_plan_review_on_task_done",
+        _record,
+    )
+    task = _drive_to_review(pg_service)
+    pg_service.node_done(
+        task.task_id,
+        actor="alice",
+        work_output={
+            "type": "code_change",
+            "summary": "implemented X",
+            "artifacts": [
+                {"kind": "commit", "description": "impl", "ref": "HEAD"}
+            ],
+        },
+    )
+
+    pg_service.approve(task.task_id, actor="bob")
+
+    assert calls == [(pg_service, task.task_id, "bob")]
+
+
 def test_approve_from_non_review_raises(pg_service):
     from pollypm.work.service_support import InvalidTransitionError
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Hydrates `Task.executions` in `PgWorkService.get()` so worker `--output` payloads are visible to CLI/API consumers.
- Wires the existing `maybe_emit_plan_review_on_task_done` backstop into pg `mark_done()` and `approve()` when approval lands the task in `done`.
- Adds pg-service regression tests for execution hydration and both plan-review backstop hook paths.

Closes #2387
Closes #2388

## Verification
- `uv run --extra dev ruff check src/pollypm/work/pg_service.py tests/test_pg_work_service_full.py`
- `uv run --extra test python -m pytest tests/test_pg_work_service_full.py::test_get_hydrates_executions_with_worker_output tests/test_pg_work_service_full.py::test_mark_done_invokes_plan_review_backstop tests/test_pg_work_service_full.py::test_approve_done_invokes_plan_review_backstop -q`
- `uv run --extra test python -m pytest tests/test_plan_review_emit.py::test_maybe_emit_fires_for_standard_flow_plan -q`
