### PR TITLE
Fix recovery cascade stall guards

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -36,9 +36,8 @@ Detection rules (each returns a list of :class:`Finding`):
    surface to the user via the empty-state affordance from #1340.)
 4. ``cancellation_no_promotion`` — ``task.status_changed`` to
    ``cancelled`` with no ``task.created`` for the same project in the
-   following ``cancel_grace_seconds`` window. Indicates a planning
-   stall after a self-cancel (savethenovel/1's class — a worker
-   self-cancels but Polly never queues a follow-up).
+   following ``cancel_grace_seconds`` window. Indicates observable
+   replacement work was not created after a self-cancel.
 5. ``task_progress_stale`` — a live task currently at ``in_progress``
    whose worker has produced no transition / heartbeat / task-context
    activity for longer than ``progress_stale_seconds``. Catches the
@@ -4154,15 +4153,12 @@ def _brief_cancellation_no_promotion(
     lines.append("")
     lines.append(
         "Your job: decide whether this cancellation ended the project "
-        "intentionally or left replacement work unqueued. Do not reply "
-        "with analysis alone; make the queue state explicit."
+        "or left replacement work unqueued. Do not reply with analysis "
+        "alone; make the queue state explicit."
     )
     lines.append(
-        f"Cli levers available: create and queue replacement work with "
-        f"`pm task create ...` then `pm task queue <replacement-task-id>`, "
-        f"or intentionally park the abandoned thread with "
-        f"`pm task context {subject} \"parked intentionally: <why>\"` "
-        f"plus cancel/hold for any remaining scoped task."
+        "Cli levers available: create and queue replacement work with "
+        "`pm task create ...` then `pm task queue <replacement-task-id>`."
     )
     return lines
 

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -1435,6 +1435,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         from pollypm.heartbeats.stall_classifier import (
             StallContext,
             classify_stall,
+            recently_nudged_from_message_store,
         )
         from pollypm.idle_placeholders import (
             pane_ends_with_unanswered_question as _pane_ends_with_unanswered_question,
@@ -1442,10 +1443,16 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         )
 
         _pane_text = context.pane_text or ""
+        output_advanced = bool((context.transcript_delta or "").strip())
         stall_ctx = StallContext(
             role=context.role or "",
             session_name=context.session_name,
             has_pending_work=self._has_pending_work(api, context),
+            recently_nudged=recently_nudged_from_message_store(
+                getattr(getattr(api, "supervisor", None), "msg_store", None),
+                context.session_name,
+            ),
+            turn_in_flight=output_advanced,
             pane_is_idle_placeholder=_pane_is_idle_placeholder(_pane_text),
             awaiting_operator_question=_pane_ends_with_unanswered_question(_pane_text),
         )
@@ -1829,7 +1836,13 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     break
         return repeated
 
-    def _nudge_stalled_worker(self, api, context: HeartbeatSessionContext) -> None:
+    def _nudge_stalled_worker(
+        self,
+        api,
+        context: HeartbeatSessionContext,
+        *,
+        message: str | None = None,
+    ) -> None:
         """Send a targeted nudge to a stalled WORKER. Never targets the operator."""
         if context.role != "worker":
             return
@@ -1952,12 +1965,13 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             )
         # Context-aware nudge for the worker
         snippet = (context.pane_text or "").strip().splitlines()[-1][:80] if context.pane_text else ""
