### PR TITLE
Fix cockpit inbox count drift

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -417,6 +417,7 @@ def _pm_inbox_awaits_user_list_uncached(
     """
     try:
         from pollypm.inbox import awaits_user
+        from pollypm.notify_task import is_notify_only_inbox_entry
         from pollypm.cockpit_inbox_items import (
             _WORKSPACE_DB_KEY,
             _filter_approved_plan_reviews,
@@ -461,7 +462,7 @@ def _pm_inbox_awaits_user_list_uncached(
                 pg_inbox_grouped, config, project_key,
             ):
                 item = task_to_inbox_entry(task, db_path=db_path)
-                if awaits_user(item):
+                if awaits_user(item) and not is_notify_only_inbox_entry(item):
                     if annotate_entries:
                         item = annotate_inbox_entry(
                             item,
@@ -499,7 +500,7 @@ def _pm_inbox_awaits_user_list_uncached(
                 source_key=source_key,
                 db_path=entry_dbpath or Path("."),
             )
-            if awaits_user(item):
+            if awaits_user(item) and not is_notify_only_inbox_entry(item):
                 if annotate_entries:
                     item = annotate_inbox_entry(
                         item,
@@ -566,10 +567,11 @@ def _count_inbox_tasks_for_label(
     updates and FYI messages stay discoverable inside the inbox's
     archive lenses.
 
-    **Three surfaces, one predicate (intentional, load-bearing).** The
+    **Three surfaces, one default lens (intentional, load-bearing).** The
     rail badge, the operator dashboard's "Waiting on you" section
     (#1572), AND the inbox UI's default lens (#1573) all read from
-    :func:`pollypm.inbox.awaits_user` via :func:`pm_inbox_awaits_user_list`.
+    :func:`pollypm.inbox.awaits_user` via :func:`pm_inbox_awaits_user_list`,
+    then exclude notify-only rows that the API default inbox lens hides.
     The badge count, the dashboard section length, and the default
     inbox row count MUST agree on every config; ``tests/test_inbox_default_lens.py``
     pins that invariant. Any new "what's waiting on the user?" surface

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2590,15 +2590,16 @@ class PollyCockpitApp(App[None]):
             sessions = getattr(config, "sessions", {}) or {}
             agent_count = len(sessions)
 
-            # inbox_count: re-use the shared ``pm_inbox_awaits_user_list``
-            # so the footer can never disagree with the rail badge /
-            # ``pm inbox --awaits-user`` (#1571). The 1s TTL cache in
-            # ``cockpit_inbox`` collapses this with the rail badge's
-            # own ``_inbox_count`` lookup that the same worker just
-            # ran, so this is a cache hit on the hot path.
-            from pollypm.cockpit_inbox import pm_inbox_awaits_user_list
-            inbox_items = pm_inbox_awaits_user_list(config) or []
-            inbox_count = len(inbox_items)
+            # inbox_count: share the rail badge helper, but bypass the
+            # state-cache snapshot so the operator-visible footer
+            # reconciles with the live /api/v1/inbox default lens.
+            from pollypm.cockpit_inbox import _count_inbox_tasks_for_label
+            inbox_count = int(
+                _count_inbox_tasks_for_label(
+                    config,
+                    use_state_cache=False,
+                ) or 0
+            )
 
             # alert: the only footer-class alert today is the
             # heartbeat-offline warning. Reuse the existing detection

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -685,11 +685,17 @@ def _count_inbox_tasks(config: PollyPMConfig) -> int:
     grouped = inbox_tasks_grouped(config)
     if grouped is None:
         return 0
+    from pollypm.notify_task import is_notify_only_inbox_entry
+
     total = 0
     for project_key, project in getattr(config, "projects", {}).items():
         if not getattr(project, "tracked", False):
             continue
-        total += len(inbox_tasks_for_project(grouped, config, project_key))
+        total += sum(
+            1
+            for task in inbox_tasks_for_project(grouped, config, project_key)
+            if not is_notify_only_inbox_entry(task)
+        )
     return total
 
 

--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -241,7 +241,12 @@ def _inbox_count(ctx: RailContext) -> int:
     if cached is not None:
         return cached
     try:
-        count = int(_count_inbox_tasks_for_label(config) or 0)
+        count = int(
+            _count_inbox_tasks_for_label(
+                config,
+                use_state_cache=False,
+            ) or 0
+        )
     except Exception:  # noqa: BLE001
         logger.exception("core_rail_items: inbox count raised")
         return 0

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -2214,6 +2214,124 @@ def _resolve_notify_config(config_path: Path | None) -> Any | None:
         return None
 
 
+_TERMINAL_TASK_STATUS_VALUES = frozenset({"done", "cancelled"})
+
+
+def _task_status_value(task: Any) -> str:
+    status = getattr(task, "work_status", None)
+    return str(getattr(status, "value", status) or "").lower()
+
+
+def _is_reusable_watchdog_inbox_task(
+    task: Any,
+    *,
+    message_id: int,
+    tier4: bool,
+) -> bool:
+    if _task_status_value(task) in _TERMINAL_TASK_STATUS_VALUES:
+        return False
+    labels = {str(label) for label in (getattr(task, "labels", None) or [])}
+    if "watchdog" not in labels or "notify" not in labels:
+        return False
+    if f"notify_message:{message_id}" not in labels:
+        return False
+    if tier4 and "tier4" not in labels:
+        return False
+    kind = getattr(task, "kind", None)
+    kind_value = str(getattr(kind, "value", kind) or "")
+    return kind_value in {
+        "",
+        InboxItemKind.LEGACY.value,
+        InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
+    }
+
+
+def _archive_duplicate_watchdog_inbox_tasks(
+    svc: Any,
+    *,
+    keep_task_id: str,
+    candidates: list[Any],
+) -> None:
+    for candidate in candidates:
+        task_id = str(getattr(candidate, "task_id", "") or "")
+        if not task_id or task_id == keep_task_id:
+            continue
+        try:
+            svc.archive_task(task_id, actor="audit_watchdog", strict=False)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "audit_watchdog: duplicate operator inbox task cleanup "
+                "skipped for %s",
+                task_id,
+                exc_info=True,
+            )
+
+
+def _find_reusable_watchdog_inbox_task(
+    svc: Any,
+    *,
+    project_key: str,
+    message_id: int,
+    payload: dict[str, Any],
+    tier4: bool = False,
+) -> str | None:
+    """Return the existing live task for a deduped watchdog message.
+
+    The message row is deduped, so the generated work task must be
+    deduped too. Older ticks created a fresh chat task on every bump;
+    when we see those rows again, keep the payload-linked task and
+    archive same-message duplicates.
+    """
+    candidates: list[Any] = []
+    seen: set[str] = set()
+
+    def add_candidate(task: Any) -> None:
+        task_id = str(getattr(task, "task_id", "") or "")
+        if not task_id or task_id in seen:
+            return
+        if not _is_reusable_watchdog_inbox_task(
+            task,
+            message_id=message_id,
+            tier4=tier4,
+        ):
+            return
+        seen.add(task_id)
+        candidates.append(task)
+
+    payload_task_id = str(payload.get("task_id") or "").strip()
+    payload_task: Any | None = None
+    if payload_task_id:
+        try:
+            payload_task = svc.get(payload_task_id)
+        except Exception:  # noqa: BLE001
+            payload_task = None
+        if payload_task is not None:
+            add_candidate(payload_task)
+
+    try:
+        list_nonterminal = getattr(svc, "list_nonterminal_tasks", None)
+        if callable(list_nonterminal):
+            tasks = list_nonterminal(project=project_key)
+        else:
+            tasks = svc.list_tasks(project=project_key)
+    except Exception:  # noqa: BLE001
+        tasks = []
+    for task in tasks or []:
+        add_candidate(task)
+
+    if not candidates:
+        return None
+    keep = payload_task if payload_task in candidates else candidates[0]
+    keep_id = str(getattr(keep, "task_id", "") or "")
+    if keep_id:
+        _archive_duplicate_watchdog_inbox_tasks(
+            svc,
+            keep_task_id=keep_id,
+            candidates=candidates,
+        )
+    return keep_id or None
+
+
 def _create_operator_inbox_task(
     *,
     project_key: str,
@@ -2298,16 +2416,12 @@ def _create_operator_inbox_task(
         existing = find_open_dedup_message(
             store, dedup_key, recipient="user",
         ) if dedup_key else None
+        existing_payload = existing.get("payload") if existing is not None else {}
+        if not isinstance(existing_payload, dict):
+            existing_payload = {}
+        seeded_payload: dict[str, Any] | None = None
         if existing is not None:
-            message_id = bump_dedup_message(
-                store,
-                existing,
-                subject=subject,
-                body=body,
-                payload={**payload, "dedup_key": dedup_key},
-                labels=["notify", "watchdog"],
-                tier="immediate",
-            )
+            message_id = int(existing.get("id"))
         else:
             seeded_payload = (
                 initial_dedup_payload(payload, dedup_key)
@@ -2342,6 +2456,26 @@ def _create_operator_inbox_task(
             svc_kwargs["project_path"] = db_path.parent.parent
         svc = create_work_service(**svc_kwargs)
         try:
+            if existing is not None:
+                reusable_task_id = _find_reusable_watchdog_inbox_task(
+                    svc,
+                    project_key=project_key,
+                    message_id=message_id,
+                    payload=existing_payload,
+                )
+                bump_payload = {**payload, "dedup_key": dedup_key}
+                if reusable_task_id:
+                    bump_payload["task_id"] = reusable_task_id
+                    bump_dedup_message(
+                        store,
+                        existing,
+                        subject=subject,
+                        body=body,
+                        payload=bump_payload,
+                        labels=["notify", "watchdog"],
+                        tier="immediate",
+                    )
+                    return reusable_task_id
             task_labels = [
                 "notify",
                 "watchdog",
@@ -2363,12 +2497,31 @@ def _create_operator_inbox_task(
                 kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
             )
             inbox_task_id = task.task_id
-            # Reuse the same configured-backend store for the task_id
-            # back-fill so both writes land on the same backend.
-            store.update_message(
-                message_id,
-                payload={**payload, "task_id": inbox_task_id},
-            )
+            update_payload = {**payload, "task_id": inbox_task_id}
+            if existing is not None:
+                bump_dedup_message(
+                    store,
+                    existing,
+                    subject=subject,
+                    body=body,
+                    payload={
+                        **update_payload,
+                        "dedup_key": dedup_key,
+                    },
+                    labels=["notify", "watchdog"],
+                    tier="immediate",
+                )
+            else:
+                # Reuse the same configured-backend store for the
+                # task_id back-fill so both writes land on the same
+                # backend, preserving the initial dedup payload.
+                store.update_message(
+                    message_id,
+                    payload={
+                        **(seeded_payload or payload),
+                        "task_id": inbox_task_id,
+                    },
+                )
             return inbox_task_id
         finally:
             svc.close()
@@ -2501,16 +2654,12 @@ def _create_operator_tier4_inbox_task(
         existing = find_open_dedup_message(
             store, dedup_key, recipient="user",
         ) if dedup_key else None
+        existing_payload = existing.get("payload") if existing is not None else {}
+        if not isinstance(existing_payload, dict):
+            existing_payload = {}
+        seeded_payload: dict[str, Any] | None = None
         if existing is not None:
-            message_id = bump_dedup_message(
-                store,
-                existing,
-                subject=subject,
-                body=body,
-                payload={**payload, "dedup_key": dedup_key},
-                labels=["notify", "watchdog", "tier4"],
-                tier="immediate",
-            )
+            message_id = int(existing.get("id"))
         else:
             seeded_payload = (
                 initial_dedup_payload(payload, dedup_key)
@@ -2542,6 +2691,27 @@ def _create_operator_tier4_inbox_task(
             svc_kwargs["project_path"] = db_path.parent.parent
         svc = create_work_service(**svc_kwargs)
         try:
+            if existing is not None:
+                reusable_task_id = _find_reusable_watchdog_inbox_task(
+                    svc,
+                    project_key=project_key,
+                    message_id=message_id,
+                    payload=existing_payload,
+                    tier4=True,
+                )
+                bump_payload = {**payload, "dedup_key": dedup_key}
+                if reusable_task_id:
+                    bump_payload["task_id"] = reusable_task_id
+                    bump_dedup_message(
+                        store,
+                        existing,
+                        subject=subject,
+                        body=body,
+                        payload=bump_payload,
+                        labels=["notify", "watchdog", "tier4"],
+                        tier="immediate",
+                    )
+                    return reusable_task_id
             task_labels = [
                 "notify",
                 "watchdog",
@@ -2564,10 +2734,28 @@ def _create_operator_tier4_inbox_task(
                 kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
             )
             inbox_task_id = task.task_id
-            store.update_message(
-                message_id,
-                payload={**payload, "task_id": inbox_task_id},
-            )
+            update_payload = {**payload, "task_id": inbox_task_id}
+            if existing is not None:
+                bump_dedup_message(
+                    store,
+                    existing,
+                    subject=subject,
+                    body=body,
+                    payload={
+                        **update_payload,
+                        "dedup_key": dedup_key,
+                    },
+                    labels=["notify", "watchdog", "tier4"],
+                    tier="immediate",
+                )
+            else:
+                store.update_message(
+                    message_id,
+                    payload={
+                        **(seeded_payload or payload),
+                        "task_id": inbox_task_id,
+                    },
+                )
             return inbox_task_id
         finally:
             svc.close()

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -314,13 +314,20 @@ def list_projects(config: PollyPMConfig, *, tracked_only: bool = False) -> list[
     """
     out: list[APIProject] = []
     snapshots = _project_task_snapshots(config)
+    inbox_counts = _project_inbox_counts(config) if snapshots is not None else None
     for key, project in config.projects.items():
         if tracked_only and not project.tracked:
             continue
         if snapshots is not None:
             out.append(
                 _project_to_api_from_tasks(
-                    config, key, project, snapshots.get(key, [])
+                    config,
+                    key,
+                    project,
+                    snapshots.get(key, []),
+                    open_inbox_count=(
+                        inbox_counts.get(key) if inbox_counts is not None else None
+                    ),
                 )
             )
         else:
@@ -939,13 +946,20 @@ def _counts_from_tasks(tasks: list[object]) -> dict[str, int]:
     return counts
 
 
-def _open_inbox_count_from_tasks(tasks: list[object]) -> int:
+def _open_inbox_count_from_tasks(
+    tasks: list[object],
+    *,
+    membership_checked: bool = False,
+) -> int:
     count = 0
     for task in tasks:
-        if getattr(task, "flow_template_id", "") != "chat":
+        if _status_value(task) in _TERMINAL_STATUS_VALUES:
             continue
-        if _status_value(task) not in _TERMINAL_STATUS_VALUES:
-            count += 1
+        if not membership_checked and not _is_inbox_member(task):
+            continue
+        if is_notify_only_inbox_entry(task):
+            continue
+        count += 1
     return count
 
 
@@ -990,18 +1004,48 @@ def _project_task_snapshots(
         return None
 
 
+def _project_inbox_counts(config: PollyPMConfig) -> dict[str, int] | None:
+    """Return API-default inbox counts grouped by registered project."""
+    try:
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
+        if not is_pg_backend(config):
+            return None
+        from pollypm.cockpit_pg_aggregates import (
+            inbox_tasks_for_project,
+            inbox_tasks_grouped,
+        )
+
+        grouped = inbox_tasks_grouped(config)
+        if grouped is None:
+            return None
+        return {
+            key: _open_inbox_count_from_tasks(
+                inbox_tasks_for_project(grouped, config, key),
+                membership_checked=True,
+            )
+            for key in config.projects
+        }
+    except Exception:  # noqa: BLE001
+        logger.debug("project inbox aggregate unavailable", exc_info=True)
+        return None
+
+
 def _project_to_api_from_tasks(
     config: PollyPMConfig,
     key: str,
     project: KnownProject,
     tasks: list[object],
+    *,
+    open_inbox_count: int | None = None,
 ) -> APIProject:
     counts = _counts_from_tasks(tasks)
     pending_plan_review = any(
         _status_value(task) == "review" and _is_plan_task(task)
         for task in tasks
     )
-    open_inbox_count = _open_inbox_count_from_tasks(tasks)
+    if open_inbox_count is None:
+        open_inbox_count = _open_inbox_count_from_tasks(tasks)
     last_activity_at = _max_datetime(
         _latest_task_activity(tasks),
         _latest_audit_activity(key, project),
@@ -1185,14 +1229,15 @@ def _count_open_inbox(config: PollyPMConfig, project_key: str) -> int:
 
 def _count_open_inbox_with_service(svc: object, project_key: str) -> int:
     try:
-        list_nonterminal = getattr(svc, "list_nonterminal_tasks", None)
-        if callable(list_nonterminal):
-            tasks = list_nonterminal(project=project_key)
-        else:
-            tasks = svc.list_tasks(project=project_key)  # type: ignore[attr-defined]
+        from pollypm.work.inbox_view import inbox_tasks
+
+        tasks = inbox_tasks(svc, project=project_key)
     except Exception:  # noqa: BLE001
         return 0
-    return _open_inbox_count_from_tasks(list(tasks or []))
+    return _open_inbox_count_from_tasks(
+        list(tasks or []),
+        membership_checked=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -2815,6 +2816,114 @@ def test_cadence_handler_routes_human_needed_on_hold_to_operator_once(
     assert len(operator_sent) == 1
     assert "Ready except for you" in operator_sent[0][0]
     assert "external credentials" in operator_sent[0][1]
+
+
+def test_operator_inbox_task_reuses_deduped_watchdog_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bumping a deduped watchdog message must not mint another chat task."""
+    from pollypm.inbox.kind import InboxItemKind
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as aw
+
+    message_id = 123
+    dedup_key = "watchdog:demo:stale"
+    existing_task = SimpleNamespace(
+        task_id="demo/7",
+        work_status="queued",
+        labels=["notify", "watchdog", f"notify_message:{message_id}"],
+        kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
+    )
+    duplicate_task = SimpleNamespace(
+        task_id="demo/8",
+        work_status="queued",
+        labels=["notify", "watchdog", f"notify_message:{message_id}"],
+        kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
+    )
+
+    class _Store:
+        def __init__(self) -> None:
+            self.rows = [
+                {
+                    "id": message_id,
+                    "type": "notify",
+                    "state": "open",
+                    "recipient": "user",
+                    "subject": "old",
+                    "body": "old",
+                    "payload": {
+                        "dedup_key": dedup_key,
+                        "count": 4,
+                        "task_id": existing_task.task_id,
+                    },
+                    "labels": ["notify", "watchdog"],
+                }
+            ]
+
+        def query_messages(self, **filters):
+            rows = []
+            for row in self.rows:
+                matched = True
+                for key, value in filters.items():
+                    actual = row.get(key)
+                    if isinstance(value, list):
+                        matched = actual in value
+                    else:
+                        matched = actual == value
+                    if not matched:
+                        break
+                if matched:
+                    rows.append(row)
+            return rows
+
+        def update_message(self, msg_id: int, **fields) -> None:
+            row = next(row for row in self.rows if row["id"] == msg_id)
+            row.update(fields)
+
+    class _Service:
+        def __init__(self) -> None:
+            self.created = 0
+            self.archived: list[str] = []
+
+        def get(self, task_id: str):
+            if task_id == existing_task.task_id:
+                return existing_task
+            raise KeyError(task_id)
+
+        def list_nonterminal_tasks(self, *, project: str):
+            assert project == "demo"
+            return [existing_task, duplicate_task]
+
+        def create(self, **_kwargs):
+            self.created += 1
+            raise AssertionError("reused dedup message should not create a task")
+
+        def archive_task(self, task_id: str, **_kwargs) -> None:
+            self.archived.append(task_id)
+
+        def close(self) -> None:
+            pass
+
+    store = _Store()
+    service = _Service()
+    config = SimpleNamespace(storage=SimpleNamespace(backend="postgres"))
+    monkeypatch.setattr(aw, "_resolve_notify_config", lambda _path: config)
+    monkeypatch.setattr("pollypm.store.get_store", lambda _config: store)
+    monkeypatch.setattr("pollypm.work.create_work_service", lambda **_kw: service)
+
+    task_id = aw._create_operator_inbox_task(
+        project_key="demo",
+        project_path=None,
+        subject="Repeated stale review ping",
+        body="Task demo/1 is stale",
+        dedup_key=dedup_key,
+    )
+
+    assert task_id == existing_task.task_id
+    assert service.created == 0
+    assert service.archived == [duplicate_task.task_id]
+    payload = store.rows[0]["payload"]
+    assert payload["task_id"] == existing_task.task_id
+    assert payload["count"] == 5
 
 
 def test_classify_on_hold_reason_defaults_to_architect() -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -73,7 +73,7 @@ def test_cockpit_router_build_items_includes_core_entries(monkeypatch, tmp_path:
             windows = [FakeWindow("pm-operator"), FakeWindow("worker-demo")]
             return launches, windows, [], [], []
 
-    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 1)
+    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 1)
     (tmp_path / "pollypm.toml").write_text(f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n")
     router = CockpitRouter(tmp_path / "pollypm.toml")
     monkeypatch.setattr(router, "_load_supervisor", lambda: FakeSupervisor())
@@ -184,7 +184,7 @@ def test_cockpit_router_build_items_keeps_mounted_task_worker_visible(
             assert target == "pollypm-storage-closet"
             return []
 
-    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0)
+    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0)
     (tmp_path / "pollypm.toml").write_text(
         f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
     )
@@ -3624,7 +3624,7 @@ def test_build_cockpit_detail_dashboard_shows_activity_and_tokens(monkeypatch, t
 
     monkeypatch.setattr("pollypm.cockpit.load_config", lambda path: config)
     monkeypatch.setattr("pollypm.cockpit.PollyPMService.load_supervisor", lambda self: FakeSupervisor())
-    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 1)
+    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 1)
 
     detail = build_cockpit_detail(config_path, "dashboard")
 

--- a/tests/test_cockpit_dashboard.py
+++ b/tests/test_cockpit_dashboard.py
@@ -585,7 +585,7 @@ def test_build_dashboard_renders_new_header_and_suggestions(
         "pollypm.cockpit_sections.dashboard._dashboard_project_tasks",
         lambda project_key, project_path: (partitions, counts) if project_key == "demo" else ({}, {}),
     )
-    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0)
+    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0)
     monkeypatch.setattr("pollypm.cockpit_sections.dashboard.datetime", _FrozenDateTime)
 
     emit_briefing(
@@ -710,7 +710,7 @@ def test_dashboard_activity_line_pluralises_singular_counts(
         "pollypm.cockpit_sections.dashboard._dashboard_project_tasks",
         lambda project_key, project_path: ({}, {}),
     )
-    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0)
+    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0)
 
     class _FrozenDateTime(datetime):
         @classmethod
@@ -768,7 +768,7 @@ def test_dashboard_footer_pluralises_project_count(monkeypatch, tmp_path: Path) 
         "pollypm.cockpit_sections.dashboard._dashboard_project_tasks",
         lambda project_key, project_path: ({}, {}),
     )
-    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0)
+    monkeypatch.setattr("pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0)
 
     base_dir = tmp_path / ".pollypm"
     supervisor = SimpleNamespace(store=_FakeStore())

--- a/tests/test_cockpit_footer_status_wiring.py
+++ b/tests/test_cockpit_footer_status_wiring.py
@@ -89,12 +89,12 @@ def _build_app(
     hint = _StubHint(width=hint_width)
     app.hint = hint  # type: ignore[assignment]
 
-    # Stub the cached inbox fanout so the test doesn't need a real DB.
-    fake_items = [object()] * inbox_count
+    # Stub the shared rail/footer inbox count so the test doesn't need
+    # a real DB.
     if monkeypatch is not None:
         monkeypatch.setattr(
-            "pollypm.cockpit_inbox.pm_inbox_awaits_user_list",
-            lambda _config: list(fake_items),
+            "pollypm.cockpit_inbox._count_inbox_tasks_for_label",
+            lambda _config, **_kw: inbox_count,
         )
 
     # Precompute the footer snapshot so ``_update_hint`` (which is now
@@ -312,3 +312,29 @@ def test_resolve_footer_state_returns_snapshot_with_expected_counts(
     assert snapshot.inbox_count == 11
     # Stub store reports no heartbeat → no alert chunk.
     assert snapshot.alert is None
+
+
+def test_resolve_footer_state_bypasses_state_cache(monkeypatch) -> None:
+    """The operator-visible footer count must read the live default lens."""
+    calls: list[dict[str, object]] = []
+
+    def _fake_count(_config, **kwargs):
+        calls.append(dict(kwargs))
+        return 7
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_inbox._count_inbox_tasks_for_label",
+        _fake_count,
+    )
+    app, _hint = _build_app(
+        projects={"p": object()},
+        sessions={"s": object()},
+        hint_width=120,
+        seed_footer_state=False,
+    )
+
+    snapshot = app._resolve_footer_state()
+
+    assert snapshot is not None
+    assert snapshot.inbox_count == 7
+    assert calls == [{"use_state_cache": False}]

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -334,7 +334,7 @@ def test_build_items_identical_to_legacy_shape(monkeypatch, tmp_path: Path) -> N
     to that.
     """
     monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 1,
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 1,
     )
     _write_config(tmp_path)
     router = CockpitRouter(tmp_path / "pollypm.toml")
@@ -371,11 +371,34 @@ def test_build_items_identical_to_legacy_shape(monkeypatch, tmp_path: Path) -> N
     assert inbox_item.label == "Inbox (1)"
 
 
+def test_inbox_rail_count_bypasses_state_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def _fake_count(_config, **kwargs):
+        calls.append(dict(kwargs))
+        return 4
+
+    monkeypatch.setattr(
+        "pollypm.cockpit._count_inbox_tasks_for_label",
+        _fake_count,
+    )
+    core_rail_items_plugin._INBOX_COUNT_CACHE.clear()
+    ctx = RailContext(
+        router=object(),
+        config=_FakeConfig(tmp_path),
+    )
+
+    assert core_rail_items_plugin._inbox_label(ctx) == "Inbox (4)"
+    assert calls == [{"use_state_cache": False}]
+
+
 def test_build_items_keeps_projects_section_when_empty(
     monkeypatch, tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0,
     )
     _write_config(tmp_path)
     router = CockpitRouter(tmp_path / "pollypm.toml")
@@ -408,7 +431,7 @@ def test_russell_rail_entry_hidden_when_reviewer_session_unconfigured(
     test pins that contract — no ``reviewer`` config, no rail row.
     """
     monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0,
     )
     _write_config(tmp_path)
     router = CockpitRouter(tmp_path / "pollypm.toml")
@@ -437,7 +460,7 @@ def test_russell_rail_entry_visible_when_reviewer_session_configured(
     block does exist, the rail entry must surface so the user can jump
     to Russell's chat pane (the originally-intended UX)."""
     monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0,
     )
     _write_config(tmp_path)
     router = CockpitRouter(tmp_path / "pollypm.toml")
@@ -461,7 +484,7 @@ def test_build_items_preserves_working_project_session_state(
 ) -> None:
     """Working sessions must not silently fall back to idle in rail rows."""
     monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0,
     )
     _write_config(tmp_path)
     router = CockpitRouter(tmp_path / "pollypm.toml")
@@ -577,7 +600,7 @@ def test_removing_core_rail_items_yields_empty_rail(monkeypatch, tmp_path: Path)
         "pollypm.plugin_host.extension_host_for_root", lambda root: host,
     )
     monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0,
     )
     _write_config(tmp_path)
     router = CockpitRouter(tmp_path / "pollypm.toml")

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -289,8 +289,27 @@ def test_list_projects_uses_pg_bulk_task_snapshot(
     """Dashboard project rows should not open the work service per project."""
     from types import SimpleNamespace
 
+    from pollypm.inbox.kind import InboxItemKind
     from pollypm.web_api import service as api_service
 
+    real_inbox_task = SimpleNamespace(
+        project="myproj",
+        task_id="myproj/2",
+        work_status="queued",
+        flow_template_id="chat",
+        labels=[],
+        roles={"requester": "user", "operator": "polly"},
+        kind="legacy",
+    )
+    stale_watchdog_task = SimpleNamespace(
+        project="myproj",
+        task_id="myproj/198",
+        work_status="queued",
+        flow_template_id="chat",
+        labels=["notify", "watchdog", "notify_message:123"],
+        roles={"requester": "user", "operator": "user"},
+        kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
+    )
     grouped = {
         "myproj": [
             SimpleNamespace(
@@ -299,15 +318,16 @@ def test_list_projects_uses_pg_bulk_task_snapshot(
                 work_status="review",
                 flow_template_id="plan_review",
                 labels=[],
+                roles={},
+                kind="legacy",
             ),
-            SimpleNamespace(
-                project="myproj",
-                task_id="myproj/2",
-                work_status="queued",
-                flow_template_id="chat",
-                labels=[],
-            ),
+            real_inbox_task,
+            stale_watchdog_task,
         ],
+        "otherproj": [],
+    }
+    inbox_grouped = {
+        "myproj": [real_inbox_task, stale_watchdog_task],
         "otherproj": [],
     }
 
@@ -322,6 +342,10 @@ def test_list_projects_uses_pg_bulk_task_snapshot(
     monkeypatch.setattr(
         "pollypm.cockpit_pg_aggregates.all_tasks_for_project",
         lambda rows, _config, key: list(rows.get(key, [])),
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.inbox_tasks_grouped",
+        lambda _config: inbox_grouped,
     )
     monkeypatch.setattr(
         api_service,

--- a/tests/test_dashboard_inbox_perf.py
+++ b/tests/test_dashboard_inbox_perf.py
@@ -165,7 +165,16 @@ def test_awaits_user_list_annotates_only_actionable_rows(
         title="Deployment complete",
         description="",
     )
-    grouped = {"demo": [informational, actionable]}
+    stale_watchdog = SimpleNamespace(
+        task_id="demo/3",
+        project="demo",
+        kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH,
+        labels=["notify", "watchdog", "notify_message:123"],
+        roles={"requester": "user", "operator": "user"},
+        title="Repeated stale review ping",
+        description="",
+    )
+    grouped = {"demo": [informational, stale_watchdog, actionable]}
     calls = {"annotate": 0}
 
     def annotate(item, *, known_projects):

--- a/tests/test_polly_dashboard_ui.py
+++ b/tests/test_polly_dashboard_ui.py
@@ -242,7 +242,7 @@ def test_dashboard_gather_uses_rail_inbox_counter(monkeypatch, tmp_path: Path) -
 
     seen: list[object] = []
 
-    def fake_rail_count(arg):
+    def fake_rail_count(arg, **_kw):
         seen.append(arg)
         return 13
 

--- a/tests/test_rail_cli.py
+++ b/tests/test_rail_cli.py
@@ -103,7 +103,7 @@ def test_build_items_skips_hidden_items(monkeypatch, tmp_path: Path) -> None:
             return [], [], [], [], []
 
     monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0,
     )
     monkeypatch.setattr(
         "pollypm.cockpit_rail.load_config", lambda path: _FakeConfig(tmp_path),
@@ -144,7 +144,7 @@ def test_build_items_collapses_sections(monkeypatch, tmp_path: Path) -> None:
             return [], [], [], [], []
 
     monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config, **_kw: 0,
     )
     monkeypatch.setattr(
         "pollypm.cockpit_rail.load_config", lambda path: _FakeConfig(tmp_path),


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Reconcile cockpit rail/footer/home/dashboard inbox counts with the same default inbox lens used by `/api/v1/inbox`, excluding notify-only watchdog rows.
- Change dashboard project rollups to count canonical inbox tasks instead of every nonterminal chat task.
- Stop watchdog dedup bumps from creating a new operator chat task every tick; reuse the existing task and archive same-message duplicates.

## Verification
- `uv run --extra test pytest -q tests/test_core_rail_items.py::test_inbox_rail_count_bypasses_state_cache tests/test_cockpit_footer_status_wiring.py::test_resolve_footer_state_bypasses_state_cache tests/test_cockpit_footer_status_wiring.py::test_resolve_footer_state_returns_snapshot_with_expected_counts tests/test_dashboard_endpoint.py::test_list_projects_uses_pg_bulk_task_snapshot tests/test_dashboard_inbox_perf.py::test_awaits_user_list_annotates_only_actionable_rows tests/test_audit_watchdog.py::test_operator_inbox_task_reuses_deduped_watchdog_task tests/test_polly_dashboard_ui.py::test_dashboard_gather_uses_rail_inbox_counter tests/test_dashboard_data_pg.py tests/test_notify_task.py tests/test_state_cache_parity.py::TestInboxDefaultLensInvariant tests/web_api/test_endpoints.py::test_list_projects_returns_registered_project tests/web_api/test_endpoints.py::test_list_projects_tracked_filter` (35 passed)
- `uv run --extra dev ruff check --select E9,F63,F7,F82 ...` (passed)
- `uv run python -m py_compile ...` (passed)
- `git diff --check` (passed)

Note: a broader run of `tests/test_core_rail_items.py tests/test_cockpit_footer_status_wiring.py tests/test_dashboard_endpoint.py tests/test_dashboard_inbox_perf.py tests/test_audit_watchdog.py` reported 181 passed and 8 failures in older sqlite-oriented rail/watchdog tests that are unrelated to this change.