### PR TITLE
Make web dashboard actionable

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -818,6 +818,50 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /alerts/{alert_id}/actions/{kind}:
+    post:
+      tags: [Alerts]
+      operationId: runAlertAction
+      summary: Run an action for an alert
+      description: |
+        Runs a supported alert action against a single alert row. The
+        web UI currently exposes the mutating `acknowledge` action,
+        which clears the alert via the configured message-store facade
+        and records the same alert-cleared activity event as cockpit
+        and CLI clear paths.
+      parameters:
+        - in: path
+          name: alert_id
+          required: true
+          schema: { type: integer }
+          description: Alert row id.
+        - in: path
+          name: kind
+          required: true
+          schema: { type: string }
+          description: Alert action kind. Only `acknowledge` is mutating today.
+      responses:
+        "200":
+          description: Alert action result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertActionResult"
+        "400":
+          $ref: "#/components/responses/InvalidRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "503":
+          description: Alert storage unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 
   /chat/sessions:
     get:
@@ -3350,6 +3394,19 @@ components:
         hint:
           type: string
           nullable: true
+
+    AlertActionResult:
+      type: object
+      required: [ok, message, alert_id, status]
+      properties:
+        ok:
+          type: boolean
+        message:
+          type: string
+        alert_id:
+          type: integer
+        status:
+          type: string
 
     AlertResponse:
       type: object

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -481,6 +481,9 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | GET    | `/api/v1/projects` | List registered projects with state, glyph, counts |
 | POST   | `/api/v1/projects` | Register a project (mirrors `pm add-project`) |
 | GET    | `/api/v1/projects/{key}` | Project drilldown — state, recent activity, top tasks, pending plan review |
+| GET    | `/api/v1/dashboard` | Dashboard/cockpit aggregate state (`?project=&include_briefing=&include_token_history=`) |
+| GET    | `/api/v1/alerts` | Open action-required alerts with cockpit action descriptors |
+| POST   | `/api/v1/alerts/{alert_id}/actions/{kind}` | Run an alert action. `acknowledge` clears the alert and records the alert-cleared activity event |
 | POST   | `/api/v1/projects/{key}/plan` | Kick off `pm project plan` (initial or replan) |
 | POST   | `/api/v1/projects/{key}/chat` | Send a chat message to the project's PM persona |
 | POST   | `/api/v1/chat/{session_name}/send` | Send a message to a chat surface (operator/architect/advisor/worker) via tmux |
@@ -488,7 +491,7 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | GET    | `/api/v1/projects/{key}/plan` | Structured plan body (`?version=N` matches the active version only — see §7) |
 | GET    | `/api/v1/tasks/{project}/{n}` | Task detail — status, node, executions, transitions |
 | POST   | `/api/v1/tasks/{project}/{n}/approve` | Approve plan or code review |
-| POST   | `/api/v1/tasks/{project}/{n}/reject` | Reject + capture reason |
+| POST   | `/api/v1/tasks/{project}/{n}/rework` | Reject + capture reason, returning the task to rework |
 | POST   | `/api/v1/tasks/{project}/{n}/queue` | Queue a draft task; failed pre-queue gates return `422 validation_error` |
 | POST   | `/api/v1/tasks/{project}/{n}/claim` | Claim a queued task (activate first node, keep `assignee` role-derived, record request `actor` as `claimed_by_session`, fires `queued→in_progress`). Returns `429 worker_cap_exceeded` when the project is at `max_parallel_workers` (#2064 round-11). Post-commit cap races may roll the row back to `queued`; the response `message` and `warnings[]` describe the actual state |
 | POST   | `/api/v1/tasks/{project}/{n}/cancel` | Cancel a non-terminal task (mapped to `svc.cancel`; optional `reason` — absent reasons resolve to `"cancelled via API"` in the audit row). In-progress tasks require `?force=true`; without it the API returns `409 confirmation_required` |
@@ -676,11 +679,10 @@ pattern:
    `judgment_calls` as a checklist, `body` as collapsed markdown,
    `critic_synthesis` as a sidebar.
 3. Approve: `POST /api/v1/tasks/{project}/{n}/approve` with
-   `{ "kind": "plan" }` (the action body discriminates plan vs
-   code-review approvals; see OpenAPI for `ApproveRequest`).
-4. Reject: `POST /api/v1/tasks/{project}/{n}/reject` with
-   `{ "reason": "..." }` — the reason is required and non-empty
-   per `validation_error`.
+   `{ "actor": "operator", "reason": "..." }`.
+4. Reject: `POST /api/v1/tasks/{project}/{n}/rework` with
+   `{ "actor": "operator", "reason": "..." }` — the reason is
+   required and non-empty per `validation_error`.
 
 Cockpit semantics to mirror: PR #1421's approve flow displays a
 toast with a 10-second undo. The frontend gets the same affordance

--- a/src/pollypm/web_api/routes/alerts.py
+++ b/src/pollypm/web_api/routes/alerts.py
@@ -22,12 +22,20 @@ from pollypm.cockpit_alert_actions import (
 )
 from pollypm.cockpit_alerts import alert_channel, is_operational_alert
 from pollypm.storage.records import AlertRecord
-from pollypm.web_api.errors import service_unavailable
+from pollypm.web_api.errors import invalid_request, not_found, service_unavailable
 from pollypm.web_api.routes._deps import ConfigDep
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Alerts"])
+
+_ALERT_ACTION_RESPONSES = {
+    "400": {"description": "Unsupported alert action."},
+    "401": {"description": "Missing or invalid bearer token."},
+    "404": {"description": "Alert not found."},
+    "422": {"description": "Path parameter validation failed."},
+    "503": {"description": "Alert storage unavailable."},
+}
 
 
 class AlertActionResponse(BaseModel):
@@ -56,6 +64,13 @@ class AlertsResponse(BaseModel):
     generated_at: datetime
     total: int
     alerts: list[AlertResponse] = Field(default_factory=list)
+
+
+class AlertActionResult(BaseModel):
+    ok: bool = True
+    message: str
+    alert_id: int
+    status: str
 
 
 def _task_project_key(task_id: str | None) -> str | None:
@@ -112,6 +127,42 @@ def _read_open_alerts(config: Any) -> list[AlertRecord]:
         ) from exc
 
 
