### PR TITLE
Cache dashboard snapshots for warm polls

### DIFF
--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -38,6 +38,7 @@ from pollypm.web_api.auth import (
     make_sse_auth_dependency,
     mint_session_cookie,
 )
+from pollypm.web_api.dashboard_snapshot_cache import DashboardSnapshotCache
 from pollypm.web_api.token import DEFAULT_TOKEN_PATH, load_token
 from pollypm.web_api.errors import (
     APIError,
@@ -443,6 +444,7 @@ def create_app(
         expose_headers=["Last-Event-ID", "X-PollyPM-Warning"],
     )
     app.state.tailnet_trust_enabled = tailnet_trust_enabled
+    app.state.dashboard_snapshot_cache = DashboardSnapshotCache()
 
     # Wire the config provider. When the loaded config carries the
     # on-disk ``config_path`` (always true for ``pm serve``), re-invoke

--- a/src/pollypm/web_api/dashboard_snapshot_cache.py
+++ b/src/pollypm/web_api/dashboard_snapshot_cache.py
@@ -1,0 +1,123 @@
+"""Stale-while-refresh cache for expensive dashboard snapshots."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class DashboardSnapshot:
+    generated_at: datetime
+    projects: tuple[Any, ...]
+    data: Any
+    refreshed_at_monotonic: float
+
+
+class DashboardSnapshotCache:
+    """Bounded stale-while-refresh cache for dashboard API snapshots."""
+
+    def __init__(
+        self,
+        *,
+        stale_after_seconds: float = 10.0,
+        max_stale_seconds: float = 60.0,
+    ) -> None:
+        if stale_after_seconds < 0:
+            raise ValueError("stale_after_seconds must be non-negative")
+        if max_stale_seconds < stale_after_seconds:
+            raise ValueError("max_stale_seconds must be >= stale_after_seconds")
+        self._stale_after_seconds = stale_after_seconds
+        self._max_stale_seconds = max_stale_seconds
+        self._snapshots: dict[int, DashboardSnapshot] = {}
+        self._refreshing: set[int] = set()
+        self._lock = threading.Lock()
+
+    def clear(self) -> None:
+        with self._lock:
+            self._snapshots.clear()
+            self._refreshing.clear()
+
+    async def get_or_refresh(
+        self,
+        config: Any,
+        loader: Callable[[Any], DashboardSnapshot],
+    ) -> DashboardSnapshot:
+        """Return a cached snapshot, refreshing in the background when stale.
+
+        The first call, or a call after the bounded stale window has
+        expired, waits for ``loader`` and propagates failures. Calls with
+        a stale-but-usable snapshot return immediately while one daemon
+        thread updates the cache.
+        """
+        key = id(config)
+        with self._lock:
+            snapshot = self._snapshots.get(key)
+            if snapshot is not None:
+                age = time.monotonic() - snapshot.refreshed_at_monotonic
+                if age <= self._stale_after_seconds:
+                    return snapshot
+                if age <= self._max_stale_seconds:
+                    self._start_background_refresh_locked(key, config, loader)
+                    return snapshot
+
+        return await asyncio.to_thread(self._refresh_sync, key, config, loader)
+
+    def _start_background_refresh_locked(
+        self,
+        key: int,
+        config: Any,
+        loader: Callable[[Any], DashboardSnapshot],
+    ) -> None:
+        if key in self._refreshing:
+            return
+        self._refreshing.add(key)
+        thread = threading.Thread(
+            target=self._refresh_background,
+            name="dashboard-snapshot-refresh",
+            args=(key, config, loader),
+            daemon=True,
+        )
+        thread.start()
+
+    def _refresh_background(
+        self,
+        key: int,
+        config: Any,
+        loader: Callable[[Any], DashboardSnapshot],
+    ) -> None:
+        try:
+            self._refresh_sync(key, config, loader)
+        except Exception:
+            logger.warning(
+                "dashboard snapshot refresh failed for cache key %r",
+                key,
+                exc_info=True,
+            )
+        finally:
+            with self._lock:
+                self._refreshing.discard(key)
+
+    def _refresh_sync(
+        self,
+        key: int,
+        config: Any,
+        loader: Callable[[Any], DashboardSnapshot],
+    ) -> DashboardSnapshot:
+        snapshot = loader(config)
+        with self._lock:
+            self._snapshots[key] = snapshot
+            self._refreshing.discard(key)
+        return snapshot
+
+
+__all__ = ["DashboardSnapshot", "DashboardSnapshotCache"]

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -22,14 +22,19 @@ The route's behaviour mirrors the cockpit per spec §3.3 edge cases:
 
 from __future__ import annotations
 
-import asyncio
 import logging
+import threading
+import time
 from datetime import datetime, timezone
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel, Field
 
+from pollypm.web_api.dashboard_snapshot_cache import (
+    DashboardSnapshot,
+    DashboardSnapshotCache,
+)
 from pollypm.web_api.errors import not_found, service_unavailable
 from pollypm.web_api.models import Project
 from pollypm.web_api.routes._deps import ConfigDep
@@ -256,6 +261,92 @@ def _gather_dashboard(config: Any) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Snapshot loading / cache access
+# ---------------------------------------------------------------------------
+
+
+def _get_dashboard_snapshot_cache(request: Request) -> DashboardSnapshotCache:
+    """Resolve the app-scoped dashboard cache, creating a fallback for tests."""
+
+    cache = getattr(request.app.state, "dashboard_snapshot_cache", None)
+    if cache is None:
+        cache = DashboardSnapshotCache()
+        request.app.state.dashboard_snapshot_cache = cache
+    return cache
+
+
+def _call_dashboard_source_pair(
+    config: Any,
+) -> tuple[tuple[bool, Any], tuple[bool, Any]]:
+    """Load project rows and rollup data concurrently."""
+
+    results: dict[str, tuple[bool, Any]] = {}
+    lock = threading.Lock()
+
+    def _run(name: str, func: Any) -> None:
+        try:
+            value = func()
+        except Exception as exc:  # noqa: BLE001
+            value = exc
+            ok = False
+        else:
+            ok = True
+        with lock:
+            results[name] = (ok, value)
+
+    threads = [
+        threading.Thread(
+            target=_run,
+            name="dashboard-list-projects",
+            args=("projects", lambda: list_projects(config)),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=_run,
+            name="dashboard-gather",
+            args=("data", lambda: _gather_dashboard(config)),
+            daemon=True,
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    return results["projects"], results["data"]
+
+
+def _load_dashboard_snapshot(config: Any) -> DashboardSnapshot:
+    """Run the expensive dashboard load once and normalize errors."""
+
+    projects_slot, data_slot = _call_dashboard_source_pair(config)
+    projects_ok, projects_result = projects_slot
+    data_ok, data_result = data_slot
+
+    if not projects_ok:
+        # list_projects swallows per-project failures internally; a
+        # raise here means the config itself is unreadable.
+        logger.warning("dashboard: list_projects failed: %s", projects_result)
+        raise service_unavailable(
+            "Failed to load project list for dashboard",
+            hint="Check `pm doctor` and config.toml health.",
+        ) from projects_result
+    if not data_ok:
+        logger.warning("dashboard: gather failed: %s", data_result)
+        raise service_unavailable(
+            "Dashboard gather failed; backing store may be unreachable",
+            hint="Retry shortly; check `pm doctor` for pg pool health.",
+        ) from data_result
+
+    return DashboardSnapshot(
+        generated_at=datetime.now(timezone.utc),
+        projects=tuple(projects_result),
+        data=data_result,
+        refreshed_at_monotonic=time.monotonic(),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Endpoint
 # ---------------------------------------------------------------------------
 
@@ -268,6 +359,7 @@ def _gather_dashboard(config: Any) -> Any:
 )
 async def get_dashboard_endpoint(
     config: ConfigDep,
+    request: Request,
     project: Annotated[
         str | None,
         Query(
@@ -315,25 +407,10 @@ async def get_dashboard_endpoint(
             hint="Drop ?project= to fetch the whole-system snapshot.",
         )
 
-    projects_result, data_result = await asyncio.gather(
-        asyncio.to_thread(list_projects, config),
-        asyncio.to_thread(_gather_dashboard, config),
-        return_exceptions=True,
+    snapshot = await _get_dashboard_snapshot_cache(request).get_or_refresh(
+        config,
+        _load_dashboard_snapshot,
     )
-    if isinstance(projects_result, Exception):
-        # list_projects swallows per-project failures internally; a
-        # raise here means the config itself is unreadable.
-        logger.warning("dashboard: list_projects failed: %s", projects_result)
-        raise service_unavailable(
-            "Failed to load project list for dashboard",
-            hint="Check `pm doctor` and config.toml health.",
-        ) from projects_result
-    if isinstance(data_result, Exception):
-        logger.warning("dashboard: gather failed: %s", data_result)
-        raise service_unavailable(
-            "Dashboard gather failed; backing store may be unreachable",
-            hint="Retry shortly; check `pm doctor` for pg pool health.",
-        ) from data_result
 
     # Projects view — list_projects is the authoritative cockpit row
     # builder; reuse it so the rollups derived below match the project
@@ -341,8 +418,8 @@ async def get_dashboard_endpoint(
     # payload (active sessions, commits, tokens, …). Transient pg outages
     # surface as 503 per spec §3.3 final bullet; a healthy daemon-down
     # state is captured below as ``daemon_status="down"`` (200, not 503).
-    projects_all = projects_result
-    data = data_result
+    projects_all = list(snapshot.projects)
+    data = snapshot.data
 
     if project is not None:
         projects_view = [p for p in projects_all if p.key == project]
@@ -436,7 +513,7 @@ async def get_dashboard_endpoint(
         briefing = getattr(data, "briefing", "") or ""
 
     return DashboardResponse(
-        generated_at=datetime.now(timezone.utc),
+        generated_at=snapshot.generated_at,
         daemon_status=daemon_status,
         projects=projects_view,
         rollups=rollups,
@@ -470,6 +547,7 @@ __all__ = [
     "CompletedItemModel",
     "DashboardResponse",
     "DashboardRollups",
+    "DashboardSnapshotCache",
     "DashboardTokens",
     "InboxPreviewModel",
     "SessionActivityModel",

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -13,6 +13,7 @@ harness which these tests intentionally avoid.
 from __future__ import annotations
 
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -381,6 +382,83 @@ def test_dashboard_route_gather_bypasses_state_cache(
     dashboard_routes._gather_dashboard(config)
 
     assert seen == {"use_state_cache": False}
+
+
+def test_dashboard_cache_hit_skips_repeated_expensive_loads(
+    client, auth_headers, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"list": 0, "gather": 0}
+
+    def fake_list_projects(_config):
+        calls["list"] += 1
+        return [_api_project("myproj")]
+
+    def fake_gather(_config):
+        calls["gather"] += 1
+        return _make_data(total_tokens=42)
+
+    monkeypatch.setattr(dashboard_routes, "list_projects", fake_list_projects)
+    monkeypatch.setattr(dashboard_routes, "_gather_dashboard", fake_gather)
+
+    first = client.get("/api/v1/dashboard", headers=auth_headers)
+    second = client.get("/api/v1/dashboard", headers=auth_headers)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert second.json()["tokens"]["total"] == 42
+    assert calls == {"list": 1, "gather": 1}
+
+
+def test_dashboard_stale_cache_returns_while_refresh_runs(
+    app, client, auth_headers, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app.state.dashboard_snapshot_cache = dashboard_routes.DashboardSnapshotCache(
+        stale_after_seconds=0.01,
+    )
+    gather_calls = 0
+    refresh_started = threading.Event()
+    release_refresh = threading.Event()
+
+    def fake_list_projects(_config):
+        return [_api_project("myproj")]
+
+    def fake_gather(_config):
+        nonlocal gather_calls
+        gather_calls += 1
+        if gather_calls == 1:
+            return _make_data(total_tokens=1)
+        refresh_started.set()
+        assert release_refresh.wait(2.0)
+        return _make_data(total_tokens=2)
+
+    monkeypatch.setattr(dashboard_routes, "list_projects", fake_list_projects)
+    monkeypatch.setattr(dashboard_routes, "_gather_dashboard", fake_gather)
+
+    first = client.get("/api/v1/dashboard", headers=auth_headers)
+    assert first.status_code == 200, first.text
+    assert first.json()["tokens"]["total"] == 1
+
+    time.sleep(0.03)
+    started_at = time.monotonic()
+    second = client.get("/api/v1/dashboard", headers=auth_headers)
+    elapsed = time.monotonic() - started_at
+
+    assert second.status_code == 200, second.text
+    assert second.json()["tokens"]["total"] == 1
+    assert elapsed < 0.5
+    assert refresh_started.wait(1.0)
+
+    release_refresh.set()
+    deadline = time.monotonic() + 2.0
+    body = second.json()
+    while time.monotonic() < deadline:
+        third = client.get("/api/v1/dashboard", headers=auth_headers)
+        assert third.status_code == 200, third.text
+        body = third.json()
+        if body["tokens"]["total"] == 2:
+            break
+        time.sleep(0.02)
+    assert body["tokens"]["total"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add an app-scoped dashboard snapshot cache with fresh-hit reuse and bounded stale-while-refresh behavior.
- Keep cold-load 503 behavior when no cached snapshot exists, while preserving project filters and optional dashboard fields.
- Cover cache hits and stale refresh behavior in dashboard endpoint tests.

## Verification
- `python -m compileall -q src/pollypm/web_api/dashboard_snapshot_cache.py src/pollypm/web_api/routes/dashboard.py src/pollypm/web_api/app.py`
- `uv run --with ruff ruff check src/pollypm/web_api/dashboard_snapshot_cache.py src/pollypm/web_api/routes/dashboard.py src/pollypm/web_api/app.py tests/test_dashboard_endpoint.py`
- `uv run --with pytest pytest --noconftest tests/test_dashboard_endpoint.py -q`

Closes #2452
