### PR TITLE
Clarify task claim command typo

### DIFF
--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -100,6 +100,24 @@ def _resolve_notify_store():
 _TASK_ID_FULL_PATTERN = re.compile(r"^([A-Za-z0-9_.-]+)/(\d+)$")
 
 
+def _reject_task_id_for_lease_command(command_name: str, session_name: str) -> None:
+    if "/" not in session_name:
+        return
+    if command_name == "claim":
+        message = (
+            f"Did you mean 'pm task claim {session_name}'? "
+            "'pm claim' sets a tmux session lease, not a work task."
+        )
+    else:
+        message = (
+            f"Did you mean a work-task command for {session_name}? "
+            f"'pm {command_name}' clears a tmux session lease, not a work task. "
+            "See 'pm task --help'."
+        )
+    typer.echo(message, err=True)
+    raise typer.Exit(code=2)
+
+
 def _resolve_send_target_name(name: str) -> str:
     """Translate ``<project>/<N>`` to ``task-<project>-<N>``; pass through otherwise.
 
@@ -614,6 +632,7 @@ def claim(
         DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
     ),
 ) -> None:
+    _reject_task_id_for_lease_command("claim", session_name)
     supervisor = helpers._load_supervisor(config_path)
     helpers._require_pollypm_session(supervisor)
     supervisor.claim_lease(session_name, owner, note)
@@ -627,6 +646,7 @@ def release(
         DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
     ),
 ) -> None:
+    _reject_task_id_for_lease_command("release", session_name)
     supervisor = helpers._load_supervisor(config_path)
     helpers._require_pollypm_session(supervisor)
     supervisor.release_lease(session_name)

--- a/tests/test_session_lease_cli.py
+++ b/tests/test_session_lease_cli.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+import pollypm.cli as cli
+
+
+def test_claim_task_id_hints_before_loading_supervisor(monkeypatch) -> None:
+    def fail_load_supervisor(_config_path):
+        raise AssertionError("task-id hint should run before supervisor loading")
+
+    monkeypatch.setattr(cli, "_load_supervisor", fail_load_supervisor)
+
+    result = CliRunner().invoke(cli.app, ["claim", "shortlink_gen/1"])
+
+    assert result.exit_code == 2
+    assert "Did you mean 'pm task claim shortlink_gen/1'?" in result.output
+    assert "'pm claim' sets a tmux session lease, not a work task." in result.output
+
+
+def test_release_task_id_hints_before_loading_supervisor(monkeypatch) -> None:
+    def fail_load_supervisor(_config_path):
+        raise AssertionError("task-id hint should run before supervisor loading")
+
+    monkeypatch.setattr(cli, "_load_supervisor", fail_load_supervisor)
+
+    result = CliRunner().invoke(cli.app, ["release", "shortlink_gen/1"])
+
+    assert result.exit_code == 2
+    assert "Did you mean a work-task command for shortlink_gen/1?" in result.output
+    assert "'pm release' clears a tmux session lease, not a work task." in result.output
+    assert "pm task --help" in result.output


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Detect slash-shaped task ids passed to top-level `pm claim`/`pm release` before supervisor loading or tmux session validation.
- Emit a wrong-domain hint that points users back to `pm task claim <id>` / `pm task --help` instead of the tmux lease error.

Closes #2444.

## Tests
- `uv run --extra test python -m pytest tests/test_session_lease_cli.py tests/test_pm_cli_registration.py -q` -> 7 passed
- `git diff --check` -> passed
- `uv run --with ruff ruff check --ignore E402 src/pollypm/cli_features/session_runtime.py tests/test_session_lease_cli.py` -> passed

## Worker Notes
Implemented in dedicated worktree `/Users/sam/dev/pollypm/.codex/watch-worktrees/20260529-141148-2444` by the #2444 worker agent. Parent Codex reviewed the diff and created this PR from that worktree.