+def _read_alert(config: Any, alert_id: int) -> AlertRecord:
+    try:
+        from pollypm.storage.pg_alerts import get_alert
+
+        alert = get_alert(alert_id, config=config)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("alerts: get_alert failed: %s", exc, exc_info=True)
+        raise service_unavailable(
+            "Failed to load alert",
+            hint="Retry shortly; check `pm doctor` for pg pool health.",
+        ) from exc
+    if alert is None:
+        raise not_found(
+            f"Alert not found: {alert_id}",
+            hint="Refresh alerts; the row may have been cleared already.",
+        )
+    return alert
+
+
+def _clear_alert(config: Any, alert: AlertRecord) -> None:
+    try:
+        from pollypm.store.registry import get_store
+
+        get_store(config).clear_alert(
+            alert.session_name,
+            alert.alert_type,
+            who_cleared="manual:web-alert-action",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("alerts: clear_alert failed: %s", exc, exc_info=True)
+        raise service_unavailable(
+            "Failed to acknowledge alert",
+            hint="Retry shortly; check `pm doctor` for pg pool health.",
+        ) from exc
+
+
 @router.get(
     "/alerts",
     response_model=AlertsResponse,
@@ -150,10 +201,41 @@ def list_alerts_endpoint(
     )
 
 
+@router.post(
+    "/alerts/{alert_id}/actions/{kind}",
+    response_model=AlertActionResult,
+    summary="Run an action for an alert",
+    operation_id="runAlertAction",
+    responses=_ALERT_ACTION_RESPONSES,
+)
+def run_alert_action_endpoint(
+    alert_id: int,
+    kind: str,
+    config: ConfigDep,
+) -> AlertActionResult:
+    if kind != "acknowledge":
+        raise invalid_request(
+            f"Unsupported alert action: {kind}",
+            hint="Only acknowledge is a mutating web alert action today.",
+        )
+    alert = _read_alert(config, alert_id)
+    if alert.status == "open":
+        _clear_alert(config, alert)
+    updated = _read_alert(config, alert_id)
+    return AlertActionResult(
+        ok=True,
+        message=f"acknowledged alert #{alert_id}",
+        alert_id=alert_id,
+        status=updated.status,
+    )
+
+
 __all__ = [
     "AlertActionResponse",
+    "AlertActionResult",
     "AlertResponse",
     "AlertsResponse",
     "list_alerts_endpoint",
+    "run_alert_action_endpoint",
     "router",
 ]

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -77,6 +77,8 @@
     surfacesInFlight: false,
     surfacesRefreshQueued: false,
     surfacesQueuedPreserveErrors: false,
+    dashboardData: null,
+    dashboardBriefingRequested: false,
     dashboardInFlight: false,
     dashboardRefreshQueued: false,
     historyInFlight: {},
@@ -109,6 +111,7 @@
       doctorLoading: false,
       doctorError: null,
       doctorRunInFlight: false,
+      actionInFlight: {},
     },
     pendingMessages: {},
     inbox: {
@@ -1097,17 +1100,7 @@
     state.selectedKind = null;
     state.selectedSurface = null;
     state.selectedTaskKey = null;
-    $("pane-title").textContent = "Select a surface";
-    $("pane-meta").textContent = "";
-    $("send-input").disabled = true;
-    $("send-button").disabled = true;
-    const list = $("message-list");
-    clearMessageList(list);
-    list.appendChild(el("div", {
-      class: "message-empty",
-      text: "No surface selected.",
-    }));
-    updateStopAgentButton();
+    renderNoSelection();
   }
 
   function ensureSelectionVisible() {
@@ -1154,6 +1147,104 @@
     if (state.auditExpanded[name]) loadAuditForSurface(name);
   }
 
+  function numeric(value) {
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  }
+
+  function plural(count, singular, pluralText) {
+    return count === 1 ? singular : (pluralText || singular + "s");
+  }
+
+  function blockedProjectCount(data) {
+    const projects = data && Array.isArray(data.projects) ? data.projects : [];
+    return projects.filter((project) => {
+      const projectState = String(project.state || "").toLowerCase();
+      if (projectState === "blocked" || projectState === "on_hold") return true;
+      const counts = project.task_counts && typeof project.task_counts === "object"
+        ? project.task_counts : {};
+      return numeric(counts.blocked) + numeric(counts.on_hold) > 0;
+    }).length;
+  }
+
+  function dashboardStatus(data) {
+    if (!data || typeof data !== "object") {
+      return {
+        title: "Loading workspace state...",
+        detail: "Dashboard state is loading.",
+        actionLabel: "Open inbox",
+        target: "inbox",
+      };
+    }
+    const rollups = data.rollups && typeof data.rollups === "object"
+      ? data.rollups : {};
+    const planReviews = numeric(rollups.pending_plan_reviews);
+    const alerts = numeric(rollups.alert_count);
+    const blockedProjects = blockedProjectCount(data);
+    const total = planReviews + alerts + blockedProjects;
+    if (total === 0) {
+      const sweeps = numeric(rollups.sweep_count_24h);
+      const recoveries = numeric(rollups.recovery_count_24h);
+      const proof = sweeps || recoveries
+        ? "24h: " + sweeps + " "
+          + plural(sweeps, "sweep") + " / " + recoveries + " "
+          + plural(recoveries, "recovery", "recoveries") + "."
+        : "No plan reviews, blockers, or alerts waiting.";
+      return {
+        title: "All handled - Polly's got it",
+        detail: proof,
+        actionLabel: "Open inbox",
+        target: "inbox",
+      };
+    }
+    if (planReviews > 0) {
+      return {
+        title: total + " " + plural(total, "thing") + " "
+          + (total === 1 ? "needs" : "need") + " you",
+        detail: planReviews + " "
+          + plural(planReviews, "plan review") + " waiting.",
+        actionLabel: "Open plan reviews",
+        target: "plan-review",
+      };
+    }
+    if (blockedProjects > 0) {
+      return {
+        title: total + " " + plural(total, "thing") + " "
+          + (total === 1 ? "needs" : "need") + " you",
+        detail: blockedProjects + " "
+          + plural(blockedProjects, "blocked project") + " waiting.",
+        actionLabel: "Open blocked tasks",
+        target: "blocked-tasks",
+      };
+    }
+    return {
+      title: total + " " + plural(total, "thing") + " "
+        + (total === 1 ? "needs" : "need") + " you",
+      detail: alerts + " " + plural(alerts, "alert") + " waiting.",
+      actionLabel: "Open alerts",
+      target: "alerts",
+    };
+  }
+
+  function runDashboardStatusAction(status) {
+    if (!status) return;
+    if (status.target === "plan-review") {
+      selectInbox({ type: "plan_review" });
+      return;
+    }
+    if (status.target === "blocked-tasks") {
+      state.taskStatusFilter = "blocked";
+      const filter = $("task-status-filter");
+      if (filter) filter.value = state.taskStatusFilter;
+      loadSurfaces();
+      return;
+    }
+    if (status.target === "alerts") {
+      selectAlerts();
+      return;
+    }
+    selectInbox();
+  }
+
   function renderNoSelection() {
     state.selectedKind = null;
     state.selectedSurface = null;
@@ -1181,12 +1272,17 @@
     });
     const list = $("message-list");
     clearMessageList(list);
