### PR TITLE
Fix account failover selection and audit gaps

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -297,6 +297,7 @@ EVENT_ACCOUNT_FAILOVER_PROACTIVE = "account.failover.proactive"
 EVENT_ACCOUNT_FAILOVER_ENGAGED = "account.failover.engaged"
 EVENT_ACCOUNT_FAILOVER_BLOCKED = "account.failover.blocked"
 EVENT_ACCOUNT_FAILOVER_FAILED = "account.failover.failed"
+EVENT_ACCOUNT_FAILOVER_SUPPRESSED = "account.failover.suppressed"
 # #2296 — public agent-side refusal observability. Agents use the
 # narrow ``pm audit agent-refusal`` command when they refuse a message
 # claiming PollyPM authority but missing/failing the auth marker.

--- a/src/pollypm/capacity.py
+++ b/src/pollypm/capacity.py
@@ -77,6 +77,7 @@ class FailoverCandidate:
     account_name: str
     provider: ProviderKind
     priority: int  # lower is better
+    remaining_pct: int | None = None
     reason: str = ""
 
 
@@ -89,6 +90,7 @@ class FailoverDecision:
     selected_account: str | None = None
     reason: str = ""
     candidates_evaluated: int = 0
+    candidate_accounts: tuple[str, ...] = ()
 
 
 @dataclass(slots=True)
