### PR TITLE
Reconcile session/window drift from heartbeat sweeps

### DIFF
--- a/src/pollypm/cockpit_pane_reaper.py
+++ b/src/pollypm/cockpit_pane_reaper.py
@@ -242,6 +242,47 @@ def _default_ps_runner() -> str:
 
 
 PsRunner = Callable[[], str]
+TmuxPanePidRunner = Callable[[], str]
+
+
+def _default_tmux_pane_pid_runner() -> str:
+    completed = subprocess.run(
+        ["tmux", "list-panes", "-a", "-F", "#{pane_pid}"],
+        capture_output=True,
+        text=True,
+        timeout=5.0,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            completed.args,
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
+    return completed.stdout
+
+
+def _list_live_tmux_pane_pids(
+    *,
+    tmux_pane_pid_runner: TmuxPanePidRunner | None = None,
+) -> set[int] | None:
+    runner = tmux_pane_pid_runner or _default_tmux_pane_pid_runner
+    try:
+        raw = runner()
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("cockpit_pane_reaper: tmux pane pid probe failed: %s", exc)
+        return None
+    out: set[int] = set()
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.add(int(line))
+        except ValueError:
+            continue
+    return out
 
 
 def _pid_alive(pid: int) -> bool:
@@ -347,8 +388,11 @@ def _emit_audit(
 def reap_orphan_cockpit_panes(
     *,
     ps_runner: PsRunner | None = None,
+    tmux_pane_pid_runner: TmuxPanePidRunner | None = None,
     sleep_fn: Callable[[float], None] = time.sleep,
     current_uid: int | None = None,
+    min_age_s: int | None = None,
+    protect_live_tmux_panes: bool = False,
 ) -> list[ReapedCockpitPane]:
     """Sweep ``ps`` for orphan ``pollypm cockpit-pane`` processes and kill them.
 
@@ -364,14 +408,33 @@ def reap_orphan_cockpit_panes(
         current_uid: override for the ownership-guard UID (#1644).
             Defaults to :func:`os.geteuid`. Tests inject a synthetic
             uid so they can assert on the filter behaviour.
+        min_age_s: when set, skip matching processes whose observed
+            age is unknown or younger than this threshold.
+        protect_live_tmux_panes: when true, first read live tmux pane
+            PIDs and skip any cockpit-pane process that is still the
+            foreground process for a tmux pane. If the tmux probe is
+            unavailable, the sweep fails closed and reaps nothing.
 
     Returns:
         The list of :class:`ReapedCockpitPane` records for processes
         that were signalled, so the caller can log / count.
     """
     procs = _list_cockpit_pane_procs(ps_runner=ps_runner, current_uid=current_uid)
+    live_tmux_pids: set[int] | None = None
+    if protect_live_tmux_panes:
+        live_tmux_pids = _list_live_tmux_pane_pids(
+            tmux_pane_pid_runner=tmux_pane_pid_runner,
+        )
+        if live_tmux_pids is None:
+            return []
     reaped: list[ReapedCockpitPane] = []
     for proc in procs:
+        if min_age_s is not None and (
+            proc.age_s is None or proc.age_s < min_age_s
+        ):
+            continue
+        if live_tmux_pids is not None and proc.pid in live_tmux_pids:
+            continue
         signal_used = _terminate_with_grace(proc.pid, sleep_fn=sleep_fn)
         if signal_used in {"denied", "already_gone"}:
             # ``denied`` — not ours to kill (different user / privileged).

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -4155,6 +4155,14 @@ def check_sessions_table_vs_tmux() -> CheckResult:
     }
     drift = sorted(pollypm_windows - db_windows)
     if drift:
+        plan_windows = _planned_session_window_names()
+        if plan_windows is None:
+            repairable_drift = drift
+            orphan_drift: list[str] = []
+        else:
+            repairable_drift = [window for window in drift if window in plan_windows]
+            orphan_drift = [window for window in drift if window not in plan_windows]
+
         def _fix() -> tuple[bool, str]:
             try:
                 from pollypm.config import DEFAULT_CONFIG_PATH
@@ -4170,6 +4178,24 @@ def check_sessions_table_vs_tmux() -> CheckResult:
                 return (False, f"repair failed: {exc}")
 
         window_word = "window" if len(drift) == 1 else "windows"
+        if repairable_drift:
+            fix = (
+                "Re-run the supervisor session repair —\n"
+                "  pm doctor --fix   # invokes repair_sessions_table()\n"
+                "Or restart the cockpit:  pm up\n"
+                "Recheck: pm doctor"
+            )
+            fixable = True
+            fix_fn = _fix
+        else:
+            fix = (
+                "This drift window is absent from the active launch plan, "
+                "so repair_sessions_table() cannot safely back-fill it. "
+                "Remove the tmux window if it is stale, or restore the "
+                "matching session config and re-run pm doctor."
+            )
+            fixable = False
+            fix_fn = None
         return _fail(
             f"{len(drift)} tmux {window_word} without a sessions row: "
             f"{', '.join(drift[:5])}",
@@ -4179,17 +4205,14 @@ def check_sessions_table_vs_tmux() -> CheckResult:
                 "here means assignment routing will silently miss those "
                 "windows."
             ),
-            fix=(
-                "Re-run the supervisor session repair —\n"
-                "  pm doctor --fix   # invokes repair_sessions_table()\n"
-                "Or restart the cockpit:  pm up\n"
-                "Recheck: pm doctor"
-            ),
+            fix=fix,
             severity="warning",
-            fixable=True,
-            fix_fn=_fix,
+            fixable=fixable,
+            fix_fn=fix_fn,
             data={
                 "drift": drift,
+                "repairable_drift": repairable_drift,
+                "orphan_drift": orphan_drift,
                 "tmux_count": len(tmux_windows),
                 "db_count": len(db_windows),
             },
@@ -4199,6 +4222,20 @@ def check_sessions_table_vs_tmux() -> CheckResult:
         f"sessions table aligned with tmux ({len(db_windows)} {row_word})",
         data={"tmux_count": len(tmux_windows), "db_count": len(db_windows)},
     )
