### PR TITLE
Stop queue-without-motion watchdog churn

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -2746,6 +2746,94 @@ _QUEUE_MOTION_EVENTS: frozenset[str] = frozenset({
 })
 
 
+_QUEUE_WITHOUT_MOTION_TITLE_RE = re.compile(
+    r"^Project\s+(?P<project>\S+)\s+has\s+\d+\s+queued task\(s\) "
+    r"but no claim / execution / status-change activity\b"
+)
+
+
+def _task_status_value(task: Any) -> str:
+    status = getattr(task, "work_status", None)
+    value = getattr(status, "value", status)
+    return value if isinstance(value, str) else ""
+
+
+def _task_scalar_value(task: Any, attr: str) -> str:
+    raw = getattr(task, attr, "") or ""
+    value = getattr(raw, "value", raw)
+    return value if isinstance(value, str) else str(value)
+
+
+def _task_label_set(task: Any) -> set[str]:
+    labels = getattr(task, "labels", None) or ()
+    if isinstance(labels, str):
+        labels = (labels,)
+    out: set[str] = set()
+    try:
+        for label in labels:
+            out.add(str(label))
+    except TypeError:
+        return set()
+    return out
+
+
+def _is_unactioned_queue_without_motion_task(
+    task: Any,
+    *,
+    project_key: str,
+) -> bool:
+    """Return True for an existing unqueued watchdog operator draft.
+
+    The tier-3 materializer writes these as ordinary work tasks so the
+    pure probe can only inspect the open-task snapshot. Keep the match
+    narrow: same project, still ``draft``, watchdog/operator-shaped,
+    and carrying the queue_without_motion subject/body produced by the
+    shipped prompt path. Older production rows may have no
+    ``created_by`` but do carry the title shape and watchdog label.
+    """
+    if _task_status_value(task) != "draft":
+        return False
+    project = _task_scalar_value(task, "project")
+    if project and project != project_key:
+        return False
+
+    labels = _task_label_set(task)
+    kind = _task_scalar_value(task, "kind")
+    created_by = _task_scalar_value(task, "created_by")
+    watchdog_shaped = (
+        kind == "watchdog_operator_dispatch"
+        or "watchdog" in labels
+        or created_by == "audit_watchdog"
+    )
+    if not watchdog_shaped:
+        return False
+
+    title = _task_scalar_value(task, "title")
+    match = _QUEUE_WITHOUT_MOTION_TITLE_RE.match(title)
+    if match is not None:
+        return match.group("project") == project_key
+
+    body = (
+        _task_scalar_value(task, "description")
+        + "\n"
+        + _task_scalar_value(task, "body")
+    )
+    return (
+        f"Project {project_key} is wedged" in body
+        and "queued_subjects" in body
+        and "threshold_seconds" in body
+    )
+
+
+def _has_unactioned_queue_without_motion_task(ctx: ProbeContext) -> bool:
+    return any(
+        _is_unactioned_queue_without_motion_task(
+            task, project_key=ctx.project_key,
+        )
+        for task in ctx.open_tasks or ()
+    )
+
+
 def _queue_without_motion_probe(ctx: ProbeContext) -> list[Finding]:
     """Safety-net probe: queued tasks but no recent activity events.
 
@@ -2801,6 +2889,8 @@ def _queue_without_motion_probe(ctx: ProbeContext) -> list[Finding]:
             last_activity_ts = ts
             last_activity_event = ev.event
     if last_activity_ts is not None and last_activity_ts >= cutoff:
+        return []
+    if _has_unactioned_queue_without_motion_task(ctx):
         return []
 
     last_iso = last_activity_ts.isoformat() if last_activity_ts else None
@@ -3043,6 +3133,83 @@ def scan_events(
     return findings
 
 
+def _audit_event_merge_key(ev: AuditEvent) -> tuple[str, str, str, str, str, str, str]:
+    try:
+        metadata = json.dumps(
+            ev.metadata or {},
+            sort_keys=True,
+            ensure_ascii=False,
+            default=str,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError):
+        metadata = str(ev.metadata or {})
+    return (
+        ev.ts,
+        ev.project,
+        ev.event,
+        ev.subject,
+        ev.actor,
+        ev.status,
+        metadata,
+    )
+
+
+def _merge_central_stuck_draft_signals(
+    events: Sequence[AuditEvent],
+    *,
+    project: str,
+    since: str,
+    project_path: Path | str | None,
+) -> list[AuditEvent]:
+    """Merge durable central stuck_draft signal rows into project readback.
+
+    ``read_events(..., project_path=...)`` intentionally prefers the
+    per-project log for lifecycle events, but production has emitted
+    some watchdog-owned ``audit.finding`` rows only to the central tail.
+    The stuck_draft terminator counts those durable rows, so the
+    cadence readback supplements the per-project event stream with the
+    central stuck_draft findings and prior terminator breadcrumbs only.
+    Other detectors keep seeing the project-local lifecycle source.
+    """
+    if project_path is None:
+        return list(events)
+
+    from pollypm.audit.log import read_events
+
+    merged = list(events)
+    seen = {_audit_event_merge_key(ev) for ev in merged}
+
+    for event_name in (EVENT_AUDIT_FINDING, EVENT_STUCK_DRAFT_TERMINATED):
+        try:
+            central_events = read_events(
+                project,
+                since=since,
+                event=event_name,
+                project_path=None,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "audit.watchdog: central stuck_draft signal read failed",
+                exc_info=True,
+            )
+            continue
+        for ev in central_events:
+            meta = ev.metadata or {}
+            if event_name == EVENT_AUDIT_FINDING and (
+                meta.get("rule") != RULE_STUCK_DRAFT
+            ):
+                continue
+            key = _audit_event_merge_key(ev)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(ev)
+
+    merged.sort(key=lambda ev: ev.ts)
+    return merged
+
+
 def scan_project(
     project: str,
     *,
@@ -3097,6 +3264,12 @@ def scan_project(
     ).isoformat()
     events = read_events(
         project,
+        since=since,
+        project_path=project_path,
+    )
+    events = _merge_central_stuck_draft_signals(
+        events,
+        project=project,
         since=since,
         project_path=project_path,
     )

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -592,6 +592,103 @@ def test_stuck_draft_terminator_durable_across_scan_project_calls(
     )
 
 
+def test_stuck_draft_terminator_counts_central_findings_when_project_log_misses(
+    now: datetime,
+    tmp_path: Path,
+) -> None:
+    """Production regression: per-project logs may miss audit.finding rows.
+
+    ``scan_project`` still reads lifecycle events from the per-project
+    log, but the stuck_draft terminator must count the central
+    ``audit.finding`` rows that were durably written there.
+    """
+    from pollypm.audit.log import emit as audit_emit, project_log_path
+
+    project = "booktalk"
+    project_path = tmp_path / project
+    (project_path / ".pollypm").mkdir(parents=True)
+    per_project = project_log_path(project_path)
+    assert per_project is not None
+
+    subject = f"{project}/158"
+    for i in range(STUCK_DRAFT_TERMINATOR_THRESHOLD):
+        emit_finding(
+            Finding(
+                rule=RULE_STUCK_DRAFT,
+                project=project,
+                subject=subject,
+                message=f"central-only stuck_draft finding #{i}",
+                recommendation="rec",
+            ),
+            project_path=None,
+        )
+
+    audit_emit(
+        event=EVENT_TASK_CREATED,
+        project=project,
+        subject=subject,
+        actor="audit_watchdog",
+        metadata={
+            "title": (
+                "Project booktalk has 3 queued task(s) but no claim / "
+                "execution / status-change activity for the entire scan window."
+            ),
+        },
+        project_path=project_path,
+    )
+
+    central = central_log_path(project)
+    central_lines: list[str] = []
+    finding_ts_base = now - timedelta(minutes=45)
+    finding_idx = 0
+    for raw in central.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        obj = json.loads(raw)
+        if obj.get("event") == "audit.finding":
+            obj["ts"] = (
+                finding_ts_base + timedelta(minutes=finding_idx)
+            ).isoformat()
+            finding_idx += 1
+        central_lines.append(json.dumps(obj))
+    central.write_text("\n".join(central_lines) + "\n", encoding="utf-8")
+
+    per_project_lines: list[str] = []
+    for raw in per_project.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        obj = json.loads(raw)
+        if obj.get("event") == EVENT_TASK_CREATED:
+            obj["ts"] = (now - timedelta(minutes=15)).isoformat()
+        per_project_lines.append(json.dumps(obj))
+    per_project.write_text(
+        "\n".join(per_project_lines) + "\n",
+        encoding="utf-8",
+    )
+
+    findings = [
+        f
+        for f in scan_project(project, project_path=project_path, now=now)
+        if f.rule == RULE_STUCK_DRAFT
+    ]
+    assert findings == [], (
+        "central audit.finding rows should trip the terminator even "
+        "when the per-project lifecycle log has no finding rows"
+    )
+
+    rows = [
+        json.loads(line)
+        for line in per_project.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    terminator_rows = [
+        r for r in rows
+        if r["event"] == EVENT_STUCK_DRAFT_TERMINATED
+        and r.get("subject") == subject
+    ]
+    assert len(terminator_rows) == 1
+
+
 def test_stuck_draft_event_path_cross_checks_open_tasks_status(now: datetime) -> None:
     """#1869: when ``open_tasks`` is supplied, the event-based fallback
     must not fire for tasks that are no longer in draft state.

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -118,6 +118,11 @@ class _StubTask:
     assignee: str | None = None
     updated_at: datetime | None = None
     created_at: datetime | None = None
