### PR TITLE
Fix task list pagination and timestamp normalization

### DIFF
--- a/src/pollypm/web_api/routes/tasks.py
+++ b/src/pollypm/web_api/routes/tasks.py
@@ -125,7 +125,19 @@ def list_tasks_endpoint(
     ] = False,
     limit: Annotated[int, Query(ge=1, le=200, description="Page size (capped at 200).")] = 50,
     cursor: Annotated[str | None, Query(description="Opaque cursor from next_cursor.")] = None,
+    offset: Annotated[
+        str | None,
+        Query(description="Unsupported legacy pagination parameter. Use cursor."),
+    ] = None,
 ) -> TaskListResponse:
+    if offset is not None:
+        raise APIError(
+            status_code=400,
+            code="invalid_request",
+            message="`offset` pagination is not supported on this endpoint.",
+            hint="Use cursor-based pagination via `cursor` and `next_cursor`.",
+        )
+
     since_dt: datetime | None = None
     if since is not None:
         try:

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -1044,7 +1044,7 @@ def _project_to_api_from_metrics(
         task_counts=counts,
         open_inbox_count=open_inbox_count,
         pending_plan_review=pending_plan_review,
-        last_activity_at=last_activity_at,
+        last_activity_at=_as_aware_datetime(last_activity_at),
     )
 
 
@@ -3706,7 +3706,7 @@ def _task_to_summary(task, *, project_paused: bool | None = None) -> APITaskSumm
         state_entered_at=timing["state_entered_at"],
         dwell_seconds=timing["dwell_seconds"],
         age_seconds=timing["age_seconds"],
-        updated_at=getattr(task, "updated_at", None),
+        updated_at=_as_aware_datetime(getattr(task, "updated_at", None)),
         project_paused=project_paused,
     )
 

--- a/tests/web_api/test_endpoints.py
+++ b/tests/web_api/test_endpoints.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import inspect
 import sqlite3
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 
@@ -81,6 +81,28 @@ def test_list_projects_tracked_filter(api_config, client, auth_headers) -> None:
     assert response.status_code == 200
     keys = [item["key"] for item in response.json()["items"]]
     assert keys == ["myproj"]
+
+
+def test_project_metrics_normalize_last_activity_at(api_config) -> None:
+    from pollypm.web_api import service as api_service
+
+    project = api_config.projects["myproj"]
+    local_activity = datetime(
+        2026, 5, 29, 7, 59, 10, tzinfo=timezone(timedelta(hours=-6))
+    )
+
+    row = api_service._project_to_api_from_metrics(
+        api_config,
+        "myproj",
+        project,
+        counts={},
+        pending_plan_review=False,
+        open_inbox_count=0,
+        last_activity_at=local_activity,
+    )
+
+    assert row.last_activity_at == datetime(2026, 5, 29, 13, 59, 10, tzinfo=UTC)
+    assert row.last_activity_at.tzinfo is UTC
 
 
 def test_list_projects_search_sort_and_activity(

--- a/tests/web_api/test_tasks_list_endpoint.py
+++ b/tests/web_api/test_tasks_list_endpoint.py
@@ -217,7 +217,7 @@ def test_list_all_tasks_uses_list_rows_without_per_item_refetch(
         current_node_id=None,
         plan_version=1,
         created_at=now - timedelta(hours=1),
-        updated_at=now,
+        updated_at=now.astimezone(timezone(timedelta(hours=-6))),
         transitions=[
             SimpleNamespace(to_state="queued", timestamp=now - timedelta(minutes=5))
         ],
@@ -244,6 +244,8 @@ def test_list_all_tasks_uses_list_rows_without_per_item_refetch(
 
     assert [item.task_id for item in items] == ["myproj/1"]
     assert items[0].state_entered_at == now - timedelta(minutes=5)
+    assert items[0].updated_at == now
+    assert items[0].updated_at.tzinfo is timezone.utc
     assert items[0].project_paused is False
     assert next_cursor is None
     assert warnings == []
@@ -574,6 +576,17 @@ def test_list_tasks_limit_capped(
     assert response.status_code == 422
     body = response.json()
     assert body["error"]["code"] == "validation_error"
+
+
+def test_list_tasks_rejects_offset_pagination(client, auth_headers) -> None:
+    response = client.get(
+        "/api/v1/tasks?limit=5&offset=50", headers=auth_headers
+    )
+
+    assert response.status_code == 400, response.text
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+    assert "cursor" in body["error"]["hint"]
 
 
 def test_list_tasks_unknown_project_returns_empty(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- reject unsupported `offset` on `GET /api/v1/tasks` with a typed `invalid_request` instead of silently replaying page one
- normalize task `updated_at` and project `last_activity_at` through the existing UTC datetime helper
- add focused regression tests for offset rejection and UTC normalization

## Verification
- `uv run --extra test pytest tests/web_api/test_tasks_list_endpoint.py::test_list_all_tasks_uses_list_rows_without_per_item_refetch tests/web_api/test_tasks_list_endpoint.py::test_list_tasks_rejects_offset_pagination tests/web_api/test_endpoints.py::test_project_metrics_normalize_last_activity_at`

Closes #2398
Closes #2399
