### PR TITLE
Guard pg task transitions under row lock

### DIFF
--- a/src/pollypm/task_invariants.py
+++ b/src/pollypm/task_invariants.py
@@ -544,11 +544,11 @@ def validate_transition(
     """Return a violation when ``from_status -> to_status`` is
     forbidden, or ``None`` when it is allowed.
 
-    Used by the work service to refuse invalid transitions at
-    write time. The audit cites #806 — recovery deleted execution
-    history because the transition the recovery applied was not
-    in the canonical table; running the validator at write time
-    would have rejected it."""
+    Intended for write paths that can enforce the canonical table
+    without changing an established operational transition. The audit
+    cites #806 — recovery deleted execution history because the
+    transition the recovery applied was not in the canonical table;
+    callers that opt in can reject that shape before writing."""
     if is_transition_allowed(from_status, to_status):
         return None
     return InvariantViolation(

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -100,6 +100,8 @@ _CAPACITY_CONSUMING_STATUS_VALUES = (
     WorkStatus.REWORK.value,
 )
 
+_ANY_NODE = object()
+
 
 # Per-process dedup for the ``work_db.opened`` audit row (#1808). The
 # event is a doctor / heartbeat diagnostic stamped at first open of a
@@ -1735,6 +1737,21 @@ class PgWorkService:
             conn.autocommit = False
             with conn.cursor() as cur:
                 cur.execute(
+                    "SELECT work_status FROM work_tasks "
+                    "WHERE project = %s AND task_number = %s "
+                    "FOR UPDATE",
+                    (project, task_number),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise TaskNotFoundError(f"Task '{task_id}' not found.")
+                current = _coerce_status(str(row[0]))
+                if current != WorkStatus.CANCELLED:
+                    raise InvalidTransitionError(
+                        f"Cannot reopen task in '{current.value}' state. "
+                        "Only cancelled tasks can be reopened."
+                    )
+                cur.execute(
                     "UPDATE work_node_executions SET status = %s, "
                     "completed_at = %s "
                     "WHERE task_project = %s AND task_number = %s "
@@ -1756,9 +1773,21 @@ class PgWorkService:
                     "assignee = NULL, current_node_id = NULL, "
                     "claimed_by_session = NULL, "
                     "updated_at = %s "
-                    "WHERE project = %s AND task_number = %s",
-                    (WorkStatus.QUEUED.value, now, project, task_number),
+                    "WHERE project = %s AND task_number = %s "
+                    "AND work_status = %s",
+                    (
+                        WorkStatus.QUEUED.value,
+                        now,
+                        project,
+                        task_number,
+                        WorkStatus.CANCELLED.value,
+                    ),
                 )
+                if cur.rowcount != 1:
+                    raise InvalidTransitionError(
+                        f"Task '{task_id}' changed during reopen; "
+                        "retry the operation."
+                    )
                 cur.execute(
                     "INSERT INTO work_transitions ("
                     "task_project, task_number, from_state, to_state, "
@@ -2068,9 +2097,13 @@ class PgWorkService:
         with self._pool.connection() as conn:
             conn.autocommit = False
             with conn.cursor() as cur:
+                # Re-run the source-state validation inside the write
+                # transaction. The pre-read in callers is only for error
+                # quality; this lock is the race boundary.
                 cur.execute(
                     "SELECT work_status FROM work_tasks "
-                    "WHERE project = %s AND task_number = %s",
+                    "WHERE project = %s AND task_number = %s "
+                    "FOR UPDATE",
                     (project, task_number),
                 )
                 row = cur.fetchone()
@@ -2080,12 +2113,31 @@ class PgWorkService:
                 # Idempotency: a re-queue against an already-queued task
                 # is a no-op. The sqlite service has the same shape.
                 if current == to_state:
+                    conn.commit()
                     return self.get(task_id)
+                if current != from_state:
+                    raise InvalidTransitionError(
+                        f"Cannot transition task from '{current.value}' to "
+                        f"'{to_state.value}'; expected source state "
+                        f"'{from_state.value}'."
+                    )
                 cur.execute(
                     "UPDATE work_tasks SET work_status = %s, updated_at = %s "
-                    "WHERE project = %s AND task_number = %s",
-                    (to_state.value, now, project, task_number),
+                    "WHERE project = %s AND task_number = %s "
+                    "AND work_status = %s",
+                    (
+                        to_state.value,
+                        now,
+                        project,
+                        task_number,
+                        from_state.value,
+                    ),
                 )
+                if cur.rowcount != 1:
+                    raise InvalidTransitionError(
+                        f"Task '{task_id}' changed state during transition; "
+                        "retry the operation."
+                    )
                 cur.execute(
                     "INSERT INTO work_transitions ("
                     "task_project, task_number, from_state, to_state, "
@@ -3444,6 +3496,12 @@ class PgWorkService:
         with self._pool.connection() as conn:
             conn.autocommit = False
             with conn.cursor() as cur:
+                self._lock_task_transition_state(
+                    cur,
+                    task,
+                    expected_statuses=(from_status,),
+                    expected_node_id=task.current_node_id,
+                )
                 cur.execute(
                     "UPDATE work_node_executions SET status = %s, "
                     "work_output = %s::jsonb, completed_at = %s "
@@ -3459,6 +3517,11 @@ class PgWorkService:
                         ExecutionStatus.ACTIVE.value,
                     ),
                 )
+                if cur.rowcount != 1:
+                    raise InvalidTransitionError(
+                        f"Task '{task_id}' no longer has an active "
+                        f"execution for node {task.current_node_id!r}."
+                    )
                 self._advance_to_node_locked(
                     cur, task, flow, node.next_node_id, actor, from_status
                 )
@@ -3621,6 +3684,12 @@ class PgWorkService:
         with self._pool.connection() as conn:
             conn.autocommit = False
             with conn.cursor() as cur:
+                self._lock_task_transition_state(
+                    cur,
+                    task,
+                    expected_statuses=(WorkStatus.REVIEW,),
+                    expected_node_id=task.current_node_id,
+                )
                 cur.execute(
                     "UPDATE work_node_executions SET status = %s, "
                     "decision = %s, decision_reason = %s, completed_at = %s "
@@ -3637,6 +3706,11 @@ class PgWorkService:
                         ExecutionStatus.ACTIVE.value,
                     ),
                 )
+                if cur.rowcount != 1:
+                    raise InvalidTransitionError(
+                        f"Task '{task_id}' no longer has an active "
+                        f"review execution for node {task.current_node_id!r}."
+                    )
                 self._advance_to_node_locked(
                     cur, task, flow, node.next_node_id, actor, WorkStatus.REVIEW
                 )
@@ -3750,6 +3824,12 @@ class PgWorkService:
         with self._pool.connection() as conn:
             conn.autocommit = False
             with conn.cursor() as cur:
+                self._lock_task_transition_state(
+                    cur,
+                    task,
+                    expected_statuses=(WorkStatus.REVIEW,),
+                    expected_node_id=task.current_node_id,
+                )
                 cur.execute(
                     "UPDATE work_node_executions SET status = %s, "
                     "decision = %s, decision_reason = %s, completed_at = %s "
@@ -3766,11 +3846,18 @@ class PgWorkService:
                         ExecutionStatus.ACTIVE.value,
                     ),
                 )
+                if cur.rowcount != 1:
+                    raise InvalidTransitionError(
+                        f"Task '{task_id}' no longer has an active "
+                        f"review execution for node {task.current_node_id!r}."
+                    )
                 reject_assignee = self._resolve_node_assignee(task, reject_target)
                 cur.execute(
                     "UPDATE work_tasks SET work_status = %s, assignee = %s, "
                     "current_node_id = %s, updated_at = %s "
-                    "WHERE project = %s AND task_number = %s",
+                    "WHERE project = %s AND task_number = %s "
+                    "AND work_status = %s "
+                    "AND current_node_id IS NOT DISTINCT FROM %s",
                     (
                         WorkStatus.REWORK.value,
                         reject_assignee,
@@ -3778,8 +3865,15 @@ class PgWorkService:
                         now,
                         task.project,
                         task.task_number,
+                        WorkStatus.REVIEW.value,
+                        task.current_node_id,
                     ),
                 )
+                if cur.rowcount != 1:
+                    raise InvalidTransitionError(
+                        f"Task '{task_id}' changed during rejection; "
+                        "retry the operation."
+                    )
                 visit = self._next_visit_locked(
                     cur, task.project, task.task_number, node.reject_node_id
                 )
@@ -3836,6 +3930,12 @@ class PgWorkService:
         with self._pool.connection() as conn:
             conn.autocommit = False
             with conn.cursor() as cur:
+                self._lock_task_transition_state(
+                    cur,
+                    task,
+                    expected_statuses=(old_status,),
+                    expected_node_id=task.current_node_id,
+                )
                 cur.execute(
                     "INSERT INTO work_task_dependencies "
                     "(from_project, from_task_number, to_project, "
@@ -3853,14 +3953,23 @@ class PgWorkService:
                 )
                 cur.execute(
                     "UPDATE work_tasks SET work_status = %s, updated_at = %s "
-                    "WHERE project = %s AND task_number = %s",
+                    "WHERE project = %s AND task_number = %s "
+                    "AND work_status = %s "
+                    "AND current_node_id IS NOT DISTINCT FROM %s",
                     (
                         WorkStatus.BLOCKED.value,
                         now,
                         task.project,
                         task.task_number,
+                        old_status.value,
+                        task.current_node_id,
                     ),
                 )
+                if cur.rowcount != 1:
+                    raise InvalidTransitionError(
+                        f"Task '{task_id}' changed during block; "
+                        "retry the operation."
+                    )
                 if task.current_node_id:
                     cur.execute(
                         "UPDATE work_node_executions SET status = %s "
@@ -5650,6 +5759,38 @@ class PgWorkService:
                     f"{node.agent_name}."
                 )
 
+    def _lock_task_transition_state(
+        self,
+        cur,
+        task: Task,
+        *,
+        expected_statuses: tuple[WorkStatus, ...],
+        expected_node_id: str | None | object = _ANY_NODE,
+    ) -> WorkStatus:
+        cur.execute(
+            "SELECT work_status, current_node_id FROM work_tasks "
+            "WHERE project = %s AND task_number = %s "
+            "FOR UPDATE",
+            (task.project, task.task_number),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise TaskNotFoundError(f"Task '{task.task_id}' not found.")
+        current = _coerce_status(str(row[0]))
+        current_node_id = row[1]
+        if current not in expected_statuses:
+            allowed = ", ".join(f"'{status.value}'" for status in expected_statuses)
+            raise InvalidTransitionError(
+                f"Cannot transition task in '{current.value}' state; "
+                f"expected {allowed}."
+            )
+        if expected_node_id is not _ANY_NODE and current_node_id != expected_node_id:
+            raise InvalidTransitionError(
+                f"Cannot transition task from node {current_node_id!r}; "
+                f"expected {expected_node_id!r}."
+            )
+        return current
+
     def _advance_to_node_locked(
         self,
         cur,
@@ -5672,9 +5813,23 @@ class PgWorkService:
             cur.execute(
                 "UPDATE work_tasks SET work_status = %s, "
                 "current_node_id = NULL, updated_at = %s "
-                "WHERE project = %s AND task_number = %s",
-                (WorkStatus.DONE.value, now, task.project, task.task_number),
+                "WHERE project = %s AND task_number = %s "
+                "AND work_status = %s "
+                "AND current_node_id IS NOT DISTINCT FROM %s",
+                (
+                    WorkStatus.DONE.value,
+                    now,
+                    task.project,
+                    task.task_number,
+                    from_status.value,
+                    task.current_node_id,
+                ),
             )
+            if cur.rowcount != 1:
+                raise InvalidTransitionError(
+                    f"Task '{task.task_id}' changed during flow advance; "
+                    "retry the operation."
+                )
             self._insert_transition_locked(
                 cur,
                 task.project,
@@ -5697,7 +5852,9 @@ class PgWorkService:
         cur.execute(
             "UPDATE work_tasks SET work_status = %s, assignee = %s, "
             "current_node_id = %s, updated_at = %s "
-            "WHERE project = %s AND task_number = %s",
+            "WHERE project = %s AND task_number = %s "
+            "AND work_status = %s "
+            "AND current_node_id IS NOT DISTINCT FROM %s",
             (
                 new_status.value,
                 next_assignee,
@@ -5705,8 +5862,15 @@ class PgWorkService:
                 now,
                 task.project,
                 task.task_number,
+                from_status.value,
+                task.current_node_id,
             ),
         )
+        if cur.rowcount != 1:
+            raise InvalidTransitionError(
+                f"Task '{task.task_id}' changed during flow advance; "
+                "retry the operation."
+            )
         cur.execute(
             "INSERT INTO work_node_executions "
             "(task_project, task_number, node_id, visit, status, started_at) "

--- a/src/pollypm/work/service_support.py
+++ b/src/pollypm/work/service_support.py
@@ -38,8 +38,8 @@ class InvariantViolationError(InvalidTransitionError):
     means the work-service refused to write a row to ``work_transitions``
     because the source/target states are known :class:`WorkStatus` values
     but the pair is not in :data:`pollypm.task_invariants.TASK_TRANSITION_TABLE`.
-    Issue #909 — invariant violations are now enforced at write time
-    rather than logged."""
+    Issue #909 — write paths that opt into the canonical table should
+    raise this instead of logging and continuing."""
 
 
 class ValidationError(WorkServiceError):

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -1538,6 +1538,24 @@ def test_mark_done_invokes_plan_review_backstop(pg_service, monkeypatch):
     assert calls == [(pg_service, task.task_id, "polly")]
 
 
+def test_simple_transition_rejects_stale_source_state(pg_service):
+    from pollypm.work.models import WorkStatus
+    from pollypm.work.service_support import InvalidTransitionError
+
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+
+    with pytest.raises(InvalidTransitionError):
+        pg_service._simple_transition(
+            task.task_id,
+            from_state=WorkStatus.IN_PROGRESS,
+            to_state=WorkStatus.DONE,
+            actor="race",
+        )
+
+    assert pg_service.get(task.task_id).work_status is WorkStatus.QUEUED
+
+
 def test_approve_done_invokes_plan_review_backstop(pg_service, monkeypatch):
     calls: list[tuple[object, str, str]] = []
 
@@ -1565,6 +1583,53 @@ def test_approve_done_invokes_plan_review_backstop(pg_service, monkeypatch):
     pg_service.approve(task.task_id, actor="bob")
 
     assert calls == [(pg_service, task.task_id, "bob")]
+
+
+def test_approve_rechecks_locked_status_before_advancing(
+    pg_service, monkeypatch,
+):
+    from pollypm.work.models import WorkStatus
+    from pollypm.work.service_support import InvalidTransitionError
+
+    task = _drive_to_review(pg_service)
+    pg_service.node_done(
+        task.task_id,
+        actor="alice",
+        work_output={
+            "type": "code_change",
+            "summary": "implemented X",
+            "artifacts": [
+                {"kind": "commit", "description": "impl", "ref": "HEAD"}
+            ],
+        },
+    )
+    stale_review = pg_service.get(task.task_id)
+
+    with pg_service._pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE work_tasks SET work_status = %s, updated_at = now() "
+            "WHERE project = %s AND task_number = %s",
+            (
+                WorkStatus.DONE.value,
+                stale_review.project,
+                stale_review.task_number,
+            ),
+        )
+        conn.commit()
+
+    real_get = pg_service.get
+
+    def stale_get(task_id):  # noqa: ANN001
+        if task_id == stale_review.task_id:
+            return stale_review
+        return real_get(task_id)
+
+    monkeypatch.setattr(pg_service, "get", stale_get)
+
+    with pytest.raises(InvalidTransitionError):
+        pg_service.approve(task.task_id, actor="bob")
+
+    assert real_get(task.task_id).work_status is WorkStatus.DONE
 
 
 def test_approve_from_non_review_raises(pg_service):


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- re-check simple status transitions, reopen, node_done, approve, reject, and block under `SELECT ... FOR UPDATE`
- add guarded `UPDATE` predicates and rowcount checks so stale pre-transaction snapshots cannot resurrect or double-advance tasks
- correct invariant-table wording so it no longer claims universal write-time enforcement where the service has established operational transitions outside the table

## Verification
- `uv run --extra test pytest tests/test_pg_work_service_full.py::test_simple_transition_rejects_stale_source_state tests/test_pg_work_service_full.py::test_approve_rechecks_locked_status_before_advancing tests/test_pg_work_service_full.py::test_node_done_advances_to_review tests/test_pg_work_service_full.py::test_approve_done_invokes_plan_review_backstop tests/test_pg_work_service_full.py::test_reject_requires_reason tests/test_pg_work_service_full.py::test_block_marks_task_blocked`
- `git diff --check`

## Notes
- `uv run --extra dev ruff check src/pollypm/work/pg_service.py src/pollypm/task_invariants.py src/pollypm/work/service_support.py tests/test_pg_work_service_full.py` still reports a pre-existing unused `Iterable` import in `task_invariants.py`; this branch did not introduce that import.

Closes #2397