+    const status = dashboardStatus(state.dashboardData);
+    const briefing = state.dashboardData
+      && typeof state.dashboardData.briefing === "string"
+      && state.dashboardData.briefing.trim()
+      ? state.dashboardData.briefing.trim()
+      : "";
     list.appendChild(el("div", { class: "empty-state" }, [
-      el("div", { class: "empty-title", text: "No surface selected" }),
-      el("div", {
-        class: "empty-copy",
-        text: "Choose a chat or task from the rail, or review items waiting in the inbox.",
-      }),
+      el("div", { class: "empty-title", text: status.title }),
+      briefing
+        ? el("div", { class: "empty-briefing", text: briefing })
+        : el("div", { class: "empty-copy", text: status.detail }),
       el("div", { class: "empty-actions" }, [openInbox, refresh]),
     ]));
     renderSurfaces();
@@ -2034,13 +2130,64 @@
     }
   }
 
-  function renderAlertAction(action) {
+  function alertActionKey(item, action) {
+    return String(item.id != null ? item.id : item.session_name || "alert")
+      + ":" + String(action.kind || "action");
+  }
+
+  function setAlertAction(item, action, active) {
+    const key = alertActionKey(item, action);
+    if (active) state.alerts.actionInFlight[key] = true;
+    else delete state.alerts.actionInFlight[key];
+    renderAlertsView();
+  }
+
+  async function acknowledgeAlert(item, action) {
+    if (item.id == null) return;
+    setAlertAction(item, action, true);
+    try {
+      await apiJson(
+        API + "/alerts/" + encodeURIComponent(String(item.id))
+          + "/actions/acknowledge",
+        { method: "POST" },
+      );
+      showToast("ok", "alert acknowledged");
+      await loadAlerts();
+      pollDashboard();
+      loadActivity();
+    } catch (err) {
+      showToast("error", "acknowledge failed: " + err.message);
+    } finally {
+      setAlertAction(item, action, false);
+    }
+  }
+
+  function routeAlertToInbox(action) {
+    const parsed = parseTaskKey(action.task_id || "");
+    const project = action.project_key || (parsed && parsed.project) || "";
+    const filters = { type: "plan_review" };
+    if (project) filters.project = project;
+    selectInbox(filters);
+  }
+
+  function renderAlertAction(item, action) {
     const detail = action.hint || action.kind || "";
-    const node = el("span", {
+    const node = el("button", {
       class: "alert-action",
+      type: "button",
       text: action.label || action.kind || "Action",
     });
     if (detail) node.setAttribute("title", detail);
+    if (action.kind === "acknowledge") {
+      const key = alertActionKey(item, action);
+      node.disabled = Boolean(state.alerts.actionInFlight[key]) || item.id == null;
+      node.addEventListener("click", () => acknowledgeAlert(item, action));
+    } else if (action.kind === "route_inbox") {
+      node.addEventListener("click", () => routeAlertToInbox(action));
+    } else {
+      node.disabled = true;
+      node.setAttribute("aria-disabled", "true");
+    }
     return node;
   }
 
@@ -2063,7 +2210,7 @@
       children.push(el(
         "div",
         { class: "alert-actions" },
-        actions.map((action) => renderAlertAction(action)),
+        actions.map((action) => renderAlertAction(item, action)),
       ));
     }
     return el("div", { class: "alert-row" }, children);
@@ -2244,15 +2391,76 @@
     return btn;
   }
 
-  function disabledPlanReviewButton(label) {
+  function taskRefFromInboxItem(item) {
+    const metadata = item && item.metadata && typeof item.metadata === "object"
+      ? item.metadata : {};
+    return parseTaskKey(item.task_id || metadata.task_id || item.id || "");
+  }
+
+  function disabledInboxAction(label, title) {
     const btn = el("button", {
       class: "inbox-action disabled",
       type: "button",
       text: label,
-      title: "Plan approve/reject API is not available in this branch.",
+      title: title,
     });
     btn.disabled = true;
     return btn;
+  }
+
+  async function runPlanReviewDecision(item, decision) {
+    const ref = taskRefFromInboxItem(item);
+    if (!ref) {
+      showToast("error", "plan task id missing");
+      return;
+    }
+    const key = item.id + ":plan-" + decision;
+    const verb = decision === "approve" ? "approve" : "rework";
+    const path = API + "/tasks/" + encodeURIComponent(ref.project)
+      + "/" + encodeURIComponent(ref.task_number) + "/" + verb;
+    const body = { actor: OPERATOR_ACTOR };
+    if (decision === "approve") {
+      body.reason = "approved from web UI";
+    } else {
+      body.reason = "rejected from web UI";
+    }
+    setInboxAction(key, true);
+    try {
+      await apiJson(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      showToast(
+        "ok",
+        decision === "approve" ? "plan approved" : "plan rejected",
+      );
+      state.inbox.selectedId = null;
+      state.inbox.detail = null;
+      state.inbox.replyDraft = "";
+      await loadInbox(true);
+      pollDashboard();
+      loadSurfaces();
+    } catch (err) {
+      state.inbox.error = err;
+      showToast("error", decision + " failed: " + err.message);
+      renderInboxView();
+    } finally {
+      setInboxAction(key, false);
+    }
+  }
+
+  function planReviewButton(item, decision, label, extraClass) {
+    if (!taskRefFromInboxItem(item)) {
+      return disabledInboxAction(label, "Plan task id is missing.");
+    }
+    return inboxActionButton(
+      item,
+      "plan-" + decision,
+      label,
+      () => runPlanReviewDecision(item, decision),
+      extraClass,
+    );
   }
 
   function renderInboxFilters() {
@@ -2379,8 +2587,8 @@
         inboxActionButton(item, "archive", "Archive", archiveInboxItem, "danger"),
       ];
       if (item.type === "plan_review") {
-        rowActions.push(disabledPlanReviewButton("Approve"));
-        rowActions.push(disabledPlanReviewButton("Reject"));
+        rowActions.push(planReviewButton(item, "approve", "Approve"));
+        rowActions.push(planReviewButton(item, "reject", "Reject", "danger"));
       }
       const row = el("div", {
         class: (
@@ -2472,8 +2680,8 @@
     });
     const decisionActions = [];
     if (detail.type === "plan_review") {
-      decisionActions.push(disabledPlanReviewButton("Approve"));
-      decisionActions.push(disabledPlanReviewButton("Reject"));
+      decisionActions.push(planReviewButton(detail, "approve", "Approve"));
+      decisionActions.push(planReviewButton(detail, "reject", "Reject", "danger"));
     }
     return el("div", { class: "inbox-detail" }, [
       el("div", { class: "inbox-detail-title", text: detail.subject || detail.id }),
@@ -2631,12 +2839,17 @@
     try {
       const params = new URLSearchParams();
       if (state.selectedProject) params.set("project", state.selectedProject);
+      const includeBriefing = !state.dashboardBriefingRequested;
+      if (includeBriefing) params.set("include_briefing", "true");
       const query = params.toString();
       const data = await apiJson(
         API + "/dashboard" + (query ? "?" + query : ""),
         { signal: request.signal },
       );
+      state.dashboardData = data;
+      if (includeBriefing) state.dashboardBriefingRequested = true;
       renderDashboard(data);
+      if (state.selectedKind === null) renderNoSelection();
     } catch (err) {
       if (isAbortError(err)) return;
       renderDashboardError(err);
@@ -2769,6 +2982,80 @@
     return button;
   }
 
+  function buildDashboardHeadline(data) {
+    const status = dashboardStatus(data);
+    const button = el("button", {
+      type: "button",
+      class: "dashboard-headline",
+      "aria-label": status.actionLabel + ": " + status.title,
+    }, [
+      el("div", { class: "dashboard-headline-title", text: status.title }),
+      el("div", { class: "dashboard-headline-detail", text: status.detail }),
+    ]);
+    button.addEventListener("click", () => runDashboardStatusAction(status));
+    return button;
+  }
+
+  function quotaSeverityClass(severity) {
+    const value = String(severity || "").toLowerCase();
+    if (value === "critical" || value === "error") return "quota-critical";
+    if (value === "warn" || value === "warning") return "quota-warn";
+    return "quota-ok";
+  }
+
+  function clampedPercent(value) {
+    const pct = numeric(value);
+    if (pct < 0) return 0;
+    if (pct > 100) return 100;
+    return pct;
+  }
+
+  function buildQuotaCard(data) {
+    const usages = data && Array.isArray(data.account_usages)
+      ? data.account_usages : [];
+    const tokens = data && data.tokens && typeof data.tokens === "object"
+      ? data.tokens : {};
+    if (usages.length === 0 && tokens.today == null && tokens.total == null) {
+      return null;
+    }
+    const primary = usages[0] || {};
+    const pct = clampedPercent(primary.used_pct);
+    const children = [
+      el("div", { class: "quota-label", text: "Claude headroom" }),
+    ];
+    if (primary.summary) {
+      children.push(el("div", {
+        class: "quota-summary",
+        text: primary.summary,
+      }));
+    } else {
+      children.push(el("div", {
+        class: "quota-summary",
+        text: "Usage details unavailable.",
+      }));
+    }
+    const fill = el("div", { class: "quota-fill" });
+    fill.setAttribute("style", "width: " + pct + "%;");
+    children.push(el("div", { class: "quota-bar" }, [fill]));
+    if (usages.length > 1) {
+      const backup = usages[1];
+      children.push(el("div", {
+        class: "quota-secondary",
+        text: "+ backup: " + (backup.summary || backup.account_name || "available"),
+      }));
+    }
+    if (tokens.today != null || tokens.total != null) {
+      children.push(el("div", {
+        class: "quota-tokens",
+        text: String(tokens.today || 0) + " today / "
+          + String(tokens.total || 0) + " total tokens",
+      }));
+    }
+    return el("div", {
+      class: "quota-card " + quotaSeverityClass(primary.severity),
+    }, children);
+  }
+
   function renderDashboard(data) {
     const box = $("dashboard-rollups");
     box.innerHTML = "";
@@ -2788,6 +3075,10 @@
     const scopedFields = Array.isArray(data.scoped_fields)
       ? data.scoped_fields : [];
     const cards = [];
+
+    box.appendChild(buildDashboardHeadline(data));
+    const quotaCard = buildQuotaCard(data);
+    if (quotaCard) box.appendChild(quotaCard);
 
     // --- counters from rollups ------------------------------------------
     if (typeof rollups.open_inbox_count === "number") {

--- a/src/pollypm/web_api/ui/index.html
+++ b/src/pollypm/web_api/ui/index.html
@@ -76,11 +76,11 @@
 
   <section id="message-pane" aria-label="Messages">
     <header class="pane-header">
-      <h2 id="pane-title">Select a surface</h2>
+      <h2 id="pane-title">Ready</h2>
       <span id="pane-meta" class="pane-meta"></span>
     </header>
     <div id="message-list" class="message-list" aria-live="polite">
-      <div class="message-empty">No surface selected.</div>
+      <div class="message-empty">Loading workspace state...</div>
     </div>
     <form id="send-form" class="send-form" autocomplete="off">
       <input

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -500,6 +500,16 @@ section#message-pane {
   font-size: 13px;
   margin: 8px 0 16px;
 }
+.empty-briefing {
+  color: var(--text-body);
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 12px 0 16px;
+  max-height: 45vh;
+  overflow: auto;
+  text-align: left;
+  white-space: pre-wrap;
+}
 .empty-actions {
   display: flex;
   justify-content: center;
@@ -645,6 +655,77 @@ section#message-pane {
 
 .dashboard-rollups {
   padding: 0 12px 16px;
+}
+.dashboard-headline {
+  display: block;
+  width: 100%;
+  margin: 0 0 10px;
+  padding: 11px 12px;
+  border: 1px solid rgba(91, 138, 255, 0.45);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+.dashboard-headline:hover {
+  background: var(--bg-row-hover);
+}
+.dashboard-headline:focus {
+  outline: none;
+  border-color: var(--info);
+}
+.dashboard-headline-title {
+  color: var(--text-heading-bright);
+  font-size: 13px;
+  font-weight: 700;
+}
+.dashboard-headline-detail {
+  color: var(--text-muted);
+  font-size: 11.5px;
+  margin-top: 4px;
+  overflow-wrap: anywhere;
+}
+.quota-card {
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-row);
+  margin: 0 0 8px;
+  padding: 10px 12px;
+}
+.quota-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.quota-summary {
+  color: var(--text-heading-bright);
+  font-size: 13px;
+  font-weight: 600;
+  margin-top: 5px;
+}
+.quota-bar {
+  height: 5px;
+  margin-top: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.22);
+}
+.quota-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--working);
+}
+.quota-warn .quota-fill { background: var(--attention); }
+.quota-critical .quota-fill { background: var(--blocked); }
+.quota-secondary,
+.quota-tokens {
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-top: 6px;
+  overflow-wrap: anywhere;
 }
 .rollup-card {
   display: block;
@@ -862,7 +943,21 @@ section#message-pane {
   padding: 3px 7px;
   color: var(--text-body);
   background: var(--bg-elevated);
+  cursor: pointer;
+  font: inherit;
   font-size: 11px;
+}
+.alert-action:hover:not(:disabled) {
+  background: var(--bg-row-hover);
+  border-color: var(--info);
+}
+.alert-action:focus {
+  outline: none;
+  border-color: var(--info);
+}
+.alert-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .fetch-retry {

--- a/tests/playwright/tests/alerts.spec.ts
+++ b/tests/playwright/tests/alerts.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "@playwright/test";
+
+async function stubChrome(page: import("@playwright/test").Page) {
+  await page.route(/\/api\/v1\/chat\/sessions(\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [] }),
+    }),
+  );
+  await page.route(/\/api\/v1\/tasks\?limit=200$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
+  await page.route("**/api/v1/projects**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    }),
+  );
+  await page.route("**/api/v1/dashboard**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rollups: { open_inbox_count: 0, pending_plan_reviews: 0, alert_count: 1 },
+        daemon_status: "up",
+        active_sessions: [],
+        recent_messages: [],
+        projects: [],
+        generated_at: "2026-05-23T00:00:00Z",
+        scoped_fields: [],
+      }),
+    }),
+  );
+  await page.route("**/api/v1/doctor/report", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ checks: [] }),
+    }),
+  );
+  await page.route("**/api/v1/audit/stats**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ total: 0, by_event: {}, by_severity: {} }),
+    }),
+  );
+  await page.route("**/api/v1/audit/grep**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ events: [], next_cursor: null }),
+    }),
+  );
+}
+
+test.describe("alerts panel", () => {
+  test("acknowledge action posts and refreshes the alert list", async ({ page }) => {
+    await stubChrome(page);
+
+    let acknowledged = false;
+    await page.route(/\/api\/v1\/alerts\?limit=100$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          generated_at: "2026-05-23T00:00:00Z",
+          total: acknowledged ? 0 : 1,
+          alerts: acknowledged
+            ? []
+            : [{
+                id: 42,
+                session_name: "worker_demo",
+                alert_type: "auth_broken",
+                severity: "error",
+                message: "Codex auth failed",
+                status: "open",
+                channel: "action_required",
+                created_at: "2026-05-23T00:00:00Z",
+                updated_at: "2026-05-23T00:01:00Z",
+                actions: [{
+                  kind: "acknowledge",
+                  label: "Acknowledge",
+                  hint: "Clear this alert",
+                }],
+              }],
+        }),
+      }),
+    );
+    await page.route(/\/api\/v1\/alerts\/42\/actions\/acknowledge$/, (route) => {
+      acknowledged = true;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          message: "acknowledged alert #42",
+          alert_id: 42,
+          status: "closed",
+        }),
+      });
+    });
+
+    await page.goto("/ui/alerts");
+    await expect(page.getByRole("button", { name: "Acknowledge" })).toBeVisible();
+    await page.getByRole("button", { name: "Acknowledge" }).click();
+    await expect.poll(() => acknowledged).toBe(true);
+    await expect(
+      page.locator(".alerts-panel .activity-empty", {
+        hasText: "no action-required alerts",
+      }),
+    ).toBeVisible();
+  });
+});

