### PR TITLE
Fail closed on plugin validation and persist plugin events

### DIFF
--- a/src/pollypm/plugin_api/v1.py
+++ b/src/pollypm/plugin_api/v1.py
@@ -22,9 +22,12 @@ Example:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal, Union
+
+logger = logging.getLogger(__name__)
 
 ProviderFactory = Callable[[], object]
 RuntimeFactory = Callable[[], object]
@@ -762,12 +765,28 @@ class PluginAPI:
             record = getattr(store, "record_event", None)
             if callable(record):
                 record(
-                    kind=f"plugin.{self._plugin_name}.{name}",
-                    payload=payload or {},
+                    "plugin",
+                    self._plugin_name,
+                    f"plugin.{self._plugin_name}.{name}",
+                    payload or {},
                 )
+        except TypeError as exc:
+            logger.warning(
+                "Plugin '%s' emit_event could not call state_store.record_event "
+                "for event '%s': %s",
+                self._plugin_name,
+                name,
+                exc,
+            )
         except Exception:  # noqa: BLE001
-            # Events are best-effort observability — swallow.
-            pass
+            # Events are best-effort observability; keep runtime store
+            # failures out of plugin initialization noise.
+            logger.debug(
+                "Plugin '%s' emit_event failed for event '%s'",
+                self._plugin_name,
+                name,
+                exc_info=True,
+            )
 
 
 @dataclass(slots=True)

--- a/src/pollypm/plugin_host.py
+++ b/src/pollypm/plugin_host.py
@@ -56,6 +56,17 @@ PLUGIN_API_VERSION = "1"
 PLUGIN_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*$")
 
 
+def _validation_summary(result: object) -> str:
+    """Return a compact validation detail without depending on old result shapes."""
+    errors = [str(error) for error in (getattr(result, "errors", None) or [])]
+    if errors:
+        return "; ".join(errors)
+    checks = [str(check) for check in (getattr(result, "checks", None) or [])]
+    if checks:
+        return "; ".join(checks)
+    return "validation failed"
+
+
 def _validate_plugin_name(plugin_name: str) -> str:
     """Reject ambiguous or path-like plugin names at the host boundary."""
     if not PLUGIN_NAME_PATTERN.fullmatch(plugin_name):
@@ -662,8 +673,8 @@ class ExtensionHost:
             # Validate the plugin implements its declared interfaces
             try:
                 result = validate_plugin(plugin)
-                if not result.passed:
-                    failures = ", ".join(c.message for c in result.checks if not c.passed)
+                if not getattr(result, "passed", False):
+                    failures = _validation_summary(result)
                     self._record_error(
                         f"Plugin {name} failed validation: {failures}",
                         plugin=name,
@@ -677,6 +688,8 @@ class ExtensionHost:
                     plugin=name,
                     stage="validate",
                 )