+
+
+def _planned_session_window_names() -> set[str] | None:
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH
+    except Exception:  # noqa: BLE001
+        return None
+    if not DEFAULT_CONFIG_PATH.exists():
+        return None
+    try:
+        supervisor = PollyPMService(DEFAULT_CONFIG_PATH).load_supervisor()
+        return {launch.window_name for launch in supervisor.plan_launches()}
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def check_persona_swap_defense_wired() -> CheckResult:

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -532,6 +533,18 @@ _PROGRESS_SIGNAL_EXEMPT_ROLES: frozenset[str] = frozenset({
 class LocalHeartbeatBackend(HeartbeatBackend):
     name = "local"
     _UNMANAGED_WINDOW_ALERT_PREFIX = "unmanaged_window:"
+    _UNMANAGED_WINDOW_RECONCILE_PREFIXES = (
+        "pm-",
+        "polly",
+        "operator",
+        "reviewer",
+        "worker-",
+        "architect",
+        "planner",
+        "critic-",
+    )
+    _SESSION_REPAIR_MIN_INTERVAL_S = 300.0
+    _last_session_repair_at_by_root: dict[str, float] = {}
     _WORKER_ACTIONABLE_STATUSES = frozenset({"queued", "in_progress", "blocked"})
     _MUTATING_SESSION_ROLES = frozenset(
         {
@@ -596,6 +609,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
     )
 
     def run(self, api, *, snapshot_lines: int = 200):
+        self._maybe_repair_sessions_table(api)
         self._process_unmanaged_windows(api)
         for context in api.list_sessions():
             try:
@@ -774,8 +788,117 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                         subject=window.window_name,
                     ),
                 )
+            if alert_type in existing_alert_types:
+                self._reconcile_persistent_unmanaged_window(
+                    api, window, alert_type=alert_type,
+                )
         for alert_type in existing_alert_types - current_alert_types:
             api.clear_alert("heartbeat", alert_type)
+
+    def _maybe_repair_sessions_table(self, api) -> None:
+        supervisor = getattr(api, "supervisor", None)
+        repair = getattr(supervisor, "repair_sessions_table", None)
+        if not callable(repair):
+            return
+        config = getattr(supervisor, "config", None)
+        project = getattr(config, "project", None)
+        root = str(
+            getattr(project, "root_dir", "")
+            or getattr(project, "base_dir", "")
+            or "default"
+        )
+        now = time.monotonic()
+        last = self._last_session_repair_at_by_root.get(root)
+        if (
+            last is not None
+            and now - last < self._SESSION_REPAIR_MIN_INTERVAL_S
+        ):
+            return
+        self._last_session_repair_at_by_root[root] = now
+        try:
+            repaired = int(repair() or 0)
+        except Exception:  # noqa: BLE001
+            logger.debug("heartbeat: sessions-table repair failed", exc_info=True)
+            return
+        if repaired <= 0:
+            return
+        from pollypm.events.summaries import activity_summary
+
+        row_word = "row" if repaired == 1 else "rows"
+        _emit_routed_event(
+            api,
+            session_name="heartbeat",
+            event_type="session_table_repair",
+            message=activity_summary(
+                summary=f"Repaired {repaired} sessions-table {row_word}",
+                severity="routine",
+                verb="repaired",
+                subject="sessions table",
+                repaired=repaired,
+            ),
+        )
+
+    def _reconcile_persistent_unmanaged_window(
+        self,
+        api,
+        window,
+        *,
+        alert_type: str,
+    ) -> None:
+        window_name = str(getattr(window, "window_name", "") or "")
+        if not any(
+            window_name.startswith(prefix)
+            for prefix in self._UNMANAGED_WINDOW_RECONCILE_PREFIXES
+        ):
+            return
+        if not bool(getattr(window, "pane_dead", False)):
+            return
+        supervisor = getattr(api, "supervisor", None)
+        session_service = getattr(supervisor, "session_service", None)
+        tmux = getattr(session_service, "tmux", None)
+        kill_window = getattr(tmux, "kill_window", None)
+        if not callable(kill_window):
+            return
+        target = str(
+            getattr(window, "pane_id", "")
+            or f"{getattr(window, 'tmux_session', '')}:{window_name}"
+        )
+        if not target:
+            return
+        try:
+            kill_window(target)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "heartbeat: failed to reap unmanaged dead window %s",
+                window_name,
+                exc_info=True,
+            )
+            return
+        message = (
+            f"Reaped unmanaged tmux window {window_name} in session "
+            f"{getattr(window, 'tmux_session', '')} after it stayed pane_dead"
+        )
+        from pollypm.events.summaries import activity_summary
+
+        _emit_routed_event(
+            api,
+            session_name="heartbeat",
+            event_type="unmanaged_window_reaped",
+            message=activity_summary(
+                summary=message,
+                severity="recommendation",
+                verb="reaped",
+                subject=window_name,
+            ),
+        )
+        try:
+            api.clear_alert("heartbeat", alert_type)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "heartbeat: failed to clear unmanaged-window alert %s",
+                alert_type,
+                exc_info=True,
+            )
 
     def _process_session(self, api, context: HeartbeatSessionContext) -> None:
         alerts: list[str] = []

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -1431,6 +1431,22 @@ def cockpit_socket_reap_handler(payload: dict[str, Any]) -> dict[str, Any]:
     return {"reaped": len(reaped)}
 
 
