### PR TITLE
Repair tier-4 escalation ladder

### DIFF
--- a/docs/recovery-cascade.md
+++ b/docs/recovery-cascade.md
@@ -95,11 +95,12 @@ authority and triggered by a distinct condition.
   cancel, re-plan, change task assignments, file new tasks, escalate
   to Polly. The architect cannot reach into other projects or the
   global system.
-- **Escalates to tier 3/4 when:** the same `root_cause_hash` has
-  produced `AUTO_PROMOTE_THRESHOLD` (currently 3) tier-3 dispatches
-  inside `AUTO_PROMOTE_WINDOW_SECONDS` (currently 24h), or a tier-3
-  Polly explicitly self-promotes via `record_self_promote`. See
-  `audit/tier4.py` for the accounting.
+- **Escalates to tier 4 when:** the same `root_cause_hash` has
+  produced `AUTO_PROMOTE_THRESHOLD` (currently 3) architect/operator
+  dispatches inside `AUTO_PROMOTE_WINDOW_SECONDS` (currently 24h); the
+  next dispatch attempt routes to tier 4. Tier-3 Polly can also
+  explicitly self-promote via `record_self_promote`. See `audit/tier4.py`
+  for the accounting.
 
 ### Tier 4: Polly / operator (broader authority)
 
@@ -135,6 +136,8 @@ audit_watchdog cadence handler
     │   └─ tracker.record_tier3_dispatch (increments K-counter)
     │
     ├─ tier-3 operator dispatch  ──►  EVENT_WATCHDOG_OPERATOR_DISPATCHED
+    │   │
+    │   └─ tracker.record_tier3_dispatch (increments K-counter)
     │
     └─ tier-4 promotion          ──►  EVENT_TIER4_PROMOTED
                                       EVENT_WATCHDOG_OPERATOR_TIER4_DISPATCHED

--- a/src/pollypm/audit/tier4.py
+++ b/src/pollypm/audit/tier4.py
@@ -59,8 +59,9 @@ logger = logging.getLogger(__name__)
 # Tunable constants — first-pass values from the 2026-05-09 spec.
 # ---------------------------------------------------------------------------
 
-#: K — auto-promote threshold. The Kth tier-3 dispatch for the same
-#: root_cause_hash inside the window routes to tier-4 instead.
+#: K — auto-promote threshold. After K recorded tier-3 dispatches for the
+#: same root_cause_hash inside the window, the next dispatch routes to
+#: tier-4 instead.
 AUTO_PROMOTE_THRESHOLD = 3
 #: W — sliding window (in seconds) the auto-promote threshold reads from.
 AUTO_PROMOTE_WINDOW_SECONDS = 24 * 60 * 60
@@ -331,13 +332,10 @@ class Tier4PromotionTracker:
         """Return True iff the next dispatch should route to tier-4.
 
         Auto-promote fires when the trailing-window dispatch count is
-        already at or above ``auto_promote_threshold``. The convention:
-        the caller has already recorded the dispatch via
-        :meth:`record_tier3_dispatch` or hasn't yet — both shapes work
-        because we count strict ``>=`` and the caller chooses whether
-        to count this dispatch in the threshold or not. The recommended
-        flow is to call this BEFORE recording, so the Kth dispatch is
-        the one that gets promoted (not the K+1th).
+        already at or above ``auto_promote_threshold``. Dispatchers call
+        this before recording the current dispatch, so K recorded
+        dispatches promote the next dispatch (the K+1th attempt) rather
+        than rewriting the Kth dispatch after the fact.
         """
         rch = root_cause_hash(finding)
         state = self.get(rch)

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -22,6 +22,21 @@ from pollypm.recovery.base import (
     SessionSignals,
 )
 from pollypm.recovery.default import DefaultRecoveryPolicy