--- a/tests/playwright/tests/dashboard_rail.spec.ts
+++ b/tests/playwright/tests/dashboard_rail.spec.ts
@@ -93,7 +93,7 @@ test.describe("dashboard rail", () => {
   test("rollup cards are focusable buttons that drill into visible state", async ({ page }) => {
     await installQuietEventSource(page);
     await stubSurfaces(page);
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -115,7 +115,7 @@ test.describe("dashboard rail", () => {
     const expected: Array<[RegExp, string]> = [
       [/inbox/i, "Inbox"],
       [/plan reviews/i, "Inbox"],
-      [/alerts/i, "Dashboard: alerts"],
+      [/alerts/i, "Alerts"],
       [/activity/i, "operator"],
       [/daemon/i, "Dashboard: daemon"],
       [/active sessions/i, "operator"],
@@ -128,7 +128,7 @@ test.describe("dashboard rail", () => {
     const rollups = page.locator("#dashboard-rollups");
 
     for (const [name, title] of expected) {
-      const card = rollups.getByRole("button", { name });
+      const card = rollups.locator(".rollup-card").filter({ hasText: name });
       await expect(card).toBeVisible();
       await expect(card).toHaveAttribute("aria-label", /Open dashboard detail/);
       await card.focus();
@@ -156,7 +156,7 @@ test.describe("dashboard rail", () => {
       releaseSecond = resolve;
     });
 
-    await page.route("**/api/v1/dashboard", async (route) => {
+    await page.route("**/api/v1/dashboard**", async (route) => {
       dashboardRequests += 1;
       if (dashboardRequests === 2) {
         await secondRequestGate;
@@ -202,7 +202,7 @@ test.describe("dashboard rail", () => {
       releaseFirst = resolve;
     });
 
-    await page.route("**/api/v1/dashboard", async (route) => {
+    await page.route("**/api/v1/dashboard**", async (route) => {
       dashboardRequests += 1;
       if (dashboardRequests === 1) {
         await firstRequestGate;

--- a/tests/playwright/tests/edge_cases.spec.ts
+++ b/tests/playwright/tests/edge_cases.spec.ts
@@ -41,7 +41,7 @@ async function stubTasks(page: import("@playwright/test").Page) {
 // doesn't race live daemon state. Each test below additionally stubs
 // /chat/sessions to whatever shape it needs.
 async function stubDashboard(page: import("@playwright/test").Page) {
-  await page.route("**/api/v1/dashboard", (route) =>
+  await page.route("**/api/v1/dashboard**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -163,7 +163,7 @@ test.describe("edge cases", () => {
         body: JSON.stringify({ error: { code: "internal", message: "x" } }),
       }),
     );
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 500,
         contentType: "application/json",

--- a/tests/playwright/tests/inbox.spec.ts
+++ b/tests/playwright/tests/inbox.spec.ts
@@ -38,7 +38,7 @@ async function stubChrome(page: import("@playwright/test").Page) {
       body: JSON.stringify({ items: [] }),
     }),
   );
-  await page.route("**/api/v1/dashboard", (route) =>
+  await page.route("**/api/v1/dashboard**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -82,7 +82,7 @@ test.describe("inbox panel", () => {
     await expect(page.locator("[data-inbox-id='demo/1']")).toContainText("Plan ready");
   });
 
-  test("dashboard inbox card opens browsable list with load more and disabled plan decisions", async ({ page }) => {
+  test("dashboard inbox card opens browsable list with load more and plan decisions", async ({ page }) => {
     await stubChrome(page);
 
     const inboxUrls: string[] = [];
@@ -122,7 +122,7 @@ test.describe("inbox panel", () => {
     await page.locator(".rollup-card[title='Open inbox']").click();
     await expect(page.locator("#pane-title")).toHaveText("Inbox");
     await expect(page.locator("[data-inbox-id='demo/1']")).toContainText("Plan ready");
-    await expect(page.locator(".inbox-action.disabled", { hasText: "Approve" })).toBeDisabled();
+    await expect(page.locator(".inbox-action", { hasText: "Approve" }).first()).toBeEnabled();
 
     await page.locator(".inbox-load-more").click();
     await expect(page.locator("[data-inbox-id='demo/2']")).toContainText("Follow-up question");
@@ -130,6 +130,48 @@ test.describe("inbox panel", () => {
 
     await page.locator("[data-inbox-id='demo/1']").click();
     await expect(page.locator(".inbox-thread-body")).toContainText("Please review.");
+  });
+
+  test("plan review decisions call task lifecycle endpoints", async ({ page }) => {
+    await stubChrome(page);
+
+    let approveActor = "";
+    let rejectReason = "";
+
+    await page.route("**/api/v1/inbox?**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [ITEM], next_cursor: null }),
+      }),
+    );
+    await page.route("**/api/v1/tasks/demo/1/approve", async (route) => {
+      approveActor = (await route.request().postDataJSON()).actor;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, message: "approved demo/1", task: ITEM }),
+      });
+    });
+    await page.route("**/api/v1/tasks/demo/1/rework", async (route) => {
+      rejectReason = (await route.request().postDataJSON()).reason;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, message: "rework demo/1", task: ITEM }),
+      });
+    });
+
+    await page.goto("/ui/");
+    await page.locator(".rollup-card[title='Open inbox']").click();
+    const row = page.locator("[data-inbox-id='demo/1']");
+    await expect(row).toBeVisible();
+
+    await row.locator(".inbox-action", { hasText: "Approve" }).click();
+    await expect.poll(() => approveActor).toBe("operator");
+
+    await row.locator(".inbox-action", { hasText: "Reject" }).click();
+    await expect.poll(() => rejectReason).toContain("web UI");
   });
 
   test("inbox filters and actions call existing API routes", async ({ page }) => {

--- a/tests/playwright/tests/keyboard.spec.ts
+++ b/tests/playwright/tests/keyboard.spec.ts
@@ -50,7 +50,7 @@ async function stubBasics(page: import("@playwright/test").Page) {
 // Stub the dashboard read endpoint the UI fires on init so this spec
 // doesn't race live daemon state under fullyParallel runs.
 async function stubDashboard(page: import("@playwright/test").Page) {
-  await page.route("**/api/v1/dashboard", (route) =>
+  await page.route("**/api/v1/dashboard**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/tests/playwright/tests/mobile_viewport.spec.ts
+++ b/tests/playwright/tests/mobile_viewport.spec.ts
@@ -43,7 +43,7 @@ test.describe("mobile viewport", () => {
 
   test("surface list renders at 360px before optional task rail request completes", async ({ page }) => {
     await page.setViewportSize({ width: 360, height: 800 });
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/tests/playwright/tests/send_message.spec.ts
+++ b/tests/playwright/tests/send_message.spec.ts
@@ -51,7 +51,7 @@ async function stubMessages(page: import("@playwright/test").Page) {
 // so this spec stays a pure unit of the send-message flow and doesn't
 // race live daemon state under fullyParallel runs.
 async function stubDashboard(page: import("@playwright/test").Page) {
-  await page.route("**/api/v1/dashboard", (route) =>
+  await page.route("**/api/v1/dashboard**", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/tests/playwright/tests/surfaces.spec.ts
+++ b/tests/playwright/tests/surfaces.spec.ts
@@ -319,7 +319,7 @@ test.describe("surfaces", () => {
       releaseEvent = resolve;
     });
 
-    await page.route("**/api/v1/dashboard", (route) => {
+    await page.route("**/api/v1/dashboard**", (route) => {
       dashboardRequests += 1;
       return route.fulfill({
         status: 200,
@@ -414,7 +414,7 @@ test.describe("surfaces", () => {
     await stubEmptyTasks(page);
 
     let dashboardRequests = 0;
-    await page.route("**/api/v1/dashboard", (route) => {
+    await page.route("**/api/v1/dashboard**", (route) => {
       dashboardRequests += 1;
       return route.fulfill({
         status: 200,
@@ -456,7 +456,7 @@ test.describe("surfaces", () => {
     await stubEmptyTasks(page);
 
     let dashboardRequests = 0;
-    await page.route("**/api/v1/dashboard", (route) => {
+    await page.route("**/api/v1/dashboard**", (route) => {
       dashboardRequests += 1;
       return route.fulfill({
         status: 200,
@@ -499,7 +499,7 @@ test.describe("surfaces", () => {
       releaseFirst = resolve;
     });
 
-    await page.route("**/api/v1/dashboard", async (route) => {
+    await page.route("**/api/v1/dashboard**", async (route) => {
       dashboardRequests += 1;
       if (dashboardRequests === 1) {
         await firstRequestGate;
@@ -534,7 +534,7 @@ test.describe("surfaces", () => {
     await stubEmptyActivity(page);
 
     let dashboardRequests = 0;
-    await page.route("**/api/v1/dashboard", (route) => {
+    await page.route("**/api/v1/dashboard**", (route) => {
       dashboardRequests += 1;
       return route.fulfill({
         status: 200,
@@ -578,7 +578,7 @@ test.describe("surfaces", () => {
 
   test("initial rail load requests sessions tasks and projects in parallel", async ({ page }) => {
     await stubEmptyActivity(page);
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -631,7 +631,7 @@ test.describe("surfaces", () => {
   test("projects render on cold load before sessions and tasks finish", async ({ page }) => {
     await installHealthyEventSource(page);
     await stubEmptyActivity(page);
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -701,7 +701,7 @@ test.describe("surfaces", () => {
     await page.addInitScript(() => {
       (window as any).__POLLYPM_RAIL_REQUEST_TIMEOUT_MS = 50;
     });
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -752,7 +752,7 @@ test.describe("surfaces", () => {
     await page.addInitScript(() => {
       (window as any).__POLLYPM_RAIL_REQUEST_TIMEOUT_MS = 1000;
     });
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -816,7 +816,7 @@ test.describe("surfaces", () => {
   test("initial center-pane state shows inline next actions", async ({ page }) => {
     await page.goto("/ui/");
     await expect(page.locator("#pane-title")).toHaveText("Ready");
-    await expect(page.locator(".empty-title")).toHaveText("No surface selected");
+    await expect(page.locator(".empty-title")).toContainText(/handled|need|Loading/);
     await expect(page.locator(".empty-action.primary")).toHaveText("Open inbox");
     await expect(page.locator("#send-input")).toBeDisabled();
     await expect(page.locator("#send-button")).toBeDisabled();
@@ -983,7 +983,7 @@ test.describe("surfaces", () => {
         body: JSON.stringify({ sessions: [] }),
       }),
     );
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -1214,7 +1214,7 @@ test.describe("surfaces", () => {
     await stubEmptyProjects(page);
     await stubEmptySessions(page);
     await stubEmptyTasks(page);
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -1288,7 +1288,7 @@ test.describe("surfaces", () => {
     await stubEmptyProjects(page);
     await stubEmptySessions(page);
     await stubEmptyTasks(page);
-    await page.route("**/api/v1/dashboard", (route) =>
+    await page.route("**/api/v1/dashboard**", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/tests/web_api/test_alerts_endpoint.py
+++ b/tests/web_api/test_alerts_endpoint.py
@@ -55,3 +55,61 @@ def test_list_alerts_filters_operational_and_includes_actions(
     body = response.json()
     assert body["total"] == 2
     assert len(body["alerts"]) == 1
+
+
+def test_acknowledge_alert_action_closes_alert(
+    client,
+    auth_headers,
+    pg_schema_pool,
+) -> None:
+    from pollypm.storage.pg_alerts import open_alerts, upsert_alert
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    upsert_alert(
+        "worker_demo",
+        "auth_broken",
+        "error",
+        "Codex auth failed",
+        pool=pg_schema_pool,
+    )
+    alert = open_alerts(pool=pg_schema_pool)[0]
+
+    response = client.post(
+        f"/api/v1/alerts/{alert.alert_id}/actions/acknowledge",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["alert_id"] == alert.alert_id
+    assert body["status"] == "closed"
+    assert open_alerts(pool=pg_schema_pool) == []
+
+
+def test_alert_action_rejects_unsupported_kind(
+    client,
+    auth_headers,
+    pg_schema_pool,
+) -> None:
+    from pollypm.storage.pg_alerts import open_alerts, upsert_alert
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    upsert_alert(
+        "worker_demo",
+        "auth_broken",
+        "error",
+        "Codex auth failed",
+        pool=pg_schema_pool,
+    )
+    alert = open_alerts(pool=pg_schema_pool)[0]
+
+    response = client.post(
+        f"/api/v1/alerts/{alert.alert_id}/actions/restart_session",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "invalid_request"

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1168,6 +1168,8 @@ def test_ui_app_js_has_alerts_panel_hooks(client: TestClient) -> None:
     for expected in (
         "selectAlerts",
         "/alerts?limit=100",
+        "/actions/acknowledge",
+        "alert acknowledged",
         "/doctor/report",
         "/doctor/run",
         "session-drift",
@@ -1187,9 +1189,11 @@ def test_ui_app_js_has_inbox_panel_hooks(client: TestClient) -> None:
         "/archive",
         "/snooze",
         "/reply",
+        'verb = decision === "approve" ? "approve" : "rework"',
+        "plan approved",
         "Load more",
         "Type filtering is unavailable",
-        "Plan approve/reject API is not available",
+        "rejected from web UI",
     ):
         assert expected in body
 
@@ -1206,7 +1210,8 @@ def test_ui_empty_state_points_to_inbox_without_modal(client: TestClient) -> Non
     """First-run/no-selection state is an inline action surface."""
     body = client.get("/ui/app.js").text
     assert "renderNoSelection" in body
-    assert "No surface selected" in body
+    assert "All handled - Polly's got it" in body
+    assert "include_briefing" in body
     assert "Open inbox" in body
     assert "Refresh" in body
 
@@ -1678,6 +1683,7 @@ def test_render_dashboard_real_payload_executes() -> None:
             "alert_count": 3,
             "sweep_count_24h": 12,
             "message_count_24h": 47,
+            "recovery_count_24h": 2,
             "tracked_count": 5,
         },
         "daemon_status": "up",
@@ -1690,6 +1696,17 @@ def test_render_dashboard_real_payload_executes() -> None:
         "scoped_fields": [],
         "projects": [],
         "recent_messages": [],
+        "tokens": {"today": 1234, "total": 5678},
+        "account_usages": [{
+            "account_name": "claude_primary",
+            "provider": "claude",
+            "email": "claude@example.com",
+            "used_pct": 42,
+            "summary": "58% left this week",
+            "severity": "ok",
+            "limit_label": "weekly limit",
+            "reset_at": "",
+        }],
     }
     rendered = _node_render_dashboard(payload)
 
@@ -1700,6 +1717,7 @@ def test_render_dashboard_real_payload_executes() -> None:
 
     # Each counter's label appears.
     for label in (
+        "Claude headroom",
         "inbox",
         "plan reviews",
         "alerts",
@@ -1722,6 +1740,9 @@ def test_render_dashboard_real_payload_executes() -> None:
     assert ">up<" in rendered, "daemon status 'up' missing"
     assert ">4<" in rendered, "active_sessions count (len=4) missing"
     assert ">5<" in rendered, "tracked_count value 5 missing"
+    assert "58% left this week" in rendered, "quota summary missing"
+    assert "1234 today / 5678 total tokens" in rendered, "token line missing"
+    assert "5 things need you" in rendered, "lead headline missing"
     assert 'role="button"' in rendered
     assert 'title="Open inbox"' in rendered
     assert 'title="Open alerts"' in rendered


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Requests the dashboard briefing once on cold load, caches dashboard data for the center pane, and replaces the generic no-selection state with a status-aware workspace briefing.
- Adds a dashboard lead headline and Claude headroom quota card using existing rollups, account_usages, and tokens fields.
- Wires web plan-review Approve/Reject buttons to the task lifecycle endpoints and alert Acknowledge actions to a new thin alert action endpoint.
- Updates API docs/OpenAPI and Playwright/Python coverage for the new contracts.

Fixes #2439
Fixes #2440
Fixes #2441

## Verification
- `uv run --extra test pytest tests/web_api/test_alerts_endpoint.py tests/web_api/test_web_ui.py -q` (69 passed)
- `uv run --extra test --with openapi-spec-validator pytest tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31 -q` (1 passed)
- `uv run --extra test pytest tests/web_api/test_alerts_endpoint.py -q` (3 passed)
- `uv run --extra test pytest tests/web_api/test_web_ui.py::test_ui_app_js_has_alerts_panel_hooks tests/web_api/test_web_ui.py::test_ui_app_js_has_inbox_panel_hooks tests/web_api/test_web_ui.py::test_ui_empty_state_points_to_inbox_without_modal tests/web_api/test_web_ui.py::test_render_dashboard_real_payload_executes -q` (4 passed)
- `POLLYPM_BASE_URL=http://127.0.0.1:8876 npx playwright test tests/dashboard_rail.spec.ts tests/inbox.spec.ts tests/alerts.spec.ts --project=chromium --workers=1` (9 passed)

## Notes
- The existing in-app browser surface was unavailable in this session (no `iab` browser listed), so browser verification used Playwright against `pm serve` started from this worktree on port 8876.