### PR TITLE
Embed build git SHA for deploy staleness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 pollypm = [
+  "_build_info.json",
   "model_registry.toml",
   "plugins_builtin/*/pollypm-plugin.toml",
   "plugins_builtin/*/profiles/*.md",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,59 @@
+"""Setuptools build customizations for PollyPM."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from setuptools import setup
+from setuptools.command.build_py import build_py
+
+
+BUILD_INFO_FILENAME = "_build_info.json"
+
+
+def _git_value(repo: Path, args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+class build_py_with_build_info(build_py):
+    """Embed source git metadata into built wheels from local checkouts."""
+
+    def run(self) -> None:
+        super().run()
+        repo = Path(__file__).resolve().parent
+        target = Path(self.build_lib) / "pollypm" / BUILD_INFO_FILENAME
+        git_sha = _git_value(repo, ["rev-parse", "HEAD"])
+        if not git_sha:
+            try:
+                target.unlink()
+            except FileNotFoundError:
+                pass
+            return
+        build_info: dict[str, str] = {"git_sha": git_sha}
+        commit_time = _git_value(repo, ["show", "-s", "--format=%cI", "HEAD"])
+        if commit_time:
+            build_info["git_commit_time"] = commit_time
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            json.dumps(build_info, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+
+setup(cmdclass={"build_py": build_py_with_build_info})

--- a/src/pollypm/deploy_info.py
+++ b/src/pollypm/deploy_info.py
@@ -25,6 +25,7 @@ from urllib.parse import unquote, urlparse
 
 PACKAGE_NAME = "pollypm"
 PACKAGE_IMPORT_NAME = "pollypm"
+BUILD_INFO_FILENAME = "_build_info.json"
 _GIT_TIMEOUT_SECONDS = 1.0
 _STALE_CLOCK_SKEW_SECONDS = 60
 _EXCLUDED_DIRS = frozenset({"__pycache__", ".git", ".mypy_cache", ".pytest_cache"})
@@ -269,6 +270,23 @@ def _latest_package_mtime(root: Path | None) -> tuple[str | None, str | None]:
     return (_iso_from_mtime(latest[0]), str(latest[1]))
 
 
+def _embedded_build_info(package_path: Path | None) -> dict[str, str]:
+    if package_path is None:
+        return {}
+    path = package_path / BUILD_INFO_FILENAME
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {
+        key: value
+        for key, value in parsed.items()
+        if isinstance(key, str) and isinstance(value, str) and value
+    }
+
+
 def _infer_stale(info: RuntimeBuildInfo) -> tuple[bool | None, str | None]:
     source_sha = info.source_git_sha
     served_sha = info.served_git_sha
@@ -310,10 +328,15 @@ def runtime_build_info(
     ) = _direct_url_fields(direct_url)
 
     served_git_root = _git_root(package_path)
+    embedded_build_info = _embedded_build_info(package_path)
     served_git_sha = _git_head(served_git_root) if served_git_root else None
     served_git_commit_time = (
         _git_head_time(served_git_root) if served_git_root else None
     )
+    if served_git_sha is None:
+        served_git_sha = embedded_build_info.get("git_sha")
+    if served_git_commit_time is None:
+        served_git_commit_time = embedded_build_info.get("git_commit_time")
     if served_git_sha is None and direct_url_vcs_commit_id:
         served_git_sha = direct_url_vcs_commit_id
 

--- a/tests/test_deploy_info.py
+++ b/tests/test_deploy_info.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import pollypm.deploy_info as deploy_info
 from pollypm.deploy_info import RuntimeBuildInfo, assess_deploy_staleness
 
 
@@ -76,3 +78,100 @@ def test_assess_deploy_staleness_passes_for_editable_checkout(tmp_path: Path) ->
 
     assert result.state == "ok"
     assert "source checkout" in result.status
+
+
+def test_runtime_build_info_reads_embedded_served_git_sha(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    package_path = tmp_path / "tool" / "pollypm"
+    _write(package_path / "__init__.py", "")
+    _write(
+        package_path / deploy_info.BUILD_INFO_FILENAME,
+        json.dumps(
+            {
+                "git_sha": "abc123",
+                "git_commit_time": "2026-05-29T12:00:00+00:00",
+            }
+        ),
+    )
+
+    monkeypatch.setattr(
+        deploy_info,
+        "_package_location",
+        lambda _import_name: (package_path, package_path / "__init__.py"),
+    )
+    monkeypatch.setattr(
+        deploy_info,
+        "_distribution_info",
+        lambda _package_name: ("1", tmp_path / "pollypm-1.dist-info", None),
+    )
+
+    info = deploy_info.runtime_build_info()
+
+    assert info.served_git_sha == "abc123"
+    assert info.served_git_commit_time == "2026-05-29T12:00:00+00:00"
+
+
+def test_runtime_build_info_flags_stale_when_embedded_sha_differs_from_source(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    package_path = tmp_path / "tool" / "pollypm"
+    source_checkout = tmp_path / "checkout"
+    _write(package_path / "__init__.py", "")
+    _write(
+        package_path / deploy_info.BUILD_INFO_FILENAME,
+        json.dumps({"git_sha": "old-sha"}),
+    )
+    _write(source_checkout / "src" / "pollypm" / "__init__.py", "")
+
+    monkeypatch.setattr(
+        deploy_info,
+        "_package_location",
+        lambda _import_name: (package_path, package_path / "__init__.py"),
+    )
+    monkeypatch.setattr(
+        deploy_info,
+        "_distribution_info",
+        lambda _package_name: (
+            "1",
+            tmp_path / "pollypm-1.dist-info",
+            {
+                "url": source_checkout.as_uri(),
+                "dir_info": {"editable": False},
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        deploy_info,
+        "_git_root",
+        lambda path: source_checkout if path == source_checkout else None,
+    )
+    monkeypatch.setattr(
+        deploy_info,
+        "_git_head",
+        lambda path: "new-sha" if path == source_checkout else None,
+    )
+
+    info = deploy_info.runtime_build_info()
+
+    assert info.served_git_sha == "old-sha"
+    assert info.source_git_sha == "new-sha"
+    assert info.stale is True
+    assert info.stale_reason == "served git SHA differs from the recorded source checkout"
+
+
+def test_infer_stale_falls_back_to_package_mtime_without_embedded_sha() -> None:
+    info = RuntimeBuildInfo(
+        package_name="pollypm",
+        version="1",
+        direct_url_editable=False,
+        source_git_commit_time="2026-05-29T12:10:00Z",
+        package_mtime="2026-05-29T12:00:00Z",
+    )
+
+    stale, reason = deploy_info._infer_stale(info)
+
+    assert stale is True
+    assert reason == "source checkout HEAD is newer than the served package files"


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a setuptools `build_py` hook that writes `pollypm/_build_info.json` with the source commit SHA and commit time when building from a git checkout.
- Include that build metadata as package data and teach `runtime_build_info()` to prefer the embedded served SHA before falling back to PEP 610 or package mtimes.
- Add deploy-info regression coverage for embedded served SHAs, stale SHA comparison, and the existing mtime fallback.

## Verification
- `uv run --extra test pytest tests/test_deploy_info.py`
- `uv run --extra dev ruff check setup.py src/pollypm/deploy_info.py tests/test_deploy_info.py`
- `python -m py_compile setup.py src/pollypm/deploy_info.py tests/test_deploy_info.py`
- `git diff --check`
- `uv build --wheel --out-dir "$tmpdir"` plus wheel inspection confirming `pollypm/_build_info.json` exists and `git_sha` equals branch HEAD `63724d8ad580909faa3dc14955745d9ea05e5c7f`.

Fixes #2411