+from pollypm.role_contract import (
+    ROLE_REGISTRY as _ROLE_REGISTRY,
+    build_remediation_message as _build_canonical_remediation,
+)
+from pollypm.signal_routing import (
+    RoutingDecision as _RoutingDecision,
+    SignalActionability as _SignalActionability,
+    SignalAudience as _SignalAudience,
+    SignalEnvelope as _SignalEnvelope,
+    SignalSeverity as _SignalSeverity,
+    compute_dedupe_key as _compute_dedupe_key,
+    envelope_for_alert as _envelope_for_alert,
+    register_routed_emitter as _register_routed_emitter,
+    route_signal as _route_signal,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -271,31 +286,6 @@ _DEFAULT_POLICY = DefaultRecoveryPolicy()
 
 def _classify_session_health(signals: SessionSignals) -> SessionHealth:
     return _DEFAULT_POLICY.classify(signals)
-
-
-# #897 — persona-drift remediation now derives from the canonical
-# role contract (#885) instead of maintaining its own role tables.
-# The legacy module-level dicts below are kept as *derived views*
-# of the canonical registry so any consumer that still imports them
-# (and the legacy-table reconciliation test) keeps working without
-# pinning a stale architect.md path or persona name.
-
-from pollypm.role_contract import (
-    ROLE_REGISTRY as _ROLE_REGISTRY,
-    build_remediation_message as _build_canonical_remediation,
-    canonical_role as _canonical_role,
-)
-from pollypm.signal_routing import (
-    RoutingDecision as _RoutingDecision,
-    SignalActionability as _SignalActionability,
-    SignalAudience as _SignalAudience,
-    SignalEnvelope as _SignalEnvelope,
-    SignalSeverity as _SignalSeverity,
-    compute_dedupe_key as _compute_dedupe_key,
-    envelope_for_alert as _envelope_for_alert,
-    register_routed_emitter as _register_routed_emitter,
-    route_signal as _route_signal,
-)
 
 
 # #894 — register the heartbeat as an emitter that routes through
@@ -1241,15 +1231,17 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 pass  # API may not have supervisor (e.g., tests)
             prev_attempts = runtime.recovery_attempts if runtime else 0
             if prev_attempts >= self._CRASH_LOOP_ATTEMPT_THRESHOLD:
+                crash_reason = (
+                    f"{context.session_name} crashed and respawned "
+                    f"{prev_attempts} times"
+                )
                 _emit_routed_alert(
                     api,
                     session_name=context.session_name,
                     alert_type="crash_loop",
                     severity="error",
                     message=(
-                        f"{context.session_name} crashed and "
-                        f"respawned {prev_attempts} times — "
-                        "escalating to operator."
+                        f"{crash_reason} — escalating to operator."
                     ),
                     subject=f"{context.session_name} crash loop",
                     suggested_action=(
@@ -1258,6 +1250,36 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                         "respawning again."
                     ),
                 )
+                try:
+                    from pollypm.events.summaries import activity_summary
+
+                    msg_store = getattr(api.supervisor, "msg_store", None)
+                    append_event = getattr(msg_store, "append_event", None)
+                    if callable(append_event):
+                        append_event(
+                            scope=context.session_name,
+                            sender=context.session_name,
+                            subject="crash_loop_escalated",
+                            payload={
+                                "message": activity_summary(
+                                    summary=(
+                                        f"Raised crash_loop alert: {crash_reason}"
+                                    ),
+                                    severity="critical",
+                                    verb="escalated",
+                                    subject=context.session_name,
+                                ),
+                                "reason": crash_reason,
+                                "role": context.role,
+                                "alert_type": "crash_loop",
+                            },
+                        )
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "heartbeat: crash_loop escalation event failed for %s",
+                        context.session_name,
+                        exc_info=True,
+                    )
                 alerts.append("crash_loop")
             else:
                 self._set_session_status(
@@ -1871,6 +1893,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                         subject=context.session_name,
                     ),
                     "reason": reason,