+def cockpit_pane_reap_handler(payload: dict[str, Any]) -> dict[str, Any]:
+    """Reap old cockpit-pane processes that are no longer live tmux panes."""
+    from pollypm.cockpit_pane_reaper import reap_orphan_cockpit_panes
+
+    raw_min_age = payload.get("min_age_s") if isinstance(payload, dict) else None
+    try:
+        min_age_s = int(raw_min_age) if raw_min_age is not None else 300
+    except (TypeError, ValueError):
+        min_age_s = 300
+    reaped = reap_orphan_cockpit_panes(
+        min_age_s=min_age_s,
+        protect_live_tmux_panes=True,
+    )
+    return {"reaped": len(reaped)}
+
+
 def notification_staging_prune_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Drop flushed + silent notification_staging rows older than 30d."""
     from pollypm.work import create_work_service

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -32,6 +32,7 @@ from pollypm.plugins_builtin.core_recurring.maintenance import (
     agent_worktree_prune_handler,
     audit_watchdog_liveness_probe_handler,
     capacity_probe_handler,
+    cockpit_pane_reap_handler,
     cockpit_socket_reap_handler,
     db_vacuum_handler,
     log_rotate_handler,
@@ -460,6 +461,10 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         max_attempts=1, timeout_seconds=60.0,
     )
     api.register_handler(
+        "cockpit_pane.reap", cockpit_pane_reap_handler,
+        max_attempts=1, timeout_seconds=60.0,
+    )
+    api.register_handler(
         "worktree.state_audit", worktree_state_audit_handler,
         max_attempts=1, timeout_seconds=120.0,
     )
@@ -562,6 +567,10 @@ def _register_roster(api: RosterAPI) -> None:
         dedupe_key="cockpit_socket.reap",
     )
     api.register_recurring(
+        "@every 5m", "cockpit_pane.reap", {},
+        dedupe_key="cockpit_pane.reap",
+    )
+    api.register_recurring(
         "@every 10m", "worktree.state_audit", {},
         dedupe_key="worktree.state_audit",
     )
@@ -644,6 +653,7 @@ plugin = PollyPMPlugin(
         Capability(kind="job_handler", name="agent_worktree.prune"),
         Capability(kind="job_handler", name="log.rotate"),
         Capability(kind="job_handler", name="cockpit_socket.reap"),
+        Capability(kind="job_handler", name="cockpit_pane.reap"),
         Capability(kind="job_handler", name="worktree.state_audit"),
         Capability(kind="job_handler", name="stuck_claims.sweep"),
         Capability(kind="job_handler", name="blocked_chain.sweep"),

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -794,6 +794,26 @@ class Supervisor:
         except Exception:  # noqa: BLE001
             _log.debug("Supervisor.start(): pm-usage-* sweep failed", exc_info=True)
 
+        try:
+            from pollypm.cockpit_pane_reaper import reap_orphan_cockpit_panes
+
+            reaped_panes = reap_orphan_cockpit_panes(
+                min_age_s=300,
+                protect_live_tmux_panes=True,
+            )
+            if reaped_panes:
+                pane_word = "pane" if len(reaped_panes) == 1 else "panes"
+                _log.info(
+                    "Supervisor.start(): reaped %d orphan cockpit %s",
+                    len(reaped_panes),
+                    pane_word,
+                )
+        except Exception:  # noqa: BLE001
+            _log.debug(
+                "Supervisor.start(): cockpit-pane reap failed",
+                exc_info=True,
+            )
+
     def stop(self) -> None:
         """Gracefully release Supervisor-owned resources.
 