-        if "permission" in snippet.lower() or "approve" in snippet.lower():
-            message = "You appear stuck on a permissions prompt. Accept or work around it."
-        elif "error" in snippet.lower() or "failed" in snippet.lower():
-            message = "You hit an error. Read it carefully, fix the root cause, and continue."
-        else:
-            message = "State the remaining task in one sentence, execute the next step, and report."
+        if message is None:
+            if "permission" in snippet.lower() or "approve" in snippet.lower():
+                message = "You appear stuck on a permissions prompt. Accept or work around it."
+            elif "error" in snippet.lower() or "failed" in snippet.lower():
+                message = "You hit an error. Read it carefully, fix the root cause, and continue."
+            else:
+                message = "State the remaining task in one sentence, execute the next step, and report."
         self._send_worker_message(api, context, message, owner="heartbeat")
         try:
             from pollypm.events.summaries import (
@@ -2019,28 +2033,10 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         # Worker asking for permission → push forward
         proceed_signals = ["if you want", "shall i", "should i", "want me to", "i can do"]
         if any(sig in lowered for sig in proceed_signals):
-            self._send_worker_message(
+            self._nudge_stalled_worker(
                 api,
                 context,
-                "Yes, proceed. Do the next step you outlined.",
-                owner="heartbeat",
-            )
-            from pollypm.events.summaries import (
-                activity_summary,
-            )
-
-            api.supervisor.msg_store.append_event(
-                scope=context.session_name,
-                sender=context.session_name,
-                subject="heuristic_triage",
-                payload={
-                    "message": activity_summary(
-                        summary="Pushed forward: proceed signal detected",
-                        severity="routine",
-                        verb="triaged",
-                        subject=context.session_name,
-                    ),
-                },
+                message="Yes, proceed. Do the next step you outlined.",
             )
             return
 

--- a/src/pollypm/heartbeats/stall_classifier.py
+++ b/src/pollypm/heartbeats/stall_classifier.py
@@ -35,6 +35,7 @@ a false-positive stall alert is user trust damage that persists.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Literal
 
 
@@ -196,6 +197,56 @@ _WORKER_ACTIONABLE_STATUSES: frozenset[str] = frozenset(
 )
 
 
+def recently_nudged_from_message_store(
+    msg_store,
+    session_name: str,
+    *,
+    within_seconds: int = 120,
+) -> bool:
+    """Return whether the session recently received recovery input.
+
+    This is the classifier's reachable false-positive guard for workers
+    that have just been nudged or sent input. We intentionally do not
+    populate ``turn_in_flight`` here: there is no established reliable
+    cross-boundary signal for an active model turn, while ``nudge`` and
+    ``send_input`` are durable message-store events emitted by the
+    existing recovery/send paths.
+    """
+    if not msg_store or not session_name:
+        return False
+    query_messages = getattr(msg_store, "query_messages", None)
+    if not callable(query_messages):
+        return False
+
+    try:
+        recent = query_messages(type="event", scope=session_name, limit=200)
+    except Exception:  # noqa: BLE001
+        return False
+
+    now = datetime.now(UTC)
+    for event in recent:
+        if event.get("subject") not in {"nudge", "send_input"}:
+            continue
+        created_at = event.get("created_at")
+        if created_at is None:
+            continue
+        stamp = (
+            created_at.isoformat()
+            if hasattr(created_at, "isoformat")
+            else str(created_at)
+        )
+        try:
+            parsed = datetime.fromisoformat(stamp)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        age = (now - parsed).total_seconds()
+        if 0 <= age <= within_seconds:
+            return True
+    return False
+
+
 def has_pending_work_for_session(config, session_name: str) -> bool:
     """Best-effort check for queued/actionable work on a session's project.
 
@@ -206,9 +257,11 @@ def has_pending_work_for_session(config, session_name: str) -> bool:
     heartbeat-backend sweep and the supervisor-boundary sweep) share a
     single definition of "is there work".
 
-    Returns ``True`` when in doubt — a false "yes" only means we run
-    the same-snapshot check that next heartbeat; a false "no" would
-    silence a real stall.
+    Returns ``False`` when the session/project/path cannot be resolved:
+    without a project, there is no scoped queue to inspect. Once the
+    project is resolved, backend read failures are swallowed and treated
+    as no actionable work from that backend. Only unexpected outer
+    failures return ``True`` as the conservative fail-closed direction.
     """
     try:
         sessions = getattr(config, "sessions", None) or {}
@@ -265,4 +318,5 @@ __all__ = [
     "StallClass",
     "classify_stall",
     "has_pending_work_for_session",
+    "recently_nudged_from_message_store",
 ]

--- a/src/pollypm/supervisor_alerts.py
+++ b/src/pollypm/supervisor_alerts.py
@@ -213,6 +213,7 @@ def _update_alerts_snapshot_stall(
     pane_text: str,
     previous_snapshot_hash: str | None,
     current_snapshot_hash: str,
+    turn_in_flight: bool,
     active_alerts: list[str],
 ) -> None:
     """Handle the snapshot-hash-based stall detection branch."""
@@ -231,6 +232,7 @@ def _update_alerts_snapshot_stall(
         StallContext,
         classify_stall,
         has_pending_work_for_session,
+        recently_nudged_from_message_store,
     )
     from pollypm.idle_placeholders import (
         pane_ends_with_unanswered_question as _pane_ends_with_unanswered_question,
@@ -245,6 +247,11 @@ def _update_alerts_snapshot_stall(
             has_pending_work=has_pending_work_for_session(
                 supervisor.config, session_name,
             ),
+            recently_nudged=recently_nudged_from_message_store(
+                supervisor.msg_store,
+                session_name,
+            ),
+            turn_in_flight=turn_in_flight,
             pane_is_idle_placeholder=_pane_is_idle_placeholder(
                 _pane_text_for_classify,
             ),
@@ -384,6 +391,10 @@ def _update_alerts(
         pane_text=pane_text,
         previous_snapshot_hash=previous_snapshot_hash,
         current_snapshot_hash=current_snapshot_hash,
+        turn_in_flight=(
+            previous_log_bytes is not None
+            and current_log_bytes > previous_log_bytes
+        ),
         active_alerts=active_alerts,
     )
 

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -1701,7 +1701,7 @@ def test_cadence_handler_dispatches_cancellation_no_promotion(
     assert target == "pollypm-storage-closet:architect-savethenovel"
     assert RULE_CANCEL_NO_PROMOTION in brief
     assert "queue replacement work" in brief
-    assert "intentionally park" in brief
+    assert "intentionally park" not in brief
 
     rows = [
         json.loads(line)

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -844,7 +844,7 @@ def test_format_unstick_brief_cancellation_no_promotion_is_decisive() -> None:
     assert "in_progress -> cancelled" in brief
     assert "No later task.created" in brief
     assert "queue replacement work" in brief
-    assert "intentionally park" in brief
+    assert "intentionally park" not in brief
     assert "Do not reply with analysis alone" in brief
 
 

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -1322,6 +1322,64 @@ def test_worker_nudge_skips_repeat_for_same_snapshot_episode(monkeypatch) -> Non
     assert len(nudge_events) == 1
 
 
+def test_same_snapshot_recent_nudge_classifies_transient(monkeypatch) -> None:
+    backend = LocalHeartbeatBackend()
+    api = FakeHeartbeatAPI(
+        [],
+        hashes={"worker_demo": ["hash-1"] * 3},
+    )
+    context = _context(
+        session_name="worker_demo",
+        transcript_delta="",
+        pane_text="Still stalled",
+        previous_snapshot_hash="hash-1",
+        snapshot_hash="hash-1",
+    )
+    monkeypatch.setattr(backend, "_has_pending_work", lambda *_args: True)
+    api.supervisor.msg_store.append_event(
+        scope=context.session_name,
+        sender=context.session_name,
+        subject="nudge",
+        payload={"snapshot_hash": "hash-1"},
+    )
+
+    alerts = backend._handle_same_snapshot_stall(
+        api,
+        context,
+        mechanical_only=False,
+    )
+
+    assert alerts == []
+    assert api.alerts == {}
+    assert api.messages == []
+
+
+def test_same_snapshot_transcript_delta_classifies_transient(monkeypatch) -> None:
+    backend = LocalHeartbeatBackend()
+    api = FakeHeartbeatAPI(
+        [],
+        hashes={"worker_demo": ["hash-1"] * 3},
+    )
+    context = _context(
+        session_name="worker_demo",
+        transcript_delta="Still applying edits.",
+        pane_text="Still stalled",
+        previous_snapshot_hash="hash-1",
+        snapshot_hash="hash-1",
+    )
+    monkeypatch.setattr(backend, "_has_pending_work", lambda *_args: True)
+
+    alerts = backend._handle_same_snapshot_stall(
+        api,
+        context,
+        mechanical_only=False,
+    )
+
+    assert alerts == []
+    assert api.alerts == {}
+    assert api.messages == []
+
+
 def test_worker_nudge_escalates_when_same_episode_keeps_repeating(monkeypatch) -> None:
     backend = LocalHeartbeatBackend()
     api = FakeHeartbeatAPI(
@@ -1358,6 +1416,44 @@ def test_worker_nudge_escalates_when_same_episode_keeps_repeating(monkeypatch) -
     ]
     assert len(escalations) == 1
     assert escalations[0]["payload"]["snapshot_hash"] == "hash-1"
+
+
+def test_triage_proceed_signal_uses_nudge_ladder(monkeypatch) -> None:
+    backend = LocalHeartbeatBackend()
+    api = FakeHeartbeatAPI(
+        [],
+        hashes={"worker_demo": ["hash-1"] * 8},
+    )
+    context = _context(
+        session_name="worker_demo",
+        transcript_delta="",
+        pane_text="I can implement the next step if you want.",
+        previous_snapshot_hash="hash-1",
+        snapshot_hash="hash-1",
+    )
+    monkeypatch.setattr(backend, "_has_pending_work", lambda *_args: True)
+    api.supervisor.msg_store.append_event(
+        scope=context.session_name,
+        sender=context.session_name,
+        subject="nudge",
+        payload={"snapshot_hash": "hash-1"},
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=601),
+    )
+
+    backend._triage_stalled_worker(api, context)
+
+    assert api.messages == []
+    assert ("worker_demo", "stuck_session") in api.alerts
+    escalations = [
+        event
+        for event in api.supervisor.msg_store.query_messages(
+            type="event",
+            scope=context.session_name,
+            limit=20,
+        )
+        if event.get("subject") == "nudge_escalated"
+    ]
+    assert len(escalations) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stall_classifier.py
+++ b/tests/test_stall_classifier.py
@@ -14,7 +14,11 @@ Regression targets tonight's reports:
 
 from __future__ import annotations
 
-from pollypm.heartbeats.stall_classifier import StallContext, classify_stall
+from pollypm.heartbeats.stall_classifier import (
+    StallContext,
+    classify_stall,
+    has_pending_work_for_session,
+)
 
 
 def _ctx(**kwargs) -> StallContext:
@@ -79,6 +83,15 @@ def test_worker_with_pending_work_and_no_user_gate_is_unrecoverable_stall() -> N
         classify_stall(_ctx(role="worker", has_pending_work=True, awaiting_user_action=False))
         == "unrecoverable_stall"
     )
+
+
+def test_has_pending_work_unresolved_session_fails_idle() -> None:
+    """Config-resolution misses mean there is no scoped queue to inspect."""
+    class _Config:
+        sessions = {}
+        projects = {}
+
+    assert has_pending_work_for_session(_Config(), "missing") is False
 
 
 def test_unknown_role_defaults_to_legitimate_idle() -> None:

--- a/tests/test_supervisor_alerts.py
+++ b/tests/test_supervisor_alerts.py
@@ -122,6 +122,153 @@ def test_supervisor_alert_helper_updates_and_nudges(monkeypatch, tmp_path: Path)
         "pollypm.heartbeats.stall_classifier.has_pending_work_for_session",
         lambda config, session_name: True,
     )
+    monkeypatch.setattr(
+        "pollypm.heartbeats.stall_classifier.recently_nudged_from_message_store",
+        lambda msg_store, session_name: False,
+    )
+    monkeypatch.setattr(_supervisor_alerts, "_build_task_nudge", lambda *_args: None)
+
+    alerts = _supervisor_alerts._update_alerts(
+        supervisor,
+        launch,
+        window,
+        pane_text="Still stalled",
+        previous_log_bytes=200,
+        previous_snapshot_hash="same-hash",
+        current_log_bytes=200,
+        current_snapshot_hash="same-hash",
+    )
+
+    assert "suspected_loop" in alerts
+    assert sent == [("worker", Supervisor._STALL_NUDGE_MESSAGE, False)]
+
+
+def test_supervisor_alert_helper_recent_nudge_is_transient(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = next(item for item in supervisor.plan_launches() if item.session.name == "worker")
+    window = TmuxWindow(
+        session=supervisor.storage_closet_session_name(),
+        index=1,
+        name="worker-pollypm",
+        active=False,
+        pane_id="%42",
+        pane_current_command="codex",
+        pane_current_path=str(tmp_path),
+        pane_dead=False,
+    )
+
+    for index in range(4):
+        supervisor.store.record_heartbeat(
+            session_name="worker",
+            tmux_window=window.name,
+            pane_id=window.pane_id,
+            pane_command=window.pane_current_command,
+            pane_dead=False,
+            log_bytes=100 + index,
+            snapshot_path=str(tmp_path / f"snapshot-{index}.txt"),
+            snapshot_hash="same-hash",
+        )
+    supervisor.store.record_heartbeat(
+        session_name="worker",
+        tmux_window=window.name,
+        pane_id=window.pane_id,
+        pane_command=window.pane_current_command,
+        pane_dead=False,
+        log_bytes=200,
+        snapshot_path=str(tmp_path / "snapshot-current.txt"),
+        snapshot_hash="same-hash",
+    )
+    supervisor.msg_store.append_event(
+        scope="worker",
+        sender="worker",
+        subject="nudge",
+        payload={"snapshot_hash": "same-hash"},
+    )
+
+    sent: list[tuple[str, str, bool]] = []
+    monkeypatch.setattr(
+        supervisor,
+        "send_input",
+        lambda session_name, text, owner="pollypm", force=False, press_enter=True: sent.append(
+            (session_name, text, force)
+        ),
+    )
+    monkeypatch.setattr(
+        "pollypm.heartbeats.stall_classifier.has_pending_work_for_session",
+        lambda config, session_name: True,
+    )
+
+    alerts = _supervisor_alerts._update_alerts(
+        supervisor,
+        launch,
+        window,
+        pane_text="Still stalled",
+        previous_log_bytes=200,
+        previous_snapshot_hash="same-hash",
+        current_log_bytes=200,
+        current_snapshot_hash="same-hash",
+    )
+
+    assert "suspected_loop" not in alerts
+    assert sent == []
+
+
+def test_supervisor_alert_helper_log_growth_is_transient(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = next(item for item in supervisor.plan_launches() if item.session.name == "worker")
+    window = TmuxWindow(
+        session=supervisor.storage_closet_session_name(),
+        index=1,
+        name="worker-pollypm",
+        active=False,
+        pane_id="%42",
+        pane_current_command="codex",
+        pane_current_path=str(tmp_path),
+        pane_dead=False,
+    )
+
+    for index in range(4):
+        supervisor.store.record_heartbeat(
+            session_name="worker",
+            tmux_window=window.name,
+            pane_id=window.pane_id,
+            pane_command=window.pane_current_command,
+            pane_dead=False,
+            log_bytes=100 + index,
+            snapshot_path=str(tmp_path / f"snapshot-{index}.txt"),
+            snapshot_hash="same-hash",
+        )
+    supervisor.store.record_heartbeat(
+        session_name="worker",
+        tmux_window=window.name,
+        pane_id=window.pane_id,
+        pane_command=window.pane_current_command,
+        pane_dead=False,
+        log_bytes=200,
+        snapshot_path=str(tmp_path / "snapshot-current.txt"),
+        snapshot_hash="same-hash",
+    )
+
+    sent: list[tuple[str, str, bool]] = []
+    monkeypatch.setattr(
+        supervisor,
+        "send_input",
+        lambda session_name, text, owner="pollypm", force=False, press_enter=True: sent.append(
+            (session_name, text, force)
+        ),
+    )
+    monkeypatch.setattr(
+        "pollypm.heartbeats.stall_classifier.has_pending_work_for_session",
+        lambda config, session_name: True,
+    )
 
     alerts = _supervisor_alerts._update_alerts(
         supervisor,
@@ -134,8 +281,8 @@ def test_supervisor_alert_helper_updates_and_nudges(monkeypatch, tmp_path: Path)
         current_snapshot_hash="same-hash",
     )
 
-    assert "suspected_loop" in alerts
-    assert sent == [("worker", Supervisor._STALL_NUDGE_MESSAGE, False)]
+    assert "suspected_loop" not in alerts
+    assert sent == []
 
 
 def test_supervisor_wrapper_delegates_alert_helper(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Populate the stall classifier transient guards from recent `nudge`/`send_input` events and observable output progress at both heartbeat construction sites.
- Route proceed-signal triage through `_nudge_stalled_worker` so debounce, same-snapshot dedupe, escalation, and recovery guards apply.
- Align the cancellation-no-promotion watchdog brief with the detector by removing the unobservable intentional-park resolution, and correct the pending-work docstring.

## Verification
- `uv run --extra test pytest tests/test_stall_classifier.py tests/test_heartbeat_plugin_api.py::test_same_snapshot_recent_nudge_classifies_transient tests/test_heartbeat_plugin_api.py::test_same_snapshot_transcript_delta_classifies_transient tests/test_heartbeat_plugin_api.py::test_triage_proceed_signal_uses_nudge_ladder tests/test_supervisor_alerts.py::test_supervisor_alert_helper_updates_and_nudges tests/test_supervisor_alerts.py::test_supervisor_alert_helper_recent_nudge_is_transient tests/test_supervisor_alerts.py::test_supervisor_alert_helper_log_growth_is_transient tests/test_audit_watchdog.py::test_format_unstick_brief_cancellation_no_promotion_is_decisive`
- `python -m py_compile src/pollypm/heartbeats/stall_classifier.py src/pollypm/heartbeats/local.py src/pollypm/supervisor_alerts.py src/pollypm/audit/watchdog.py tests/test_stall_classifier.py tests/test_heartbeat_plugin_api.py tests/test_supervisor_alerts.py tests/test_audit_watchdog.py`
- `git diff --check`
- `uv run --extra dev ruff check --select F821,F822,F823,F541 src/pollypm/heartbeats/stall_classifier.py src/pollypm/heartbeats/local.py src/pollypm/supervisor_alerts.py src/pollypm/audit/watchdog.py tests/test_stall_classifier.py tests/test_heartbeat_plugin_api.py tests/test_supervisor_alerts.py tests/test_audit_watchdog.py`

Note: a full ruff pass over these whole files still reports unrelated pre-existing findings in `src/pollypm/heartbeats/local.py`, `tests/test_heartbeat_plugin_api.py`, and `tests/test_supervisor_alerts.py`; the targeted correctness lint above passed.

Fixes #2406
