### PR TITLE
Rotate auth markers and scrub dispatch audit logs

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -3481,13 +3481,16 @@ def emit_escalation_dispatched(
     """Emit a ``watchdog.escalation_dispatched`` event.
 
     The metadata carries enough to reconstruct the dispatch decision:
-    finding_type, subject, and the brief that was sent. #2015 — also
+    finding_type, subject, and the unsigned brief body. #2015 — also
     carries ``dedup_hash`` (the subject-independent finding-body hash
     from :func:`dispatch_dedup_hash`) so the throttle reader can
     collapse same-root-cause emits across sibling subjects.
     Best-effort — never raises.
     """
     from pollypm.audit.log import emit as _audit_emit
+    from pollypm.session_auth import strip_auth_marker
+
+    audit_brief = strip_auth_marker(brief)
     try:
         _audit_emit(
             event=EVENT_WATCHDOG_ESCALATION_DISPATCHED,
@@ -3498,7 +3501,7 @@ def emit_escalation_dispatched(
             metadata={
                 "finding_type": finding_type,
                 "subject": subject,
-                "brief": brief,
+                "brief": audit_brief,
                 "dedup_hash": dedup_hash,
             },
             project_path=project_path,

--- a/src/pollypm/session_auth.py
+++ b/src/pollypm/session_auth.py
@@ -27,10 +27,15 @@ This module owns:
 * :func:`format_auth_marker` — renders ``[PollyPM-Auth: <token>]\\n``
   given a token. Returns the empty string when token is empty / None
   so callers can unconditionally prepend the result.
+* :func:`strip_auth_marker` — removes a leading marker before text is
+  persisted to operator-readable logs.
 * :func:`ensure_session_auth_tokens` — sweep helper that mints tokens
   for every session in ``config.sessions`` that lacks one. Mutates the
   dataclass in place; the caller decides when to ``write_config`` and
   persist. Idempotent: sessions that already have a token are skipped.
+* :func:`rotate_session_auth_token` — re-mints a configured session's
+  token before a fresh launch so previously leaked markers stop
+  authenticating future control messages.
 
 The token contract documented for agents (consumed by the agent-profile
 prompts):
@@ -63,7 +68,9 @@ __all__ = [
     "TOKEN_BYTES",
     "mint_auth_token",
     "format_auth_marker",
+    "strip_auth_marker",
     "ensure_session_auth_tokens",
+    "rotate_session_auth_token",
 ]
 
 
@@ -106,6 +113,23 @@ def format_auth_marker(token: str | None) -> str:
     return f"{AUTH_MARKER_PREFIX}{token}{AUTH_MARKER_SUFFIX}"
 
 
+def strip_auth_marker(text: str) -> str:
+    """Remove one leading PollyPM auth marker from ``text``.
+
+    Outbound briefs must carry the marker when they are injected into a
+    session, but audit/event logs must store only the unsigned body. The
+    helper is deliberately format-based rather than token-validating:
+    if a future token alphabet changes, a leading marker line still
+    gets stripped before persistence.
+    """
+    if not text.startswith(AUTH_MARKER_PREFIX):
+        return text
+    suffix_index = text.find(AUTH_MARKER_SUFFIX, len(AUTH_MARKER_PREFIX))
+    if suffix_index < 0:
+        return text
+    return text[suffix_index + len(AUTH_MARKER_SUFFIX):]
+
+
 def ensure_session_auth_tokens(config: "PollyPMConfig") -> int:
     """Mint an ``auth_token`` for every session that lacks one.
 
@@ -128,3 +152,24 @@ def ensure_session_auth_tokens(config: "PollyPMConfig") -> int:
             "session_auth: minted auth_token for session %s", session_name,
         )
     return minted
+
+
+def rotate_session_auth_token(
+    config: "PollyPMConfig",
+    session_name: str,
+) -> str | None:
+    """Mint a fresh token for ``session_name``.
+
+    Returns the new token, or ``None`` when the session is not present in
+    the supplied config. Mutates in place; the caller owns persistence.
+    """
+    session = (config.sessions or {}).get(session_name)
+    if session is None:
+        return None
+    previous = session.auth_token
+    token = mint_auth_token()
+    while token == previous:
+        token = mint_auth_token()
+    session.auth_token = token
+    logger.info("session_auth: rotated auth_token for session %s", session_name)
+    return token

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -58,7 +58,7 @@ import subprocess
 import sys
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -1066,6 +1066,11 @@ class Supervisor:
 
         failures: list[str] = []
         for controller_account in self._controller_candidates():
+            self._rotate_auth_tokens_for_fresh_launches(
+                session.name
+                for session in self.config.sessions.values()
+                if session.enabled
+            )
             launches = self.plan_launches(controller_account=controller_account)
             if not launches:
                 raise RuntimeError("No enabled sessions found in config.")
@@ -4261,6 +4266,75 @@ class Supervisor:
             self._stabilize_launch(launch, target, on_status=on_status)
         return launch
 
+    def _rotate_auth_tokens_for_fresh_launches(
+        self,
+        session_names: Iterable[str],
+    ) -> None:
+        """Rotate auth tokens before creating fresh agent panes.
+
+        The auth contract tells agents a token is renewed on each fresh
+        launch. Keep that guarantee true before the launch planner
+        renders prompts/commands, and persist through the shared config
+        RMW lock when the config came from disk. Hand-built test configs
+        without ``config_path`` rotate only in memory so tests never
+        accidentally mutate the operator's default config.
+        """
+        names = [
+            name for name in dict.fromkeys(session_names)
+            if name in self.config.sessions
+        ]
+        if not names:
+            return
+        from pollypm.session_auth import rotate_session_auth_token
+
+        config_path = getattr(self.config, "config_path", None)
+        if config_path is None:
+            changed = False
+            for name in names:
+                rotated = rotate_session_auth_token(self.config, name)
+                changed = rotated is not None or changed
+            if changed:
+                self.invalidate_launch_cache()
+            return
+
+        from pollypm.config import config_rmw_lock, load_config, write_config
+
+        rotated: list[str] = []
+        try:
+            with config_rmw_lock(config_path):
+                fresh = load_config(config_path)
+                for name in names:
+                    if rotate_session_auth_token(fresh, name) is not None:
+                        rotated.append(name)
+                if rotated:
+                    write_config(fresh, config_path, force=True)
+                    self.config = fresh
+                    self._launch_planner_instance = None
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "session_auth: failed to rotate auth tokens before launch",
+                exc_info=True,
+            )
+            raise RuntimeError(
+                "failed to rotate session auth token before launch"
+            ) from None
+        if rotated:
+            self.invalidate_launch_cache()
+
+    def _rotate_auth_token_for_fresh_launch(self, session_name: str) -> bool:
+        before = (
+            self.config.sessions.get(session_name).auth_token
+            if session_name in self.config.sessions
+            else None
+        )
+        self._rotate_auth_tokens_for_fresh_launches([session_name])
+        after = (
+            self.config.sessions.get(session_name).auth_token
+            if session_name in self.config.sessions
+            else None
+        )
+        return bool(after and after != before)
+
     def _refresh_architect_worktree_before_launch(
         self,
         launch: SessionLaunchSpec,
@@ -4355,6 +4429,12 @@ class Supervisor:
         # #1096 — scope existence-check to the launch's tmux_session.
         if (tmux_session, launch.window_name) in window_map:
             return launch, None
+        if self._rotate_auth_token_for_fresh_launch(session_name):
+            launch = self._launch_by_session(session_name)
+            tmux_session = self._tmux_session_for_launch(launch)
+            window_map = self._window_map()
+            if (tmux_session, launch.window_name) in window_map:
+                return launch, None
         self._refresh_architect_worktree_before_launch(launch)
         existing_claude_ids: set[str] | None = None
         if (

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -42,6 +42,8 @@ from pollypm.session_auth import (
     ensure_session_auth_tokens,
     format_auth_marker,
     mint_auth_token,
+    rotate_session_auth_token,
+    strip_auth_marker,
 )
 
 
@@ -92,6 +94,15 @@ def test_format_auth_marker_empty_for_missing_token() -> None:
     """
     assert format_auth_marker("") == ""
     assert format_auth_marker(None) == ""
+
+
+def test_strip_auth_marker_removes_leading_marker_only() -> None:
+    token = "deadbeef" * 8
+    body = "WATCHDOG ESCALATION\n\nProject: demo"
+    assert strip_auth_marker(format_auth_marker(token) + body) == body
+    assert strip_auth_marker(body) == body
+    embedded = body + "\n" + format_auth_marker(token)
+    assert strip_auth_marker(embedded) == embedded
 
 
 # ---------------------------------------------------------------------------
@@ -166,6 +177,21 @@ def test_ensure_session_auth_tokens_is_idempotent(tmp_path: Path) -> None:
     }
     assert minted == 0
     assert before == after
+
+
+def test_rotate_session_auth_token_replaces_existing_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _bare_config(tmp_path)
+    config.sessions["architect"].auth_token = "a" * 64
+    monkeypatch.setattr("pollypm.session_auth.mint_auth_token", lambda: "b" * 64)
+
+    token = rotate_session_auth_token(config, "architect")
+
+    assert token == "b" * 64
+    assert config.sessions["architect"].auth_token == "b" * 64
+    assert config.sessions["reviewer"].auth_token == ""
+    assert rotate_session_auth_token(config, "missing") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_auth_emit.py
+++ b/tests/test_session_auth_emit.py
@@ -14,9 +14,11 @@ from pathlib import Path
 import pytest
 
 from pollypm.audit.watchdog import (
+    EVENT_WATCHDOG_ESCALATION_DISPATCHED,
     Finding,
     RULE_STUCK_DRAFT,
     RULE_TASK_ON_HOLD_STALE,
+    emit_escalation_dispatched,
     format_unstick_brief,
 )
 from pollypm.models import (
@@ -177,6 +179,35 @@ def test_brief_marker_with_tier2_template() -> None:
     brief = format_unstick_brief(finding, auth_token="d" * 64)
     assert brief.startswith(AUTH_MARKER_PREFIX + ("d" * 64))
     assert "WATCHDOG ESCALATION" in brief
+
+
+def test_escalation_dispatch_audit_metadata_strips_auth_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sent brief is signed, but persisted audit metadata is not."""
+    captured: dict[str, object] = {}
+
+    def fake_emit(**kwargs) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("pollypm.audit.log.emit", fake_emit)
+    token = "feedface" * 8
+    signed = format_unstick_brief(_stuck_draft_finding(), auth_token=token)
+
+    emit_escalation_dispatched(
+        project="demo",
+        finding_type=RULE_STUCK_DRAFT,
+        subject="demo/1",
+        brief=signed,
+        dedup_hash="abc123",
+    )
+
+    assert captured["event"] == EVENT_WATCHDOG_ESCALATION_DISPATCHED
+    metadata = captured["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["brief"].startswith("WATCHDOG ESCALATION")
+    assert AUTH_MARKER_PREFIX not in metadata["brief"]
+    assert token not in metadata["brief"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -847,6 +847,34 @@ def test_launch_session_creates_worker_window_detached(monkeypatch, tmp_path: Pa
     assert created_windows[0][3] is True
 
 
+def test_fresh_launch_rotation_persists_before_replanning(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    from pollypm.config import load_config, write_config
+
+    config = _config(tmp_path)
+    old_token = "a" * 64
+    config.sessions["operator"].auth_token = old_token
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+    loaded = load_config(config_path)
+    supervisor = Supervisor(loaded)
+    monkeypatch.setattr(
+        "pollypm.session_auth.mint_auth_token",
+        lambda: "b" * 64,
+    )
+
+    assert supervisor.launch_by_session("operator").session.auth_token == old_token
+    supervisor._rotate_auth_tokens_for_fresh_launches(["operator"])
+
+    new_token = "b" * 64
+    assert supervisor.config.sessions["operator"].auth_token == new_token
+    assert supervisor.launch_by_session("operator").session.auth_token == new_token
+    persisted = config_path.read_text(encoding="utf-8")
+    assert f'auth_token = "{new_token}"' in persisted
+    assert f'auth_token = "{old_token}"' not in persisted
+
+
 def test_write_snapshot_targets_pane_id_for_mounted_windows(tmp_path: Path, monkeypatch) -> None:
     config = _config(tmp_path)
     supervisor = Supervisor(config)


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Strip `[PollyPM-Auth: ...]` from persisted escalation-dispatch audit metadata while continuing to send signed briefs to agents.
- Add session-auth token rotation before fresh supervisor launches and persist rotations through the config RMW lock.
- Rebuild launch planning after persisted rotation so freshly rendered prompts/commands use the new token.

Fixes #2404

## Verification
- `python -m py_compile src/pollypm/session_auth.py src/pollypm/audit/watchdog.py src/pollypm/supervisor.py`
- `uv run --extra dev ruff check src/pollypm/session_auth.py src/pollypm/audit/watchdog.py tests/test_session_auth.py tests/test_session_auth_emit.py`
- `uv run --extra dev ruff check --ignore E402,F401 src/pollypm/supervisor.py tests/test_supervisor.py` (supervisor files have pre-existing E402/F401 findings)
- `git diff --check`
- `uv run --extra test pytest tests/test_session_auth.py::test_strip_auth_marker_removes_leading_marker_only tests/test_session_auth.py::test_rotate_session_auth_token_replaces_existing_token tests/test_session_auth_emit.py::test_escalation_dispatch_audit_metadata_strips_auth_marker tests/test_supervisor.py::test_fresh_launch_rotation_persists_before_replanning` (4 passed)
- `uv run --extra test pytest tests/test_session_auth.py tests/test_session_auth_emit.py` (30 passed)
