### PR TITLE
Fix task-flow churn and unspawnable auto-claims

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -90,11 +90,13 @@ __all__ = [
     "RULE_MARKER_LEAKED",
     "RULE_STUCK_DRAFT",
     "RULE_CANCEL_NO_PROMOTION",
+    "RULE_CANCELLATION_CHURN",
     "RULE_TASK_REVIEW_STALE",
     "RULE_TASK_PROGRESS_STALE",
     "RULE_ROLE_SESSION_MISSING",
     "RULE_WORKER_SESSION_DEAD_LOOP",
     "RULE_TASK_ON_HOLD_STALE",
+    "RULE_TASK_REWORK_STALE",
     "RULE_DUPLICATE_ADVISOR_TASKS",
     "RULE_PLAN_REVIEW_MISSING",
     "RULE_PLAN_REVIEW_BYPASSED_APPROVAL",
@@ -142,6 +144,7 @@ RULE_ORPHAN_MARKER = "orphan_marker"
 RULE_MARKER_LEAKED = "marker_leaked"
 RULE_STUCK_DRAFT = "stuck_draft"
 RULE_CANCEL_NO_PROMOTION = "cancellation_no_promotion"
+RULE_CANCELLATION_CHURN = "cancellation_churn"
 # #1414 — auto-unstick rules. ``task_review_stale`` catches a task
 # parked at status=review with no transitions for a while; that's the
 # savethenovel/10 pattern (reviewer agent never spawned). The other
@@ -160,6 +163,7 @@ RULE_WORKER_SESSION_DEAD_LOOP = "worker_session_dead_loop"
 # reviewer's findings and either fixes them or, if the issue genuinely
 # requires human judgement, calls ``pm notify`` itself.
 RULE_TASK_ON_HOLD_STALE = "task_on_hold_stale"
+RULE_TASK_REWORK_STALE = "task_rework_stale"
 # #1510 — duplicate_advisor_tasks catches a pile-up of non-terminal
 # advisor-labeled tasks for the same project. The advisor.tick handler
 # is supposed to enqueue at most one ``advisor_review`` per project at
@@ -373,6 +377,11 @@ class WatchdogConfig:
     # queue the replacement. If no ``task.created`` for the same
     # project lands in that window, fire the finding.
     cancel_grace_seconds: int = 300
+    # Cancellation churn is counted independently from replacement
+    # creates. Recreate loops can be "healthy" for
+    # cancellation_no_promotion but still pathological at volume.
+    cancel_churn_window_seconds: int = 1800
+    cancel_churn_threshold: int = 5
     # #1414 — task_review_stale: a task at status=review must have its
     # most recent transition older than this before we fire. 30 min
     # mirrors the savethenovel/10 case (reviewer agent never spawned).
@@ -390,6 +399,10 @@ class WatchdogConfig:
     # parks task), not a sustained state. Anything longer than the
     # cadence-tick stride means a human is now load-bearing.
     on_hold_stale_seconds: int = 900
+    # Rework consumes worker capacity but does not spawn a fresh worker
+    # on reject. A markerless rework task older than this is escalated
+    # like other stale machine-owned states.
+    rework_stale_seconds: int = 1200
     # #1414 — worker_session_dead_loop: how many reaper events for the
     # same task within ``dead_loop_window_seconds`` count as a loop.
     dead_loop_threshold: int = 3
@@ -1029,44 +1042,125 @@ def _detect_cancellation_no_promotion(
             if to_state == "cancelled" and ts >= window_start and ts <= grace_cutoff:
                 cancellations.append((ev, ts))
 
+    for values in created_by_project.values():
+        values.sort()
+    cancellations_by_project: dict[str, list[tuple[AuditEvent, datetime]]] = {}
     for ev, ts in cancellations:
-        creates = created_by_project.get(ev.project, [])
-        # Was there *any* task.created for this project after the
-        # cancellation? Even one means Polly kept the queue moving.
-        followed = any(c > ts for c in creates)
-        if followed:
+        cancellations_by_project.setdefault(ev.project, []).append((ev, ts))
+
+    for project, project_cancellations in cancellations_by_project.items():
+        project_cancellations.sort(key=lambda item: item[1])
+        creates = created_by_project.get(project, [])
+        create_index = 0
+        for ev, ts in project_cancellations:
+            while create_index < len(creates) and creates[create_index] <= ts:
+                create_index += 1
+            if create_index < len(creates):
+                create_index += 1
+                continue
+            findings.append(Finding(
+                rule=RULE_CANCEL_NO_PROMOTION,
+                tier=TIER_2,
+                project=ev.project,
+                subject=ev.subject,
+                message=(
+                    f"Task {ev.subject} was cancelled at {ev.ts} but no "
+                    f"replacement task.created landed in the next "
+                    f"{config.cancel_grace_seconds // 60} min. The "
+                    f"planning queue may have stalled."
+                ),
+                recommendation=(
+                    f"Open the project drilldown and check Polly's "
+                    f"planning state, or run `pm chat {ev.project}` and "
+                    f"prompt 'what's next?' to nudge the queue."
+                ),
+                metadata={
+                    "cancelled_at": ev.ts,
+                    "actor": ev.actor,
+                    "from": (ev.metadata or {}).get("from"),
+                    "detected_via": "event",
+                },
+                evidence={
+                    "cancelled_task_id": ev.subject,
+                    "cancelled_at": ev.ts,
+                    "from": (ev.metadata or {}).get("from"),
+                    "actor": ev.actor,
+                    "replacement_task_created": False,
+                    "required_decision": (
+                        "queue_replacement_or_mark_project_intentionally_parked"
+                    ),
+                },
+            ))
+    return findings
+
+
+def _detect_cancellation_churn(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[Finding]:
+    """Detect high cancellation volume even when recreates keep landing."""
+    threshold = max(1, int(config.cancel_churn_threshold))
+    window_seconds = max(1, int(config.cancel_churn_window_seconds))
+    cutoff = now - timedelta(seconds=window_seconds)
+    by_project: dict[str, list[tuple[datetime, AuditEvent]]] = {}
+    for ev in events:
+        if ev.event != EVENT_TASK_STATUS_CHANGED:
             continue
+        meta = ev.metadata or {}
+        if meta.get("to") != "cancelled":
+            continue
+        ts = _parse_iso(ev.ts)
+        if ts is None or ts < cutoff:
+            continue
+        key = _task_subject_key(ev.subject)
+        project = ev.project or (key[0] if key is not None else "")
+        if not project:
+            continue
+        by_project.setdefault(project, []).append((ts, ev))
+
+    findings: list[Finding] = []
+    for project, hits in by_project.items():
+        if len(hits) < threshold:
+            continue
+        hits.sort(key=lambda item: item[0])
+        subjects = [ev.subject for _, ev in hits if ev.subject]
+        first_ts = hits[0][0]
+        latest_ts = hits[-1][0]
         findings.append(Finding(
-            rule=RULE_CANCEL_NO_PROMOTION,
+            rule=RULE_CANCELLATION_CHURN,
             tier=TIER_2,
-            project=ev.project,
-            subject=ev.subject,
+            project=project,
+            subject=project,
             message=(
-                f"Task {ev.subject} was cancelled at {ev.ts} but no "
-                f"replacement task.created landed in the next "
-                f"{config.cancel_grace_seconds // 60} min. The "
-                f"planning queue may have stalled."
+                f"Project {project} cancelled {len(hits)} tasks in the last "
+                f"{window_seconds // 60} min. Replacement creates do not "
+                f"clear this volume signal."
             ),
             recommendation=(
-                f"Open the project drilldown and check Polly's "
-                f"planning state, or run `pm chat {ev.project}` and "
-                f"prompt 'what's next?' to nudge the queue."
+                "Architect: inspect the cancellation loop and stop using "
+                "cancel-and-recreate as the default unstick path. Preserve "
+                "in-flight work where possible and choose reassign/resume "
+                "before discarding task state."
             ),
             metadata={
-                "cancelled_at": ev.ts,
-                "actor": ev.actor,
-                "from": (ev.metadata or {}).get("from"),
+                "cancel_count": len(hits),
+                "threshold": threshold,
+                "window_seconds": window_seconds,
+                "first_cancelled_at": first_ts.isoformat(),
+                "latest_cancelled_at": latest_ts.isoformat(),
+                "cancelled_subjects": subjects[:20],
                 "detected_via": "event",
             },
             evidence={
-                "cancelled_task_id": ev.subject,
-                "cancelled_at": ev.ts,
-                "from": (ev.metadata or {}).get("from"),
-                "actor": ev.actor,
-                "replacement_task_created": False,
-                "required_decision": (
-                    "queue_replacement_or_mark_project_intentionally_parked"
-                ),
+                "cancel_count": len(hits),
+                "threshold": threshold,
+                "window_seconds": window_seconds,
+                "cancelled_subjects": subjects[:50],
+                "first_cancelled_at": first_ts.isoformat(),
+                "latest_cancelled_at": latest_ts.isoformat(),
+                "required_decision": "stop_cancel_recreate_loop",
             },
         ))
     return findings
@@ -1401,6 +1495,111 @@ def _detect_task_on_hold_stale(
     return findings
 
 
+def _detect_task_rework_stale(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+    open_tasks: Sequence[Any] | None = None,
+) -> list[Finding]:
+    """Detect tasks parked in ``rework`` with no fresh claim or transition."""
+    findings: list[Finding] = []
+    seen_subjects: set[str] = set()
+    cutoff = now - timedelta(seconds=config.rework_stale_seconds)
+
+    if open_tasks:
+        for task in open_tasks:
+            status = getattr(task, "work_status", None)
+            status_value = getattr(status, "value", status)
+            if status_value != "rework":
+                continue
+            project = getattr(task, "project", "") or ""
+            task_number = getattr(task, "task_number", None)
+            if not project or task_number is None:
+                continue
+            subject = f"{project}/{task_number}"
+            entry_ts, tr_meta = _state_entry_time(task, "rework")
+            if entry_ts is None or entry_ts > cutoff:
+                continue
+            stuck_minutes = max(1, int((now - entry_ts).total_seconds() // 60))
+            seen_subjects.add(subject)
+            findings.append(Finding(
+                rule=RULE_TASK_REWORK_STALE,
+                tier=TIER_2,
+                project=project,
+                subject=subject,
+                message=(
+                    f"Task {subject} has been at status=rework for "
+                    f"~{stuck_minutes} min with no fresh claim or transition."
+                ),
+                recommendation=(
+                    f"Architect: inspect the rejected work for {subject}, "
+                    "then requeue, reassign, or resume it. Cancel only if "
+                    "the partial work should be intentionally abandoned."
+                ),
+                metadata={
+                    "rework_since": entry_ts.isoformat(),
+                    "stuck_minutes": stuck_minutes,
+                    "from": tr_meta.get("from"),
+                    "actor": tr_meta.get("actor"),
+                    "reason": tr_meta.get("reason"),
+                    "assignee": getattr(task, "assignee", None),
+                    "current_node_id": getattr(task, "current_node_id", None),
+                    "detected_via": "state",
+                },
+            ))
+
+    latest: dict[str, tuple[datetime, AuditEvent]] = {}
+    for ev in events:
+        if ev.event != EVENT_TASK_STATUS_CHANGED:
+            continue
+        ts = _parse_iso(ev.ts)
+        if ts is None:
+            continue
+        prior = latest.get(ev.subject)
+        if prior is None or ts > prior[0]:
+            latest[ev.subject] = (ts, ev)
+
+    for subject, (ts, ev) in latest.items():
+        if subject in seen_subjects:
+            continue
+        meta = ev.metadata or {}
+        if meta.get("to") != "rework":
+            continue
+        if ts > cutoff:
+            continue
+        key = _task_subject_key(subject)
+        if key is None:
+            continue
+        project, _ = key
+        stuck_minutes = max(1, int((now - ts).total_seconds() // 60))
+        seen_subjects.add(subject)
+        findings.append(Finding(
+            rule=RULE_TASK_REWORK_STALE,
+            tier=TIER_2,
+            project=project,
+            subject=subject,
+            message=(
+                f"Task {subject} has been at status=rework for "
+                f"~{stuck_minutes} min with no fresh claim or transition."
+            ),
+            recommendation=(
+                f"Architect: inspect the rejected work for {subject}, "
+                "then requeue, reassign, or resume it. Cancel only if "
+                "the partial work should be intentionally abandoned."
+            ),
+            metadata={
+                "rework_since": ev.ts,
+                "stuck_minutes": stuck_minutes,
+                "from": meta.get("from"),
+                "actor": ev.actor,
+                "reason": meta.get("reason"),
+                "detected_via": "event",
+            },
+        ))
+    return findings
+
+
 def _latest_worker_heartbeat_time(
     events: Sequence[AuditEvent],
     *,
@@ -1517,8 +1716,9 @@ def _detect_task_progress_stale(
                 ),
                 recommendation=(
                     f"Architect: inspect the worker for {subject}; check "
-                    f"auth, sandbox, and worker logic, then reassign, "
-                    f"resume, or cancel the task."
+                    f"auth, sandbox, and worker logic, then reassign or "
+                    f"resume the task. Cancel only if the partial work "
+                    f"should be intentionally abandoned."
                 ),
                 metadata={
                     "in_progress_since": entry_ts.isoformat(),
@@ -1584,8 +1784,9 @@ def _detect_task_progress_stale(
             ),
             recommendation=(
                 f"Architect: inspect the worker for {subject}; check "
-                f"auth, sandbox, and worker logic, then reassign, "
-                f"resume, or cancel the task."
+                f"auth, sandbox, and worker logic, then reassign or "
+                f"resume the task. Cancel only if the partial work "
+                f"should be intentionally abandoned."
             ),
             metadata={
                 "in_progress_since": ev.ts,
@@ -1807,9 +2008,9 @@ def _detect_worker_session_dead_loop(
                 f"reaper is firing in a loop."
             ),
             recommendation=(
-                f"Inspect the task and decide whether to cancel "
-                f"(`pm task cancel {subject}`), reassign, or fix the "
-                f"underlying spawn failure."
+                "Inspect the task, fix the underlying spawn failure, "
+                "then reassign or resume it. Cancel only if the partial "
+                "work should be intentionally abandoned."
             ),
             metadata={
                 "reap_count": len(hits),
@@ -3043,10 +3244,16 @@ def scan_events(
     findings.extend(_detect_cancellation_no_promotion(
         materialised, now=now, config=config,
     ))
+    findings.extend(_detect_cancellation_churn(
+        materialised, now=now, config=config,
+    ))
     findings.extend(_detect_task_review_stale(
         materialised, now=now, config=config, open_tasks=open_tasks,
     ))
     findings.extend(_detect_task_on_hold_stale(
+        materialised, now=now, config=config, open_tasks=open_tasks,
+    ))
+    findings.extend(_detect_task_rework_stale(
         materialised, now=now, config=config, open_tasks=open_tasks,
     ))
     findings.extend(_detect_task_progress_stale(
@@ -4124,8 +4331,52 @@ def _brief_task_progress_stale(
         "evidence rather than ratifying any framing in this brief."
     )
     lines.append(
-        f"Cli levers available: `pm task cancel {subject}`, "
-        "`pm chat <project>`, `pm notify`."
+        f"Cli levers available: `pm chat <project>`, `pm notify`; "
+        f"use `pm task cancel {subject}` only after preserving or "
+        "intentionally abandoning partial work."
+    )
+    return lines
+
+
+def _brief_task_rework_stale(
+    finding: Finding,
+    subject: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``task_rework_stale``."""
+    stuck_minutes = meta.get("stuck_minutes")
+    rework_since = meta.get("rework_since")
+    from_state = meta.get("from") or "<unknown>"
+    reason = meta.get("reason") or ""
+    assignee = meta.get("assignee") or "<unknown>"
+    node = meta.get("current_node_id") or "<unknown>"
+    lines: list[str] = []
+    lines.append(
+        f"Stuck for: {stuck_minutes} minutes in rework"
+        if stuck_minutes else "Stuck for: unknown duration"
+    )
+    lines.append("Observed evidence:")
+    if rework_since:
+        lines.append(
+            f"- Task transitioned {from_state} -> rework at {rework_since}"
+        )
+    if reason:
+        lines.append(f"- Rework reason: {str(reason).splitlines()[0][:240]}")
+    lines.append(f"- Assignee: {assignee}; node: {node}")
+    lines.append(
+        "- Rework consumes worker capacity but no fresh worker session is "
+        "guaranteed after a markerless reject."
+    )
+    lines.append("")
+    lines.append(
+        "Your job: inspect the rejected work and create a concrete next "
+        "state. Prefer requeue, reassign, or resume so partial work is "
+        "preserved."
+    )
+    lines.append(
+        f"Cli levers available: `pm task queue {subject}`, "
+        f"`pm chat <project>`, `pm notify`; use `pm task cancel {subject}` "
+        "only if the partial work should be discarded."
     )
     return lines
 
@@ -4162,6 +4413,43 @@ def _brief_cancellation_no_promotion(
     lines.append(
         "Cli levers available: create and queue replacement work with "
         "`pm task create ...` then `pm task queue <replacement-task-id>`."
+    )
+    return lines
+
+
+def _brief_cancellation_churn(
+    finding: Finding,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``cancellation_churn``."""
+    cancel_count = meta.get("cancel_count") or "?"
+    threshold = meta.get("threshold") or "?"
+    window_seconds = meta.get("window_seconds") or 0
+    latest = meta.get("latest_cancelled_at") or "<unknown>"
+    subjects = meta.get("cancelled_subjects") or []
+    try:
+        window_minutes = max(1, int(window_seconds) // 60)
+    except (TypeError, ValueError):
+        window_minutes = 30
+    lines: list[str] = []
+    lines.append(
+        f"Stuck for: {cancel_count} cancellations in the last "
+        f"{window_minutes} min (threshold {threshold})"
+    )
+    lines.append("Observed evidence:")
+    lines.append(f"- Latest cancellation at {latest}")
+    if subjects:
+        preview = ", ".join(str(subject) for subject in subjects[:10])
+        lines.append(f"- Cancelled tasks: {preview}")
+    lines.append(
+        "- Replacement task.created events do not clear this volume signal; "
+        "a cancel/recreate loop can otherwise mask itself."
+    )
+    lines.append("")
+    lines.append(
+        "Your job: stop the cancellation loop and choose a preserving "
+        "state transition. Reassign or resume in-flight work before "
+        "discarding it."
     )
     return lines
 
@@ -4359,7 +4647,8 @@ def _brief_worker_session_dead_loop(
         "than ratifying any framing in this brief."
     )
     lines.append(
-        f"Cli levers available: `pm task cancel {subject}`, `pm notify`."
+        f"Cli levers available: `pm notify`; use `pm task cancel {subject}` "
+        "only after confirming the partial work should be discarded."
     )
     return lines
 
@@ -4445,8 +4734,12 @@ def format_unstick_brief(
         lines.extend(_brief_task_review_stale(finding, subject, meta))
     elif finding.rule == RULE_TASK_PROGRESS_STALE:
         lines.extend(_brief_task_progress_stale(finding, subject, meta))
+    elif finding.rule == RULE_TASK_REWORK_STALE:
+        lines.extend(_brief_task_rework_stale(finding, subject, meta))
     elif finding.rule == RULE_CANCEL_NO_PROMOTION:
         lines.extend(_brief_cancellation_no_promotion(finding, subject, meta))
+    elif finding.rule == RULE_CANCELLATION_CHURN:
+        lines.extend(_brief_cancellation_churn(finding, meta))
     elif finding.rule == RULE_ROLE_SESSION_MISSING:
         lines.extend(_brief_role_session_missing(finding, project, meta))
     elif finding.rule == RULE_PLAN_REVIEW_MISSING:

--- a/src/pollypm/plugins_builtin/advisor/handlers/assess.py
+++ b/src/pollypm/plugins_builtin/advisor/handlers/assess.py
@@ -18,9 +18,9 @@ ad03 wires three things:
    build_context_pack, writes it next to the advisor task's worktree,
    and returns the path + the computed pack structure.
 
-The actual session launch (``pm task claim`` + worker spawn) lives in
-the tick handler's enqueue path — ad03 just packages the context and
-exposes the output-parsing surface. ad04 wires the history-log
+The advisor tick queues the task; the recurring no-session recovery
+owns starting the advisor lane when it is missing. ad03 just packages
+the context and exposes the output-parsing surface. ad04 wires the history-log
 append; ad05 wires the inbox emission.
 """
 from __future__ import annotations

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -13,7 +13,7 @@ which holds the pure detectors. The heartbeat scheduler invokes
 
 1. Emit a ``heartbeat.tick`` audit event so liveness is observable.
 2. For each known project, read the last ``window_seconds * 2`` of
-   audit events and run the four detectors.
+   audit events and run the watchdog detectors.
 3. For every finding, emit an ``audit.finding`` audit event AND
    upsert an alert keyed by ``(rule, project, subject)``.
 
@@ -39,6 +39,7 @@ from pollypm.audit.watchdog import (
     ESCALATION_THROTTLE_SECONDS,
     OPERATOR_DISPATCH_THROTTLE_SECONDS,
     Finding,
+    RULE_CANCELLATION_CHURN,
     RULE_CANCEL_NO_PROMOTION,
     RULE_DUPLICATE_ADVISOR_TASKS,
     RULE_LEGACY_DB_SHADOW,
@@ -52,6 +53,7 @@ from pollypm.audit.watchdog import (
     RULE_STUCK_DRAFT,
     RULE_TASK_ON_HOLD_STALE,
     RULE_TASK_PROGRESS_STALE,
+    RULE_TASK_REWORK_STALE,
     RULE_TASK_REVIEW_STALE,
     RULE_WORKER_SESSION_DEAD_LOOP,
     WATCHDOG_ALERT_TYPE,
@@ -147,8 +149,10 @@ _DISPATCHABLE_RULES: frozenset[str] = frozenset({
     # cancel, or rewrite them.
     RULE_STUCK_DRAFT,
     RULE_CANCEL_NO_PROMOTION,
+    RULE_CANCELLATION_CHURN,
     RULE_TASK_REVIEW_STALE,
     RULE_TASK_PROGRESS_STALE,
+    RULE_TASK_REWORK_STALE,
     RULE_WORKER_SESSION_DEAD_LOOP,
     # #1424 — on_hold escalation lands in the architect's pane with the
     # reviewer's rationale folded into the brief. Default first responder
@@ -233,9 +237,12 @@ def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
         "window_seconds",
         "stuck_draft_seconds",
         "cancel_grace_seconds",
+        "cancel_churn_window_seconds",
+        "cancel_churn_threshold",
         "review_stale_seconds",
         "progress_stale_seconds",
         "on_hold_stale_seconds",
+        "rework_stale_seconds",
     ):
         raw = payload.get(field_name)
         if raw is None:

--- a/src/pollypm/plugins_builtin/core_recurring/blocked_chain.py
+++ b/src/pollypm/plugins_builtin/core_recurring/blocked_chain.py
@@ -271,10 +271,22 @@ def sweep_blocked_chains(
             work, project=project, task_number=task_number,
         )
         if not visited:
-            # Task is in BLOCKED state with no recursive blocker rows —
-            # nothing to dead-end against. Some other process (manual
-            # state edit, sync drift) put it there; not our concern.
-            counters["skipped_no_blockers"] += 1
+            counters["dead_end_detected"] += 1
+            message = (
+                f"Task {task.task_id} is blocked but has no blocker "
+                "dependency rows. Auto-unblock has no edge to observe, "
+                "so this task cannot leave BLOCKED without manual repair. "
+                "Re-plan the task, add the missing dependency, or unlink/"
+                "requeue it if the blocked state is stale."
+            )
+            if _emit_alert(
+                msg_store=msg_store,
+                state_store=state_store,
+                project=project,
+                task_number=task_number,
+                message=message,
+            ):
+                counters["alerts_raised"] += 1
             continue
         # Drop resolved blockers from the dead-end consideration. If
         # any remain in flight the chain is alive.

--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -116,8 +116,10 @@ _AUTO_CLAIM_EVENT_SKIPPED_PLAN_MISSING = "auto_claim_skipped_plan_missing"
 _AUTO_CLAIM_EVENT_FAILED = "auto_claim_failed"
 _AUTO_CLAIM_EVENT_CIRCUIT_BREAKER = "auto_claim_circuit_breaker"
 _AUTO_CLAIM_EVENT_SKIPPED_PAUSED = "auto_claim_skipped_paused"
+_AUTO_CLAIM_EVENT_SKIPPED_UNSPAWNABLE = "auto_claim_skipped_unspawnable_project"
 TMUX_WINDOW_PROBE_UNAVAILABLE_ALERT_TYPE = "tmux_window_probe_unavailable"
 TMUX_WINDOW_PROBE_UNAVAILABLE_THRESHOLD = 3
+PROJECT_PATH_UNSPAWNABLE_ALERT_TYPE = "project_path_unspawnable"
 
 # Work statuses the sweeper cares about — those where a machine actor is
 # the expected next mover. ``in_progress`` / ``rework`` are gated on an
@@ -1438,6 +1440,76 @@ def _pause_store(services: Any) -> Any | None:
     )
 
 
+def _worker_project_session_name(project_key: str) -> str:
+    candidates = role_candidate_names("worker", project_key)
+    return candidates[0] if candidates else f"worker-{project_key}"
+
+
+def _project_path_spawnability(project_path: Path) -> tuple[bool, str]:
+    try:
+        if not project_path.exists():
+            return False, f"project path does not exist: {project_path}"
+        if not (project_path / ".git").exists():
+            return False, f"project path is not a git checkout: {project_path}"
+    except OSError as exc:
+        return False, f"project path cannot be inspected: {exc}"
+    return True, ""
+
+
+def _emit_project_path_unspawnable_alert(
+    services: Any,
+    *,
+    project_key: str,
+    task_id: str,
+    project_path: Path,
+    reason: str,
+) -> None:
+    store = _pause_store(services)
+    if store is None:
+        return
+    scope = _worker_project_session_name(project_key)
+    message = (
+        f"Auto-claim skipped task {task_id} because the registered "
+        f"project path cannot host a per-task worker: {reason}. "
+        "Fix the project registration or clone/restore the git checkout, "
+        "then rerun the sweep or claim the task manually."
+    )
+    try:
+        store.upsert_alert(
+            scope,
+            PROJECT_PATH_UNSPAWNABLE_ALERT_TYPE,
+            "warn",
+            message,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "task_auto_claim: upsert_alert(%s) failed for %s",
+            PROJECT_PATH_UNSPAWNABLE_ALERT_TYPE,
+            scope,
+            exc_info=True,
+        )
+
+
+def _clear_project_path_unspawnable_alert(
+    services: Any,
+    *,
+    project_key: str,
+) -> None:
+    store = _pause_store(services)
+    if store is None:
+        return
+    scope = _worker_project_session_name(project_key)
+    try:
+        store.clear_alert(scope, PROJECT_PATH_UNSPAWNABLE_ALERT_TYPE)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "task_auto_claim: clear_alert(%s) failed for %s",
+            PROJECT_PATH_UNSPAWNABLE_ALERT_TYPE,
+            scope,
+            exc_info=True,
+        )
+
+
 def _skip_if_task_worker_paused(
     services: Any,
     *,
@@ -2260,6 +2332,41 @@ def _auto_claim_next(
             },
         )
         return
+
+    project_path_obj = Path(project_path)
+    spawnable, unspawnable_reason = _project_path_spawnability(project_path_obj)
+    if not spawnable:
+        totals["by_outcome"][_AUTO_CLAIM_EVENT_SKIPPED_UNSPAWNABLE] = (
+            totals["by_outcome"].get(
+                _AUTO_CLAIM_EVENT_SKIPPED_UNSPAWNABLE,
+                0,
+            )
+            + 1
+        )
+        _emit_project_path_unspawnable_alert(
+            services,
+            project_key=project_key,
+            task_id=task_id,
+            project_path=project_path_obj,
+            reason=unspawnable_reason,
+        )
+        _emit_auto_claim_audit(
+            services,
+            project=project,
+            task=target,
+            outcome=_AUTO_CLAIM_EVENT_SKIPPED_UNSPAWNABLE,
+            status="warn",
+            metadata={
+                "reason": unspawnable_reason,
+                "active_workers_before": len(active),
+                "cap": cap,
+                "project_path": str(project_path_obj),
+            },
+        )
+        return
+    _clear_project_path_unspawnable_alert(
+        services, project_key=project_key,
+    )
 
     # Gate: plan must be approved before we can claim for the project.
     # Run this after finding a real queued candidate so a closed gate

--- a/src/pollypm/recovery/no_session_spawn.py
+++ b/src/pollypm/recovery/no_session_spawn.py
@@ -68,8 +68,13 @@ logger = logging.getLogger(__name__)
 # service, not by ``pm worker-start``. ``operator`` / ``heartbeat`` /
 # ``triage`` are workspace singletons managed by the supervisor's own
 # launch path; they should never appear as the subject of a
-# ``no_session`` alert in normal operation.
-_AUTO_SPAWN_ROLES: frozenset[str] = frozenset({"reviewer", "architect"})
+# ``no_session`` alert in normal operation. ``advisor`` is a
+# project-scoped role lane like ``architect``.
+_AUTO_SPAWN_ROLES: frozenset[str] = frozenset({
+    "reviewer",
+    "architect",
+    "advisor",
+})
 
 # Defaults — overridable per-call so tests can force the behaviour
 # without sleeping.

--- a/src/pollypm/task_assignment_notify.py
+++ b/src/pollypm/task_assignment_notify.py
@@ -697,6 +697,14 @@ def _escalate_no_session(
                 "for a long-running session)\n"
                 f"     (or pm task claim {event.task_id} for a per-task worker)"
             )
+        elif event.actor_name == "advisor":
+            action_hint = (
+                f"Open Workers and start or recover the advisor for "
+                f"project '{event.project}'."
+            )
+            cli_hint = (
+                f"Try: pm worker-start --role advisor {event.project}"
+            )
         else:
             # #1057 — non-base roles (e.g. ``critic_simplicity``) don't
             # have a ``pm worker-start --role <X>`` path; they ship via

--- a/src/pollypm/work/task_assignment.py
+++ b/src/pollypm/work/task_assignment.py
@@ -155,7 +155,11 @@ _ROLE_STATIC_NAMES: dict[str, tuple[str, ...]] = {
 # worker shipping convention is underscore (``workers.py``), but the
 # resolver is tolerant of either so naming drift between operators,
 # tests, and docs doesn't break lookup.
-_PROJECT_SCOPED_ROLES: frozenset[str] = frozenset({"worker", "architect"})
+_PROJECT_SCOPED_ROLES: frozenset[str] = frozenset({
+    "worker",
+    "architect",
+    "advisor",
+})
 
 
 def role_candidate_names(
@@ -167,7 +171,7 @@ def role_candidate_names(
     """Return the ordered list of session names a role *could* map to.
 
     Callers match the first candidate that actually has a live session.
-    Project-scoped roles (``worker``, ``architect``) expand to both
+    Project-scoped roles (``worker``, ``architect``, ``advisor``) expand to both
     ``<role>-<project>`` and ``<role>_<project>`` — we accept either
     convention so drift between docs and shipping code doesn't break
     lookup. Process-wide singletons (reviewer / operator / heartbeat /

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -28,10 +28,12 @@ from pollypm.audit.watchdog import (
     EVENT_HEARTBEAT_TICK,
     EVENT_STUCK_DRAFT_TERMINATED,
     RULE_CANCEL_NO_PROMOTION,
+    RULE_CANCELLATION_CHURN,
     RULE_MARKER_LEAKED,
     RULE_ORPHAN_MARKER,
     RULE_STUCK_DRAFT,
     RULE_TASK_PROGRESS_STALE,
+    RULE_TASK_REWORK_STALE,
     STUCK_DRAFT_TERMINATOR_THRESHOLD,
     TIER_2,
     Finding,
@@ -820,6 +822,66 @@ def test_cancel_with_followup_create_silenced(now: datetime) -> None:
         if f.rule == RULE_CANCEL_NO_PROMOTION
     ]
     assert findings == []
+
+
+def test_cancel_no_promotion_is_volume_aware(now: datetime) -> None:
+    """One later create suppresses one cancel, not every cancel in a burst."""
+    events: list[AuditEvent] = []
+    for idx in range(6):
+        events.append(_make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            subject=f"demo/{idx + 1}",
+            metadata={"to": "cancelled"},
+            ts=now - timedelta(minutes=20 - idx),
+        ))
+    events.append(_make_event(
+        event=EVENT_TASK_CREATED,
+        subject="demo/99",
+        ts=now - timedelta(minutes=10),
+    ))
+
+    findings = [
+        f for f in scan_events(events, now=now)
+        if f.rule == RULE_CANCEL_NO_PROMOTION
+    ]
+
+    assert len(findings) == 5
+    assert {f.subject for f in findings} == {
+        "demo/2",
+        "demo/3",
+        "demo/4",
+        "demo/5",
+        "demo/6",
+    }
+
+
+def test_cancellation_churn_fires_with_interleaved_creates(now: datetime) -> None:
+    """Create/cancel/recreate loops must not mask cancellation volume."""
+    events: list[AuditEvent] = []
+    for idx in range(5):
+        minute = 25 - (idx * 3)
+        events.append(_make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            subject=f"demo/{idx + 1}",
+            metadata={"from": "draft", "to": "cancelled"},
+            ts=now - timedelta(minutes=minute),
+        ))
+        events.append(_make_event(
+            event=EVENT_TASK_CREATED,
+            subject=f"demo/{idx + 20}",
+            ts=now - timedelta(minutes=minute - 1),
+        ))
+
+    findings = [
+        f for f in scan_events(events, now=now)
+        if f.rule == RULE_CANCELLATION_CHURN
+    ]
+
+    assert len(findings) == 1
+    assert findings[0].project == "demo"
+    assert findings[0].tier == TIER_2
+    assert findings[0].metadata["cancel_count"] == 5
+    assert findings[0].evidence["required_decision"] == "stop_cancel_recreate_loop"
 
 
 def test_format_unstick_brief_cancellation_no_promotion_is_decisive() -> None:
@@ -2719,6 +2781,62 @@ def test_stuck_draft_state_dedupes_with_event_path(now: datetime) -> None:
     matched = [f for f in findings if f.rule == RULE_STUCK_DRAFT]
     assert len(matched) == 1
     assert matched[0].metadata["detected_via"] == "state"
+
+
+def test_task_rework_stale_state_based_fires_for_old_rework(
+    now: datetime,
+) -> None:
+    task = _StatefulTask(
+        project="savethenovel",
+        task_number=16,
+        work_status="rework",
+        transitions=[
+            _FakeTransition(
+                from_state="review",
+                to_state="rework",
+                timestamp=now - timedelta(minutes=35),
+                actor="reviewer",
+                reason="tests still failing",
+            ),
+        ],
+        updated_at=now - timedelta(minutes=35),
+        assignee="worker",
+        current_node_id="implement",
+    )
+
+    findings = scan_events([], now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_TASK_REWORK_STALE]
+
+    assert len(matched) == 1
+    assert matched[0].subject == "savethenovel/16"
+    assert matched[0].tier == TIER_2
+    assert matched[0].metadata["detected_via"] == "state"
+    assert matched[0].metadata["reason"] == "tests still failing"
+
+
+def test_task_rework_stale_event_path_silent_when_resumed(
+    now: datetime,
+) -> None:
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/16",
+            metadata={"from": "review", "to": "rework"},
+            ts=now - timedelta(minutes=35),
+        ),
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/16",
+            metadata={"from": "rework", "to": "queued"},
+            ts=now - timedelta(minutes=5),
+        ),
+    ]
+
+    findings = scan_events(events, now=now)
+
+    assert not any(f.rule == RULE_TASK_REWORK_STALE for f in findings)
 
 
 def test_task_progress_stale_state_based_fires_for_old_in_progress(

--- a/tests/test_blocked_chain_sweep.py
+++ b/tests/test_blocked_chain_sweep.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from pollypm.plugins_builtin.core_recurring import blocked_chain
+from pollypm.work.models import WorkStatus
+
+
+class _FakeWork:
+    def __init__(self, task: SimpleNamespace) -> None:
+        self.task = task
+
+    def list_tasks(self, *, work_status: str) -> list[SimpleNamespace]:
+        if work_status == WorkStatus.BLOCKED.value:
+            return [self.task]
+        return []
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.alerts: list[tuple[str, str, str, str]] = []
+
+    def upsert_alert(
+        self,
+        session_name: str,
+        alert_type: str,
+        severity: str,
+        message: str,
+    ) -> None:
+        self.alerts.append((session_name, alert_type, severity, message))
+
+
+def test_blocked_task_with_no_blocker_rows_alerts(monkeypatch) -> None:
+    now = datetime(2026, 5, 29, 12, 0, tzinfo=timezone.utc)
+    task = SimpleNamespace(
+        project="demo",
+        task_number=7,
+        task_id="demo/7",
+    )
+    monkeypatch.setattr(
+        blocked_chain,
+        "_blocked_since",
+        lambda *_args, **_kwargs: now - timedelta(hours=2),
+    )
+    monkeypatch.setattr(
+        blocked_chain,
+        "_walk_blocker_chain",
+        lambda *_args, **_kwargs: (set(), {}),
+    )
+    store = _FakeStore()
+
+    counters = blocked_chain.sweep_blocked_chains(
+        work=_FakeWork(task),
+        msg_store=store,
+        state_store=None,
+        now=now,
+        stale_threshold_seconds=3600,
+    )
+
+    assert counters["blocked_considered"] == 1
+    assert counters["dead_end_detected"] == 1
+    assert counters["alerts_raised"] == 1
+    assert counters["skipped_no_blockers"] == 0
+    assert store.alerts == [
+        (
+            "blocked-demo-7",
+            blocked_chain.BLOCKED_DEAD_END_ALERT_TYPE,
+            "warn",
+            store.alerts[0][3],
+        ),
+    ]
+    assert "has no blocker dependency rows" in store.alerts[0][3]

--- a/tests/test_no_session_auto_recovery.py
+++ b/tests/test_no_session_auto_recovery.py
@@ -308,6 +308,30 @@ def test_auto_recovery_skips_worker_role() -> None:
     assert [d.outcome for d in decisions] == ["skipped_role"]
 
 
+def test_auto_recovery_spawns_advisor_after_threshold() -> None:
+    alert = _make_no_session_alert(
+        role="advisor",
+        session_name="advisor-bikepath",
+    )
+    store = _FakeStore(alerts=[alert])
+    services = _FakeServices(
+        msg_store=store, known_projects=(_FakeProject("bikepath"),),
+    )
+    spawn_calls: list[tuple[str, str]] = []
+
+    def fake_spawn(*, config_path: Path, project: str, role: str) -> tuple[bool, str]:
+        spawn_calls.append((role, project))
+        return True, "session=advisor_bikepath"
+
+    decisions = auto_recover_no_session_alerts(
+        services, config_path=Path("/dev/null"), spawn=fake_spawn,
+    )
+
+    assert spawn_calls == [("advisor", "bikepath")]
+    assert [d.outcome for d in decisions] == ["spawned"]
+    assert decisions[0].attempt_number == 1
+
+
 def test_auto_recovery_skips_unknown_projects() -> None:
     """Ghost projects (alert references a project not in the registry) are
     left to the existing ``_sweep_ghost_project_alerts`` cleanup."""

--- a/tests/test_task_assignment_notify_helpers.py
+++ b/tests/test_task_assignment_notify_helpers.py
@@ -147,6 +147,12 @@ class TestRoleCandidates:
             "pm-reviewer",
         ]
 
+    def test_advisor_is_project_scoped(self):
+        assert role_candidate_names("advisor", "bikepath") == [
+            "advisor-bikepath",
+            "advisor_bikepath",
+        ]
+
     def test_reviewer_with_task_number_still_uses_reviewer_lane(self):
         # #1439 — a still-open per-task worker pane must not steal
         # review-node handoff pings from the long-lived reviewer lane.

--- a/tests/test_task_assignment_recovery_audit.py
+++ b/tests/test_task_assignment_recovery_audit.py
@@ -293,6 +293,7 @@ def test_auto_claim_next_claims_worker_task_and_emits_audit(
     monkeypatch.setattr(sweep_mod, "has_acceptable_plan", lambda *_a, **_kw: True)
     project_path = tmp_path / "demo"
     (project_path / ".pollypm").mkdir(parents=True)
+    (project_path / ".git").mkdir()
     task = SimpleNamespace(
         project="demo",
         task_number=3,
@@ -334,6 +335,54 @@ def test_auto_claim_next_claims_worker_task_and_emits_audit(
     assert event.metadata["cap"] == 2
 
 
+def test_auto_claim_next_skips_when_project_path_cannot_spawn_worker(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit-home"))
+    monkeypatch.setattr(sweep_mod, "has_acceptable_plan", lambda *_a, **_kw: True)
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    task = SimpleNamespace(
+        project="demo",
+        task_number=6,
+        task_id="demo/6",
+        roles={"worker": "worker"},
+        labels=[],
+        flow_template_id="standard",
+    )
+    work = _FakeAutoClaimWork([task])
+    msg_store = _FakeMsgStore()
+    services = SimpleNamespace(
+        enforce_plan=True,
+        plan_dir="docs/plan",
+        max_concurrent_per_project=2,
+        msg_store=msg_store,
+        project_root=tmp_path,
+    )
+    project = SimpleNamespace(key="demo", path=project_path)
+    totals = {"by_outcome": {}}
+
+    _auto_claim_next(services, work, project, totals)
+
+    assert work.claimed == []
+    assert totals["by_outcome"]["auto_claim_skipped_unspawnable_project"] == 1
+    assert msg_store.alerts
+    scope, alert_type, severity, message = msg_store.alerts[0]
+    assert scope == "worker-demo"
+    assert alert_type == sweep_mod.PROJECT_PATH_UNSPAWNABLE_ALERT_TYPE
+    assert severity == "warn"
+    assert "not a git checkout" in message
+
+    events = read_events(
+        "demo",
+        project_path=project_path,
+        event="auto_claim_skipped_unspawnable_project",
+    )
+    assert len(events) == 1
+    assert events[0].subject == "demo/6"
+
+
 def test_auto_claim_next_skips_paused_task_worker(
     monkeypatch,
     tmp_path: Path,
@@ -344,6 +393,7 @@ def test_auto_claim_next_skips_paused_task_worker(
     _reset_skip_throttle_for_tests()
     project_path = tmp_path / "demo"
     (project_path / ".pollypm").mkdir(parents=True)
+    (project_path / ".git").mkdir()
     _write_pause_marker(tmp_path, ["task-demo-11"])
     task = SimpleNamespace(
         project="demo",
@@ -397,6 +447,7 @@ def test_auto_claim_next_plan_missing_emits_skip_audit_without_claiming(
     monkeypatch.setattr(sweep_mod, "has_acceptable_plan", lambda *_a, **_kw: False)
     project_path = tmp_path / "demo"
     (project_path / ".pollypm").mkdir(parents=True)
+    (project_path / ".git").mkdir()
     task = SimpleNamespace(
         project="demo",
         task_number=4,
@@ -464,6 +515,7 @@ def test_auto_claim_next_claim_failure_emits_failed_audit(
     monkeypatch.setattr(sweep_mod, "has_acceptable_plan", lambda *_a, **_kw: True)
     project_path = tmp_path / "demo"
     (project_path / ".pollypm").mkdir(parents=True)
+    (project_path / ".git").mkdir()
     task = SimpleNamespace(
         project="demo",
         task_number=5,


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds volume-aware cancellation watchdog behavior: one replacement create suppresses one cancellation, while cancellation churn still dispatches as a separate tier-2 finding.
- Adds stale rework detection and updates unstick briefs to prefer requeue/reassign/resume before cancellation.
- Surfaces blocked tasks with no blocker rows as blocked-dead-end alerts instead of silently skipping them.
- Skips worker auto-claim when the registered project path cannot spawn a per-task worker, and emits a warning alert/audit event instead.
- Treats advisor as a project-scoped auto-recoverable role and updates the stale advisor docstring.

## Notes
- Addresses #2431, #2432, and #2433.
- For #2432, this keeps task lifecycle transitions explicit: the change alerts/dispatches stale rework instead of auto-moving rework/blocked tasks, preserving the work-service state invariant.
- PR branch was pushed from /Users/sam/dev/pollypm/.codex/watch-worktrees/20260529-121943. Pre-PR status was clean on codex/task-flow-watchdog-healing-2431-2433...origin/codex/task-flow-watchdog-healing-2431-2433.

## Tests
- uv run --extra test pytest tests/test_audit_watchdog.py tests/test_blocked_chain_sweep.py tests/test_no_session_auto_recovery.py tests/test_task_assignment_notify_helpers.py tests/test_task_assignment_recovery_audit.py
- uv run --extra dev ruff check src/pollypm/audit/watchdog.py src/pollypm/plugins_builtin/advisor/handlers/assess.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py src/pollypm/plugins_builtin/core_recurring/blocked_chain.py src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py src/pollypm/recovery/no_session_spawn.py src/pollypm/task_assignment_notify.py src/pollypm/work/task_assignment.py tests/test_audit_watchdog.py tests/test_blocked_chain_sweep.py tests/test_no_session_auto_recovery.py tests/test_task_assignment_notify_helpers.py tests/test_task_assignment_recovery_audit.py