### PR TITLE
Reclaim stuck watchdog drafts

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -117,6 +117,8 @@ The current event families are:
 | `account.failover.failed` | supervisor hard recovery when every failover candidate fails launch | `session`, `failure_type`, `from`, `reason`, `last_error` |
 | `audit.finding` | audit watchdog findings | `rule`, `message`, `recommendation`, plus rule-specific data |
 | `audit.finding_dismissed` | `pm audit dismiss-finding` false-positive resolution | `rule`, `reason`, `source`, `scope` |
+| `audit.stuck_draft_terminated` | stuck-draft terminator when one subject crosses the repeat threshold | `rule`, `prior_finding_count`, `threshold`, `recommendation` |
+| `audit.stuck_draft_reclaimed` | stuck-draft terminator after it cancels a watchdog-owned draft | `rule`, `prior_finding_count`, `threshold`, `action`, `created_by`, `reason` |
 | `agent.injection.flagged` | `pm audit agent-refusal` / auth-marker refusal contract | `reason`, `source`, `paired_event` |
 | `agent.refusal` | `pm audit agent-refusal` / auth-marker refusal contract | `reason`, `source`, `paired_event` |
 | `worker.session_reaped` | worker marker reaper | `window_name`, `marker_path`, `reason` |
@@ -162,6 +164,11 @@ an alert keyed by `(rule, project, subject)`.
 Several auto-unstick rules can dispatch a structured brief to the project's
 architect. Dispatch is throttled for 30 minutes by reading prior
 `watchdog.escalation_dispatched` events from the audit log itself.
