### PR TITLE
Expose web alerts and cache activity stats

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -111,6 +111,8 @@ tags:
       recent messages, token usage, and account quotas. SSE streaming
       variant (`/dashboard/stream`) ships in a follow-up PR per Phase 2
       §3.2.
+  - name: Alerts
+    description: Open alert drill-down rows for dashboard rollups.
   - name: Config
     description: |
       Read-only view of the loaded `PollyPMConfig`. Credential-shaped
@@ -773,6 +775,44 @@ paths:
             Backing-store / gather failure (`service_unavailable`).
             Distinct from a daemon-down state, which is returned as a
             200 response with `daemon_status: "down"`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /alerts:
+    get:
+      tags: [Alerts]
+      operationId: listAlerts
+      summary: List currently open alerts
+      description: |
+        Returns currently open alerts from the canonical alert storage
+        facade, newest first, with the same action-plan descriptors the
+        cockpit alert detail uses. By default operational heartbeat /
+        supervisor noise is filtered so this list mirrors the dashboard
+        action-required alert rollup.
+      parameters:
+        - in: query
+          name: include_operational
+          schema: { type: boolean, default: false }
+          description: Include operational heartbeat/supervisor alerts.
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 200, default: 100 }
+          description: Maximum alert rows to return.
+      responses:
+        "200":
+          description: Open alert rows.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "503":
+          description: Alert storage unavailable.
           content:
             application/json:
               schema:
@@ -3287,6 +3327,82 @@ components:
           description: Whether Tailscale CGNAT peers are accepted without bearer or cookie credentials.
         build:
           $ref: "#/components/schemas/RuntimeBuildInfo"
+
+    AlertActionResponse:
+      type: object
+      required: [kind, label]
+      properties:
+        kind:
+          type: string
+          description: Stable action discriminator from the cockpit alert-action registry.
+        label:
+          type: string
+          description: Short operator-facing action label.
+        session_name:
+          type: string
+          nullable: true
+        project_key:
+          type: string
+          nullable: true
+        task_id:
+          type: string
+          nullable: true
+        hint:
+          type: string
+          nullable: true
+
+    AlertResponse:
+      type: object
+      required:
+        - session_name
+        - alert_type
+        - severity
+        - message
+        - status
+        - channel
+        - created_at
+        - updated_at
+        - actions
+      properties:
+        id:
+          type: integer
+          nullable: true
+          description: Alert row id when available.
+        session_name:
+          type: string
+        alert_type:
+          type: string
+        severity:
+          type: string
+        message:
+          type: string
+        status:
+          type: string
+        channel:
+          type: string
+          enum: [operational, informational, action_required]
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AlertActionResponse"
+
+    AlertsResponse:
+      type: object
+      required: [generated_at, total, alerts]
+      properties:
+        generated_at:
+          type: string
+          format: date-time
+        total:
+          type: integer
+        alerts:
+          type: array
+          items:
+            $ref: "#/components/schemas/AlertResponse"
 
     DoctorCheck:
       type: object

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -47,6 +47,7 @@ from pollypm.web_api.errors import (
     handle_validation_error,
 )
 from pollypm.web_api.routes import audit as audit_routes
+from pollypm.web_api.routes import alerts as alerts_routes
 from pollypm.web_api.routes import briefings as briefings_routes
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
 from pollypm.web_api.routes import chat_send as chat_send_routes