+    created_by: str | None = None
+    title: str | None = None
+    description: str | None = None
+    labels: tuple[str, ...] = ()
+    kind: str | None = None
 
     @property
     def work_status(self) -> _StubStatus:
@@ -569,6 +574,42 @@ def test_queue_without_motion_fires_when_no_recent_activity(
     assert f.evidence["queued_subjects"] == ["demo/4"]
     # The probe captures threshold info for downstream prompts.
     assert f.evidence["threshold_seconds"] == 600
+
+
+def test_queue_without_motion_silent_when_operator_draft_already_exists(
+    now: datetime,
+) -> None:
+    cfg = WatchdogConfig(queue_motion_threshold_seconds=600)
+    queued = _StubTask(
+        project="demo",
+        task_number=4,
+        work_status_str="queued",
+        executions=[],
+        updated_at=now - timedelta(hours=2),
+    )
+    existing_operator_draft = _StubTask(
+        project="demo",
+        task_number=99,
+        work_status_str="draft",
+        executions=[],
+        created_by="audit_watchdog",
+        title=(
+            "Project demo has 1 queued task(s) but no claim / execution / "
+            "status-change activity for the entire scan window."
+        ),
+        labels=("notify", "watchdog", "notify_message:123"),
+        kind="watchdog_operator_dispatch",
+    )
+
+    findings = scan_events(
+        [],
+        now=now,
+        config=cfg,
+        open_tasks=[queued, existing_operator_draft],
+        project="demo",
+    )
+
+    assert not any(f.rule == RULE_QUEUE_WITHOUT_MOTION for f in findings)
 
 
 def test_queue_without_motion_silent_for_pollypm_meta_project(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- suppress `queue_without_motion` when an unactioned watchdog operator draft already exists for the project
- merge central-tail `stuck_draft` findings/terminator breadcrumbs into `scan_project` readback so the terminator can engage when per-project logs miss `audit.finding`
- add targeted regressions for the existing-operator-draft gate and central-findings terminator path

## Verification
- `uv run --extra test pytest tests/test_heartbeat_cascade_foundation.py::test_queue_without_motion_fires_when_no_recent_activity tests/test_heartbeat_cascade_foundation.py::test_queue_without_motion_silent_when_operator_draft_already_exists tests/test_audit_watchdog.py::test_stuck_draft_terminator_durable_across_scan_project_calls tests/test_audit_watchdog.py::test_stuck_draft_terminator_counts_central_findings_when_project_log_misses`
- `uv run --extra dev ruff check src/pollypm/audit/watchdog.py tests/test_audit_watchdog.py`
- `git diff --check`

## Notes
- Broader `uv run --extra test pytest tests/test_heartbeat_cascade_foundation.py tests/test_audit_watchdog.py -q` ran 168 tests with 167 passing and one unrelated failure in `test_integration_state_db_missing_routes_to_tier1_healer` (`Unknown project: demo`).
- I did not add an auto-cancel path for existing synthetic drafts because that would change task lifecycle behavior; this PR closes the self-feeding loop by preventing repeated materialization and making the existing stuck_draft terminator durable.

Closes #2396