@@ -308,7 +310,10 @@ def evaluate_proactive_controller_failover(
         if candidate_probe.state in FAILOVER_TRIGGERS:
             continue
         candidate_used = _probe_used_pct(candidate_probe)
-        if candidate_used is None or candidate_used >= threshold:
+        if candidate_used is None:
+            if candidate_probe.state is not CapacityState.HEALTHY:
+                continue
+        elif candidate_used >= threshold:
             continue
         if current == candidate_name:
             return ProactiveFailoverDecision(
@@ -349,12 +354,16 @@ def select_failover_account(
     config: PollyPMConfig,
     store: object | None,
     failed_account: str,
+    *,
+    require_failed_trigger: bool = True,
 ) -> FailoverDecision:
     """Select the best failover account when one fails.
 
-    Selection follows ``config.pollypm.failover_accounts`` first, then
-    the controller account, then any remaining configured accounts. The
-    first healthy account in that order wins.
+    Selection follows ``config.pollypm.failover_accounts`` first, then the
+    controller account, then any remaining configured accounts. Viable
+    accounts with known capacity are ordered by remaining headroom, with the
+    configured chain used as the tiebreaker. Unknown-headroom accounts remain
+    last-resort candidates instead of outranking known-capacity accounts.
     """
     if not config.pollypm.failover_enabled:
         return FailoverDecision(
@@ -373,7 +382,7 @@ def select_failover_account(
 
     # Check if the failed account actually needs failover
     probe = probe_capacity(config, store, failed_account)
-    if probe.state not in FAILOVER_TRIGGERS:
+    if require_failed_trigger and probe.state not in FAILOVER_TRIGGERS:
         return FailoverDecision(
             should_failover=False,
             failed_account=failed_account,
@@ -407,14 +416,17 @@ def select_failover_account(
         capacity = probe_capacity(config, store, name)
         if capacity.state in FAILOVER_TRIGGERS:
             continue  # Skip accounts that are also failing
+        remaining_pct = _probe_remaining_pct(capacity)
 
         candidates.append(FailoverCandidate(
             account_name=name,
             provider=account.provider,
             priority=order,
+            remaining_pct=remaining_pct,
             reason=(
                 f"order={order}, state={capacity.state}, "
-                f"same_provider={account.provider == failed_provider}"
+                f"same_provider={account.provider == failed_provider}, "
+                f"remaining_pct={remaining_pct if remaining_pct is not None else 'unknown'}"
             ),
         ))
 
@@ -426,16 +438,24 @@ def select_failover_account(
             candidates_evaluated=0,
         )
 
-    # Sort by configured/fallback order (lower is better)
-    candidates.sort(key=lambda c: c.priority)
+    candidates.sort(key=_failover_candidate_sort_key)
     best = candidates[0]
+    candidate_accounts = tuple(candidate.account_name for candidate in candidates)
+    remaining_label = (
+        f"{best.remaining_pct}% remaining"
+        if best.remaining_pct is not None
+        else "unknown remaining"
+    )
 
     return FailoverDecision(
         should_failover=True,
         failed_account=failed_account,
         selected_account=best.account_name,
-        reason=f"Selected {best.account_name} ({best.provider}) with priority {best.priority}",
+        reason=(
+            f"Selected {best.account_name} ({best.provider}) with {remaining_label}"
+        ),
         candidates_evaluated=len(candidates),
+        candidate_accounts=candidate_accounts,
     )
 
 
@@ -603,6 +623,24 @@ def _probe_used_pct(probe: CapacityProbeResult) -> int | None:
     if probe.used_pct is not None:
         return max(0, min(100, int(probe.used_pct)))
     return _used_pct_from_remaining(probe.remaining_pct)
+
+
+def _probe_remaining_pct(probe: CapacityProbeResult) -> int | None:
+    if probe.remaining_pct is not None:
+        return max(0, min(100, int(probe.remaining_pct)))
+    used = _probe_used_pct(probe)
+    if used is None:
+        return None
+    return max(0, min(100, 100 - used))
+
+
+def _failover_candidate_sort_key(candidate: FailoverCandidate) -> tuple[bool, int, int]:
+    remaining = candidate.remaining_pct
+    return (
+        remaining is None,
+        -(remaining if remaining is not None else -1),
+        candidate.priority,
+    )
 
 
 def _coerce_usage_threshold(value: object) -> int:

--- a/src/pollypm/providers/codex/adapter.py
+++ b/src/pollypm/providers/codex/adapter.py
@@ -110,6 +110,10 @@ class CodexAdapter(ProviderAdapterBase):
                 tmux.send_keys(target, "", press_enter=True)
                 time.sleep(1)
                 continue
+            if self._is_enter_to_continue_interstitial(lowered):
+                tmux.send_keys(target, "", press_enter=True)
+                time.sleep(1)
+                continue
             # Codex 0.125+ surfaces usage only via the /status slash command.
             # Wait until the prompt is up (›) then drive /status, give it a
             # beat to render, and parse the response.
@@ -123,6 +127,14 @@ class CodexAdapter(ProviderAdapterBase):
                     continue
             time.sleep(1)
         return self._parse_usage_text(text)
+
+    @staticmethod
+    def _is_enter_to_continue_interstitial(lowered_text: str) -> bool:
+        if "press enter to continue" not in lowered_text:
+            return False
+        if "update available" in lowered_text:
+            return True
+        return "openai codex" not in lowered_text or "›" not in lowered_text
 
     def _parse_usage_text(self, text: str) -> ProviderUsageSnapshot:
         # Codex /status surfaces multiple buckets — typically a 5h limit and a

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -2800,7 +2800,11 @@ class Supervisor:
                 account_name,
                 exc_info=True,
             )
-        if account.home is None:
+        return self._account_has_credentials(account_name)
+
+    def _account_has_credentials(self, account_name: str) -> bool:
+        account = self.config.accounts.get(account_name)
+        if account is None or account.home is None:
             return False
         if account.provider is ProviderKind.CLAUDE:
             claude_dir = account.home / ".claude"
@@ -2815,18 +2819,54 @@ class Supervisor:
             return (account.home / ".codex" / "auth.json").exists()
         return False
 
+    def _effective_account_for_launch(self, launch: SessionLaunchSpec) -> str:
+        runtime = self._get_session_runtime(launch.session.name)
+        if runtime is not None and runtime.effective_account in self.config.accounts:
+            return runtime.effective_account
+        return launch.account.name
+
     def _candidate_accounts(self, launch: SessionLaunchSpec, *, allow_same: bool) -> list[str]:
         preferred = []
-        current = launch.account.name
+        current = self._effective_account_for_launch(launch)
+        if not allow_same:
+            try:
+                from pollypm.capacity import select_failover_account
+
+                decision = select_failover_account(
+                    self.config,
+                    None,
+                    current,
+                    require_failed_trigger=False,
+                )
+                return [
+                    name
+                    for name in decision.candidate_accounts
+                    if self._account_has_credentials(name)
+                ]
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "account failover selector failed for %s; falling back",
+                    current,
+                    exc_info=True,
+                )
         if allow_same:
             preferred.append(current)
         for name in self.config.pollypm.failover_accounts:
-            if name not in preferred:
+            if not allow_same and name == current:
+                continue
+            if name in self.config.accounts and name not in preferred:
                 preferred.append(name)
         controller = self.config.pollypm.controller_account
-        if controller and controller not in preferred:
+        if (
+            controller
+            and controller in self.config.accounts
+            and controller not in preferred
+            and (allow_same or controller != current)
+        ):
             preferred.append(controller)
         for name in self.config.accounts:
+            if not allow_same and name == current:
+                continue
             if name not in preferred:
                 preferred.append(name)
         same_provider = [name for name in preferred if self.config.accounts[name].provider is launch.session.provider]
@@ -3833,6 +3873,25 @@ class Supervisor:
                 last_failure_type=failure_type,
                 last_failure_message=failure_message,
             )
+            if failure_type in self._ACCOUNT_FAILOVER_FAILURES:
+                from pollypm.audit.log import EVENT_ACCOUNT_FAILOVER_SUPPRESSED
+
+                self._emit_session_recovery_audit(
+                    EVENT_ACCOUNT_FAILOVER_SUPPRESSED,
+                    launch,
+                    status="warn",
+                    actor="supervisor",
+                    metadata={
+                        "failure_type": failure_type,
+                        "failure_message": failure_message,
+                        "from": launch.account.name,
+                        "to": None,
+                        "account": launch.account.name,
+                        "provider": launch.account.provider.value,
+                        "reason": "rate_limited",
+                        "attempts": attempts,
+                    },
+                )
             return
 
         # Force failover for auth_broken / capacity_exhausted and
@@ -4069,27 +4128,43 @@ class Supervisor:
                     actor="supervisor",
                     metadata=recovery_metadata,
                 )
-            if (
-                failure_type in self._ACCOUNT_FAILOVER_FAILURES
-                and account_name != previous_account
-            ):
-                from pollypm.audit.log import EVENT_ACCOUNT_FAILOVER_ENGAGED
+            if failure_type in self._ACCOUNT_FAILOVER_FAILURES:
+                if account_name != previous_account:
+                    from pollypm.audit.log import EVENT_ACCOUNT_FAILOVER_ENGAGED
 
-                self._emit_session_recovery_audit(
-                    EVENT_ACCOUNT_FAILOVER_ENGAGED,
-                    launch,
-                    status="ok",
-                    actor="supervisor",
-                    metadata={
-                        "failure_type": failure_type,
-                        "from": previous_account,
-                        "to": account_name,
-                        "account": account_name,
-                        "provider": account.provider.value,
-                        "configured_account": getattr(launch.session, "account", ""),
-                        "reason": "recovery_failover",
-                    },
-                )
+                    self._emit_session_recovery_audit(
+                        EVENT_ACCOUNT_FAILOVER_ENGAGED,
+                        launch,
+                        status="ok",
+                        actor="supervisor",
+                        metadata={
+                            "failure_type": failure_type,
+                            "from": previous_account,
+                            "to": account_name,
+                            "account": account_name,
+                            "provider": account.provider.value,
+                            "configured_account": getattr(launch.session, "account", ""),
+                            "reason": "recovery_failover",
+                        },
+                    )
+                else:
+                    from pollypm.audit.log import EVENT_ACCOUNT_FAILOVER_SUPPRESSED
+
+                    self._emit_session_recovery_audit(
+                        EVENT_ACCOUNT_FAILOVER_SUPPRESSED,
+                        launch,
+                        status="warn",
+                        actor="supervisor",
+                        metadata={
+                            "failure_type": failure_type,
+                            "from": previous_account,
+                            "to": account_name,
+                            "account": account_name,
+                            "provider": account.provider.value,
+                            "configured_account": getattr(launch.session, "account", ""),
+                            "reason": "same_account",
+                        },
+                    )
         # Inject recovery prompt so the agent knows what it was doing.
         # For role-scoped agents (reviewer / heartbeat) prepend an
         # identity reminder so a recovery that lands inside a noisy

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -376,6 +376,56 @@ class TestEvaluateProactiveControllerFailover:
         assert decision.selected_account == "codex_main"
         assert decision.candidates_evaluated == 2
 
+    def test_selects_healthy_unknown_usage_candidate_as_last_resort(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        store = _store(tmp_path)
+        _usage(store, "claude_main", 90)
+        _usage(store, "claude_backup", 90)
+        store.upsert_account_usage(
+            account_name="codex_main",
+            provider="codex",
+            plan="pro",
+            health="healthy",
+            usage_summary="usage unavailable",
+            raw_text="",
+            used_pct=None,
+            remaining_pct=None,
+        )
+
+        decision = evaluate_proactive_controller_failover(
+            config,
+            store,
+            current_account="claude_main",
+        )
+
+        assert decision.action == "switch"
+        assert decision.selected_account == "codex_main"
+
+    def test_skips_unknown_state_unknown_usage_candidate(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        store = _store(tmp_path)
+        _usage(store, "claude_main", 90)
+        _usage(store, "claude_backup", 90)
+        store.upsert_account_usage(
+            account_name="codex_main",
+            provider="codex",
+            plan="pro",
+            health="unknown",
+            usage_summary="usage unavailable",
+            raw_text="",
+            used_pct=None,
+            remaining_pct=None,
+        )
+
+        decision = evaluate_proactive_controller_failover(
+            config,
+            store,
+            current_account="claude_main",
+        )
+
+        assert decision.action == "alert"
+        assert decision.selected_account is None
+
 
 # ---------------------------------------------------------------------------
 # Failover selection
@@ -405,7 +455,7 @@ class TestSelectFailoverAccount:
         decision = select_failover_account(config, store, "claude_main")
         assert not decision.should_failover
 
-    def test_selects_same_provider_non_controller(self, tmp_path: Path) -> None:
+    def test_selects_highest_headroom_candidate(self, tmp_path: Path) -> None:
         config = _config(tmp_path)
         store = _store(tmp_path)
         # Mark claude_main as exhausted
@@ -436,8 +486,8 @@ class TestSelectFailoverAccount:
 
         decision = select_failover_account(config, store, "claude_main")
         assert decision.should_failover
-        # Should prefer claude_backup (same provider, non-controller)
-        assert decision.selected_account == "claude_backup"
+        assert decision.selected_account == "codex_main"
+        assert decision.candidate_accounts == ("codex_main", "claude_backup")
 
     def test_selects_first_healthy_account_in_failover_order(self, tmp_path: Path) -> None:
         config = _config(tmp_path)

--- a/tests/test_provider_sdk.py
+++ b/tests/test_provider_sdk.py
@@ -205,6 +205,49 @@ def test_codex_provider_drives_status_for_new_pane_format(tmp_path: Path) -> Non
     assert snapshot.reset_at == "10:09 on 5 May"
 
 
+def test_codex_provider_dismisses_update_interstitial_before_status(tmp_path: Path) -> None:
+    adapter = CodexAdapter()
+    account = AccountConfig(
+        name="codex_primary",
+        provider=ProviderKind.CODEX,
+        home=tmp_path / "home",
+    )
+    session = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=tmp_path,
+        project="pollypm",
+    )
+    interstitial = (
+        "Update available! 0.133.0 -> 0.135.0\n"
+        "1. Update now\n"
+        "2. Skip\n"
+        "3. Skip until next version\n"
+        "Press enter to continue"
+    )
+    welcome_pane = "OpenAI Codex (v0.135.0)\n› Implement {feature}\n"
+    status_pane = (
+        "OpenAI Codex (v0.135.0)\n"
+        "/status\n"
+        "  Weekly limit: [###############-----] 75% left "
+        "(resets 10:09 on 5 May)\n"
+        "› Implement {feature}\n"
+    )
+    tmux = _FakeTmux([interstitial, welcome_pane, status_pane])
+
+    snapshot = adapter.collect_usage_snapshot(
+        tmux, "session:0", account=account, session=session,
+    )
+
+    assert tmux.sent[0] == ("session:0", "", True)
+    assert ("session:0", "/status", True) in tmux.sent
+    assert snapshot.health == "healthy"
+    assert snapshot.used_pct == 25
+    assert snapshot.remaining_pct == 75
+
+
 def test_codex_provider_uses_cli_prompt_for_fresh_launch(tmp_path: Path) -> None:
     adapter = CodexAdapter()
     account = AccountConfig(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -102,10 +102,20 @@ def test_supervisor_failover_prefers_viable_backup(monkeypatch, tmp_path: Path) 
     config = _config(tmp_path)
     supervisor = Supervisor(config)
     supervisor.ensure_layout()
-    launch = next(item for item in supervisor.plan_launches() if item.session.name == "operator")
+    launch = SessionLaunchSpec(
+        session=config.sessions["operator"],
+        account=config.accounts["claude_controller"],
+        window_name="pm-operator",
+        log_path=tmp_path / ".pollypm/logs/operator.log",
+        command="claude",
+    )
     restarted: dict[str, str] = {}
+    backup_auth = config.accounts["codex_backup"].home / ".codex" / "auth.json"
+    backup_auth.parent.mkdir(parents=True, exist_ok=True)
+    backup_auth.write_text("{}")
 
-    monkeypatch.setattr(supervisor, "_account_is_viable", lambda name: name == "codex_backup")
+    monkeypatch.setattr(supervisor, "_get_lease", lambda _name: None)
+    monkeypatch.setattr(supervisor, "_get_session_runtime", lambda _name: None)
     monkeypatch.setattr(
         supervisor,
         "_record_recovery_attempt",
@@ -137,9 +147,12 @@ def test_supervisor_failover_skips_pg_exhausted_account(monkeypatch, tmp_path: P
     backup_auth.write_text("{}")
     supervisor = Supervisor(config)
     supervisor.ensure_layout()
-    launch = next(
-        item for item in supervisor.plan_launches()
-        if item.session.name == "operator"
+    launch = SessionLaunchSpec(
+        session=config.sessions["operator"],
+        account=config.accounts["claude_controller"],
+        window_name="pm-operator",
+        log_path=tmp_path / ".pollypm/logs/operator.log",
+        command="claude",
     )
     restarted: dict[str, str] = {}
 
@@ -157,6 +170,86 @@ def test_supervisor_failover_skips_pg_exhausted_account(monkeypatch, tmp_path: P
         )
 
     monkeypatch.setattr("pollypm.capacity.probe_capacity", fake_probe_capacity)
+    monkeypatch.setattr(supervisor, "_get_lease", lambda _name: None)
+    monkeypatch.setattr(supervisor, "_get_session_runtime", lambda _name: None)
+    monkeypatch.setattr(
+        supervisor,
+        "_record_recovery_attempt",
+        lambda *_args, **_kwargs: (True, 1),
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_restart_session",
+        lambda session_name, account_name, failure_type: restarted.update(
+            {"session": session_name, "account": account_name, "failure": failure_type}
+        ),
+    )
+
+    supervisor._maybe_recover_session(
+        launch,
+        failure_type="capacity_exhausted",
+        failure_message="0% left",
+    )
+
+    assert restarted == {
+        "session": "operator",
+        "account": "codex_backup",
+        "failure": "capacity_exhausted",
+    }
+
+
+def test_supervisor_failover_prefers_highest_headroom_candidate(monkeypatch, tmp_path: Path) -> None:
+    from pollypm.capacity import CapacityProbeResult, CapacityState
+
+    config = _config(tmp_path)
+    config.accounts["claude_low"] = AccountConfig(
+        name="claude_low",
+        provider=ProviderKind.CLAUDE,
+        email="claude-low@example.com",
+        home=tmp_path / ".pollypm/homes/claude_low",
+    )
+    config.pollypm.failover_accounts = ["claude_low", "codex_backup"]
+    for account_name in ("claude_low", "codex_backup"):
+        account = config.accounts[account_name]
+        if account.provider is ProviderKind.CLAUDE:
+            credentials = account.home / ".claude" / ".credentials.json"
+        else:
+            credentials = account.home / ".codex" / "auth.json"
+        credentials.parent.mkdir(parents=True, exist_ok=True)
+        credentials.write_text("{}")
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = SessionLaunchSpec(
+        session=config.sessions["operator"],
+        account=config.accounts["claude_controller"],
+        window_name="pm-operator",
+        log_path=tmp_path / ".pollypm/logs/operator.log",
+        command="claude",
+    )
+    restarted: dict[str, str] = {}
+
+    def fake_probe_capacity(config, store, account_name: str):
+        if account_name == "claude_controller":
+            state = CapacityState.EXHAUSTED
+            remaining = 0
+        elif account_name == "claude_low":
+            state = CapacityState.HEALTHY
+            remaining = 5
+        else:
+            state = CapacityState.HEALTHY
+            remaining = 80
+        return CapacityProbeResult(
+            account_name=account_name,
+            provider=config.accounts[account_name].provider,
+            state=state,
+            remaining_pct=remaining,
+            used_pct=100 - remaining,
+            reason=state.value,
+        )
+
+    monkeypatch.setattr("pollypm.capacity.probe_capacity", fake_probe_capacity)
+    monkeypatch.setattr(supervisor, "_get_lease", lambda _name: None)
+    monkeypatch.setattr(supervisor, "_get_session_runtime", lambda _name: None)
     monkeypatch.setattr(
         supervisor,
         "_record_recovery_attempt",
@@ -1664,6 +1757,7 @@ def test_restart_session_hard_failover_emits_account_failover_audit(
         "operator",
         "codex_backup",
         failure_type="auth_broken",
+        force=True,
     )
 
     events = read_events(
@@ -1684,6 +1778,62 @@ def test_restart_session_hard_failover_emits_account_failover_audit(
     assert event.metadata["provider"] == "codex"
     assert event.metadata["reason"] == "recovery_failover"
     assert event.metadata["target_session"] == "operator"
+
+
+def test_restart_session_same_account_failover_emits_suppressed_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.audit.log import (
+        EVENT_ACCOUNT_FAILOVER_SUPPRESSED,
+        read_events,
+    )
+
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = SessionLaunchSpec(
+        session=config.sessions["operator"],
+        account=config.accounts["claude_controller"],
+        window_name="pm-operator",
+        log_path=tmp_path / ".pollypm/logs/operator.log",
+        command="claude",
+    )
+    supervisor.store.upsert_session_runtime(
+        session_name="operator",
+        status="recovering",
+        effective_account="codex_backup",
+        effective_provider="codex",
+    )
+
+    monkeypatch.setattr(
+        supervisor.session_service.tmux,
+        "has_session",
+        lambda _name: False,
+    )
+    monkeypatch.setattr(supervisor, "_launch_by_session", lambda _name: launch)
+    monkeypatch.setattr(supervisor, "launch_session", lambda _name: launch)
+
+    supervisor.restart_session(
+        "operator",
+        "codex_backup",
+        failure_type="auth_broken",
+        force=True,
+    )
+
+    events = read_events(
+        "pollypm",
+        project_path=tmp_path,
+        event=EVENT_ACCOUNT_FAILOVER_SUPPRESSED,
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "warn"
+    assert event.metadata["failure_type"] == "auth_broken"
+    assert event.metadata["from"] == "codex_backup"
+    assert event.metadata["to"] == "codex_backup"
+    assert event.metadata["reason"] == "same_account"
 
 
 def test_auth_broken_without_candidate_emits_failover_blocked_audit(
@@ -1708,6 +1858,7 @@ def test_auth_broken_without_candidate_emits_failover_blocked_audit(
     )
 
     monkeypatch.setattr(supervisor, "_policy_recommendation", lambda *_args: None)
+    monkeypatch.setattr(supervisor, "_get_lease", lambda _name: None)
     monkeypatch.setattr(
         supervisor,
         "_record_recovery_attempt",
@@ -1734,6 +1885,56 @@ def test_auth_broken_without_candidate_emits_failover_blocked_audit(
     assert event.metadata["from"] == "claude_controller"
     assert event.metadata["to"] is None
     assert event.metadata["reason"] == "no_viable_account"
+
+
+def test_rate_limited_account_failover_emits_suppressed_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from pollypm.audit.log import (
+        EVENT_ACCOUNT_FAILOVER_SUPPRESSED,
+        read_events,
+    )
+
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = SessionLaunchSpec(
+        session=config.sessions["operator"],
+        account=config.accounts["claude_controller"],
+        window_name="pm-operator",
+        log_path=tmp_path / ".pollypm/logs/operator.log",
+        command="claude",
+    )
+
+    monkeypatch.setattr(supervisor, "_policy_recommendation", lambda *_args: None)
+    monkeypatch.setattr(supervisor, "_get_lease", lambda _name: None)
+    monkeypatch.setattr(
+        supervisor,
+        "_record_recovery_attempt",
+        lambda *_args, **_kwargs: (False, 6),
+    )
+
+    supervisor.maybe_recover_session(
+        launch,
+        failure_type="capacity_exhausted",
+        failure_message="0% left",
+    )
+
+    events = read_events(
+        "pollypm",
+        project_path=tmp_path,
+        event=EVENT_ACCOUNT_FAILOVER_SUPPRESSED,
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "warn"
+    assert event.metadata["failure_type"] == "capacity_exhausted"
+    assert event.metadata["from"] == "claude_controller"
+    assert event.metadata["to"] is None
+    assert event.metadata["reason"] == "rate_limited"
+    assert event.metadata["attempts"] == 6
 
 
 def test_supervisor_record_heartbeat_routes_through_pg_facade(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Dismiss Codex "Update available" / "Press enter to continue" interstitials before driving `/status`, so usage snapshots can render instead of falling through as unknown.
- Make proactive failover allow an explicitly healthy candidate with unknown usage as a last resort, while still skipping unknown-state candidates.
- Route hard account failover candidate ordering through `capacity.select_failover_account`, sort viable candidates by remaining headroom, and exclude the effective failed account from same-account fallback relaunches.
- Add `account.failover.suppressed` audit events for recovery rate limits and same-account relaunch outcomes.

## Issues
- Fixes #2417
- Fixes #2418
- Fixes #2419
- Fixes #2420
- Fixes #2421

## Tests
- `uv run --extra test pytest tests/test_capacity.py tests/test_provider_sdk.py tests/test_supervisor.py::test_supervisor_failover_prefers_viable_backup tests/test_supervisor.py::test_supervisor_failover_skips_pg_exhausted_account tests/test_supervisor.py::test_supervisor_failover_prefers_highest_headroom_candidate tests/test_supervisor.py::test_restart_session_hard_failover_emits_account_failover_audit tests/test_supervisor.py::test_restart_session_same_account_failover_emits_suppressed_audit tests/test_supervisor.py::test_auth_broken_without_candidate_emits_failover_blocked_audit tests/test_supervisor.py::test_rate_limited_account_failover_emits_suppressed_audit -q`
- `uv run --extra dev ruff check src/pollypm/capacity.py src/pollypm/providers/codex/adapter.py src/pollypm/audit/log.py tests/test_capacity.py tests/test_provider_sdk.py`
- `git diff --check`

Note: a whole-file ruff pass that includes `src/pollypm/supervisor.py` and `tests/test_supervisor.py` still reports pre-existing E402/F401 import-layout findings unrelated to this change.