@@ -518,6 +519,7 @@ def create_app(
     app.include_router(projects_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(tasks_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(inbox_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
+    app.include_router(alerts_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     app.include_router(dashboard_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     # Phase 2 surface §13 — read-only config endpoints. Mutation is
     # deferred to Phase 3 per the spec; config edits stay TOML-first.

--- a/src/pollypm/web_api/routes/alerts.py
+++ b/src/pollypm/web_api/routes/alerts.py
@@ -1,0 +1,159 @@
+"""Alert list endpoints for the web dashboard.
+
+The dashboard rollup already exposes an alert count via
+``/api/v1/dashboard``. This route provides the matching drill-down
+surface without teaching the UI how alerts are stored: rows come from
+the existing ``pg_alerts`` facade and action labels come from the
+cockpit alert-action registry.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from pollypm.cockpit_alert_actions import (
+    recovery_actions_for,
+    task_id_from_alert_type,
+)
+from pollypm.cockpit_alerts import alert_channel, is_operational_alert
+from pollypm.storage.records import AlertRecord
+from pollypm.web_api.errors import service_unavailable
+from pollypm.web_api.routes._deps import ConfigDep
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Alerts"])
+
+
+class AlertActionResponse(BaseModel):
+    kind: str
+    label: str
+    session_name: str | None = None
+    project_key: str | None = None
+    task_id: str | None = None
+    hint: str | None = None
+
+
+class AlertResponse(BaseModel):
+    id: int | None = None
+    session_name: str
+    alert_type: str
+    severity: str
+    message: str
+    status: str
+    channel: str
+    created_at: str
+    updated_at: str
+    actions: list[AlertActionResponse] = Field(default_factory=list)
+
+
+class AlertsResponse(BaseModel):
+    generated_at: datetime
+    total: int
+    alerts: list[AlertResponse] = Field(default_factory=list)
+
+
+def _task_project_key(task_id: str | None) -> str | None:
+    if not task_id or "/" not in task_id:
+        return None
+    project, _, _number = task_id.partition("/")
+    return project or None
+
+
+def _alert_to_response(alert: AlertRecord) -> AlertResponse:
+    task_id = task_id_from_alert_type(alert.alert_type)
+    project_key = _task_project_key(task_id)
+    plans = recovery_actions_for(
+        alert.alert_type,
+        session_name=alert.session_name,
+        project_key=project_key,
+        task_id=task_id,
+        severity=alert.severity,
+    )
+    return AlertResponse(
+        id=alert.alert_id,
+        session_name=alert.session_name,
+        alert_type=alert.alert_type,
+        severity=alert.severity,
+        message=alert.message,
+        status=alert.status,
+        channel=alert_channel(alert.alert_type).value,
+        created_at=alert.created_at,
+        updated_at=alert.updated_at,
+        actions=[
+            AlertActionResponse(
+                kind=plan.kind,
+                label=plan.label,
+                session_name=plan.session_name,
+                project_key=plan.project_key,
+                task_id=plan.task_id,
+                hint=plan.hint,
+            )
+            for plan in plans
+        ],
+    )
+
+
+def _read_open_alerts(config: Any) -> list[AlertRecord]:
+    try:
+        from pollypm.storage.pg_alerts import open_alerts
+
+        return list(open_alerts(config=config))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("alerts: open_alerts failed: %s", exc, exc_info=True)
+        raise service_unavailable(
+            "Failed to load alerts",
+            hint="Retry shortly; check `pm doctor` for pg pool health.",
+        ) from exc
+
+
+@router.get(
+    "/alerts",
+    response_model=AlertsResponse,
+    summary="List currently open alerts",
+    operation_id="listAlerts",
+)
+def list_alerts_endpoint(
+    config: ConfigDep,
+    include_operational: Annotated[
+        bool,
+        Query(
+            description=(
+                "Include operational heartbeat/supervisor alerts. Default "
+                "false so the list mirrors the dashboard's action-required "
+                "rollup."
+            ),
+        ),
+    ] = False,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=200, description="Maximum alert rows to return."),
+    ] = 100,
+) -> AlertsResponse:
+    alerts = _read_open_alerts(config)
+    if not include_operational:
+        alerts = [
+            alert for alert in alerts
+            if not is_operational_alert(alert.alert_type)
+        ]
+    total = len(alerts)
+    rows = [_alert_to_response(alert) for alert in alerts[:limit]]
+    return AlertsResponse(
+        generated_at=datetime.now(timezone.utc),
+        total=total,
+        alerts=rows,
+    )
+
+
+__all__ = [
+    "AlertActionResponse",
+    "AlertResponse",
+    "AlertsResponse",
+    "list_alerts_endpoint",
+    "router",
+]

--- a/src/pollypm/web_api/routes/audit.py
+++ b/src/pollypm/web_api/routes/audit.py
@@ -40,6 +40,9 @@ HTTP guardrails added in round 2:
 from __future__ import annotations
 
 import re
+import threading
+import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Annotated, Any
 
@@ -51,6 +54,7 @@ from pollypm.audit.query import (
     iter_matching_events,
     parse_since,
     resolve_target_files,
+    walk_log_chain,
 )
 from pollypm.web_api.errors import invalid_request
 from pollypm.web_api.models import Event
@@ -71,6 +75,31 @@ _GREP_LIMIT_MAX = 1000
 # regexes without giving an attacker room for a 50 KB catastrophic
 # backtracker (Codex round-1 P0 ReDoS finding).
 _PATTERN_LENGTH_MAX = 200
+
+# Activity polls can overlap across browser refreshes/SSE refresh bursts, and
+# ``/audit/stats`` is the expensive half of the activity rail. Keep a tiny,
+# freshness-bounded process-local cache so repeated calls for the same log
+# signature don't re-walk the same rotation chain.
+_STATS_CACHE_TTL_SECONDS = 10.0
+_STATS_CACHE_MAX_ENTRIES = 64
+
+
+@dataclass(frozen=True, slots=True)
+class _AuditStatsCacheKey:
+    project: str
+    since: str
+    deadline_seconds: float
+    target_signature: tuple[tuple[str, int | None, int | None], ...]
+
+
+@dataclass(slots=True)
+class _AuditStatsCacheEntry:
+    expires_at: float
+    response: "AuditStatsResponse"
+
+
+_STATS_CACHE_LOCK = threading.Lock()
+_STATS_CACHE: dict[_AuditStatsCacheKey, _AuditStatsCacheEntry] = {}
 
 
 class AuditGrepResponse(BaseModel):
@@ -249,6 +278,70 @@ def _coerce_record_to_event(record: dict[str, Any]) -> Event | None:
         # ``int(record.get("schema"))`` etc. can blow up on garbage
         # input types — treat the same as a validation miss.
         return None
+
+
+def _stat_signature(path: Any) -> tuple[str, int | None, int | None]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return (str(path), None, None)
+    return (str(path), int(stat.st_size), int(stat.st_mtime_ns))
+
+
+def _stats_target_signature(
+    targets: list[Any],
+) -> tuple[tuple[str, int | None, int | None], ...]:
+    signature: list[tuple[str, int | None, int | None]] = []
+    for live_path in targets:
+        seen_any = False
+        for chain_path in walk_log_chain(live_path):
+            seen_any = True
+            signature.append(_stat_signature(chain_path))
+        if not seen_any:
+            signature.append(_stat_signature(live_path))
+    return tuple(signature)
+
+
+def _get_stats_cache(
+    key: _AuditStatsCacheKey,
+    *,
+    now: float,
+) -> AuditStatsResponse | None:
+    with _STATS_CACHE_LOCK:
+        entry = _STATS_CACHE.get(key)
+        if entry is None:
+            return None
+        if entry.expires_at <= now:
+            _STATS_CACHE.pop(key, None)
+            return None
+        return entry.response
+
+
+def _store_stats_cache(
+    key: _AuditStatsCacheKey,
+    response: AuditStatsResponse,
+    *,
+    now: float,
+) -> None:
+    with _STATS_CACHE_LOCK:
+        if len(_STATS_CACHE) >= _STATS_CACHE_MAX_ENTRIES:
+            expired = [
+                cache_key
+                for cache_key, entry in _STATS_CACHE.items()
+                if entry.expires_at <= now
+            ]
+            for cache_key in expired:
+                _STATS_CACHE.pop(cache_key, None)
+            while len(_STATS_CACHE) >= _STATS_CACHE_MAX_ENTRIES:
+                oldest_key = min(
+                    _STATS_CACHE,
+                    key=lambda cache_key: _STATS_CACHE[cache_key].expires_at,
+                )
+                _STATS_CACHE.pop(oldest_key, None)
+        _STATS_CACHE[key] = _AuditStatsCacheEntry(
+            expires_at=now + _STATS_CACHE_TTL_SECONDS,
+            response=response,
+        )
 
 
 @router.get(
@@ -464,13 +557,24 @@ def stats_audit_endpoint(
     since_dt = _parse_since_or_400(since)
     targets = resolve_target_files(project_filter=project, config=config)
 
+    cache_key = _AuditStatsCacheKey(
+        project=project or "",
+        since=(since or "").strip(),
+        deadline_seconds=round(float(deadline_seconds), 3),
+        target_signature=_stats_target_signature(targets),
+    )
+    now = time.monotonic()
+    cached = _get_stats_cache(cache_key, now=now)
+    if cached is not None:
+        return cached
+
     aggregate = aggregate_recent_stats(
         targets=targets,
         since=since_dt,
         deadline_s=deadline_seconds,
     )
 
-    return AuditStatsResponse(
+    response = AuditStatsResponse(
         total=aggregate.total,
         by_event=aggregate.by_event,
         by_severity=aggregate.by_severity,
@@ -480,6 +584,8 @@ def stats_audit_endpoint(
         _corrupt_archives_skipped=aggregate.corrupt_archives_skipped,
         _malformed_rows_skipped=aggregate.malformed_rows_skipped,
     )
+    _store_stats_cache(cache_key, response, now=now)
+    return response
 
 
 __all__ = [

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -49,6 +49,7 @@
     && railRequestTimeoutOverride > 0
   ) ? railRequestTimeoutOverride : 10000;
   const ACTIVITY_REQUEST_TIMEOUT_MS = 3000;
+  const ACTIVITY_STATS_REQUEST_TIMEOUT_MS = 5000;
   const ACTIVITY_STATS_DEADLINE_SECONDS = 2.5;
 
   const state = {
@@ -94,10 +95,21 @@
     activitySince: ACTIVITY_DEFAULT_SINCE,
     activityEntries: [],
     activityStats: null,
+    activityStatsNote: null,
     activityLoading: false,
     activityError: null,
     activityInFlight: false,
     activityRefreshQueued: false,
+    alerts: {
+      items: [],
+      loading: false,
+      error: null,
+      reloadQueued: false,
+      doctorReport: null,
+      doctorLoading: false,
+      doctorError: null,
+      doctorRunInFlight: false,
+    },
     pendingMessages: {},
     inbox: {
       items: [],
@@ -1944,6 +1956,207 @@
     loadInbox(true);
   }
 
+  function selectAlerts() {
+    state.selectedKind = "alerts";
+    state.selectedSurface = null;
+    state.selectedTaskKey = null;
+    state.inbox.selectedId = null;
+    $("pane-title").textContent = "Alerts";
+    $("pane-meta").textContent = "";
+    $("send-input").disabled = true;
+    $("send-button").disabled = true;
+    updateStopAgentButton();
+    renderSurfaces();
+    renderAlertsView();
+    loadAlerts();
+    loadDoctorReport();
+  }
+
+  async function loadAlerts() {
+    if (state.alerts.loading) {
+      state.alerts.reloadQueued = true;
+      return;
+    }
+    state.alerts.loading = true;
+    state.alerts.error = null;
+    renderAlertsView();
+    try {
+      const data = await apiJson(API + "/alerts?limit=100");
+      state.alerts.items = Array.isArray(data.alerts) ? data.alerts : [];
+    } catch (err) {
+      state.alerts.error = err;
+      state.alerts.items = [];
+    } finally {
+      state.alerts.loading = false;
+      renderAlertsView();
+      if (state.alerts.reloadQueued) {
+        state.alerts.reloadQueued = false;
+        loadAlerts();
+      }
+    }
+  }
+
+  async function loadDoctorReport() {
+    if (state.alerts.doctorLoading) return;
+    state.alerts.doctorLoading = true;
+    state.alerts.doctorError = null;
+    renderAlertsView();
+    try {
+      state.alerts.doctorReport = await apiJson(API + "/doctor/report");
+    } catch (err) {
+      if (err && err.status === 404) {
+        state.alerts.doctorReport = null;
+      } else {
+        state.alerts.doctorError = err;
+      }
+    } finally {
+      state.alerts.doctorLoading = false;
+      renderAlertsView();
+    }
+  }
+
+  async function runSessionDriftCheck() {
+    if (state.alerts.doctorRunInFlight) return;
+    state.alerts.doctorRunInFlight = true;
+    state.alerts.doctorError = null;
+    renderAlertsView();
+    try {
+      state.alerts.doctorReport = await apiJson(API + "/doctor/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ check: "session-drift", fix: false }),
+      });
+    } catch (err) {
+      state.alerts.doctorError = err;
+    } finally {
+      state.alerts.doctorRunInFlight = false;
+      renderAlertsView();
+    }
+  }
+
+  function renderAlertAction(action) {
+    const detail = action.hint || action.kind || "";
+    const node = el("span", {
+      class: "alert-action",
+      text: action.label || action.kind || "Action",
+    });
+    if (detail) node.setAttribute("title", detail);
+    return node;
+  }
+
+  function renderAlertRow(item) {
+    const label = [
+      item.severity || "alert",
+      item.channel || "",
+    ].filter(Boolean).join(" · ");
+    const actions = Array.isArray(item.actions) ? item.actions : [];
+    const children = [
+      el("div", { class: "alert-row-head" }, [
+        el("span", { class: "alert-session", text: item.session_name || "unknown" }),
+        el("span", { class: "alert-updated", text: formatShortTime(item.updated_at) }),
+      ]),
+      el("div", { class: "alert-row-type", text: item.alert_type || "alert" }),
+      el("div", { class: "alert-row-message", text: item.message || "" }),
+      el("div", { class: "alert-row-meta", text: label }),
+    ];
+    if (actions.length > 0) {
+      children.push(el(
+        "div",
+        { class: "alert-actions" },
+        actions.map((action) => renderAlertAction(action)),
+      ));
+    }
+    return el("div", { class: "alert-row" }, children);
+  }
+
+  function sessionDriftRow(report) {
+    const checks = report && Array.isArray(report.checks) ? report.checks : [];
+    return checks.find((check) => check.name === "session-drift") || null;
+  }
+
+  function renderDoctorDriftPanel() {
+    const run = el("button", {
+      type: "button",
+      class: "empty-action",
+      text: state.alerts.doctorRunInFlight ? "Running..." : "Run session drift",
+      "aria-label": "Run session drift doctor check",
+    });
+    run.disabled = state.alerts.doctorRunInFlight;
+    run.addEventListener("click", () => runSessionDriftCheck());
+
+    const children = [
+      el("div", { class: "alert-panel-title", text: "Session drift" }),
+    ];
+    if (state.alerts.doctorLoading) {
+      children.push(el("div", {
+        class: "alert-row-message",
+        text: "loading doctor report...",
+      }));
+    } else if (state.alerts.doctorError) {
+      children.push(el("div", {
+        class: "alert-row-message alert-error",
+        text: "doctor unavailable: " + state.alerts.doctorError.message,
+      }));
+    } else {
+      const row = sessionDriftRow(state.alerts.doctorReport);
+      if (row) {
+        children.push(el("div", {
+          class: "alert-row-message",
+          text: (row.status || (row.passed ? "ok" : "warning")),
+        }));
+        if (row.why) {
+          children.push(el("div", { class: "alert-row-meta", text: row.why }));
+        }
+        if (row.fix) {
+          children.push(el("div", { class: "alert-row-meta", text: row.fix }));
+        }
+      } else {
+        children.push(el("div", {
+          class: "alert-row-message",
+          text: "No cached session-drift report.",
+        }));
+      }
+    }
+    children.push(el("div", { class: "empty-actions" }, [run]));
+    return el("div", { class: "alert-doctor" }, children);
+  }
+
+  function renderAlertsView() {
+    if (state.selectedKind !== "alerts") return;
+    const list = $("message-list");
+    clearMessageList(list);
+    const children = [];
+    children.push(renderDoctorDriftPanel());
+    if (state.alerts.loading) {
+      children.push(el("div", {
+        class: "activity-empty",
+        text: "loading alerts...",
+      }));
+    } else if (state.alerts.error) {
+      const retry = el("button", {
+        type: "button",
+        class: "fetch-retry",
+        text: "Retry",
+        "aria-label": "Retry loading alerts",
+      });
+      retry.addEventListener("click", () => loadAlerts());
+      children.push(el("div", { class: "activity-empty" }, [
+        document.createTextNode("alerts unavailable: " + state.alerts.error.message),
+        retry,
+      ]));
+    } else if (state.alerts.items.length === 0) {
+      children.push(el("div", {
+        class: "activity-empty",
+        text: "no action-required alerts",
+      }));
+    } else {
+      for (const item of state.alerts.items) {
+        children.push(renderAlertRow(item));
+      }
+    }
+    list.appendChild(el("div", { class: "alerts-panel" }, children));
+  }
+
   async function loadInbox(reset, omitType, preserveSelection) {
     if (state.inbox.loading || state.inbox.loadingMore) {
       state.inbox.reloadQueued = true;
@@ -2530,6 +2743,10 @@
         selectInbox(card.filter || undefined);
         return;
       }
+      if (card.target === "alerts") {
+        selectAlerts();
+        return;
+      }
       renderDashboardDrilldown(card);
     };
   }
@@ -2615,10 +2832,10 @@
         dashboardCardAction({
           label: "alerts",
           value: rollups.alert_count,
-          target: "detail",
-          detail: "Shows the current alert count.",
+          target: "alerts",
+          detail: "Opens the current alert list.",
         }, data),
-        "Show alert count",
+        "Open alerts",
       ));
     }
 
@@ -2742,6 +2959,7 @@
     state.activityInFlight = true;
     state.activityLoading = true;
     state.activityError = null;
+    state.activityStatsNote = null;
     renderActivity();
     try {
       const [grepResult, statsResult] = await Promise.allSettled([
@@ -2749,7 +2967,7 @@
           "activity feed", activityGrepPath(), ACTIVITY_REQUEST_TIMEOUT_MS,
         ),
         apiJsonOptionalWithTimeout(
-          "activity stats", activityStatsPath(), ACTIVITY_REQUEST_TIMEOUT_MS,
+          "activity stats", activityStatsPath(), ACTIVITY_STATS_REQUEST_TIMEOUT_MS,
         ),
       ]);
       if (grepResult.status === "fulfilled") {
@@ -2764,19 +2982,19 @@
       state.activityStats = statsResult.status === "fulfilled"
         ? statsResult.value : null;
       if (statsResult.status === "rejected" && !state.activityError) {
-        state.activityError = statsResult.reason instanceof Error
+        const err = statsResult.reason instanceof Error
           ? statsResult.reason
           : new Error(String(statsResult.reason));
+        state.activityStatsNote = "stats unavailable: " + err.message;
       } else if (
         statsResult.status === "fulfilled"
         && statsResult.value
         && statsResult.value._truncated_by_deadline
-        && !state.activityError
       ) {
         const lines = Number(statsResult.value._lines_scanned || 0);
-        state.activityError = new Error(
-          "activity stats timed out"
-          + (lines > 0 ? " after scanning " + lines + " lines" : ""),
+        state.activityStatsNote = (
+          "stats partial"
+          + (lines > 0 ? " after scanning " + lines + " lines" : "")
         );
       }
     } finally {
@@ -2854,6 +3072,12 @@
         el("span", { class: "activity-chip-label", text: card[0] }),
         el("span", { class: "activity-chip-value", text: String(card[1]) }),
       ]));
+    }
+    if (state.activityStatsNote) {
+      summaryBox.appendChild(el("div", {
+        class: "activity-note",
+        text: state.activityStatsNote,
+      }));
     }
   }
 
@@ -3165,6 +3389,7 @@
       ? window.location.pathname.replace(/\/+$/, "")
       : "";
     if (path === "/ui/inbox") return "inbox";
+    if (path === "/ui/alerts") return "alerts";
     return null;
   }
 
@@ -3175,8 +3400,11 @@
     wireActivityControls();
     wireSendForm();
     wireStopAgentButton();
-    if (initialUiRoute() === "inbox") {
+    const route = initialUiRoute();
+    if (route === "inbox") {
       selectInbox();
+    } else if (route === "alerts") {
+      selectAlerts();
     } else {
       renderNoSelection();
     }
@@ -3199,6 +3427,7 @@
     selectSurface: selectSurface,
     selectTask: selectTask,
     selectInbox: selectInbox,
+    selectAlerts: selectAlerts,
     interruptSurface: interruptSurface,
     loadInbox: loadInbox,
     renderInboxView: renderInboxView,

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -746,6 +746,16 @@ section#message-pane {
   font-weight: 600;
   margin-top: 2px;
 }
+.activity-note {
+  grid-column: 1 / -1;
+  padding: 7px 8px;
+  border: 1px solid var(--waiting);
+  border-radius: 6px;
+  color: var(--waiting);
+  background: rgba(240, 196, 90, 0.08);
+  font-size: 11.5px;
+  overflow-wrap: anywhere;
+}
 .activity-feed {
   display: flex;
   flex-direction: column;
@@ -783,6 +793,76 @@ section#message-pane {
   color: var(--text-body);
   font-size: 11.5px;
   overflow-wrap: anywhere;
+}
+
+.alerts-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.alert-doctor,
+.alert-row {
+  padding: 10px 11px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-row);
+}
+.alert-panel-title {
+  color: var(--text-heading-bright);
+  font-size: 13px;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+.alert-row-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.alert-session {
+  color: var(--text-label);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+.alert-updated {
+  flex: 0 0 auto;
+}
+.alert-row-type {
+  color: var(--blocked);
+  font-size: 12px;
+  font-weight: 700;
+  margin-top: 4px;
+  overflow-wrap: anywhere;
+}
+.alert-row-message {
+  color: var(--text-body);
+  font-size: 12.5px;
+  margin-top: 5px;
+  overflow-wrap: anywhere;
+}
+.alert-row-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-top: 5px;
+  overflow-wrap: anywhere;
+}
+.alert-error {
+  color: var(--blocked);
+}
+.alert-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.alert-action {
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  padding: 3px 7px;
+  color: var(--text-body);
+  background: var(--bg-elevated);
+  font-size: 11px;
 }
 
 .fetch-retry {

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -1284,6 +1284,63 @@ test.describe("surfaces", () => {
     await expect(page.locator("#activity-feed")).toContainText("watchdog.warning");
   });
 
+  test("activity panel keeps feed when stats are partial", async ({ page }) => {
+    await stubEmptyProjects(page);
+    await stubEmptySessions(page);
+    await stubEmptyTasks(page);
+    await page.route("**/api/v1/dashboard", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dashboardPayload(0)),
+      }),
+    );
+    await page.route("**/api/v1/audit/stats**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          total: 1,
+          by_event: { "task.created": 1 },
+          by_severity: { ok: 1 },
+          since: "2026-05-21T00:00:00Z",
+          _truncated_by_deadline: true,
+          _lines_scanned: 42,
+        }),
+      }),
+    );
+    await page.route("**/api/v1/audit/grep**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          events: [
+            {
+              schema: 1,
+              ts: "2026-05-23T00:00:00Z",
+              project: "demo",
+              event: "task.created",
+              subject: "demo/9",
+              actor: "polly",
+              status: "ok",
+              metadata: {},
+            },
+          ],
+          next_cursor: null,
+        }),
+      }),
+    );
+
+    await page.goto("/ui/");
+    await expect(page.locator("#activity-feed")).toContainText("task.created");
+    await expect(page.locator("#activity-summary")).toContainText(
+      "stats partial after scanning 42 lines",
+    );
+    await expect(page.locator("#activity-feed")).not.toContainText(
+      "activity unavailable",
+    );
+  });
+
   test("audit panel expands and queries current surface scope", async ({ page }) => {
     await page.route("**/api/v1/chat/*/messages*", (route) =>
       route.fulfill({

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -670,6 +670,52 @@ def test_stats_default_deadline_matches_ui_budget(
     assert captured == {"deadline_s": 2.5}
 
 
+def test_audit_stats_reuses_short_lived_cache(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated activity stats calls should not re-walk unchanged logs."""
+    from pollypm.audit.query import AuditStatsAggregate
+    from pollypm.web_api.routes import audit as audit_routes
+
+    audit_routes._STATS_CACHE.clear()
+    calls = {"count": 0}
+
+    def fake_aggregate_recent_stats(**kwargs):
+        calls["count"] += 1
+        return AuditStatsAggregate(
+            total=3,
+            by_event={"task.done": 3},
+            by_severity={"ok": 3},
+            lines_scanned=9,
+        )
+
+    monkeypatch.setattr(
+        audit_routes,
+        "aggregate_recent_stats",
+        fake_aggregate_recent_stats,
+    )
+    params = {"project": "myproj", "since": "24h"}
+    first = client.get(
+        "/api/v1/audit/stats",
+        params=params,
+        headers=auth_headers,
+    )
+    second = client.get(
+        "/api/v1/audit/stats",
+        params=params,
+        headers=auth_headers,
+    )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["total"] == 3
+    assert second.json()["total"] == 3
+    assert calls == {"count": 1}
+
+
 # ---------------------------------------------------------------------------
 # Round-2 guardrails (Codex review on PR #2062): ReDoS, malformed rows,
 # unbounded stats. See module docstring in

--- a/tests/web_api/test_alerts_endpoint.py
+++ b/tests/web_api/test_alerts_endpoint.py
@@ -1,0 +1,57 @@
+"""Tests for the web alert drill-down endpoint."""
+
+from __future__ import annotations
+
+
+def test_list_alerts_filters_operational_and_includes_actions(
+    client,
+    auth_headers,
+    pg_schema_pool,
+) -> None:
+    from pollypm.storage.pg_alerts import upsert_alert
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    upsert_alert(
+        "worker_demo",
+        "auth_broken",
+        "error",
+        "Codex auth failed",
+        pool=pg_schema_pool,
+    )
+    upsert_alert(
+        "worker_demo",
+        "suspected_loop",
+        "warn",
+        "Heartbeat saw repeated output",
+        pool=pg_schema_pool,
+    )
+
+    response = client.get("/api/v1/alerts", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 1
+    alert = body["alerts"][0]
+    assert alert["session_name"] == "worker_demo"
+    assert alert["alert_type"] == "auth_broken"
+    assert alert["channel"] == "action_required"
+    assert [action["kind"] for action in alert["actions"]] == ["acknowledge"]
+
+    response = client.get(
+        "/api/v1/alerts?include_operational=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["total"] == 2
+
+    response = client.get(
+        "/api/v1/alerts?include_operational=true&limit=1",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 2
+    assert len(body["alerts"]) == 1

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -325,6 +325,8 @@ def test_ui_app_js_selects_inbox_for_deep_link(client: TestClient) -> None:
     body = client.get("/ui/app.js").text
     assert 'path === "/ui/inbox"' in body
     assert "selectInbox();" in body
+    assert 'path === "/ui/alerts"' in body
+    assert "selectAlerts();" in body
 
 
 def test_ui_static_css_served(client: TestClient) -> None:
@@ -1147,11 +1149,30 @@ def test_ui_app_js_activity_stats_has_timeout_and_retry(client: TestClient) -> N
     body = client.get("/ui/app.js").text
     for expected in (
         "ACTIVITY_REQUEST_TIMEOUT_MS = 3000",
+        "ACTIVITY_STATS_REQUEST_TIMEOUT_MS = 5000",
         "ACTIVITY_STATS_DEADLINE_SECONDS = 2.5",
         "apiJsonOptionalWithTimeout",
         "_truncated_by_deadline",
+        "activityStatsNote",
+        "stats partial",
+        "stats unavailable:",
         "activity unavailable:",
         "Retry loading activity",
+    ):
+        assert expected in body
+
+
+def test_ui_app_js_has_alerts_panel_hooks(client: TestClient) -> None:
+    """The dashboard alert count opens an API-backed alerts surface."""
+    body = client.get("/ui/app.js").text
+    for expected in (
+        "selectAlerts",
+        "/alerts?limit=100",
+        "/doctor/report",
+        "/doctor/run",
+        "session-drift",
+        "Run session drift",
+        "Open alerts",
     ):
         assert expected in body
 
@@ -1235,14 +1256,15 @@ const payload = JSON.parse(process.argv[2]);
 
 // ---- minimal DOM shim --------------------------------------------------
 function makeNode(tag) {
-  const node = {
-    tagName: (tag || "div").toUpperCase(),
-    children: [],
-    attrs: {},
-    className: "",
-    textContent: "",
-    style: {},
-  };
+    const node = {
+      tagName: (tag || "div").toUpperCase(),
+      children: [],
+      attrs: {},
+      className: "",
+      textContent: "",
+      dataset: {},
+      style: {},
+    };
   Object.defineProperty(node, "innerHTML", {
     get() {
       function render(n) {
@@ -1702,6 +1724,7 @@ def test_render_dashboard_real_payload_executes() -> None:
     assert ">5<" in rendered, "tracked_count value 5 missing"
     assert 'role="button"' in rendered
     assert 'title="Open inbox"' in rendered
+    assert 'title="Open alerts"' in rendered
 
     # Color-coding contract: daemon=up → rollup-working; alert_count>0
     # → rollup-blocked. Pin these too so a future restyle that drops


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add `GET /api/v1/alerts` backed by the canonical pg alert facade and cockpit alert-action registry, plus OpenAPI docs.
- Wire the dashboard alerts card to an API-backed `/ui/alerts` drill-down with session-drift doctor report/run access.
- Add a short-lived signature-keyed cache for `/api/v1/audit/stats` and keep partial stats/truncation as a non-fatal UI note so the activity feed can still render.

Fixes #2400
Fixes #2401

## Verification
- `python -m py_compile src/pollypm/web_api/routes/audit.py src/pollypm/web_api/routes/alerts.py src/pollypm/web_api/app.py`
- `node --check src/pollypm/web_api/ui/app.js`
- `git diff --check`
- `uv run --extra dev ruff check src/pollypm/web_api/routes/alerts.py src/pollypm/web_api/routes/audit.py src/pollypm/web_api/app.py tests/web_api/test_alerts_endpoint.py tests/test_audit_endpoint.py tests/web_api/test_web_ui.py`
- `uv run --extra dev pytest tests/test_audit_endpoint.py::test_audit_stats_reuses_short_lived_cache tests/web_api/test_alerts_endpoint.py tests/web_api/test_web_ui.py::test_ui_app_js_activity_stats_has_timeout_and_retry tests/web_api/test_web_ui.py::test_ui_app_js_has_alerts_panel_hooks tests/web_api/test_web_ui.py::test_ui_app_js_selects_inbox_for_deep_link tests/web_api/test_web_ui.py::test_render_dashboard_real_payload_executes tests/web_api/test_openapi_conformance.py` (31 passed)