+After three prior `stuck_draft` findings for the same subject, the watchdog
+emits `audit.stuck_draft_terminated` and suppresses further findings for that
+subject. If the underlying task is still a draft and was created by
+`audit_watchdog` or by a legacy empty creator, the terminator also cancels it
+and emits `audit.stuck_draft_reclaimed`.
 
 When a finding is a real false positive rather than stale state, record the
 terminal judgment with `pm audit dismiss-finding <rule> <project> --reason

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -60,6 +60,7 @@ import hashlib
 import json
 import logging
 import re
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
@@ -92,6 +93,7 @@ __all__ = [
     "EVENT_AUDIT_FINDING",
     "EVENT_AUDIT_FINDING_DISMISSED",
     "EVENT_STUCK_DRAFT_TERMINATED",
+    "EVENT_STUCK_DRAFT_RECLAIMED",
     "STUCK_DRAFT_TERMINATOR_THRESHOLD",
     "RULE_ORPHAN_MARKER",
     "RULE_MARKER_LEAKED",
@@ -328,10 +330,13 @@ QUEUE_MOTION_THRESHOLD_SECONDS = 1800
 # After ``STUCK_DRAFT_TERMINATOR_THRESHOLD`` prior ``audit.finding`` rows
 # for ``(rule=stuck_draft, subject=X)`` we stop re-emitting the finding
 # for that subject and write a single ``audit.stuck_draft_terminated``
-# breadcrumb. The operator can still manually retry by promoting or
-# cancelling the underlying draft — the terminator just stops the loop.
+# breadcrumb. #2456 also attempts to reclaim watchdog-created draft
+# tasks at the same threshold so the source row stops accumulating
+# queue_without_motion follow-up drafts.
 EVENT_STUCK_DRAFT_TERMINATED = "audit.stuck_draft_terminated"
+EVENT_STUCK_DRAFT_RECLAIMED = "audit.stuck_draft_reclaimed"
 STUCK_DRAFT_TERMINATOR_THRESHOLD = 3
+_STUCK_DRAFT_RECLAIMABLE_CREATORS = frozenset({"", "audit_watchdog"})
 
 # Audit events emitted *by* the watchdog itself.
 EVENT_HEARTBEAT_TICK = "heartbeat.tick"
@@ -737,8 +742,10 @@ def _emit_stuck_draft_terminator(
     Emits a single ``audit.stuck_draft_terminated`` row so a forensic
     grep can answer "why did the heartbeat stop nagging me about
     pollypm/191?" without us having to dig through the detector.
-    Best-effort — must never raise; the loss of a single forensic
-    breadcrumb is far better than crashing the cadence handler.
+    Once that breadcrumb is durable, also best-effort cancels a still-draft
+    watchdog-owned source row so synthetic queue-without-motion drafts stop
+    feeding the cascade. Both actions must never raise into the cadence
+    handler.
 
     ``project_path`` MUST be threaded through from the cadence handler
     (via ``scan_project``) so the breadcrumb lands in the per-project
@@ -754,6 +761,7 @@ def _emit_stuck_draft_terminator(
     values; ``scan_project`` materialises them via this helper. Pure
     ``scan_events`` callers never reach this code path.
     """
+    terminator_emitted = False
     try:
         from pollypm.audit.log import emit as _audit_emit
 
@@ -774,9 +782,82 @@ def _emit_stuck_draft_terminator(
             },
             project_path=project_path,
         )
+        terminator_emitted = True
     except Exception:  # noqa: BLE001
         logger.debug(
             "audit.watchdog: stuck_draft_terminated emit failed for %s",
+            subject, exc_info=True,
+        )
+    if terminator_emitted:
+        _maybe_reclaim_stuck_draft(
+            project=project,
+            subject=subject,
+            prior_count=prior_count,
+            project_path=project_path,
+        )
+
+
+def _maybe_reclaim_stuck_draft(
+    *,
+    project: str,
+    subject: str,
+    prior_count: int,
+    project_path: Path | str | None,
+) -> None:
+    parsed = _task_subject_key(subject)
+    if parsed is None or parsed[0] != project:
+        return
+
+    reason = (
+        "stuck_draft terminator threshold reached "
+        f"after {prior_count} prior findings"
+    )
+    creator = ""
+    try:
+        from pollypm.work import create_work_service
+
+        svc = create_work_service(
+            project_path=project_path,
+            project_key=project,
+        )
+        manager = svc if hasattr(svc, "__enter__") else nullcontext(svc)
+        with manager as work:
+            task = work.get(subject)
+            if _task_status_value(task) != "draft":
+                return
+            creator = _task_scalar_value(task, "created_by")
+            if creator not in _STUCK_DRAFT_RECLAIMABLE_CREATORS:
+                return
+            work.cancel(subject, "audit_watchdog", reason)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: stuck_draft reclaim failed for %s",
+            subject, exc_info=True,
+        )
+        return
+
+    try:
+        from pollypm.audit.log import emit as _audit_emit
+
+        _audit_emit(
+            event=EVENT_STUCK_DRAFT_RECLAIMED,
+            project=project,
+            subject=subject,
+            actor="audit_watchdog",
+            status="ok",
+            metadata={
+                "rule": RULE_STUCK_DRAFT,
+                "prior_finding_count": prior_count,
+                "threshold": STUCK_DRAFT_TERMINATOR_THRESHOLD,
+                "action": "cancelled",
+                "created_by": creator or None,
+                "reason": reason,
+            },
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: stuck_draft_reclaimed emit failed for %s",
             subject, exc_info=True,
         )
 
@@ -3041,26 +3122,15 @@ def _is_unactioned_queue_without_motion_task(
 
     The tier-3 materializer writes these as ordinary work tasks so the
     pure probe can only inspect the open-task snapshot. Keep the match
-    narrow: same project, still ``draft``, watchdog/operator-shaped,
-    and carrying the queue_without_motion subject/body produced by the
-    shipped prompt path. Older production rows may have no
-    ``created_by`` but do carry the title shape and watchdog label.
+    narrow: same project, still ``draft``, and carrying the generated
+    queue_without_motion subject/body produced by the shipped prompt
+    path. Older production rows may have no ``created_by``, kind, or
+    watchdog labels, so the generated title/body is the durable shape.
     """
     if _task_status_value(task) != "draft":
         return False
     project = _task_scalar_value(task, "project")
     if project and project != project_key:
-        return False
-
-    labels = _task_label_set(task)
-    kind = _task_scalar_value(task, "kind")
-    created_by = _task_scalar_value(task, "created_by")
-    watchdog_shaped = (
-        kind == "watchdog_operator_dispatch"
-        or "watchdog" in labels
-        or created_by == "audit_watchdog"
-    )
-    if not watchdog_shaped:
         return False
 
     title = _task_scalar_value(task, "title")

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -27,6 +27,7 @@ from pollypm.audit.watchdog import (
     EVENT_AUDIT_FINDING_DISMISSED,
     EVENT_AUDIT_FINDING,
     EVENT_HEARTBEAT_TICK,
+    EVENT_STUCK_DRAFT_RECLAIMED,
     EVENT_STUCK_DRAFT_TERMINATED,
     RULE_QUEUE_WITHOUT_MOTION,
     RULE_CANCEL_NO_PROMOTION,
@@ -445,6 +446,134 @@ def test_scan_events_remains_pure_when_terminator_threshold_hit(
         "authorised emitter for stuck_draft_terminated breadcrumbs. "
         f"Observed: {spy_calls!r}"
     )
+
+
+@pytest.mark.parametrize("created_by", [None, "", "audit_watchdog"])
+def test_stuck_draft_terminator_reclaims_watchdog_owned_drafts(
+    created_by: str | None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.audit.watchdog import _emit_stuck_draft_terminator
+
+    class _Status:
+        value = "draft"
+
+    class _Task:
+        work_status = _Status()
+
+        def __init__(self, creator: str | None = created_by) -> None:
+            self.created_by = creator
+
+    emitted: list[dict[str, object]] = []
+    cancel_calls: list[tuple[str, str, str]] = []
+    factory_calls: list[dict[str, object]] = []
+
+    def _record(**kwargs: object) -> None:
+        emitted.append(kwargs)
+
+    class _Service:
+        def __enter__(self) -> "_Service":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def get(self, task_id: str) -> _Task:
+            assert task_id == "demo/2"
+            return _Task()
+
+        def cancel(self, task_id: str, actor: str, reason: str) -> _Task:
+            cancel_calls.append((task_id, actor, reason))
+            return _Task()
+
+    def _factory(**kwargs: object) -> _Service:
+        factory_calls.append(kwargs)
+        return _Service()
+
+    monkeypatch.setattr("pollypm.audit.log.emit", _record)
+    monkeypatch.setattr("pollypm.work.create_work_service", _factory)
+
+    _emit_stuck_draft_terminator(
+        project="demo",
+        subject="demo/2",
+        prior_count=STUCK_DRAFT_TERMINATOR_THRESHOLD,
+        project_path=tmp_path,
+    )
+
+    assert factory_calls == [
+        {"project_path": tmp_path, "project_key": "demo"},
+    ]
+    assert len(cancel_calls) == 1
+    task_id, actor, reason = cancel_calls[0]
+    assert task_id == "demo/2"
+    assert actor == "audit_watchdog"
+    assert "terminator threshold reached" in reason
+    assert [event["event"] for event in emitted] == [
+        EVENT_STUCK_DRAFT_TERMINATED,
+        EVENT_STUCK_DRAFT_RECLAIMED,
+    ]
+    assert emitted[1]["metadata"] == {
+        "rule": RULE_STUCK_DRAFT,
+        "prior_finding_count": STUCK_DRAFT_TERMINATOR_THRESHOLD,
+        "threshold": STUCK_DRAFT_TERMINATOR_THRESHOLD,
+        "action": "cancelled",
+        "created_by": created_by or None,
+        "reason": reason,
+    }
+
+
+def test_stuck_draft_terminator_preserves_human_owned_drafts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.audit.watchdog import _emit_stuck_draft_terminator
+
+    class _Status:
+        value = "draft"
+
+    class _Task:
+        work_status = _Status()
+        created_by = "samhotchkiss"
+
+    emitted: list[dict[str, object]] = []
+    cancel_calls: list[tuple[str, str, str]] = []
+
+    def _record(**kwargs: object) -> None:
+        emitted.append(kwargs)
+
+    class _Service:
+        def __enter__(self) -> "_Service":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def get(self, task_id: str) -> _Task:
+            assert task_id == "demo/2"
+            return _Task()
+
+        def cancel(self, task_id: str, actor: str, reason: str) -> _Task:
+            cancel_calls.append((task_id, actor, reason))
+            return _Task()
+
+    monkeypatch.setattr("pollypm.audit.log.emit", _record)
+    monkeypatch.setattr(
+        "pollypm.work.create_work_service",
+        lambda **_: _Service(),
+    )
+
+    _emit_stuck_draft_terminator(
+        project="demo",
+        subject="demo/2",
+        prior_count=STUCK_DRAFT_TERMINATOR_THRESHOLD,
+        project_path=tmp_path,
+    )
+
+    assert cancel_calls == []
+    assert [event["event"] for event in emitted] == [
+        EVENT_STUCK_DRAFT_TERMINATED,
+    ]
 
 
 def test_stuck_draft_terminator_durable_across_scan_project_calls(

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -25,7 +25,6 @@ issue calls out).
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -38,13 +37,11 @@ from pollypm.audit.log import (
     EVENT_TASK_STATUS_CHANGED,
     EVENT_WATCHDOG_OPERATOR_DISPATCHED,
     AuditEvent,
-    central_log_path,
     read_events,
 )
 from pollypm.audit.watchdog import (
     Finding,
     InboxItemBuilder,
-    OPERATOR_DISPATCH_THROTTLE_SECONDS,
     REJECTION_LOOP_THRESHOLD,
     REJECTION_LOOP_WINDOW_SECONDS,
     RULE_DUPLICATE_ADVISOR_TASKS,
@@ -606,6 +603,42 @@ def test_queue_without_motion_silent_when_operator_draft_already_exists(
         now=now,
         config=cfg,
         open_tasks=[queued, existing_operator_draft],
+        project="demo",
+    )
+
+    assert not any(f.rule == RULE_QUEUE_WITHOUT_MOTION for f in findings)
+
+
+def test_queue_without_motion_silent_when_legacy_generated_draft_exists(
+    now: datetime,
+) -> None:
+    cfg = WatchdogConfig(queue_motion_threshold_seconds=600)
+    queued = _StubTask(
+        project="demo",
+        task_number=4,
+        work_status_str="queued",
+        executions=[],
+        updated_at=now - timedelta(hours=2),
+    )
+    legacy_operator_draft = _StubTask(
+        project="demo",
+        task_number=99,
+        work_status_str="draft",
+        executions=[],
+        title=(
+            "Project demo has 1 queued task(s) but no claim / execution / "
+            "status-change activity for the entire scan window."
+        ),
+        labels=(),
+        kind=None,
+        created_by=None,
+    )
+
+    findings = scan_events(
+        [],
+        now=now,
+        config=cfg,
+        open_tasks=[queued, legacy_operator_draft],
         project="demo",
     )
 
@@ -1614,8 +1647,6 @@ def test_get_workspace_state_tolerates_missing_table(tmp_path: Path) -> None:
     ``OperationalError`` so downstream consumers (gate / doctor) treat
     it as "no state".
     """
-    import sqlite3
-
     from pollypm.storage.state import StateStore
     db = tmp_path / "no_table.db"
     store = StateStore(db)


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a stuck-draft terminator reclaim path that cancels only same-project draft tasks created by `audit_watchdog` or a legacy empty creator after the repeat threshold is durably emitted.
- Emit `audit.stuck_draft_reclaimed` for successful reclaims and document both stuck-draft terminator events.
- Tighten `queue_without_motion` duplicate suppression so legacy generated operator drafts suppress duplicate synthetic drafts even when creator/kind/labels are missing.

Fixes #2456.

## Verification
- `python -m compileall -q src/pollypm/audit/watchdog.py tests/test_audit_watchdog.py tests/test_heartbeat_cascade_foundation.py`
- `uv run --with ruff ruff check src/pollypm/audit/watchdog.py tests/test_audit_watchdog.py tests/test_heartbeat_cascade_foundation.py`
- `uv run --with pytest pytest tests/test_audit_watchdog.py::test_stuck_draft_terminator_reclaims_watchdog_owned_drafts tests/test_audit_watchdog.py::test_stuck_draft_terminator_preserves_human_owned_drafts tests/test_audit_watchdog.py::test_scan_events_remains_pure_when_terminator_threshold_hit tests/test_audit_watchdog.py::test_stuck_draft_terminator_durable_across_scan_project_calls tests/test_audit_watchdog.py::test_stuck_draft_terminator_counts_central_findings_when_project_log_misses tests/test_heartbeat_cascade_foundation.py::test_queue_without_motion_silent_when_operator_draft_already_exists tests/test_heartbeat_cascade_foundation.py::test_queue_without_motion_silent_when_legacy_generated_draft_exists -q` (9 passed)

Broader check attempted:
- `uv run --with pytest pytest tests/test_audit_watchdog.py tests/test_heartbeat_cascade_foundation.py -q` failed in this environment with existing cadence/state-db integration failures: dispatch counters stayed at 0 for several cadence handler tests, and `state_db_missing` repair hit `Unknown project: demo`.