+                    "role": context.role,
+                    "alert_type": "stuck_session",
                 },
             )
         except Exception:  # noqa: BLE001

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -2890,10 +2890,11 @@ def _route_tier4_to_terminal(
 ) -> bool:
     """Route a tier-4 row past its budget to the terminal path.
 
-    Sets ``product_state=broken`` (idempotent) and creates an urgent
-    inbox handoff via :func:`build_urgent_human_handoff`. Returns True
-    iff the urgent handoff was successfully written; the caller still
-    flips ``tier4_active=0`` regardless because the budget is up.
+    Sets ``product_state=broken`` (idempotent), creates an urgent inbox
+    handoff via :func:`build_urgent_human_handoff`, and fires a best-effort
+    desktop notification. Returns True iff the durable urgent handoff was
+    successfully written; callers must not mark the terminal gate until this
+    returns True because the handoff is the user-visible recovery surface.
 
     Mock-able via the ``services`` argument: the StateStore + the inbox
     sink both come from there so tests can pass a stub.
@@ -2954,9 +2955,17 @@ def _route_tier4_to_terminal(
             "tier4: set_product_state_broken raised", exc_info=True,
         )
 
+    push_title = "PollyPM tier-4 cascade exhausted"
+    push_body = (
+        f"{handoff.subject}\n"
+        f"{hypothesis}\n"
+        f"Forensics: {handoff.forensics_path}"
+    )
+
     # Drop the urgent inbox row via the same plumbing the tier-3 leg uses.
     msg_store = getattr(services, "msg_store", None)
     if msg_store is None:
+        _send_tier4_global_action_push(title=push_title, body=push_body)
         return False
     try:
         message_id = msg_store.enqueue_message(
@@ -2975,14 +2984,19 @@ def _route_tier4_to_terminal(
                 "tier": "terminal",
                 "forensics_path": handoff.forensics_path,
             },
-            state="closed",
+            state="open",
             kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
         )
-        return bool(message_id)
+        if not message_id:
+            _send_tier4_global_action_push(title=push_title, body=push_body)
+            return False
+        _send_tier4_global_action_push(title=push_title, body=push_body)
+        return True
     except Exception:  # noqa: BLE001
         logger.warning(
             "tier4: urgent handoff enqueue raised", exc_info=True,
         )
+        _send_tier4_global_action_push(title=push_title, body=push_body)
         return False
 
 
@@ -3005,7 +3019,8 @@ def _sweep_tier4_budget_and_demotion(
       product-broken — defeating the recovery (#1554 HIGH-1).
     * If ``now - tier4_entered_at`` >= budget → fire the terminal path:
       emit ``audit.tier4_budget_exhausted``, route to product-broken +
-      urgent inbox via :func:`_route_tier4_to_terminal`, then demote.
+      urgent inbox via :func:`_route_tier4_to_terminal`, then demote only
+      after the urgent handoff lands.
     * Otherwise leave the row alone — let the next tick check again.
 
     Resolved-finding demotion runs BEFORE the budget check so a row
@@ -3019,6 +3034,7 @@ def _sweep_tier4_budget_and_demotion(
     counters: dict[str, int] = {
         "tier4_budget_exhausted": 0,
         "tier4_demoted_cleared": 0,
+        "tier4_terminal_handoff_failed": 0,
     }
     tracker = _build_tier4_tracker()
     if tracker is None:
@@ -3076,9 +3092,12 @@ def _sweep_tier4_budget_and_demotion(
                     ),
                     project_path=project_path,
                 )
-                _route_tier4_to_terminal(
+                handoff_written = _route_tier4_to_terminal(
                     state=state, services=services, now=now,
                 )
+                if not handoff_written:
+                    counters["tier4_terminal_handoff_failed"] += 1
+                    continue
                 # #1997 — stamp the persistent terminal-handoff gate
                 # BEFORE clearing tier4_active. Without this, the
                 # ``tracker.clear`` below flips tier4_active to 0 and
@@ -3329,6 +3348,7 @@ def _scan_one_project_counters() -> dict[str, int]:
         "tier4_dispatches_failed": 0,
         "tier4_demoted_cleared": 0,
         "tier4_budget_exhausted": 0,
+        "tier4_terminal_handoff_failed": 0,
     }
 
 
@@ -3422,6 +3442,9 @@ def _route_one_finding(
     # #1414 — eligible findings get an architect dispatch on top
     # of the alert. Throttle window is owned by the audit log so
     # repeat dispatches are deduped across cadence-process restarts.
+    # #2434 — architect-dispatched rules also feed the tier-4
+    # promotion tracker. Otherwise tier-2 can re-brief indefinitely
+    # without ever reaching the broader-authority rung.
     # #1424 — for ``task_on_hold_stale`` we enrich the finding with
     # the reviewer's recent execution rows + inbox messages so the
     # architect's brief carries the rejection rationale, not just
@@ -3432,6 +3455,35 @@ def _route_one_finding(
         project_path=project_path,
         msg_store=msg_store,
     )
+    tracker = _build_tier4_tracker()
+    promoted = False
+    if tracker is not None:
+        try:
+            if tracker.should_auto_promote(dispatch_finding, now=now):
+                outcome = _dispatch_to_operator_tier4(
+                    dispatch_finding,
+                    project_path=project_path,
+                    now=now,
+                    promotion_path="watchdog",
+                    tracker=tracker,
+                    config_path=config_path,
+                )
+                if outcome == "dispatched":
+                    counters["tier4_dispatches_sent"] += 1
+                    promoted = True
+                elif outcome == "throttled":
+                    counters["tier4_dispatches_throttled"] += 1
+                    promoted = True
+                elif outcome == "send_failed":
+                    counters["tier4_dispatches_failed"] += 1
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "tier4: architect auto-promote check raised for %s/%s",
+                dispatch_finding.rule, dispatch_finding.project, exc_info=True,
+            )
+    if promoted:
+        return
+
     outcome = _maybe_dispatch_to_architect(
         dispatch_finding,
         project_path=project_path,
@@ -3441,6 +3493,14 @@ def _route_one_finding(
     )
     if outcome == "dispatched":
         counters["dispatches_sent"] += 1
+        if tracker is not None:
+            try:
+                tracker.record_tier3_dispatch(dispatch_finding, now=now)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "tier4: record_tier3_dispatch raised",
+                    exc_info=True,
+                )
     elif outcome == "throttled":
         counters["dispatches_throttled"] += 1
     elif outcome == "send_failed":
@@ -3697,6 +3757,7 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "tier4_dispatches_failed": 0,
         "tier4_demoted_cleared": 0,
         "tier4_budget_exhausted": 0,
+        "tier4_terminal_handoff_failed": 0,
     }
 
     try:

--- a/src/pollypm/storage/product_state.py
+++ b/src/pollypm/storage/product_state.py
@@ -178,9 +178,9 @@ def clear_product_state(store: Any) -> bool:
 def is_product_broken(store: Any) -> ProductState | None:
     """Return the ProductState iff the workspace is in the broken state.
 
