### PR TITLE
Surface human-needed holds to the operator

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -77,6 +77,11 @@ from pollypm.audit.log import (
     EVENT_WORKER_HEARTBEAT,
     AuditEvent,
 )
+from pollypm.operator_holds import (
+    ARCHITECT_ACTIONABLE_TAG,
+    HUMAN_NEEDED_TAG,
+    classify_on_hold_reason,
+)
 
 
 __all__ = [
@@ -278,8 +283,8 @@ TIER_TERMINAL = "terminal"
 # the user; the dispatch path can escalate to user directly when it
 # spots this prefix. The strings are matched case-insensitively against
 # the leading characters of the on_hold transition reason.
-ON_HOLD_ARCHITECT_TAG = "architect-actionable"
-ON_HOLD_HUMAN_NEEDED_TAG = "human-needed"
+ON_HOLD_ARCHITECT_TAG = ARCHITECT_ACTIONABLE_TAG
+ON_HOLD_HUMAN_NEEDED_TAG = HUMAN_NEEDED_TAG
 
 # Throttle window for the dispatch path. We re-fire findings on every
 # tick (the audit log is forensic and operators want repeat counts),
@@ -1255,17 +1260,60 @@ def _classify_on_hold_reason(reason: str | None) -> str:
     sets as the post-mortem default — the architect can always escalate
     upward, but parking on the human is the failure mode.
     """
-    if not reason:
-        return ON_HOLD_ARCHITECT_TAG
-    head = reason.strip().lower()
-    if head.startswith(ON_HOLD_HUMAN_NEEDED_TAG.lower()):
-        return ON_HOLD_HUMAN_NEEDED_TAG
-    # ``[architect-actionable] ...`` and bare ``architect-actionable: ...``
-    # both collapse to the architect default. Anything else also defaults
-    # to architect — the reviewer just didn't tag it.
-    if head.startswith("[" + ON_HOLD_HUMAN_NEEDED_TAG.lower()):
-        return ON_HOLD_HUMAN_NEEDED_TAG
-    return ON_HOLD_ARCHITECT_TAG
+    return classify_on_hold_reason(reason)
+
+
+def _on_hold_stale_finding_copy(
+    *,
+    subject: str,
+    stuck_minutes: int,
+    routing: str,
+) -> tuple[str, str, str]:
+    if routing == ON_HOLD_HUMAN_NEEDED_TAG:
+        return (
+            TIER_3,
+            (
+                f"Ready except for you: task {subject} has been at "
+                f"status=on_hold for ~{stuck_minutes} min waiting on "
+                f"operator input."
+            ),
+            (
+                f"Operator: answer the human-needed hold for {subject}; "
+                "Polly should wait without re-escalating it to the architect."
+            ),
+        )
+    return (
+        TIER_2,
+        (
+            f"Task {subject} has been at status=on_hold for "
+            f"~{stuck_minutes} min - escalating to architect for "
+            f"first-responder unstick."
+        ),
+        (
+            f"Architect: re-read the reviewer's rationale, fix the "
+            f"issue, then `pm task queue {subject}`. Only escalate "
+            f"to user via `pm notify` if the issue genuinely needs "
+            f"human judgement."
+        ),
+    )
+
+
+def _on_hold_stale_evidence(
+    *,
+    subject: str,
+    on_hold_since: str,
+    reason: str | None,
+    routing: str,
+) -> dict[str, Any]:
+    if routing != ON_HOLD_HUMAN_NEEDED_TAG:
+        return {}
+    return {
+        "task": subject,
+        "status": "on_hold",
+        "on_hold_since": on_hold_since,
+        "reason": reason or "",
+        "routing": routing,
+    }
 
 
 def _detect_task_on_hold_stale(
@@ -1313,25 +1361,22 @@ def _detect_task_on_hold_stale(
             routing = _classify_on_hold_reason(
                 reason if isinstance(reason, str) else None,
             )
+            tier, message, recommendation = _on_hold_stale_finding_copy(
+                subject=subject,
+                stuck_minutes=stuck_minutes,
+                routing=routing,
+            )
+            on_hold_since = entry_ts.isoformat()
             seen_subjects.add(subject)
             findings.append(Finding(
                 rule=RULE_TASK_ON_HOLD_STALE,
-                tier=TIER_2,
+                tier=tier,
                 project=project,
                 subject=subject,
-                message=(
-                    f"Task {subject} has been at status=on_hold for "
-                    f"~{stuck_minutes} min — escalating to architect for "
-                    f"first-responder unstick."
-                ),
-                recommendation=(
-                    f"Architect: re-read the reviewer's rationale, fix the "
-                    f"issue, then `pm task queue {subject}`. Only escalate "
-                    f"to user via `pm notify` if the issue genuinely needs "
-                    f"human judgement."
-                ),
+                message=message,
+                recommendation=recommendation,
                 metadata={
-                    "on_hold_since": entry_ts.isoformat(),
+                    "on_hold_since": on_hold_since,
                     "stuck_minutes": stuck_minutes,
                     "from": tr_meta.get("from"),
                     "reason": reason if isinstance(reason, str) else None,
@@ -1339,6 +1384,12 @@ def _detect_task_on_hold_stale(
                     "actor": tr_meta.get("actor"),
                     "detected_via": "state",
                 },
+                evidence=_on_hold_stale_evidence(
+                    subject=subject,
+                    on_hold_since=on_hold_since,
+                    reason=reason if isinstance(reason, str) else None,
+                    routing=routing,
+                ),
             ))
 
     # Event-based fallback path (backward-compat with old fixtures).
@@ -1371,23 +1422,19 @@ def _detect_task_on_hold_stale(
         routing = _classify_on_hold_reason(
             reason if isinstance(reason, str) else None,
         )
+        tier, message, recommendation = _on_hold_stale_finding_copy(
+            subject=subject,
+            stuck_minutes=stuck_minutes,
+            routing=routing,
+        )
         seen_subjects.add(subject)
         findings.append(Finding(
             rule=RULE_TASK_ON_HOLD_STALE,
-            tier=TIER_2,
+            tier=tier,
             project=project,
             subject=subject,
-            message=(
-                f"Task {subject} has been at status=on_hold for "
-                f"~{stuck_minutes} min — escalating to architect for "
-                f"first-responder unstick."
-            ),
-            recommendation=(
-                f"Architect: re-read the reviewer's rationale, fix the "
-                f"issue, then `pm task queue {subject}`. Only escalate "
-                f"to user via `pm notify` if the issue genuinely needs "
-                f"human judgement."
-            ),
+            message=message,
+            recommendation=recommendation,
             metadata={
                 "on_hold_since": ev.ts,
                 "stuck_minutes": stuck_minutes,
@@ -1397,6 +1444,12 @@ def _detect_task_on_hold_stale(
                 "actor": ev.actor,
                 "detected_via": "event",
             },
+            evidence=_on_hold_stale_evidence(
+                subject=subject,
+                on_hold_since=ev.ts,
+                reason=reason if isinstance(reason, str) else None,
+                routing=routing,
+            ),
         ))
     return findings
 

--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -23,6 +23,7 @@ from pollypm.rejection_feedback import (
     feedback_target_task_id,
     is_rejection_feedback_task,
 )
+from pollypm.operator_holds import is_human_needed_hold_reason
 from pollypm.work.inbox_view import inbox_tasks
 from pollypm.work.inbox_plan_reviews import (
     PLAN_APPROVAL_NODE_ID,
@@ -204,6 +205,21 @@ def _is_orphaned_project(project: str, *, known_projects: set[str]) -> bool:
     return project not in known_projects
 
 
+def _hold_reason_for_entry(item: InboxEntry) -> str:
+    for attr in ("hold_reason", "reason"):
+        value = getattr(item, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    transitions = getattr(item, "transitions", None) or []
+    for transition in reversed(list(transitions)):
+        if getattr(transition, "to_state", "") != "on_hold":
+            continue
+        reason = getattr(transition, "reason", None)
+        if isinstance(reason, str) and reason.strip():
+            return reason.strip()
+    return ""
+
+
 def _triage_for_entry(
     item: InboxEntry,
     *,
@@ -237,6 +253,13 @@ def _triage_for_entry(
         return "info", 2, "digest"
     if _OPS_ANOMALY_SUBJECT_RE.search(title_lower):
         return "info", 2, "operations alert"
+    if getattr(item, "source", None) == "task":
+        status_obj = getattr(item, "work_status", None)
+        status = str(getattr(status_obj, "value", status_obj) or "").lower()
+        if status == "on_hold" and is_human_needed_hold_reason(
+            _hold_reason_for_entry(item),
+        ):
+            return "action", 0, "ready except for you"
     matches = [
         rule
         for rule in _TRIAGE_PATTERN_REGISTRY

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -85,6 +85,10 @@ from pollypm.cockpit_inbox_items import (
     message_row_to_inbox_entry,
     task_to_inbox_entry,
 )
+from pollypm.operator_holds import (
+    human_needed_hold_prompt,
+    is_human_needed_hold_reason,
+)
 from pollypm.cockpit_first_shipped import (  # noqa: F401  (re-exported)
     _FIRST_SHIPPED_FRAMES,
     _FirstShippedCelebrationModal,
@@ -13021,6 +13025,33 @@ def _project_hold_failure_summary(data: object) -> str:
     return ""
 
 
+def _project_human_needed_hold(data: object) -> dict | None:
+    buckets = getattr(data, "task_buckets", {}) or {}
+    for item in buckets.get("on_hold", []) or []:
+        if not isinstance(item, dict):
+            continue
+        reason = str(item.get("hold_reason") or "")
+        if is_human_needed_hold_reason(reason):
+            return item
+    return None
+
+
+def _human_needed_hold_banner_prompt(item: dict) -> str:
+    task_label = ""
+    num = item.get("task_number")
+    if num is not None:
+        task_label = f"task #{num}"
+    title = str(item.get("title") or "").strip()
+    if title:
+        task_label = f"{task_label}: {title}" if task_label else title
+    if not task_label:
+        task_label = "a task"
+    prompt = human_needed_hold_prompt(str(item.get("hold_reason") or ""))
+    if prompt:
+        return f"{task_label} needs your input - {prompt}"
+    return f"{task_label} needs your input"
+
+
 def _user_pending_review_count(data: object) -> int:
     """Return the number of review tasks that need a user decision.
 
@@ -15352,8 +15383,15 @@ class PollyProjectDashboardApp(App[None]):
     def _banner_on_hold(self, data: ProjectDashboardData) -> str:
         """Banner for the on-hold lead (outranks active worker)."""
         on_hold_count = int(data.task_counts.get("on_hold", 0))
-        label = "task is" if on_hold_count == 1 else "tasks are"
-        lead = f"Paused: {on_hold_count} {label} on hold"
+        human_needed = _project_human_needed_hold(data)
+        if human_needed is not None:
+            lead = (
+                "Ready except for you: "
+                + _human_needed_hold_banner_prompt(human_needed)
+            )
+        else:
+            label = "task is" if on_hold_count == 1 else "tasks are"
+            lead = f"Paused: {on_hold_count} {label} on hold"
         # Drop the redundant ``N on hold`` from the suffix — same
         # trick the action_items branch above uses for inbox/review
         # overlap. Without this, the banner read "Paused: 1 task

--- a/src/pollypm/operator_holds.py
+++ b/src/pollypm/operator_holds.py
@@ -1,0 +1,55 @@
+"""Shared parsing for operator-owned on-hold task reasons.
+
+Contract:
+- Inputs: free-form task hold reasons, usually from ``Task.transitions``.
+- Outputs: stable routing tags and operator-facing cleaned prompts.
+- Side effects: none.
+- Invariants: the ``human-needed`` prefix is the single source of truth
+  for holds that should wait on the operator instead of re-escalating to
+  an architect.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+ARCHITECT_ACTIONABLE_TAG = "architect-actionable"
+HUMAN_NEEDED_TAG = "human-needed"
+
+_HUMAN_NEEDED_PREFIX_RE = re.compile(
+    r"^\s*(?:\[" + re.escape(HUMAN_NEEDED_TAG) + r"\]|"
+    + re.escape(HUMAN_NEEDED_TAG) + r")\s*[:\]-]?\s*",
+    re.IGNORECASE,
+)
+
+
+def classify_on_hold_reason(reason: str | None) -> str:
+    """Return the routing tag implied by an ``on_hold`` reason."""
+    if is_human_needed_hold_reason(reason):
+        return HUMAN_NEEDED_TAG
+    return ARCHITECT_ACTIONABLE_TAG
+
+
+def is_human_needed_hold_reason(reason: str | None) -> bool:
+    """True when ``reason`` starts with the reserved human-needed tag."""
+    if not reason:
+        return False
+    return _HUMAN_NEEDED_PREFIX_RE.match(reason) is not None
+
+
+def human_needed_hold_prompt(reason: str | None) -> str:
+    """Strip routing syntax and return the operator-facing ask."""
+    if not reason:
+        return ""
+    cleaned = _HUMAN_NEEDED_PREFIX_RE.sub("", reason, count=1)
+    return " ".join(part.strip() for part in cleaned.splitlines() if part.strip())
+
+
+__all__ = [
+    "ARCHITECT_ACTIONABLE_TAG",
+    "HUMAN_NEEDED_TAG",
+    "classify_on_hold_reason",
+    "human_needed_hold_prompt",
+    "is_human_needed_hold_reason",
+]

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -54,6 +54,7 @@ from pollypm.audit.watchdog import (
     RULE_TASK_PROGRESS_STALE,
     RULE_TASK_REVIEW_STALE,
     RULE_WORKER_SESSION_DEAD_LOOP,
+    TIER_3,
     WATCHDOG_ALERT_TYPE,
     WatchdogConfig,
     dispatch_dedup_hash,
@@ -69,6 +70,7 @@ from pollypm.audit.watchdog import (
     was_recently_operator_dispatched,
     watchdog_alert_session_name,
 )
+from pollypm.operator_holds import HUMAN_NEEDED_TAG
 
 
 @dataclass(slots=True, frozen=True)
@@ -1991,6 +1993,35 @@ def _operator_dedup_key(
     return f"watchdog-operator:{rule}:{project}:{safe_subject}"
 
 
+def _is_human_needed_on_hold_finding(finding: Finding) -> bool:
+    meta = finding.metadata or {}
+    return (
+        finding.rule == RULE_TASK_ON_HOLD_STALE
+        and str(meta.get("routing") or "") == HUMAN_NEEDED_TAG
+    )
+
+
+def _operator_dispatch_throttle_seconds(finding: Finding) -> int:
+    if _is_human_needed_on_hold_finding(finding):
+        # Human-needed holds should create one operator ask and then
+        # wait. Use the audit log as the durable "already asked" record.
+        return 10 * 365 * 24 * 60 * 60
+    return OPERATOR_DISPATCH_THROTTLE_SECONDS
+
+
+def _operator_dispatch_question(finding: Finding) -> str:
+    if _is_human_needed_on_hold_finding(finding):
+        subject = finding.subject or "the held task"
+        return (
+            f"{subject} is ready except for operator input. What should "
+            "Polly do next?"
+        )
+    return (
+        f"Project {finding.project} is wedged in a way the architect "
+        f"can't unstick. What structural change do you want to apply?"
+    )
+
+
 def _maybe_dispatch_to_operator(
     finding: Finding,
     *,
@@ -2015,7 +2046,7 @@ def _maybe_dispatch_to_operator(
     * ``"dispatched"`` — inbox row + audit event written.
     * ``"send_failed"`` — emit ran, inbox write raised.
     """
-    if finding.rule not in _OPERATOR_DISPATCHABLE_RULES:
+    if finding.rule not in _OPERATOR_DISPATCHABLE_RULES and finding.tier != TIER_3:
         return "skipped"
     # #2015 — throttle on the subject-independent finding-body hash so
     # the same root-cause across sibling subjects collapses to one
@@ -2027,7 +2058,7 @@ def _maybe_dispatch_to_operator(
         subject=finding.subject,
         now=now,
         project_path=project_path,
-        throttle_seconds=OPERATOR_DISPATCH_THROTTLE_SECONDS,
+        throttle_seconds=_operator_dispatch_throttle_seconds(finding),
         dedup_hash=dedup_hash,
     ):
         return "throttled"
@@ -2035,10 +2066,7 @@ def _maybe_dispatch_to_operator(
     # Build the body via the structured-evidence helper. We hand the
     # finding's evidence dict and a single decision-shaped question;
     # the helper refuses any solution-menu shape.
-    question = (
-        f"Project {finding.project} is wedged in a way the architect "
-        f"can't unstick. What structural change do you want to apply?"
-    )
+    question = _operator_dispatch_question(finding)
     try:
         body = tier_handoff_prompt(finding.evidence or {}, question)
     except Exception:  # noqa: BLE001
@@ -3409,14 +3437,28 @@ def _route_one_finding(
     # #1553 — auto-promote: if the same root_cause_hash has hit
     # tier-3 K times in 24h, route to tier-4 instead. The tracker
     # is best-effort — failures fall back to tier-3 unchanged.
-    if finding.rule in _OPERATOR_DISPATCHABLE_RULES:
-        _dispatch_operator_or_tier4(
-            finding,
-            project_path=project_path,
-            now=now,
-            config_path=config_path,
-            counters=counters,
-        )
+    if finding.rule in _OPERATOR_DISPATCHABLE_RULES or finding.tier == TIER_3:
+        if _is_human_needed_on_hold_finding(finding):
+            op_outcome = _maybe_dispatch_to_operator(
+                finding,
+                project_path=project_path,
+                now=now,
+                config_path=config_path,
+            )
+            if op_outcome == "dispatched":
+                counters["operator_dispatches_sent"] += 1
+            elif op_outcome == "throttled":
+                counters["operator_dispatches_throttled"] += 1
+            elif op_outcome == "send_failed":
+                counters["operator_dispatches_failed"] += 1
+        else:
+            _dispatch_operator_or_tier4(
+                finding,
+                project_path=project_path,
+                now=now,
+                config_path=config_path,
+                counters=counters,
+            )
         return
 
     # #1414 — eligible findings get an architect dispatch on top

--- a/src/pollypm/recovery_actions.py
+++ b/src/pollypm/recovery_actions.py
@@ -39,6 +39,11 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
+from pollypm.operator_holds import (
+    human_needed_hold_prompt,
+    is_human_needed_hold_reason,
+)
+
 
 @dataclass(frozen=True)
 class RecoveryAction:
@@ -322,6 +327,27 @@ def _action_permission_prompt(reason: str, task_label: str) -> RecoveryAction | 
     )
 
 
+def _action_human_needed(reason: str, task_label: str) -> RecoveryAction | None:
+    if not is_human_needed_hold_reason(reason):
+        return None
+    prompt = human_needed_hold_prompt(reason)
+    detail = (
+        f"Operator input needed: {prompt}."
+        if prompt
+        else "Operator input needed before Polly can continue."
+    )
+    return RecoveryAction(
+        title=f"Recovery action for {task_label} - operator input",
+        detail=detail,
+        cli_steps=[
+            f"pm task get {task_label}",
+            "# provide the requested input, credentials, or decision",
+            f"pm task resume {task_label}",
+        ],
+        keybinding="R",
+    )
+
+
 def _action_generic(task_label: str, status: str) -> RecoveryAction:
     """Fall-through affordance.
 
@@ -357,6 +383,7 @@ _DISPATCH = (
     _action_auto_merge,
     _action_blocked_dep,
     _action_permission_prompt,
+    _action_human_needed,
     _action_operator_decision,
 )
 

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -2046,6 +2046,7 @@ def test_task_on_hold_stale_human_needed_routing(now: datetime) -> None:
     from pollypm.audit.watchdog import (
         ON_HOLD_HUMAN_NEEDED_TAG,
         RULE_TASK_ON_HOLD_STALE,
+        TIER_3,
     )
 
     events = [
@@ -2065,6 +2066,9 @@ def test_task_on_hold_stale_human_needed_routing(now: datetime) -> None:
     matched = [f for f in findings if f.rule == RULE_TASK_ON_HOLD_STALE]
     assert len(matched) == 1
     assert matched[0].metadata["routing"] == ON_HOLD_HUMAN_NEEDED_TAG
+    assert matched[0].tier == TIER_3
+    assert "Ready except for you" in matched[0].message
+    assert matched[0].evidence["reason"].startswith("[human-needed]")
 
 
 def test_format_unstick_brief_on_hold_includes_evidence_and_default() -> None:
@@ -2342,6 +2346,80 @@ def test_cadence_handler_throttles_on_hold_repeat_dispatch(
     assert second["dispatches_sent"] == 0
     assert second["dispatches_throttled"] == 1
     assert len(sent) == 1
+
+
+def test_cadence_handler_routes_human_needed_on_hold_to_operator_once(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Human-needed holds create one operator ask and never ping architect."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    class FakeStatus:
+        value = "on_hold"
+
+    class FakeTransition:
+        to_state = "on_hold"
+        from_state = "review"
+        actor = "russell"
+        timestamp = now - timedelta(hours=3)
+        reason = "[human-needed] external credentials only S.E. can supply"
+
+    class FakeTask:
+        project = "savethenovel"
+        task_number = 94
+        work_status = FakeStatus()
+        transitions = [FakeTransition()]
+        updated_at = now - timedelta(hours=3)
+
+    architect_sent: list[str] = []
+    operator_sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        lambda target, brief: architect_sent.append(brief) or True,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._create_operator_inbox_task",
+        lambda **kw: operator_sent.append((kw["subject"], kw["body"])) or "savethenovel/249",
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [FakeTask()],
+    )
+
+    store = _RecordingStore()
+    first = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+    second = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now + timedelta(hours=2),
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert first["dispatches_sent"] == 0
+    assert first["operator_dispatches_sent"] == 1
+    assert second["operator_dispatches_sent"] == 0
+    assert second["operator_dispatches_throttled"] == 1
+    assert architect_sent == []
+    assert len(operator_sent) == 1
+    assert "Ready except for you" in operator_sent[0][0]
+    assert "external credentials" in operator_sent[0][1]
 
 
 def test_classify_on_hold_reason_defaults_to_architect() -> None:

--- a/tests/test_operator_holds.py
+++ b/tests/test_operator_holds.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pollypm.cockpit_inbox_items import InboxEntry, _triage_for_entry
+from pollypm.cockpit_ui import PollyProjectDashboardApp
+from pollypm.operator_holds import (
+    ARCHITECT_ACTIONABLE_TAG,
+    HUMAN_NEEDED_TAG,
+    classify_on_hold_reason,
+    human_needed_hold_prompt,
+)
+
+
+def test_human_needed_hold_parser_strips_routing_prefix() -> None:
+    reason = "[human-needed] external credentials only S.E. can supply"
+
+    assert classify_on_hold_reason(reason) == HUMAN_NEEDED_TAG
+    assert human_needed_hold_prompt(reason) == (
+        "external credentials only S.E. can supply"
+    )
+    assert classify_on_hold_reason("plain reviewer issue") == (
+        ARCHITECT_ACTIONABLE_TAG
+    )
+
+
+def test_human_needed_on_hold_task_triages_as_operator_action() -> None:
+    class Status:
+        value = "on_hold"
+
+    class Transition:
+        to_state = "on_hold"
+        reason = "human-needed: provide the production deploy token"
+
+    item = InboxEntry(
+        source="task",
+        project="savethenovel",
+        title="Deploy ready",
+        description="",
+        work_status=Status(),
+        transitions=[Transition()],
+    )
+
+    assert _triage_for_entry(item, known_projects={"savethenovel"}) == (
+        "action",
+        0,
+        "ready except for you",
+    )
+
+
+def test_project_banner_names_ready_except_for_you_hold() -> None:
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    data = SimpleNamespace(
+        task_counts={"on_hold": 1},
+        task_buckets={
+            "on_hold": [
+                {
+                    "task_number": 94,
+                    "title": "Deploy smoke test",
+                    "hold_reason": (
+                        "[human-needed] external credentials only S.E. can supply"
+                    ),
+                }
+            ],
+            "review": [],
+        },
+        alert_count=0,
+        active_worker=None,
+    )
+
+    banner = app._banner_on_hold(data)
+
+    assert banner.startswith("Ready except for you:")
+    assert "task #94: Deploy smoke test needs your input" in banner
+    assert "external credentials only S.E. can supply" in banner

--- a/tests/test_recovery_actions.py
+++ b/tests/test_recovery_actions.py
@@ -136,6 +136,20 @@ def test_auto_merge_refused_routes_to_retry_action() -> None:
     assert any("--retry" in step for step in action.cli_steps)
 
 
+def test_human_needed_hold_routes_to_operator_input_action() -> None:
+    proxy = _proxy(
+        status="on_hold",
+        reason="[human-needed] external credentials only S.E. can supply",
+    )
+
+    action = recovery_action_for(proxy)
+
+    assert action is not None
+    assert "operator input" in action.title
+    assert "external credentials only S.E. can supply" in action.detail
+    assert action.cli_steps[-1] == "pm task resume demo/1"
+
+
 def test_blocked_dep_routes_to_unblock_dep_first() -> None:
     proxy = _proxy(
         status="blocked",


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a shared `human-needed` hold parser so watchdog, inbox, dashboard, and recovery hints use the same routing contract.
- Route stale `[human-needed]` on-hold tasks to tier-3 operator dispatch instead of architect dispatch, with durable single-ask throttling.
- Surface human-needed holds as `Ready except for you` in the project banner and inbox triage, and provide a concrete recovery action.

## Verification
- `uv run --extra test pytest tests/test_audit_watchdog.py::test_task_on_hold_stale_human_needed_routing tests/test_audit_watchdog.py::test_cadence_handler_routes_human_needed_on_hold_to_operator_once tests/test_operator_holds.py tests/test_recovery_actions.py::test_human_needed_hold_routes_to_operator_input_action -q`
- `uv run --extra test pytest tests/test_audit_watchdog.py::test_task_on_hold_stale_fires_after_threshold tests/test_audit_watchdog.py::test_task_on_hold_stale_human_needed_routing tests/test_audit_watchdog.py::test_cadence_handler_throttles_on_hold_repeat_dispatch tests/test_audit_watchdog.py::test_cadence_handler_routes_human_needed_on_hold_to_operator_once tests/test_audit_watchdog.py::test_classify_on_hold_reason_defaults_to_architect tests/test_operator_holds.py tests/test_recovery_actions.py -q`
- `python -m compileall -q src/pollypm/operator_holds.py src/pollypm/audit/watchdog.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py src/pollypm/cockpit_inbox_items.py src/pollypm/cockpit_ui.py src/pollypm/recovery_actions.py tests/test_operator_holds.py tests/test_audit_watchdog.py tests/test_recovery_actions.py && git diff --check`
- `uv run --extra dev ruff check src/pollypm/operator_holds.py tests/test_operator_holds.py src/pollypm/recovery_actions.py tests/test_recovery_actions.py src/pollypm/audit/watchdog.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py tests/test_audit_watchdog.py`

Full changed-file ruff still hits pre-existing `cockpit_ui.py` E402/unused-symbol debt and pre-existing unused imports in `cockpit_inbox_items.py`; the narrower ruff command above covers the new parser, watchdog dispatch code, and tests that are clean under current lint.

Fixes #2426