+                _mark_disabled(name, source, "load_error", f"validation error: {exc}")
+                return
             if name in loaded:
                 logger.warning(
                     "Plugin '%s' from source '%s' overrides earlier registration from source '%s'",

--- a/tests/test_downtime_flow.py
+++ b/tests/test_downtime_flow.py
@@ -17,8 +17,6 @@ Covers:
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from pathlib import Path
-
 import pytest
 
 from pollypm.plugins_builtin.downtime.flow_validator import (

--- a/tests/test_downtime_flow.py
+++ b/tests/test_downtime_flow.py
@@ -306,11 +306,13 @@ class TestInitializeHookValidates:
         from pollypm.jobs import JobHandlerRegistry
         from pollypm.plugins_builtin.downtime import plugin as plugin_module
 
-        events: list[tuple[str, dict]] = []
+        events: list[tuple[str, str, str, dict]] = []
 
         class _StubStore:
-            def record_event(self, *, kind: str, payload: dict) -> None:
-                events.append((kind, payload))
+            def record_event(
+                self, scope: str, sender: str, subject: str, payload: dict,
+            ) -> None:
+                events.append((scope, sender, subject, payload))
 
         api = PluginAPI(
             plugin_name="downtime",
@@ -319,7 +321,11 @@ class TestInitializeHookValidates:
             state_store=_StubStore(),
         )
         plugin_module.initialize(api)
-        init_events = [p for k, p in events if k.endswith(".initialize")]
+        init_events = [
+            p
+            for _scope, _sender, subject, p in events
+            if subject.endswith(".initialize")
+        ]
         assert init_events, "initialize event not emitted"
         payload = init_events[-1]
         assert payload["flow_validator_ok"] is True

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1096,8 +1096,6 @@ def test_initialize_content_paths_shortcut(tmp_path: Path) -> None:
     host.plugins()
     degraded = host.initialize_plugins()
     assert degraded == {}
-    # Introspect the plugin module to get COLLECTED
-    plugin = host.plugins()["cp_shortcut"]
     # API content_paths returned something (3 paths: bundled + user + project).
     # Resolve via the host directly to confirm equivalence.
     assert len(host.content_paths("cp_shortcut", kind="skill")) >= 3

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -104,6 +104,69 @@ def test_extension_host_rejects_wrong_api_version(tmp_path: Path) -> None:
     assert any("API version 99" in item for item in host.errors)
 
 
+def test_extension_host_disables_plugin_on_validation_failure(tmp_path: Path) -> None:
+    bad_plugin = tmp_path / ".pollypm" / "plugins" / "bad_validation"
+    _write_plugin(
+        bad_plugin,
+        name="bad_validation",
+        body=(
+            "from pollypm.plugin_api.v1 import PollyPMPlugin\n"
+            "plugin = PollyPMPlugin(name='bad_validation', providers={'broken': object()})\n"
+        ),
+    )
+
+    host = ExtensionHost(tmp_path)
+
+    assert "bad_validation" not in host.plugins()
+    disabled = host.disabled_plugins["bad_validation"]
+    assert disabled.reason == "load_error"
+    assert "Provider factory 'broken' is not callable" in disabled.detail
+    assert any(
+        error.plugin == "bad_validation"
+        and error.stage == "validate"
+        and "Provider factory 'broken' is not callable" in error.message
+        for error in host.load_errors()
+    )
+
+
+def test_extension_host_disables_plugin_on_validation_exception(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    plugin_dir = tmp_path / ".pollypm" / "plugins" / "validation_raises"
+    _write_plugin(
+        plugin_dir,
+        name="validation_raises",
+        body=(
+            "from pollypm.plugin_api.v1 import PollyPMPlugin\n"
+            "plugin = PollyPMPlugin(name='validation_raises')\n"
+        ),
+    )
+
+    import pollypm.plugin_host as plugin_host
+
+    real_validate = plugin_host.validate_plugin
+
+    def _validate(plugin):
+        if plugin.name == "validation_raises":
+            raise RuntimeError("validator unavailable")
+        return real_validate(plugin)
+
+    monkeypatch.setattr(plugin_host, "validate_plugin", _validate)
+
+    host = ExtensionHost(tmp_path)
+
+    assert "validation_raises" not in host.plugins()
+    disabled = host.disabled_plugins["validation_raises"]
+    assert disabled.reason == "load_error"
+    assert "validator unavailable" in disabled.detail
+    assert any(
+        error.plugin == "validation_raises"
+        and error.stage == "validate"
+        and "validator unavailable" in error.message
+        for error in host.load_errors()
+    )
+
+
 def test_extension_host_load_errors_capture_broken_plugin(tmp_path: Path) -> None:
     """#960: a plugin that fails to import must show up on the public
     :meth:`ExtensionHost.load_errors` accessor with structured fields
@@ -632,7 +695,11 @@ def test_project_plugin_shadows_user_plugin(monkeypatch, tmp_path: Path) -> None
         manifest_extras='[[capabilities]]\nkind = "provider"\nname = "mine"\n',
         body=(
             "from pollypm.plugin_api.v1 import PollyPMPlugin\n"
-            "class UserMarker: pass\n"
+            "class UserMarker:\n"
+            "    name = 'user'\n"
+            "    def transcript_sources(self): return []\n"
+            "    def build_launch_command(self, *a, **k): return []\n"
+            "    def collect_usage_snapshot(self): return None\n"
             "plugin = PollyPMPlugin(name='shadow_test', providers={'x': UserMarker})\n"
         ),
     )
@@ -642,7 +709,11 @@ def test_project_plugin_shadows_user_plugin(monkeypatch, tmp_path: Path) -> None
         manifest_extras='[[capabilities]]\nkind = "provider"\nname = "mine"\n',
         body=(
             "from pollypm.plugin_api.v1 import PollyPMPlugin\n"
-            "class ProjectMarker: pass\n"
+            "class ProjectMarker:\n"
+            "    name = 'project'\n"
+            "    def transcript_sources(self): return []\n"
+            "    def build_launch_command(self, *a, **k): return []\n"
+            "    def collect_usage_snapshot(self): return None\n"
             "plugin = PollyPMPlugin(name='shadow_test', providers={'x': ProjectMarker})\n"
         ),
     )

--- a/tests/test_rail_api.py
+++ b/tests/test_rail_api.py
@@ -165,6 +165,46 @@ def test_plugin_api_rail_without_api_raises() -> None:
         _ = api.rail
 
 
+def test_plugin_api_emit_event_calls_store_contract_positionally() -> None:
+    calls: list[tuple[str, str, str, dict[str, object]]] = []
+
+    class _Store:
+        def record_event(
+            self, scope: str, sender: str, subject: str, payload: dict[str, object],
+        ) -> int:
+            calls.append((scope, sender, subject, payload))
+            return 1
+
+    api = PluginAPI(
+        plugin_name="demo", roster_api=None, jobs_api=None, state_store=_Store(),
+    )
+
+    api.emit_event("ready", {"ok": True})
+
+    assert calls == [("plugin", "demo", "plugin.demo.ready", {"ok": True})]
+
+
+def test_plugin_api_emit_event_logs_signature_drift(caplog) -> None:
+    import logging
+
+    class _LegacyStore:
+        def record_event(self, *, kind: str, payload: dict[str, object]) -> None:
+            raise AssertionError("old contract should not be called")
+
+    api = PluginAPI(
+        plugin_name="demo", roster_api=None, jobs_api=None, state_store=_LegacyStore(),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pollypm.plugin_api.v1"):
+        api.emit_event("ready", {"ok": True})
+
+    assert any(
+        "emit_event could not call state_store.record_event" in rec.message
+        and "ready" in rec.message
+        for rec in caplog.records
+    )
+
+
 # ---------------------------------------------------------------------------
 # Integration: ExtensionHost initialize_plugins wires RailAPI into plugins
 # and the registry collects registrations.

--- a/tests/test_rail_api.py
+++ b/tests/test_rail_api.py
@@ -19,7 +19,7 @@ from pollypm.plugin_api.v1 import (
     RailItemRegistration,
     RailRegistry,
 )
-from pollypm.plugin_host import ExtensionHost, PluginManifest
+from pollypm.plugin_host import ExtensionHost
 
 
 def _noop_handler(ctx: RailContext) -> PanelSpec:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Make plugin validation failures and validation exceptions mark plugins disabled and return before installation.
- Build validation summaries from the current `ValidationResult` string fields instead of old check-object assumptions.
- Make public `PluginAPI.emit_event()` call the store `record_event(scope, sender, subject, payload)` contract positionally and log signature drift.

Fixes #2405

## Verification
- `python -m py_compile src/pollypm/plugin_host.py src/pollypm/plugin_api/v1.py tests/test_plugins.py tests/test_rail_api.py tests/test_downtime_flow.py`
- `git diff --check`
- `uv run --extra dev ruff check src/pollypm/plugin_host.py src/pollypm/plugin_api/v1.py tests/test_plugins.py tests/test_rail_api.py tests/test_downtime_flow.py`
- `uv run --extra test pytest tests/test_plugins.py::test_extension_host_disables_plugin_on_validation_failure tests/test_plugins.py::test_extension_host_disables_plugin_on_validation_exception tests/test_plugins.py::test_project_plugin_shadows_user_plugin tests/test_rail_api.py::test_plugin_api_emit_event_calls_store_contract_positionally tests/test_rail_api.py::test_plugin_api_emit_event_logs_signature_drift tests/test_downtime_flow.py::TestInitializeHookValidates::test_bundled_flow_emits_ok` (6 passed)

Note: a broader run of `tests/test_plugins.py tests/test_rail_api.py tests/test_downtime_flow.py` still has unrelated existing HOME/global-config expectation failures around user-global plugin/content paths.