--- a/tests/test_cockpit_pane_reaper.py
+++ b/tests/test_cockpit_pane_reaper.py
@@ -408,6 +408,77 @@ def test_current_uid_override_filters_to_supplied_uid() -> None:
     assert reaped == []
 
 
+def test_min_age_threshold_preserves_young_pane(
+    sentinel: subprocess.Popen,
+) -> None:
+    ps_runner = _make_ps_runner(
+        [
+            _ps_line(
+                sentinel.pid,
+                "00:01:00",
+                "python -m pollypm cockpit-pane activity",
+            ),
+        ]
+    )
+
+    reaped = reap_orphan_cockpit_panes(
+        ps_runner=ps_runner,
+        min_age_s=300,
+    )
+
+    assert reaped == []
+    assert sentinel.poll() is None
+
+
+def test_live_tmux_pane_pid_protection_preserves_pane(
+    sentinel: subprocess.Popen,
+) -> None:
+    ps_runner = _make_ps_runner(
+        [
+            _ps_line(
+                sentinel.pid,
+                "00:10:00",
+                "python -m pollypm cockpit-pane activity",
+            ),
+        ]
+    )
+
+    reaped = reap_orphan_cockpit_panes(
+        ps_runner=ps_runner,
+        protect_live_tmux_panes=True,
+        tmux_pane_pid_runner=lambda: f"{sentinel.pid}\n",
+    )
+
+    assert reaped == []
+    assert sentinel.poll() is None
+
+
+def test_live_tmux_pane_pid_protection_fails_closed(
+    sentinel: subprocess.Popen,
+) -> None:
+    ps_runner = _make_ps_runner(
+        [
+            _ps_line(
+                sentinel.pid,
+                "00:10:00",
+                "python -m pollypm cockpit-pane activity",
+            ),
+        ]
+    )
+
+    def _tmux_unavailable() -> str:
+        raise OSError("tmux unavailable")
+
+    reaped = reap_orphan_cockpit_panes(
+        ps_runner=ps_runner,
+        protect_live_tmux_panes=True,
+        tmux_pane_pid_runner=_tmux_unavailable,
+    )
+
+    assert reaped == []
+    assert sentinel.poll() is None
+
+
 def test_malformed_uid_column_skips_row() -> None:
     """A row with a non-integer ``uid`` column (e.g. the literal
     ``ps`` header) is dropped — we never signal a row we can't
@@ -438,3 +509,32 @@ def test_pane_process_dataclass_is_frozen() -> None:
     assert proc.pane_kind == "activity"
     with pytest.raises(Exception):  # frozen dataclass → FrozenInstanceError
         proc.pid = 9999  # type: ignore[misc]
+
+
+def test_cockpit_pane_reap_registered_on_roster_every_5m() -> None:
+    from pollypm.heartbeat import Roster
+    from pollypm.heartbeat.roster import EverySchedule
+    from pollypm.plugin_api.v1 import RosterAPI
+    from pollypm.plugins_builtin.core_recurring.plugin import plugin as core_plugin
+
+    roster = Roster()
+    api = RosterAPI(roster, plugin_name="core_recurring")
+    core_plugin.register_roster(api)
+
+    entries = {entry.handler_name: entry for entry in roster.entries}
+    entry = entries.get("cockpit_pane.reap")
+    assert entry is not None, "cockpit_pane.reap missing from roster"
+    assert isinstance(entry.schedule, EverySchedule)
+    assert int(entry.schedule.interval.total_seconds()) == 300
+
+
+def test_cockpit_pane_reap_handler_registered() -> None:
+    from pollypm.jobs import JobHandlerRegistry
+    from pollypm.plugin_api.v1 import JobHandlerAPI
+    from pollypm.plugins_builtin.core_recurring.plugin import plugin as core_plugin
+
+    registry = JobHandlerRegistry()
+    api = JobHandlerAPI(registry, plugin_name="core_recurring")
+    core_plugin.register_handlers(api)
+
+    assert "cockpit_pane.reap" in registry.names()

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -1265,6 +1265,68 @@ def test_local_heartbeat_backend_clears_stale_unmanaged_window_alerts() -> None:
     assert ("heartbeat", "unmanaged_window:pollypm:e2e-sandbox") not in api.alerts
 
 
+def test_local_heartbeat_backend_reaps_persistent_unmanaged_dead_window() -> None:
+    class _Tmux:
+        def __init__(self) -> None:
+            self.killed: list[str] = []
+
+        def kill_window(self, target: str) -> None:
+            self.killed.append(target)
+
+    tmux = _Tmux()
+    api = FakeHeartbeatAPI(
+        [_context()],
+        unmanaged_windows=[
+            HeartbeatUnmanagedWindow(
+                tmux_session="pollypm",
+                window_name="worker-rogue",
+                pane_id="%9",
+                pane_command="zsh",
+                pane_dead=True,
+                pane_path="/workspace/sandbox",
+            )
+        ],
+    )
+    api.supervisor.session_service = SimpleNamespace(tmux=tmux)
+
+    LocalHeartbeatBackend().run(api)
+
+    assert tmux.killed == []
+
+    LocalHeartbeatBackend().run(api)
+
+    assert tmux.killed == ["%9"]
+    assert ("heartbeat", "unmanaged_window:pollypm:worker-rogue") not in api.alerts
+    assert any(
+        event_type == "unmanaged_window_reaped"
+        for _scope, event_type, _message in api.events
+    )
+
+
+def test_local_heartbeat_backend_runs_session_table_repair_on_cadence(
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+    LocalHeartbeatBackend._last_session_repair_at_by_root.clear()
+
+    api = FakeHeartbeatAPI([_context()])
+    api.supervisor.config = SimpleNamespace(
+        project=SimpleNamespace(root_dir=tmp_path, base_dir=tmp_path / ".pollypm"),
+        sessions={},
+        projects={},
+    )
+    api.supervisor.repair_sessions_table = lambda: calls.append("repair") or 2
+
+    LocalHeartbeatBackend().run(api)
+    LocalHeartbeatBackend().run(api)
+
+    assert calls == ["repair"]
+    assert any(
+        event_type == "session_table_repair"
+        for _scope, event_type, _message in api.events
+    )
+
+
 def test_local_heartbeat_backend_marks_stopped_pane_stuck() -> None:
     api = FakeHeartbeatAPI([
         _context(

--- a/tests/test_pg_doctor_enhancements.py
+++ b/tests/test_pg_doctor_enhancements.py
@@ -258,10 +258,40 @@ def test_session_drift_warn(
     monkeypatch.setattr(
         doctor, "_run_cmd", lambda cmd, **kw: (0, "polly:worker-rogue"),
     )
+    monkeypatch.setattr(doctor, "_planned_session_window_names", lambda: set())
     result = doctor.check_sessions_table_vs_tmux()
     assert not result.passed
     assert result.severity == "warning"
     assert "worker-rogue" in result.status
+    assert result.fixable is False
+    assert result.fix_fn is None
+    assert result.data["orphan_drift"] == ["worker-rogue"]
+
+
+def test_session_drift_plan_window_stays_fixable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    db = _make_state_db(tmp_path / "state.db")
+    monkeypatch.setattr(doctor, "_supervisor_state_db", lambda: db)
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: db)
+    monkeypatch.setattr(
+        doctor,
+        "_tool_path",
+        lambda name: "/usr/bin/tmux" if name == "tmux" else None,
+    )
+    monkeypatch.setattr(
+        doctor, "_run_cmd", lambda cmd, **kw: (0, "polly:worker-pollypm"),
+    )
+    monkeypatch.setattr(
+        doctor, "_planned_session_window_names", lambda: {"worker-pollypm"},
+    )
+
+    result = doctor.check_sessions_table_vs_tmux()
+
+    assert not result.passed
+    assert result.fixable is True
+    assert result.fix_fn is not None
+    assert result.data["repairable_drift"] == ["worker-pollypm"]
 
 
 def test_session_drift_skip_without_tmux(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Run the idempotent sessions-table repair from heartbeat on a bounded cadence so mid-lifetime drift can self-heal without waiting for cockpit restart.
- Reconcile persistent unmanaged role-prefixed windows with dead panes by reaping the dead tmux target after the first alert tick.
- Make `pm doctor` stop advertising `--fix` for drift windows absent from the active launch plan.
- Protect cockpit-pane process reaping with age and live tmux pane PID checks, then wire it into bootstrap and the recurring roster.

Addresses #2423.

## Tests
- `uv run --extra test pytest tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_alerts_on_unmanaged_window_once tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_reaps_persistent_unmanaged_dead_window tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_runs_session_table_repair_on_cadence`
- `uv run --extra test pytest tests/test_pg_doctor_enhancements.py::test_session_drift_warn tests/test_pg_doctor_enhancements.py::test_session_drift_plan_window_stays_fixable`
- `uv run --extra test pytest tests/test_cockpit_pane_reaper.py::test_min_age_threshold_preserves_young_pane tests/test_cockpit_pane_reaper.py::test_live_tmux_pane_pid_protection_preserves_pane tests/test_cockpit_pane_reaper.py::test_live_tmux_pane_pid_protection_fails_closed tests/test_cockpit_pane_reaper.py::test_cockpit_pane_reap_registered_on_roster_every_5m tests/test_cockpit_pane_reaper.py::test_cockpit_pane_reap_handler_registered`
- `uv run --extra test pytest tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_reaps_persistent_unmanaged_dead_window tests/test_heartbeat_plugin_api.py::test_local_heartbeat_backend_runs_session_table_repair_on_cadence tests/test_pg_doctor_enhancements.py::test_session_drift_warn tests/test_pg_doctor_enhancements.py::test_session_drift_plan_window_stays_fixable tests/test_cockpit_pane_reaper.py::test_min_age_threshold_preserves_young_pane tests/test_cockpit_pane_reaper.py::test_live_tmux_pane_pid_protection_preserves_pane tests/test_cockpit_pane_reaper.py::test_live_tmux_pane_pid_protection_fails_closed tests/test_cockpit_pane_reaper.py::test_cockpit_pane_reap_registered_on_roster_every_5m tests/test_cockpit_pane_reaper.py::test_cockpit_pane_reap_handler_registered`
- `python -m compileall -q src/pollypm/heartbeats/local.py src/pollypm/doctor.py src/pollypm/cockpit_pane_reaper.py src/pollypm/plugins_builtin/core_recurring/maintenance.py src/pollypm/plugins_builtin/core_recurring/plugin.py src/pollypm/supervisor.py`
- `git diff --check`