-    Convenience wrapper used by the create-task gate. Returns
-    ``None`` (the falsy sentinel) when the workspace is healthy so
-    the gate can short-circuit with ``if state := is_product_broken(store):``.
+    Convenience wrapper for readers and future queueing gates. Returns
+    ``None`` (the falsy sentinel) when the workspace is healthy so callers
+    can short-circuit with ``if state := is_product_broken(store):``.
     """
     state = get_product_state(store)
     if state is None:
@@ -191,7 +191,7 @@ def is_product_broken(store: Any) -> ProductState | None:
 
 
 class ProductBrokenError(RuntimeError):
-    """Raised by the create-task gate when the workspace is broken.
+    """Error type for callers that gate new work while the workspace is broken.
 
     Carries the ``ProductState`` so callers can render the reason +
     forensics path back to the operator.

--- a/src/pollypm/storage/state.py
+++ b/src/pollypm/storage/state.py
@@ -355,11 +355,11 @@ CREATE TABLE IF NOT EXISTS architect_resume_tokens (
     last_active_at TEXT NOT NULL
 );
 
--- #1546 — workspace_state: small key-value store for cascade flags that
--- live above the per-project layer. Today the only writer is the
--- product_state plumbing (the "broken" sentinel that refuses new task
--- queueing); future heartbeat-cascade flags can park here without
--- fanning out yet another table.
+    -- #1546 — workspace_state: small key-value store for cascade flags that
+    -- live above the per-project layer. Today the only writer is the
+    -- product_state plumbing (the "broken" sentinel surfaced by doctor and
+    -- terminal cascade handoff); future heartbeat-cascade flags can park
+    -- here without fanning out yet another table.
 CREATE TABLE IF NOT EXISTS workspace_state (
     key TEXT PRIMARY KEY,
     value_json TEXT NOT NULL,
@@ -771,8 +771,8 @@ class StateStore:
         (16, "Collapse duplicate open alerts + partial unique index (#1044)", []),
         # --- Migration 17 ----------------------------------------------
         # #1546 — workspace_state key/value table for cascade-level flags
-        # (today: the product_state ``broken`` sentinel that gates new
-        # task queueing). The table is also declared in SCHEMA with
+        # (today: the product_state ``broken`` sentinel surfaced by doctor
+        # and terminal cascade handoff). The table is also declared in SCHEMA with
         # ``CREATE TABLE IF NOT EXISTS`` so fresh DBs get it on first
         # open; this migration row makes upgraded DBs that opened
         # read-only against pre-#1546 schema also pick it up the next

--- a/tests/test_heartbeat_cascade_tier4.py
+++ b/tests/test_heartbeat_cascade_tier4.py
@@ -42,7 +42,6 @@ from pollypm.audit.tier4 import (
     SELF_PROMOTE_COOLDOWN_SECONDS,
     TIER4_BUDGET_SECONDS,
     Tier4PromotionTracker,
-    Tier4State,
     root_cause_hash,
 )
 from pollypm.audit.watchdog import (
@@ -50,7 +49,6 @@ from pollypm.audit.watchdog import (
     RULE_QUEUE_WITHOUT_MOTION,
     RULE_TASK_PROGRESS_STALE,
     TIER_2,
-    TIER_3,
 )
 
 
@@ -205,6 +203,25 @@ def test_should_auto_promote_true_at_threshold(
     assert tracker.should_auto_promote(finding, now=now + timedelta(minutes=10)) is True
 
 
+def test_should_auto_promote_first_true_on_k_plus_one_attempt(
+    tracker: Tier4PromotionTracker, now: datetime,
+) -> None:
+    """Dispatchers check before recording, so the K+1th attempt promotes."""
+    finding = _finding()
+    for i in range(AUTO_PROMOTE_THRESHOLD):
+        assert tracker.should_auto_promote(
+            finding, now=now + timedelta(minutes=i),
+        ) is False
+        tracker.record_tier3_dispatch(
+            finding, now=now + timedelta(minutes=i),
+        )
+
+    assert tracker.should_auto_promote(
+        finding,
+        now=now + timedelta(minutes=AUTO_PROMOTE_THRESHOLD),
+    ) is True
+
+
 def test_should_auto_promote_false_outside_window(
     tracker: Tier4PromotionTracker, now: datetime,
 ) -> None:
@@ -355,7 +372,7 @@ def test_clear_flips_active_to_zero(
     assert state is not None
     assert state.tier4_active is False
     # Idempotent.
-    cleared2 = tracker.clear(rch, now=now + timedelta(minutes=30))
+    tracker.clear(rch, now=now + timedelta(minutes=30))
     # The row is updated again but tier4_active was already 0 — UPDATE
     # rowcount is still 1 (we touched the row). Either result is fine
     # for idempotence; we assert the state stays cleared.
@@ -451,6 +468,105 @@ def test_auto_promote_routes_fourth_dispatch_to_tier4(
     assert state is not None
     assert state.tier4_active is True
     assert state.promotion_path == PROMOTION_PATH_WATCHDOG
+
+
+class _StubAlertStore:
+    def __init__(self) -> None:
+        self.alerts: list[tuple[str, str, str, str]] = []
+
+    def upsert_alert(
+        self,
+        session_name: str,
+        alert_type: str,
+        severity: str,
+        message: str,
+    ) -> None:
+        self.alerts.append((session_name, alert_type, severity, message))
+
+
+def test_architect_dispatch_records_tier4_counter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
+) -> None:
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as cadence
+
+    db_path = tmp_path / "state.db"
+    _patch_workspace_db(monkeypatch, db_path)
+    finding = _finding(
+        rule=RULE_TASK_PROGRESS_STALE,
+        project="demo",
+        subject="demo/7",
+    )
+    monkeypatch.setattr(
+        cadence,
+        "_maybe_dispatch_to_architect",
+        lambda *_args, **_kwargs: "dispatched",
+    )
+    counters = cadence._scan_one_project_counters()
+
+    cadence._route_one_finding(
+        finding,
+        project_key="demo",
+        project_path=None,
+        msg_store=_StubAlertStore(),
+        state_store=None,
+        storage_closet_name="polly-storage",
+        config_path=None,
+        now=now,
+        counters=counters,
+    )
+
+    tracker = Tier4PromotionTracker(db_path)
+    state = tracker.get(root_cause_hash(finding))
+    assert state is not None
+    assert len(state.dispatch_history) == 1
+    assert counters["dispatches_sent"] == 1
+
+
+def test_architect_dispatch_promotes_to_tier4_after_threshold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
+) -> None:
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as cadence
+
+    db_path = tmp_path / "state.db"
+    _patch_workspace_db(monkeypatch, db_path)
+    finding = _finding(
+        rule=RULE_TASK_PROGRESS_STALE,
+        project="demo",
+        subject="demo/7",
+    )
+    architect_calls: list[datetime] = []
+    tier4_calls: list[dict[str, Any]] = []
+
+    def _stub_architect(*_args: Any, **kwargs: Any) -> str:
+        architect_calls.append(kwargs["now"])
+        return "dispatched"
+
+    def _stub_tier4(*_args: Any, **kwargs: Any) -> str:
+        tier4_calls.append(kwargs)
+        return "dispatched"
+
+    monkeypatch.setattr(cadence, "_maybe_dispatch_to_architect", _stub_architect)
+    monkeypatch.setattr(cadence, "_dispatch_to_operator_tier4", _stub_tier4)
+    counters = cadence._scan_one_project_counters()
+    store = _StubAlertStore()
+
+    for i in range(AUTO_PROMOTE_THRESHOLD + 1):
+        cadence._route_one_finding(
+            finding,
+            project_key="demo",
+            project_path=None,
+            msg_store=store,
+            state_store=None,
+            storage_closet_name="polly-storage",
+            config_path=None,
+            now=now + timedelta(minutes=i),
+            counters=counters,
+        )
+
+    assert len(architect_calls) == AUTO_PROMOTE_THRESHOLD
+    assert len(tier4_calls) == 1
+    assert tier4_calls[0]["promotion_path"] == PROMOTION_PATH_WATCHDOG
+    assert counters["tier4_dispatches_sent"] == 1
 
 
 def test_auto_promote_throttled_when_tier4_already_active(
@@ -718,6 +834,21 @@ class _StubServices:
             pass
 
 
+class _StubServicesNoMessageStore:
+    def __init__(self, db_path: Path) -> None:
+        from pollypm.storage.state import StateStore
+        self.state_store = StateStore(db_path)
+        self.msg_store = None
+        self.known_projects = ()
+        self.storage_closet_name = "polly-storage"
+
+    def close(self) -> None:
+        try:
+            self.state_store.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def test_budget_exhaustion_routes_to_terminal_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
 ) -> None:
@@ -726,6 +857,12 @@ def test_budget_exhaustion_routes_to_terminal_path(
 
     db_path = tmp_path / "state.db"
     _patch_workspace_db(monkeypatch, db_path)
+    pushed: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        cadence,
+        "_send_tier4_global_action_push",
+        lambda *, title, body: pushed.append((title, body)) or True,
+    )
 
     # Promote a finding → fast-forward past the budget.
     tracker = Tier4PromotionTracker(db_path)
@@ -771,10 +908,50 @@ def test_budget_exhaustion_routes_to_terminal_path(
     assert "Tier-4" in body
     assert "Forensics:" in body
     assert "tier4-terminal" in msgs[0]["labels"]
+    assert msgs[0]["state"] == "open"
+    assert pushed and pushed[0][0] == "PollyPM tier-4 cascade exhausted"
     # Tracker row is now demoted (active=0).
     state = tracker.get(rch)
     assert state is not None
     assert state.tier4_active is False
+
+
+def test_budget_exhaustion_retries_when_terminal_handoff_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
+) -> None:
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as cadence
+
+    db_path = tmp_path / "state.db"
+    _patch_workspace_db(monkeypatch, db_path)
+    pushed: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        cadence,
+        "_send_tier4_global_action_push",
+        lambda *, title, body: pushed.append((title, body)) or True,
+    )
+    tracker = Tier4PromotionTracker(db_path)
+    finding = _finding(project="demo", subject="demo")
+    tracker.record_promotion(
+        finding, now=now, promotion_path=PROMOTION_PATH_WATCHDOG,
+    )
+    rch = root_cause_hash(finding)
+
+    services = _StubServicesNoMessageStore(db_path)
+    try:
+        counters = cadence._sweep_tier4_budget_and_demotion(
+            services=services,
+            now=now + timedelta(seconds=TIER4_BUDGET_SECONDS + 600),
+        )
+    finally:
+        services.close()
+
+    assert counters["tier4_terminal_handoff_failed"] == 1
+    assert counters["tier4_budget_exhausted"] == 0
+    assert pushed and pushed[0][0] == "PollyPM tier-4 cascade exhausted"
+    state = tracker.get(rch)
+    assert state is not None
+    assert state.tier4_active is True
+    assert state.terminal_handoff_at is None
 
 
 # ---------------------------------------------------------------------------
@@ -802,6 +979,11 @@ def test_sweep_threads_project_path_to_per_project_audit(
 
     db_path = tmp_path / "state.db"
     _patch_workspace_db(monkeypatch, db_path)
+    monkeypatch.setattr(
+        cadence,
+        "_send_tier4_global_action_push",
+        lambda *, title, body: True,
+    )
 
     project_root = tmp_path / "demo-project"
     (project_root / ".pollypm").mkdir(parents=True)
@@ -863,6 +1045,11 @@ def test_clear_tier4_for_finding_emits_demoted(
 
     db_path = tmp_path / "state.db"
     _patch_workspace_db(monkeypatch, db_path)
+    monkeypatch.setattr(
+        cadence,
+        "_send_tier4_global_action_push",
+        lambda *, title, body: True,
+    )
     tracker = Tier4PromotionTracker(db_path)
     finding = _finding(project="demo")
     tracker.record_promotion(

--- a/tests/test_heartbeat_role_respawn.py
+++ b/tests/test_heartbeat_role_respawn.py
@@ -46,17 +46,19 @@ class _RoleCrashFakeAPI:
         self.alerts_raised: list[dict] = []
         self.cleared_alerts: list[tuple[str, str]] = []
         self.cursor_updates: list[dict] = []
+        self.appended_events: list[dict] = []
         self.checkpoints: list[tuple[str, list[str]]] = []
         runtime = SimpleNamespace(
             recovery_attempts=recovery_attempts,
             status="healthy",
         )
         self.supervisor = SimpleNamespace(
+            get_session_runtime=lambda _name: runtime,
             store=SimpleNamespace(
                 get_session_runtime=lambda _name: runtime,
             ),
             config=SimpleNamespace(sessions={}, projects={}),
-            msg_store=None,
+            msg_store=SimpleNamespace(append_event=self.append_event),
         )
 
     # _process_session protocol ---------------------------------------
@@ -77,6 +79,9 @@ class _RoleCrashFakeAPI:
 
     def record_event(self, *_args, **_kwargs) -> None:
         pass
+
+    def append_event(self, **kwargs) -> None:
+        self.appended_events.append(kwargs)
 
     def raise_alert(
         self,
@@ -276,6 +281,9 @@ def test_crash_loop_threshold_escalates_instead_of_respawning() -> None:
         a.get("alert_type") == "crash_loop"
         for a in api.alerts_raised
     )
+    assert api.appended_events
+    assert api.appended_events[-1]["subject"] == "crash_loop_escalated"
+    assert api.appended_events[-1]["payload"]["role"] == "architect"
 
 
 def test_alive_role_pane_does_not_trigger_role_crashed_recovery() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Makes architect-dispatched watchdog findings feed the tier-4 promotion tracker and check the auto-promotion gate before re-briefing the architect.
- Writes terminal budget-exhausted handoffs as open inbox items, fires a best-effort desktop notification, and only marks the terminal handoff gate/clears tier4_active after the durable handoff write succeeds.
- Documents the K+1 auto-promotion contract and adds regression coverage for the exact first promotable dispatch.
- Adds a durable crash_loop escalation event for role crash loops and includes role/alert metadata on stuck_session escalation events.
- Updates recovery-cascade/product-state docs so they match the implemented escalation and product-broken surfaces.

## Notes
- Addresses #2434, #2435, and #2436.
- For #2436, the pane_stopped SIGCONT item was investigated and intentionally left out of this RC-safe branch: the issue itself marks it optional/low value, the existing route_signal/tier-2 backstop is intact, and blind auto-SIGCONT can mask the underlying stopped-process cause.
- PR branch was pushed from /Users/sam/dev/pollypm/.codex/watch-worktrees/20260529-121943. Pre-PR status was clean on codex/tier4-escalation-ladder-2434-2436...origin/codex/tier4-escalation-ladder-2434-2436.

## Tests
- uv run --extra test pytest tests/test_heartbeat_cascade_tier4.py tests/test_heartbeat_role_respawn.py
- uv run --extra dev ruff check src/pollypm/audit/tier4.py src/pollypm/heartbeats/local.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py src/pollypm/storage/product_state.py src/pollypm/storage/state.py tests/test_heartbeat_cascade_tier4.py tests/test_heartbeat_role_respawn.py