### PR TITLE
Fix cockpit actionability and stale watchdog cleanup

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -11058,6 +11058,35 @@ def _dashboard_trim(text: str, *, limit: int = 220) -> str:
     return text[: limit - 1].rstrip() + "…"
 
 
+_TIER4_STATIC_BLOCK_RE = _re.compile(
+    r"<tier4_authority\b[^>]*>.*?</tier4_authority>|"
+    r"<tier4_runtime\b[^>]*>.*?</tier4_runtime>",
+    _re.IGNORECASE | _re.DOTALL,
+)
+
+
+def _dashboard_action_body_from_message(body: str) -> str:
+    """Return the user-action portion of a stored message body.
+
+    Tier-4 watchdog dispatches prepend static authority/rubric text to
+    the actual finding handoff. Dashboard cards must summarize the
+    concrete finding, not the authority rubric.
+    """
+    text = str(body or "").replace("\\n", "\n")
+    if "<tier4_authority" not in text.lower():
+        return text
+    stripped = _TIER4_STATIC_BLOCK_RE.sub("", text)
+    marker = "--- Finding ---"
+    if marker in stripped:
+        stripped = stripped.split(marker, 1)[1]
+    lines = [
+        line for line in stripped.splitlines()
+        if line.strip() != "TIER 4 BROADER AUTHORITY DISPATCH"
+    ]
+    cleaned = "\n".join(lines).strip()
+    return cleaned or text
+
+
 def _dashboard_summary_from_body(body: str) -> str:
     paragraphs = [
         _dashboard_plain_text(part)
@@ -12431,8 +12460,9 @@ def _dashboard_inbox_build_message_item(
     if hasattr(updated_at, "isoformat"):
         updated_at = updated_at.isoformat()
     body = message_body
+    action_body = _dashboard_action_body_from_message(body)
     subject = getattr(entry, "title", "") or "(no subject)"
-    steps = _dashboard_steps_from_body(body)
+    steps = _dashboard_steps_from_body(action_body)
     task_refs = [
         match.group(0)
         for match in _PROJECT_TASK_REF_RE.finditer(
@@ -12461,14 +12491,14 @@ def _dashboard_inbox_build_message_item(
         or _dashboard_plan_review_decision(
             project_path,
             labels,
-            body,
+            action_body,
             fallback_task_id=(
                 str(payload.get("task_id") or "")
                 if payload.get("task_id")
                 else None
             ),
         )
-        or _dashboard_plain_decision_from_body(subject, body, steps)
+        or _dashboard_plain_decision_from_body(subject, action_body, steps)
     )
     # #1397: when this is a plan_review item but
     # ``_user_prompt_decision`` won the dispatch (the
@@ -12482,7 +12512,7 @@ def _dashboard_inbox_build_message_item(
         plan_review_extras = _dashboard_plan_review_decision(
             project_path,
             labels,
-            body,
+            action_body,
             fallback_task_id=(
                 str(payload.get("task_id") or "")
                 if payload.get("task_id")
@@ -12517,10 +12547,10 @@ def _dashboard_inbox_build_message_item(
         "source": "message",
         "has_user_prompt": payload.get("user_prompt") is not None,
         "is_plan_review": "plan_review" in labels,
-        "summary": _dashboard_summary_from_body(body),
+        "summary": _dashboard_summary_from_body(action_body),
         "steps": steps,
         "next_action": _dashboard_decision_prompt_from_body(
-            subject, body, steps,
+            subject, action_body, steps,
         ),
         "primary_ref": primary_ref,
         **decision,

--- a/src/pollypm/inbox_sweep.py
+++ b/src/pollypm/inbox_sweep.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -50,6 +51,7 @@ DEFAULT_NOTIFY_RETENTION_DAYS = 14
 # this here rather than threading it through the API so callers don't
 # need to know the implementation detail.
 _PINNED_LABEL = "pinned"
+_WATCHDOG_LABEL = "watchdog"
 
 
 def _retention_days() -> int:
@@ -109,6 +111,38 @@ def _row_created_at(row: dict[str, Any]) -> datetime | None:
             return None
         return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
     return None
+
+
+def _task_ref_re(task_id: str) -> re.Pattern[str]:
+    return re.compile(rf"(?<![\w/-]){re.escape(task_id)}(?![\w/-])")
+
+
+def _payload_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        out: list[str] = []
+        for key, child in value.items():
+            out.extend(_payload_strings(key))
+            out.extend(_payload_strings(child))
+        return out
+    if isinstance(value, (list, tuple, set)):
+        out = []
+        for child in value:
+            out.extend(_payload_strings(child))
+        return out
+    return []
+
+
+def _row_mentions_task_ref(row: dict[str, Any], task_id: str) -> bool:
+    ref_re = _task_ref_re(task_id)
+    fields = [
+        str(row.get("subject") or ""),
+        str(row.get("body") or ""),
+        *_payload_strings(row.get("payload") or {}),
+        *_row_labels(row),
+    ]
+    return any(ref_re.search(field) for field in fields)
 
 
 def sweep_stale_notifies(
@@ -216,8 +250,62 @@ def sweep_notifies_for_done_task(
     return archived
 
 
+def sweep_watchdog_notifies_for_terminal_task(
+    store,
+    task_id: str,
+) -> int:
+    """Archive open watchdog notifies that mention a terminal task.
+
+    Watchdog operator dispatches can reference the real source task in
+    the message body while ``payload.task_id`` points at the generated
+    inbox task. This sweep closes those stale pings when the source task
+    itself is completed or cancelled.
+    """
+    if not task_id:
+        return 0
+    try:
+        rows = store.query_messages(
+            type="notify", state="open", recipient="user",
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "watchdog notify sweep failed for %s", task_id, exc_info=True,
+        )
+        return 0
+
+    archived = 0
+    for row in rows:
+        labels = _row_labels(row)
+        if _PINNED_LABEL in labels:
+            continue
+        if _WATCHDOG_LABEL not in labels:
+            continue
+        if not _row_mentions_task_ref(row, task_id):
+            continue
+        msg_id = row.get("id")
+        if msg_id is None:
+            continue
+        try:
+            store.close_message(int(msg_id))
+            archived += 1
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "watchdog notify close_message(%r) failed",
+                msg_id,
+                exc_info=True,
+            )
+    if archived:
+        word = "notify" if archived == 1 else "notifies"
+        logger.info(
+            "watchdog notify sweep archived %d %s for %s",
+            archived, word, task_id,
+        )
+    return archived
+
+
 __all__ = [
     "DEFAULT_NOTIFY_RETENTION_DAYS",
     "sweep_notifies_for_done_task",
     "sweep_stale_notifies",
+    "sweep_watchdog_notifies_for_terminal_task",
 ]

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -237,6 +237,35 @@ def _project_from_task_id(task_id: str) -> str | None:
     return None
 
 
+def _infer_project_from_cwd(config_obj: object | None) -> str | None:
+    """Return the registered project containing the current directory."""
+    projects = getattr(config_obj, "projects", {}) or {}
+    if not projects:
+        return None
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return None
+    matches: list[tuple[int, str]] = []
+    for key, project in projects.items():
+        raw_path = getattr(project, "path", None)
+        if raw_path is None:
+            continue
+        try:
+            project_path = Path(raw_path).expanduser().resolve()
+        except (OSError, TypeError):
+            continue
+        try:
+            cwd.relative_to(project_path)
+        except ValueError:
+            continue
+        matches.append((len(project_path.parts), str(key)))
+    if not matches:
+        return None
+    matches.sort(reverse=True)
+    return matches[0][1]
+
+
 def _value(value):
     return getattr(value, "value", value)
 
@@ -1335,6 +1364,13 @@ def task_next(
     output_json: bool = _JSON_OPTION,
 ) -> None:
     """Return the highest-priority queued+unblocked task."""
+    if project is None:
+        try:
+            from pollypm.config import load_config
+
+            project = _infer_project_from_cwd(load_config())
+        except Exception:  # noqa: BLE001
+            project = None
     svc = _svc(project=project)
     task = svc.next(agent=agent, project=project)
     if task is None:

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -176,6 +177,49 @@ def _coerce_status(raw: str) -> WorkStatus:
         # Unknown statuses surface as DRAFT so a corrupt row is at least
         # readable. Matches the sqlite path's tolerant decode.
         return WorkStatus.DRAFT
+
+
+def _task_ref_re(task_id: str) -> re.Pattern[str]:
+    return re.compile(rf"(?<![\w/-]){re.escape(task_id)}(?![\w/-])")
+
+
+def _string_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        out: list[str] = []
+        for key, child in value.items():
+            out.extend(_string_values(key))
+            out.extend(_string_values(child))
+        return out
+    if isinstance(value, (list, tuple, set)):
+        out = []
+        for child in value:
+            out.extend(_string_values(child))
+        return out
+    return []
+
+
+def _task_mentions_task_ref(task: Task, task_id: str) -> bool:
+    ref_re = _task_ref_re(task_id)
+    fields = [
+        task.title or "",
+        task.description or "",
+        *[str(label) for label in task.labels],
+        *_string_values(task.external_refs),
+    ]
+    return any(ref_re.search(field) for field in fields)
+
+
+def _is_watchdog_dispatch_task(task: Task) -> bool:
+    labels = {str(label) for label in task.labels}
+    return (
+        "watchdog" in labels
+        and (
+            task.kind == InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+            or "notify" in labels
+        )
+    )
 
 
 def _coerce_priority(raw: str) -> Priority:
@@ -1978,6 +2022,66 @@ class PgWorkService:
             ended_at=ended_at,
         )
 
+    def _after_terminal_transition(self, task_id: str) -> None:
+        self._sweep_notifies_for_terminal_task(task_id)
+        self._archive_watchdog_dispatches_for_terminal_subject(task_id)
+
+    def _sweep_notifies_for_terminal_task(self, task_id: str) -> None:
+        if self._config is None:
+            return
+        try:
+            from pollypm.inbox_sweep import (
+                sweep_notifies_for_done_task,
+                sweep_watchdog_notifies_for_terminal_task,
+            )
+            from pollypm.store.registry import get_store
+
+            store = get_store(self._config)
+            sweep_notifies_for_done_task(store, task_id)
+            sweep_watchdog_notifies_for_terminal_task(store, task_id)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "terminal notify sweep skipped for %s",
+                task_id,
+                exc_info=True,
+            )
+
+    def _archive_watchdog_dispatches_for_terminal_subject(
+        self,
+        task_id: str,
+    ) -> None:
+        try:
+            project, _ = _parse_task_id(task_id)
+            candidates = self.list_nonterminal_tasks(project=project)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "watchdog dispatch cleanup scan skipped for %s",
+                task_id,
+                exc_info=True,
+            )
+            return
+
+        for candidate in candidates:
+            if candidate.task_id == task_id:
+                continue
+            if not _is_watchdog_dispatch_task(candidate):
+                continue
+            if not _task_mentions_task_ref(candidate, task_id):
+                continue
+            try:
+                self.archive_task(
+                    candidate.task_id,
+                    actor="audit_watchdog",
+                    strict=False,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "watchdog dispatch cleanup skipped %s for %s",
+                    candidate.task_id,
+                    task_id,
+                    exc_info=True,
+                )
+
     def mark_done(self, task_id: str, actor: str) -> Task:
         """Force a task to ``done`` without running the flow.
 
@@ -2174,6 +2278,8 @@ class PgWorkService:
             to_state=to_state,
             ended_at=now,
         )
+        if to_state in TERMINAL_STATUSES:
+            self._after_terminal_transition(task_id)
         return task
 
     def _emit_status_changed_audit(
@@ -3736,6 +3842,7 @@ class PgWorkService:
                     task_id,
                     exc_info=True,
                 )
+            self._after_terminal_transition(task_id)
             # #1782: record the first_shipped milestone the same way
             # the sqlite service does. ``maybe_record_first_shipped``
             # checks whether the task landed a commit artifact and, if
@@ -4569,6 +4676,7 @@ class PgWorkService:
                 task_id,
                 exc_info=True,
             )
+        self._after_terminal_transition(task_id)
         return result
 
     def task_numbers_with_context_entry(

--- a/tests/test_inbox_sweep.py
+++ b/tests/test_inbox_sweep.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pollypm.inbox_sweep import sweep_watchdog_notifies_for_terminal_task
+
+
+class _Store:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+        self.closed: list[int] = []
+
+    def query_messages(self, **filters: object) -> list[dict[str, object]]:
+        out = []
+        for row in self.rows:
+            if all(row.get(key) == value for key, value in filters.items()):
+                out.append(row)
+        return out
+
+    def close_message(self, msg_id: int) -> None:
+        self.closed.append(msg_id)
+        for row in self.rows:
+            if row.get("id") == msg_id:
+                row["state"] = "closed"
+
+
+def test_watchdog_notify_sweep_closes_exact_terminal_task_refs() -> None:
+    store = _Store([
+        {
+            "id": 1,
+            "type": "notify",
+            "state": "open",
+            "recipient": "user",
+            "subject": "Task demo/1 needs operator action",
+            "body": "",
+            "payload": {},
+            "labels": ["notify", "watchdog"],
+        },
+        {
+            "id": 2,
+            "type": "notify",
+            "state": "open",
+            "recipient": "user",
+            "subject": "Task demo/10 needs operator action",
+            "body": "",
+            "payload": {},
+            "labels": ["notify", "watchdog"],
+        },
+        {
+            "id": 3,
+            "type": "notify",
+            "state": "open",
+            "recipient": "user",
+            "subject": "Pinned demo/1",
+            "body": "",
+            "payload": {},
+            "labels": ["notify", "watchdog", "pinned"],
+        },
+        {
+            "id": 4,
+            "type": "notify",
+            "state": "open",
+            "recipient": "user",
+            "subject": "Non-watchdog demo/1",
+            "body": "",
+            "payload": {},
+            "labels": ["notify"],
+        },
+    ])
+
+    archived = sweep_watchdog_notifies_for_terminal_task(store, "demo/1")
+
+    assert archived == 1
+    assert store.closed == [1]

--- a/tests/test_pg_inbox_actions.py
+++ b/tests/test_pg_inbox_actions.py
@@ -24,6 +24,7 @@ import time
 
 import pytest
 
+from pollypm.inbox.kind import InboxItemKind
 from pollypm.work.models import WorkStatus
 from pollypm.work.service_support import (
     InvalidTransitionError,
@@ -43,6 +44,22 @@ def _inbox_task(svc, *, title: str = "Hello Sam", body: str = "Read me.") -> str
         roles={"requester": "user", "operator": "polly"},
         priority="normal",
         created_by="polly",
+    )
+    return task.task_id
+
+
+def _watchdog_dispatch_task(svc, *, body: str, title: str = "Watchdog") -> str:
+    task = svc.create(
+        title=title,
+        description=body,
+        type="task",
+        project="demo",
+        flow_template="chat",
+        roles={"requester": "user", "operator": "user"},
+        priority="high",
+        created_by="audit_watchdog",
+        labels=["notify", "watchdog", "notify_message:123"],
+        kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
     )
     return task.task_id
 
@@ -283,6 +300,41 @@ class TestArchiveTask:
             and (tr.reason or "").startswith("inbox.archive")
         ]
         assert len(archive_transitions) == 1
+
+
+# ---------------------------------------------------------------------------
+# stale watchdog dispatch cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestWatchdogDispatchCleanup:
+    def test_terminal_subject_archives_related_watchdog_dispatch(
+        self, pg_work_service,
+    ):
+        svc = pg_work_service
+        source_id = _inbox_task(svc, title="Real work")
+        dispatch_id = _watchdog_dispatch_task(
+            svc,
+            body=f"Tier handoff for completed task {source_id}.",
+        )
+
+        svc.mark_done(source_id, actor="worker")
+
+        assert svc.get(dispatch_id).work_status == WorkStatus.DONE
+
+    def test_terminal_subject_cleanup_requires_exact_task_ref(
+        self, pg_work_service,
+    ):
+        svc = pg_work_service
+        source_id = _inbox_task(svc, title="Real work")
+        dispatch_id = _watchdog_dispatch_task(
+            svc,
+            body=f"Tier handoff for a different task {source_id}0.",
+        )
+
+        svc.mark_done(source_id, actor="worker")
+
+        assert svc.get(dispatch_id).work_status != WorkStatus.DONE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pg_plan_review_flow.py
+++ b/tests/test_pg_plan_review_flow.py
@@ -31,11 +31,48 @@ from pollypm.cockpit_ui import (
     PollyProjectDashboardApp,
     _build_plan_review_denial_primer,
     _build_plan_review_primer,
+    _dashboard_action_body_from_message,
+    _dashboard_steps_from_body,
     _extract_plan_judgment_calls,
     _extract_plan_review_meta,
     _extract_plan_summary_block,
     _plan_review_has_round_trip,
 )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard action-card body extraction.
+# ---------------------------------------------------------------------------
+
+
+def test_tier4_authority_block_not_used_for_dashboard_action_copy() -> None:
+    body = """TIER 4 BROADER AUTHORITY DISPATCH
+
+<tier4_authority>
+1. Reversible without data loss
+2. Scoped appropriately
+3. Operationally safe
+</tier4_authority>
+
+--- Finding ---
+
+TIER HANDOFF
+
+Question: Project savethenovel task savethenovel/11 is stuck.
+
+Evidence:
+- subject: savethenovel/11
+- next step: archive stale watchdog ping
+"""
+
+    action_body = _dashboard_action_body_from_message(body)
+
+    assert "Reversible without data loss" not in action_body
+    assert "Scoped appropriately" not in action_body
+    assert "Question: Project savethenovel" in action_body
+    steps = _dashboard_steps_from_body(action_body)
+    assert all("Reversible without data loss" not in step for step in steps)
+    assert all("Scoped appropriately" not in step for step in steps)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_task_next_project_scope.py
+++ b/tests/test_task_next_project_scope.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pollypm.work import cli as work_cli
+
+
+def test_infer_project_from_cwd_uses_registered_project(
+    tmp_path, monkeypatch,
+) -> None:
+    project_root = tmp_path / "savethenovel"
+    nested = project_root / "chapters"
+    other_root = tmp_path / "media"
+    nested.mkdir(parents=True)
+    other_root.mkdir()
+    config = SimpleNamespace(
+        projects={
+            "savethenovel": SimpleNamespace(path=project_root),
+            "media": SimpleNamespace(path=other_root),
+        }
+    )
+
+    monkeypatch.chdir(nested)
+
+    assert work_cli._infer_project_from_cwd(config) == "savethenovel"
+
+
+def test_task_next_defaults_to_current_registered_project(
+    monkeypatch, capsys,
+) -> None:
+    calls: dict[str, str | None] = {}
+
+    class _Svc:
+        def next(self, *, agent: str | None, project: str | None):
+            calls["agent"] = agent
+            calls["next_project"] = project
+            return None
+
+    def fake_svc(*, project: str | None = None) -> _Svc:
+        calls["svc_project"] = project
+        return _Svc()
+
+    monkeypatch.setattr(
+        "pollypm.config.load_config",
+        lambda: SimpleNamespace(projects={}),
+    )
+    monkeypatch.setattr(
+        work_cli,
+        "_infer_project_from_cwd",
+        lambda _config: "savethenovel",
+    )
+    monkeypatch.setattr(work_cli, "_svc", fake_svc)
+
+    work_cli.task_next(project=None, agent="architect", output_json=True)
+
+    assert calls == {
+        "agent": "architect",
+        "next_project": "savethenovel",
+        "svc_project": "savethenovel",
+    }
+    assert capsys.readouterr().out.strip() == "null"


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Strips Tier-4 static authority/runtime blocks before dashboard Action Needed cards derive summaries, steps, and decisions.
- Clears stale watchdog notify messages and generated watchdog dispatch tasks when their referenced task reaches a terminal state.
- Makes `pm task next` infer the current registered project from the working directory when `--project` is omitted, preserving project-PM task scope.

Fixes #2461.

## Verification
- `uv run python -m py_compile src/pollypm/cockpit_ui.py src/pollypm/work/cli.py src/pollypm/work/pg_service.py src/pollypm/inbox_sweep.py`
- `uv run --with pytest python -m pytest tests/test_inbox_sweep.py tests/test_task_next_project_scope.py tests/test_pg_plan_review_flow.py tests/test_pg_inbox_actions.py -q` (`59 passed`)
- `git diff --check`
