### PR TITLE
Switch Claude sessions to Opus 4.8

### DIFF
--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -1432,10 +1432,10 @@ def _build_example_config(root: Path, *, tmux_session: str = "pollypm") -> Polly
             # example-config` round-trips — delete any line to opt back
             # into the computed fallback.
             role_assignments={
-                "operator_pm": ModelAssignment(alias="opus-4.7"),
+                "operator_pm": ModelAssignment(alias="opus-4.8"),
                 "architect": ModelAssignment(alias="codex-gpt-5.4"),
                 "worker": ModelAssignment(alias="codex-gpt-5.4"),
-                "reviewer": ModelAssignment(alias="opus-4.7"),
+                "reviewer": ModelAssignment(alias="opus-4.8"),
             },
         ),
         accounts={

--- a/src/pollypm/model_registry.py
+++ b/src/pollypm/model_registry.py
@@ -36,6 +36,16 @@ class Registry:
 def _fallback_registry() -> Registry:
     return Registry(
         aliases={
+            "opus-4.8": AliasRecord(
+                provider="claude",
+                model="claude-opus-4-8",
+                capabilities=(
+                    "reasoning",
+                    "tool_use",
+                    "long_context",
+                    "strong_planning",
+                ),
+            ),
             "opus-4.7": AliasRecord(
                 provider="claude",
                 model="claude-opus-4-7",

--- a/src/pollypm/model_registry.toml
+++ b/src/pollypm/model_registry.toml
@@ -1,3 +1,8 @@
+[aliases."opus-4.8"]
+provider = "claude"
+model = "claude-opus-4-8"
+capabilities = ["reasoning", "tool_use", "long_context", "strong_planning"]
+
 [aliases."opus-4.7"]
 provider = "claude"
 model = "claude-opus-4-7"

--- a/src/pollypm/role_routing.py
+++ b/src/pollypm/role_routing.py
@@ -19,10 +19,10 @@ _ROLE_KEYS = ("operator_pm", "architect", "worker", "reviewer", "advisor")
 # roles (worker, architect, advisor) where its tool dispatch shines.
 # See #1737.
 _DUAL_PROVIDER_DEFAULTS: dict[str, ModelAssignment] = {
-    "operator_pm": ModelAssignment(alias="opus-4.7"),
+    "operator_pm": ModelAssignment(alias="opus-4.8"),
     "architect": ModelAssignment(alias="codex-gpt-5.4"),
     "worker": ModelAssignment(alias="codex-gpt-5.4"),
-    "reviewer": ModelAssignment(alias="opus-4.7"),
+    "reviewer": ModelAssignment(alias="opus-4.8"),
     "advisor": ModelAssignment(alias="codex-gpt-5.4"),
 }
 
@@ -30,11 +30,11 @@ _DUAL_PROVIDER_DEFAULTS: dict[str, ModelAssignment] = {
 # are configured, every role falls back to that provider's strongest
 # alias. Preserves the "config still works with one provider" invariant.
 _CLAUDE_ONLY_DEFAULTS: dict[str, ModelAssignment] = {
-    "operator_pm": ModelAssignment(alias="opus-4.7"),
-    "architect": ModelAssignment(alias="opus-4.7"),
-    "worker": ModelAssignment(alias="opus-4.7"),
-    "reviewer": ModelAssignment(alias="opus-4.7"),
-    "advisor": ModelAssignment(alias="opus-4.7"),
+    "operator_pm": ModelAssignment(alias="opus-4.8"),
+    "architect": ModelAssignment(alias="opus-4.8"),
+    "worker": ModelAssignment(alias="opus-4.8"),
+    "reviewer": ModelAssignment(alias="opus-4.8"),
+    "advisor": ModelAssignment(alias="opus-4.8"),
 }
 _CODEX_ONLY_DEFAULTS: dict[str, ModelAssignment] = {
     "operator_pm": ModelAssignment(alias="codex-gpt-5.4"),
@@ -45,15 +45,14 @@ _CODEX_ONLY_DEFAULTS: dict[str, ModelAssignment] = {
 }
 
 # Static safety net used when no PollyPMConfig is in hand or no
-# accounts are configured (e.g. some unit tests). Matches the historical
-# table that shipped before #1737 so anything reaching this branch
-# behaves like the pre-#1737 system.
+# accounts are configured (e.g. some unit tests). Keeps the historical
+# pre-#1737 provider split while using the current default aliases.
 _FALLBACK_ASSIGNMENTS: dict[str, ModelAssignment] = {
     "operator_pm": ModelAssignment(alias="codex-gpt-5.4"),
-    "architect": ModelAssignment(alias="opus-4.7"),
+    "architect": ModelAssignment(alias="opus-4.8"),
     "worker": ModelAssignment(alias="codex-gpt-5.4"),
     "reviewer": ModelAssignment(alias="sonnet-4.6"),
-    "advisor": ModelAssignment(alias="opus-4.7"),
+    "advisor": ModelAssignment(alias="opus-4.8"),
 }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,8 @@ def test_load_example_config(tmp_path: Path) -> None:
     assert config.pollypm.failover_accounts == ["claude_primary"]
     assert config.pollypm.failover_usage_threshold_pct == 85
     assert config.pollypm.lease_timeout_minutes == 30
+    assert config.pollypm.role_assignments["operator_pm"].alias == "opus-4.8"
+    assert config.pollypm.role_assignments["reviewer"].alias == "opus-4.8"
     assert config.memory.backend == "file"
     assert set(config.accounts) == {"codex_primary", "claude_primary"}
     assert set(config.sessions) == {"heartbeat", "operator"}

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -19,6 +19,7 @@ def test_shipped_registry_includes_minimum_aliases() -> None:
     registry = load_registry(overlay_path=Path("/tmp/does-not-exist"))
 
     assert {
+        "opus-4.8",
         "opus-4.7",
         "sonnet-4.6",
         "haiku-4.5",
@@ -28,6 +29,7 @@ def test_shipped_registry_includes_minimum_aliases() -> None:
     shipped_text = resources.files("pollypm").joinpath("model_registry.toml").read_text(
         encoding="utf-8"
     )
+    assert "opus-4.8" in shipped_text
     assert "opus-4.7" in shipped_text
 
 
@@ -63,6 +65,14 @@ def test_resolve_alias_returns_assignment_and_miss_none() -> None:
     assert resolve_alias("codex-gpt-5.5", registry=registry) == ModelAssignment(
         provider="codex",
         model="gpt-5.5",
+    )
+    assert resolve_alias("opus-4.8", registry=registry) == ModelAssignment(
+        provider="claude",
+        model="claude-opus-4-8",
+    )
+    assert resolve_alias("opus-4.7", registry=registry) == ModelAssignment(
+        provider="claude",
+        model="claude-opus-4-7",
     )
     assert resolve_alias("missing-alias", registry=registry) is None
 
@@ -115,6 +125,7 @@ def test_malformed_registry_tolerates_bad_shipped_and_overlay(
     with caplog.at_level(logging.WARNING, logger="pollypm.model_registry"):
         registry = load_registry(overlay_path=overlay_path)
 
+    assert "opus-4.8" in registry.aliases
     assert "opus-4.7" in registry.aliases
     messages = [record.getMessage() for record in caplog.records]
     assert any("shipped model registry" in message for message in messages)

--- a/tests/test_role_routing.py
+++ b/tests/test_role_routing.py
@@ -77,7 +77,7 @@ def test_fallback_assignment_used_when_no_configured_assignment(tmp_path: Path) 
 
     resolved = resolve_role_assignment("reviewer", "demo", config=config)
 
-    assert resolved.alias == "opus-4.7"
+    assert resolved.alias == "opus-4.8"
     assert resolved.provider == "claude"
     assert resolved.source == "fallback"
 
@@ -97,8 +97,8 @@ def test_dual_provider_fallback_table(tmp_path: Path) -> None:
     )
 
     expectations = {
-        "operator_pm": ("opus-4.7", "claude"),
-        "reviewer": ("opus-4.7", "claude"),
+        "operator_pm": ("opus-4.8", "claude"),
+        "reviewer": ("opus-4.8", "claude"),
         "worker": ("codex-gpt-5.4", "codex"),
         "architect": ("codex-gpt-5.4", "codex"),
         "advisor": ("codex-gpt-5.4", "codex"),
@@ -144,7 +144,7 @@ def test_claude_only_fallback_routes_all_roles_to_claude(tmp_path: Path) -> None
         project = None if role == "operator_pm" else "demo"
         resolved = resolve_role_assignment(role, project, config=config)
         assert resolved.provider == "claude"
-        assert resolved.alias == "opus-4.7"
+        assert resolved.alias == "opus-4.8"
         assert resolved.source == "fallback"
 
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds the `opus-4.8` Claude alias to the shipped and fallback model registries while keeping `opus-4.7` selectable.
- Repoints Claude-backed default role assignments from `opus-4.7` to `opus-4.8` in role routing and example config defaults.
- Updates registry/config/routing tests for the new default alias.

Fixes #2460.

## Verification
- `uv run --with pytest python -m pytest tests/test_model_registry.py tests/test_role_routing.py tests/test_config.py` (`40 passed`)
- `git diff --check`
