### PR TITLE
fix(audit): backfill stuck draft reclaims

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -168,7 +168,10 @@ After three prior `stuck_draft` findings for the same subject, the watchdog
 emits `audit.stuck_draft_terminated` and suppresses further findings for that
 subject. If the underlying task is still a draft and was created by
 `audit_watchdog` or by a legacy empty creator, the terminator also cancels it
-and emits `audit.stuck_draft_reclaimed`.
+and emits `audit.stuck_draft_reclaimed`. The cadence also backfills that
+reclaim on later sweeps for still-draft tasks that already have a durable
+`audit.stuck_draft_terminated` row, so old terminated subjects do not remain
+stuck just because they crossed the threshold before reclaim support existed.
 
 When a finding is a real false positive rather than stale state, record the
 terminal judgment with `pm audit dismiss-finding <rule> <project> --reason

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -730,6 +730,13 @@ class _StuckDraftScanResult:
     terminator_breadcrumbs: list[_TerminatorBreadcrumb]
 
 
+@dataclass(slots=True, frozen=True)
+class _StuckDraftReclaimCandidate:
+    project: str
+    subject: str
+    prior_count: int
+
+
 def _emit_stuck_draft_terminator(
     *,
     project: str,
@@ -860,6 +867,69 @@ def _maybe_reclaim_stuck_draft(
             "audit.watchdog: stuck_draft_reclaimed emit failed for %s",
             subject, exc_info=True,
         )
+
+
+def _stuck_draft_reclaim_backfill_candidates(
+    events: Sequence[AuditEvent],
+    *,
+    project: str,
+    open_tasks: Sequence[Any] | None,
+) -> list[_StuckDraftReclaimCandidate]:
+    if not open_tasks:
+        return []
+
+    terminated_subjects: dict[str, int] = {}
+    for ev in events:
+        if ev.event != EVENT_STUCK_DRAFT_TERMINATED:
+            continue
+        meta = ev.metadata or {}
+        if meta.get("rule") not in (None, "", RULE_STUCK_DRAFT):
+            continue
+        if ev.project and ev.project != project:
+            continue
+        key = _task_subject_key(ev.subject)
+        if key is None or key[0] != project:
+            continue
+        try:
+            prior_count = int(
+                meta.get(
+                    "prior_finding_count",
+                    STUCK_DRAFT_TERMINATOR_THRESHOLD,
+                )
+            )
+        except (TypeError, ValueError):
+            prior_count = STUCK_DRAFT_TERMINATOR_THRESHOLD
+        terminated_subjects[ev.subject] = max(
+            prior_count,
+            terminated_subjects.get(ev.subject, 0),
+        )
+    if not terminated_subjects:
+        return []
+
+    candidates: list[_StuckDraftReclaimCandidate] = []
+    seen: set[str] = set()
+    for task in open_tasks:
+        if _task_status_value(task) != "draft":
+            continue
+        task_project = _task_scalar_value(task, "project") or project
+        if task_project != project:
+            continue
+        task_number = getattr(task, "task_number", None)
+        if task_number is None:
+            continue
+        subject = f"{project}/{task_number}"
+        if subject in seen or subject not in terminated_subjects:
+            continue
+        creator = _task_scalar_value(task, "created_by")
+        if creator not in _STUCK_DRAFT_RECLAIMABLE_CREATORS:
+            continue
+        seen.add(subject)
+        candidates.append(_StuckDraftReclaimCandidate(
+            project=project,
+            subject=subject,
+            prior_count=terminated_subjects[subject],
+        ))
+    return candidates
 
 
 def _detect_stuck_drafts(
@@ -3670,6 +3740,18 @@ def scan_project(
         since=since,
         project_path=project_path,
     )
+    backfill_reclaims = _stuck_draft_reclaim_backfill_candidates(
+        events,
+        project=project,
+        open_tasks=open_tasks,
+    )
+    if backfill_reclaims:
+        dismissed_scopes = _dismissed_finding_scopes(events)
+        backfill_reclaims = [
+            candidate
+            for candidate in backfill_reclaims
+            if (RULE_STUCK_DRAFT, candidate.project) not in dismissed_scopes
+        ]
     # #2349 (round 3) — owned by the cadence handler. The pure
     # detector appends one :class:`_TerminatorBreadcrumb` per subject
     # that first crossed the terminator threshold this scan; we emit
@@ -3694,7 +3776,7 @@ def scan_project(
         worker_cap_back_pressure=worker_cap_back_pressure,
         stuck_draft_terminator_breadcrumbs=pending_terminators,
     )
-    if findings or pending_terminators:
+    if findings or pending_terminators or backfill_reclaims:
         durable_dismissals = _read_durable_finding_dismissals(
             project=project,
             project_path=project_path,
@@ -3710,11 +3792,24 @@ def scan_project(
                 if (RULE_STUCK_DRAFT, breadcrumb.project)
                 not in durable_dismissals
             ]
+            backfill_reclaims = [
+                candidate
+                for candidate in backfill_reclaims
+                if (RULE_STUCK_DRAFT, candidate.project)
+                not in durable_dismissals
+            ]
     for breadcrumb in pending_terminators:
         _emit_stuck_draft_terminator(
             project=breadcrumb.project,
             subject=breadcrumb.subject,
             prior_count=breadcrumb.prior_count,
+            project_path=project_path,
+        )
+    for candidate in backfill_reclaims:
+        _maybe_reclaim_stuck_draft(
+            project=candidate.project,
+            subject=candidate.subject,
+            prior_count=candidate.prior_count,
             project_path=project_path,
         )
     return findings

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -822,6 +822,181 @@ def test_stuck_draft_terminator_counts_central_findings_when_project_log_misses(
     assert len(terminator_rows) == 1
 
 
+def test_stuck_draft_backfill_reclaims_prior_terminated_watchdog_draft(
+    now: datetime,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2458: a pre-existing terminator row must still reclaim a draft.
+
+    #2457 reclaimed only on the first termination edge. Backlog drafts
+    that were already terminated before that code landed never crossed
+    the edge again, so they stayed in draft forever.
+    """
+    from pollypm.audit.log import emit as audit_emit
+
+    project = "demo"
+    project_path = tmp_path / project
+    (project_path / ".pollypm").mkdir(parents=True)
+    subject = f"{project}/42"
+    prior_count = STUCK_DRAFT_TERMINATOR_THRESHOLD + 2
+
+    audit_emit(
+        event=EVENT_STUCK_DRAFT_TERMINATED,
+        project=project,
+        subject=subject,
+        actor="audit_watchdog",
+        status="warn",
+        metadata={
+            "rule": RULE_STUCK_DRAFT,
+            "prior_finding_count": prior_count,
+            "threshold": STUCK_DRAFT_TERMINATOR_THRESHOLD,
+        },
+        project_path=project_path,
+    )
+
+    class _Status:
+        value = "draft"
+
+    class _Task:
+        task_number = 42
+        work_status = _Status()
+        created_by = None
+
+        def __init__(self, project_key: str = project) -> None:
+            self.project = project_key
+
+    emitted: list[dict[str, object]] = []
+    cancel_calls: list[tuple[str, str, str]] = []
+    factory_calls: list[dict[str, object]] = []
+
+    def _record(**kwargs: object) -> None:
+        emitted.append(kwargs)
+
+    class _Service:
+        def __enter__(self) -> "_Service":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def get(self, task_id: str) -> _Task:
+            assert task_id == subject
+            return _Task()
+
+        def cancel(self, task_id: str, actor: str, reason: str) -> _Task:
+            cancel_calls.append((task_id, actor, reason))
+            return _Task()
+
+    def _factory(**kwargs: object) -> _Service:
+        factory_calls.append(kwargs)
+        return _Service()
+
+    monkeypatch.setattr("pollypm.audit.log.emit", _record)
+    monkeypatch.setattr("pollypm.work.create_work_service", _factory)
+
+    findings = scan_project(
+        project,
+        project_path=project_path,
+        now=now,
+        open_tasks=[_Task()],
+    )
+
+    assert findings == []
+    assert factory_calls == [
+        {"project_path": project_path, "project_key": project},
+    ]
+    assert len(cancel_calls) == 1
+    task_id, actor, reason = cancel_calls[0]
+    assert task_id == subject
+    assert actor == "audit_watchdog"
+    assert str(prior_count) in reason
+    assert [event["event"] for event in emitted] == [
+        EVENT_STUCK_DRAFT_RECLAIMED,
+    ]
+    assert emitted[0]["metadata"] == {
+        "rule": RULE_STUCK_DRAFT,
+        "prior_finding_count": prior_count,
+        "threshold": STUCK_DRAFT_TERMINATOR_THRESHOLD,
+        "action": "cancelled",
+        "created_by": None,
+        "reason": reason,
+    }
+
+
+def test_stuck_draft_backfill_preserves_human_owned_prior_terminated_draft(
+    now: datetime,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.audit.log import emit as audit_emit
+
+    project = "demo"
+    project_path = tmp_path / project
+    (project_path / ".pollypm").mkdir(parents=True)
+    subject = f"{project}/43"
+
+    audit_emit(
+        event=EVENT_STUCK_DRAFT_TERMINATED,
+        project=project,
+        subject=subject,
+        actor="audit_watchdog",
+        status="warn",
+        metadata={
+            "rule": RULE_STUCK_DRAFT,
+            "prior_finding_count": STUCK_DRAFT_TERMINATOR_THRESHOLD,
+            "threshold": STUCK_DRAFT_TERMINATOR_THRESHOLD,
+        },
+        project_path=project_path,
+    )
+
+    class _Status:
+        value = "draft"
+
+    class _Task:
+        task_number = 43
+        work_status = _Status()
+        created_by = "samhotchkiss"
+
+        def __init__(self, project_key: str = project) -> None:
+            self.project = project_key
+
+    emitted: list[dict[str, object]] = []
+    cancel_calls: list[tuple[str, str, str]] = []
+
+    class _Service:
+        def __enter__(self) -> "_Service":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def get(self, task_id: str) -> _Task:
+            assert task_id == subject
+            return _Task()
+
+        def cancel(self, task_id: str, actor: str, reason: str) -> _Task:
+            cancel_calls.append((task_id, actor, reason))
+            return _Task()
+
+    monkeypatch.setattr("pollypm.audit.log.emit", lambda **kw: emitted.append(kw))
+    monkeypatch.setattr(
+        "pollypm.work.create_work_service",
+        lambda **_: _Service(),
+    )
+
+    findings = scan_project(
+        project,
+        project_path=project_path,
+        now=now,
+        open_tasks=[_Task()],
+    )
+
+    assert findings == []
+    assert cancel_calls == []
+    assert emitted == []
+
+
 def test_stuck_draft_event_path_cross_checks_open_tasks_status(now: datetime) -> None:
     """#1869: when ``open_tasks`` is supplied, the event-based fallback
     must not fire for tasks that are no longer in draft state.


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a cadence-level backfill for already-terminated `stuck_draft` subjects that are still live draft tasks.
- Reuse `_maybe_reclaim_stuck_draft` so the authoritative cancel path keeps the same project, status, and creator safety gates as #2457.
- Filter backfill candidates by same-project subject, durable dismissals, and reclaimable creators, then document the periodic reclaim behavior.

Fixes #2458.

## Verification
- `uv run --extra test pytest tests/test_audit_watchdog.py -q -k 'stuck_draft_backfill or stuck_draft_terminator'` -> 9 passed, 121 deselected.
- `uv run --extra dev ruff check src/pollypm/audit/watchdog.py tests/test_audit_watchdog.py` -> passed.
- `git diff --check` -> passed.
- `uv run --extra test pytest tests/test_audit_watchdog.py::test_cadence_handler_dispatches_stuck_draft -q` -> 1 passed.
- Full watchdog module note: `uv run --extra test pytest tests/test_audit_watchdog.py -q` reported 125 passed / 5 failed in architect-dispatch counter tests. One failing case passes in isolation as listed above; failures appear to be existing order/global-state leakage outside this stuck-draft backfill path.