### PR TITLE
Calm Home counts, briefing, and headroom refresh

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -755,10 +755,11 @@ paths:
             pairs). Off by default — the list can be large.
         - in: query
           name: include_briefing
-          schema: { type: boolean, default: false }
+          schema: { type: boolean, default: true }
           description: |
             Include the morning-briefing narrative in the response.
-            Off by default — the body can be megabytes.
+            On by default for the Home surface; set false for small
+            machine-polling responses.
       responses:
         "200":
           description: Aggregate dashboard snapshot.
@@ -3830,8 +3831,8 @@ components:
         briefing:
           type: string
           description: |
-            Optional morning-briefing narrative. Only populated when
-            `?include_briefing=true`.
+            Optional morning-briefing narrative. Populated by default;
+            omitted only when `?include_briefing=false`.
 
     ProjectDrilldown:
       allOf:

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -481,7 +481,7 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | GET    | `/api/v1/projects` | List registered projects with state, glyph, counts |
 | POST   | `/api/v1/projects` | Register a project (mirrors `pm add-project`) |
 | GET    | `/api/v1/projects/{key}` | Project drilldown — state, recent activity, top tasks, pending plan review |
-| GET    | `/api/v1/dashboard` | Dashboard/cockpit aggregate state (`?project=&include_briefing=&include_token_history=`) |
+| GET    | `/api/v1/dashboard` | Dashboard/cockpit aggregate state (`?project=&include_briefing=true&include_token_history=`; set `include_briefing=false` for tiny polling responses) |
 | GET    | `/api/v1/alerts` | Open action-required alerts with cockpit action descriptors |
 | POST   | `/api/v1/alerts/{alert_id}/actions/{kind}` | Run an alert action. `acknowledge` clears the alert and records the alert-cleared activity event |
 | POST   | `/api/v1/projects/{key}/plan` | Kick off `pm project plan` (initial or replan) |

--- a/src/pollypm/account_usage_sampler.py
+++ b/src/pollypm/account_usage_sampler.py
@@ -13,6 +13,7 @@ Contract:
 from __future__ import annotations
 
 import logging
+import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +27,28 @@ from pollypm.session_services import create_tmux_client
 from pollypm.storage.records import AccountUsageRecord
 
 logger = logging.getLogger(__name__)
+
+
+def _is_missing_probe_target_error(exc: BaseException) -> bool:
+    """Return True when tmux lost the probe window before capture."""
+
+    parts = [str(exc)]
+    if isinstance(exc, subprocess.CalledProcessError):
+        parts.extend(
+            str(part or "")
+            for part in (exc.cmd, exc.stderr, exc.output)
+        )
+    text = " ".join(parts).lower()
+    return (
+        "capture-pane" in text
+        and (
+            "non-zero exit status 1" in text
+            or "can't find" in text
+            or "can't find pane" in text
+            or "can't find window" in text
+            or "can't find session" in text
+        )
+    )
 
 
 def _read_cached_usage(config, account_name: str) -> AccountUsageRecord | None:
@@ -105,6 +128,12 @@ def refresh_account_usage(
         if account.provider is ProviderKind.CLAUDE and "not authenticated" in lowered:
             health = "auth-broken"
             usage_summary = "usage refresh failed · Claude still opens the login flow"
+        elif _is_missing_probe_target_error(exc):
+            health = cached.health if cached is not None else "unknown"
+            usage_summary = (
+                "headroom unavailable - usage probe window disappeared; "
+                "retrying on next refresh"
+            )
         else:
             health = cached.health if cached is not None else "unknown"
             usage_summary = f"usage refresh failed · {raw_text}"
@@ -164,39 +193,56 @@ def collect_account_usage_sample(
     account = config.accounts[account_name]
     session = _probe_session_spec(config.project.root_dir, account_name, account.provider)
     tmux = tmux_client or create_tmux_client()
-    probe_session = f"{USAGE_PROBE_SESSION_PREFIX}{account_name}-{int(time.time())}"
-    try:
-        tmux.create_session(
-            probe_session,
-            "probe",
-            _build_probe_command(config, account, session),
+    last_missing_target_error: BaseException | None = None
+    for attempt in range(2):
+        probe_session = (
+            f"{USAGE_PROBE_SESSION_PREFIX}{account_name}-{time.time_ns()}"
         )
-        snapshot = collect_usage_snapshot(
-            account,
-            tmux=tmux,
-            target=f"{probe_session}:0",
-            session=session,
-        )
-        return AccountUsageSample(
-            account_name=account_name,
-            provider=account.provider,
-            plan=snapshot.plan or "unknown",
-            health=snapshot.health or "unknown",
-            usage_summary=snapshot.summary or "usage unavailable",
-            raw_text=snapshot.raw_text or "",
-            used_pct=snapshot.used_pct,
-            remaining_pct=snapshot.remaining_pct,
-            reset_at=snapshot.reset_at,
-            period_label=snapshot.period_label,
-        )
-    finally:
-        # Per-probe cleanup. Belt-and-suspenders for #1009 — first try the
-        # wrapped client (lets fakes track the kill in tests); if THAT
-        # raises, fall through to ``tmux kill-session`` directly so a
-        # broken client wrapper can't leak the session. Either way the
-        # ``=`` exact-target prefix prevents accidentally killing
-        # something whose name starts with our probe prefix.
-        _kill_probe_session(probe_session, tmux=tmux)
+        try:
+            tmux.create_session(
+                probe_session,
+                "probe",
+                _build_probe_command(config, account, session),
+            )
+            snapshot = collect_usage_snapshot(
+                account,
+                tmux=tmux,
+                target=f"{probe_session}:0",
+                session=session,
+            )
+            return AccountUsageSample(
+                account_name=account_name,
+                provider=account.provider,
+                plan=snapshot.plan or "unknown",
+                health=snapshot.health or "unknown",
+                usage_summary=snapshot.summary or "usage unavailable",
+                raw_text=snapshot.raw_text or "",
+                used_pct=snapshot.used_pct,
+                remaining_pct=snapshot.remaining_pct,
+                reset_at=snapshot.reset_at,
+                period_label=snapshot.period_label,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if attempt == 0 and _is_missing_probe_target_error(exc):
+                last_missing_target_error = exc
+                logger.info(
+                    "account_usage_sampler: probe window vanished for %s; "
+                    "respawning once",
+                    account_name,
+                )
+                continue
+            raise
+        finally:
+            # Per-probe cleanup. Belt-and-suspenders for #1009 — first try the
+            # wrapped client (lets fakes track the kill in tests); if THAT
+            # raises, fall through to ``tmux kill-session`` directly so a
+            # broken client wrapper can't leak the session. Either way the
+            # ``=`` exact-target prefix prevents accidentally killing
+            # something whose name starts with our probe prefix.
+            _kill_probe_session(probe_session, tmux=tmux)
+    if last_missing_target_error is not None:
+        raise last_missing_target_error
+    raise RuntimeError("usage probe failed before a sample was collected")
 
 
 def _kill_probe_session(name: str, *, tmux=None) -> None:

--- a/src/pollypm/alert_actionability.py
+++ b/src/pollypm/alert_actionability.py
@@ -1,0 +1,173 @@
+"""Shared user-actionable alert filtering for cockpit surfaces.
+
+This module is intentionally storage-light: callers hand it alert rows and,
+when available, the small workspace context needed to demote stale watchdog
+alerts. The web alert list, dashboard rollups, and Home headline should all
+consult this policy instead of each keeping local alert-count rules.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
+
+from pollypm.cockpit_alerts import is_operational_alert
+
+
+_STUCK_ON_TASK_PREFIX = "stuck_on_task:"
+_QUEUE_WITHOUT_MOTION_SESSION_PREFIX = "audit-queue_without_motion-"
+_WATCHDOG_ALERT_TYPE = "audit_watchdog"
+_QWM_PROJECT_RE = re.compile(r"\bProject\s+(?P<project>[A-Za-z0-9_.-]+)\s+has\b")
+
+
+@dataclass(slots=True, frozen=True)
+class AlertActionabilityContext:
+    """Workspace facts used by :func:`is_user_actionable_alert`."""
+
+    user_waiting_task_ids: frozenset[str] = frozenset()
+    known_projects: frozenset[str] | None = None
+    tracked_projects: frozenset[str] | None = None
+    project_task_counts: Mapping[str, Mapping[str, int]] = field(default_factory=dict)
+
+
+def _row_value(row: object, *names: str) -> object:
+    if isinstance(row, Mapping):
+        for name in names:
+            value = row.get(name)
+            if value is not None:
+                return value
+        return None
+    for name in names:
+        value = getattr(row, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _text_value(row: object, *names: str) -> str:
+    value = _row_value(row, *names)
+    return str(value or "")
+
+
+def _stuck_alert_already_user_waiting(
+    alert_type: str,
+    user_waiting_task_ids: frozenset[str],
+) -> bool:
+    if not alert_type.startswith(_STUCK_ON_TASK_PREFIX):
+        return False
+    task_id = alert_type[len(_STUCK_ON_TASK_PREFIX):].strip()
+    return bool(task_id and task_id in user_waiting_task_ids)
+
+
+def _queue_without_motion_project(
+    alert: object,
+    *,
+    known_projects: frozenset[str] | None,
+) -> str | None:
+    session_name = _text_value(alert, "session_name", "scope")
+    if not session_name.startswith(_QUEUE_WITHOUT_MOTION_SESSION_PREFIX):
+        return None
+
+    message = _text_value(alert, "message", "body")
+    match = _QWM_PROJECT_RE.search(message)
+    if match is not None:
+        return match.group("project")
+
+    tail = session_name[len(_QUEUE_WITHOUT_MOTION_SESSION_PREFIX):]
+    if known_projects:
+        for project in sorted(known_projects, key=len, reverse=True):
+            if tail == project or tail.startswith(project + "-"):
+                return project
+    return None
+
+
+def _queue_without_motion_is_stale(
+    alert: object,
+    *,
+    context: AlertActionabilityContext,
+) -> bool:
+    alert_type = _text_value(alert, "alert_type", "type")
+    if alert_type != _WATCHDOG_ALERT_TYPE:
+        return False
+
+    project = _queue_without_motion_project(
+        alert,
+        known_projects=context.known_projects or context.tracked_projects,
+    )
+    if not project:
+        return False
+
+    if context.tracked_projects is not None and project not in context.tracked_projects:
+        return True
+
+    counts = context.project_task_counts.get(project)
+    if counts is not None and int(counts.get("queued", 0) or 0) <= 0:
+        return True
+
+    return False
+
+
+def is_user_actionable_alert(
+    alert: object,
+    *,
+    context: AlertActionabilityContext | None = None,
+    include_operational: bool = False,
+) -> bool:
+    """Return whether ``alert`` belongs on user-facing action surfaces."""
+
+    alert_type = _text_value(alert, "alert_type", "type")
+    if not include_operational and is_operational_alert(alert_type):
+        return False
+
+    ctx = context or AlertActionabilityContext()
+    if _stuck_alert_already_user_waiting(alert_type, ctx.user_waiting_task_ids):
+        return False
+    if _queue_without_motion_is_stale(alert, context=ctx):
+        return False
+
+    return True
+
+
+def user_actionable_alerts(
+    alerts: Iterable[object],
+    *,
+    context: AlertActionabilityContext | None = None,
+    include_operational: bool = False,
+) -> list[object]:
+    """Filter alert rows to the set that should drive Home/Alerts counts."""
+
+    return [
+        alert
+        for alert in alerts
+        if is_user_actionable_alert(
+            alert,
+            context=context,
+            include_operational=include_operational,
+        )
+    ]
+
+
+def count_user_actionable_alerts(
+    alerts: Iterable[object],
+    *,
+    context: AlertActionabilityContext | None = None,
+    include_operational: bool = False,
+) -> int:
+    """Count the same filtered set returned by :func:`user_actionable_alerts`."""
+
+    return len(
+        user_actionable_alerts(
+            alerts,
+            context=context,
+            include_operational=include_operational,
+        )
+    )
+
+
+__all__ = [
+    "AlertActionabilityContext",
+    "count_user_actionable_alerts",
+    "is_user_actionable_alert",
+    "user_actionable_alerts",
+]

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -12,6 +12,10 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from pollypm.config import PollyPMConfig, load_config
+from pollypm.idle_placeholders import (
+    is_codex_idle_placeholder as _is_codex_idle_placeholder,
+)
+from pollypm.projects import project_state_db_path
 
 logger = logging.getLogger(__name__)
 
@@ -107,18 +111,6 @@ def _now_feed_friendly_fallback(line: str) -> str | None:
     if text[0].islower():
         return "On the line"
     return None
-
-
-# Codex idle-input placeholder detection lives in
-# :mod:`pollypm.idle_placeholders` (#1010 extraction) so the dashboard
-# renderer here and the heartbeat session-health classifier share one
-# definition. Re-export under the legacy name for backward compat with
-# any external callers / tests pinning the old symbol.
-from pollypm.idle_placeholders import (
-    CODEX_IDLE_PLACEHOLDERS as _CODEX_IDLE_PLACEHOLDERS,
-    is_codex_idle_placeholder as _is_codex_idle_placeholder,
-)
-from pollypm.projects import project_state_db_path
 
 
 def _snapshot_activity_status(line: str) -> str | None:
@@ -568,7 +560,6 @@ def _compute_session_description(status: str, role: str, snapshot_path: str | No
                 _sanitize_snapshot_line(line)
                 for line in text.splitlines()
             ]
-            cleaned_lines = [text for text, _dirty in sanitized]
             clean_lines = [text for text, dirty in sanitized if not dirty]
             # Check for progress indicators first — only over the
             # trustworthy (escape-free) lines so we don't echo a
@@ -755,6 +746,199 @@ def _stuck_alert_already_user_waiting(
         return False
     task_id = alert_type[len(prefix):].strip()
     return bool(task_id) and task_id in user_waiting_task_ids
+
+
+def _tracked_project_keys(config: PollyPMConfig) -> frozenset[str]:
+    projects = getattr(config, "projects", {}) or {}
+    return frozenset(
+        key
+        for key, project in projects.items()
+        if getattr(project, "tracked", True)
+    )
+
+
+def _known_project_keys(config: PollyPMConfig) -> frozenset[str]:
+    return frozenset((getattr(config, "projects", {}) or {}).keys())
+
+
+def _project_task_counts_for_alert_filter(
+    config: PollyPMConfig,
+    open_alerts: list[object],
+) -> dict[str, dict[str, int]]:
+    """Return per-project work-status counts only when alert policy needs them."""
+
+    if not any(
+        str(getattr(alert, "session_name", "") or "").startswith(
+            "audit-queue_without_motion-"
+        )
+        for alert in open_alerts
+    ):
+        return {}
+    try:
+        from pollypm.cockpit_pg_aggregates import (
+            all_tasks_for_project,
+            all_tasks_grouped,
+        )
+
+        grouped = all_tasks_grouped(config)
+        if grouped is None:
+            return {}
+        counts_by_project: dict[str, dict[str, int]] = {}
+        for project_key in (getattr(config, "projects", {}) or {}):
+            counts: dict[str, int] = {}
+            for task in all_tasks_for_project(grouped, config, project_key):
+                status = getattr(task, "work_status", "") or ""
+                status_value = getattr(status, "value", status)
+                status_key = str(status_value or "")
+                if not status_key:
+                    continue
+                counts[status_key] = counts.get(status_key, 0) + 1
+            counts_by_project[project_key] = counts
+        return counts_by_project
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "dashboard_data: project task counts for alert filter failed",
+            exc_info=True,
+        )
+        return {}
+
+
+def dashboard_actionable_alerts(
+    config: PollyPMConfig,
+    open_alerts: list[object],
+    *,
+    user_waiting_task_ids: frozenset[str] | None = None,
+) -> list[object]:
+    """Return the alert rows that should drive Home/Alerts action counts."""
+
+    from pollypm.alert_actionability import (
+        AlertActionabilityContext,
+        user_actionable_alerts,
+    )
+
+    if user_waiting_task_ids is None:
+        try:
+            user_waiting_task_ids = _user_waiting_task_ids_across_projects(config)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "dashboard_data: user-waiting task lookup failed",
+                exc_info=True,
+            )
+            user_waiting_task_ids = frozenset()
+    context = AlertActionabilityContext(
+        user_waiting_task_ids=frozenset(user_waiting_task_ids),
+        known_projects=_known_project_keys(config),
+        tracked_projects=_tracked_project_keys(config),
+        project_task_counts=_project_task_counts_for_alert_filter(
+            config,
+            open_alerts,
+        ),
+    )
+    return user_actionable_alerts(open_alerts, context=context)
+
+
+def count_dashboard_alerts(
+    config: PollyPMConfig,
+    open_alerts: list[object] | None = None,
+    *,
+    user_waiting_task_ids: frozenset[str] | None = None,
+) -> int:
+    """Count the same user-actionable alert set the Home dashboard renders."""
+
+    if open_alerts is None:
+        from pollypm.storage.pg_alerts import open_alerts as pg_open_alerts
+
+        open_alerts = list(pg_open_alerts(config=config))
+    return len(
+        dashboard_actionable_alerts(
+            config,
+            open_alerts,
+            user_waiting_task_ids=user_waiting_task_ids,
+        )
+    )
+
+
+def _plural(count: int, singular: str, plural: str | None = None) -> str:
+    word = singular if count == 1 else (plural or f"{singular}s")
+    return f"{count} {word}"
+
+
+_TASK_ID_TOKEN_RE = re.compile(r"\b[A-Za-z0-9_.-]+/\d+\b")
+
+
+def _clean_briefing_title(title: str) -> str:
+    text = re.sub(r"\s+", " ", title or "").strip()
+    text = _TASK_ID_TOKEN_RE.sub("a task", text)
+    return text.rstrip(".")
+
+
+def _build_dashboard_briefing(
+    *,
+    commits: list[CommitInfo],
+    completed: list[CompletedItem],
+    inbox_count: int,
+    recent_messages: list[InboxPreview],
+    recovery_count_24h: int,
+) -> str:
+    """Build the concise Home briefing from already-gathered dashboard facts."""
+
+    lines: list[str] = ["Morning. Here's the overnight read."]
+    if completed:
+        lines.append(
+            "Shipped: "
+            + _plural(len(completed), "item")
+            + " wrapped in the last 72 hours."
+        )
+    if commits:
+        projects_touched = len({c.project for c in commits})
+        lines.append(
+            "Progress: "
+            + _plural(len(commits), "commit")
+            + " across "
+            + _plural(projects_touched, "project")
+            + "."
+        )
+    if recovery_count_24h:
+        lines.append(
+            "Saved: "
+            + _plural(recovery_count_24h, "recovery", "recoveries")
+            + " handled without handing you a mess."
+        )
+
+    if inbox_count:
+        decision = ""
+        for message in recent_messages:
+            decision = _clean_briefing_title(getattr(message, "title", "") or "")
+            if decision:
+                break
+        if decision:
+            if inbox_count == 1:
+                lines.append(
+                    "One thing needs you: "
+                    + decision
+                    + ". Open Inbox and clear that first."
+                )
+            else:
+                lines.append(
+                    "First up: "
+                    + decision
+                    + ". "
+                    + _plural(inbox_count, "inbox item")
+                    + " waiting."
+                )
+        else:
+            prefix = "One thing needs you: " if inbox_count == 1 else "Inbox needs you: "
+            lines.append(
+                prefix
+                + _plural(inbox_count, "inbox item")
+                + " waiting. Open Inbox and clear the oldest first."
+            )
+    elif len(lines) == 1:
+        lines.append("Quiet night. Nothing needs you right now.")
+    else:
+        lines.append("All handled: no inbox items waiting.")
+
+    return "\n".join(lines[:6])
 
 
 def _inbox_sender(task) -> str:
@@ -1053,58 +1237,24 @@ def gather(
     sweeps = sum(1 for e in day_events if e.event_type == "heartbeat")
     recoveries = sum(1 for e in day_events if "recover" in e.event_type)
 
-    # Morning briefing: generate if there are overnight results
-    def _plural(count: int, singular: str, plural: str | None = None) -> str:
-        word = singular if count == 1 else (plural or f"{singular}s")
-        return f"{count} {word}"
-
-    # 24h activity briefing. The earlier "While you were away" framing
-    # presumed every cockpit launch was a return from a trip — including
-    # the literal first-ever launch on a fresh install (#854). Use a
-    # neutral 24-hour heading instead. Recovery counts are internal
-    # plumbing (see #879 for elevation policy) and are deliberately not
-    # surfaced here so the dashboard reflects what the user did, not
-    # what the supervisor patched up behind the scenes.
-    briefing = ""
-    if commits or completed or inbox_count:
-        parts: list[str] = []
-        if commits:
-            projects_touched = len({c.project for c in commits})
-            parts.append(
-                f"{_plural(len(commits), 'commit')} across "
-                f"{_plural(projects_touched, 'project')}"
-            )
-        if completed:
-            parts.append(f"{_plural(len(completed), 'issue')} completed")
-        if inbox_count:
-            parts.append(
-                f"{_plural(inbox_count, 'inbox item')} waiting for you"
-            )
-        briefing = "Last 24 hours: " + ", ".join(parts) + "."
-
-    # Late import keeps dashboard_data out of the cockpit_alerts import
-    # graph (cockpit_alerts → cockpit_palette → cockpit, which pulls
-    # dashboard_data in at top level).
-    from pollypm.cockpit_alerts import is_operational_alert
-
-    # Drop ``stuck_on_task:<id>`` alerts whose task is already in a
-    # user-waiting state — the session sat idle because the user
-    # hasn't responded, which is the system doing what it should,
-    # not a fault to surface as a separate alert. Mirrors cycles 45
-    # / 53 / 55 dedup at the global polly-dashboard count level.
-    user_waiting = _user_waiting_task_ids_across_projects(config)
     if use_pg:
         open_alerts = pg_open_alerts()
     elif store is not None:
         open_alerts = store.open_alerts()  # type: ignore[attr-defined]
     else:
         open_alerts = []
-    alert_count = sum(
-        1 for a in open_alerts
-        if not is_operational_alert(a.alert_type)
-        and not _stuck_alert_already_user_waiting(
-            a.alert_type, user_waiting,
-        )
+    user_waiting = _user_waiting_task_ids_across_projects(config)
+    alert_count = count_dashboard_alerts(
+        config,
+        list(open_alerts),
+        user_waiting_task_ids=user_waiting,
+    )
+    briefing = _build_dashboard_briefing(
+        commits=commits,
+        completed=completed,
+        inbox_count=inbox_count,
+        recent_messages=recent_messages,
+        recovery_count_24h=recoveries,
     )
 
     return DashboardData(

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -230,6 +230,81 @@ def _route_to_alert_sink(
         return False
 
 
+def _clear_alert_best_effort(store: Any, session_name: str, alert_type: str) -> bool:
+    clear = getattr(store, "clear_alert", None)
+    if not callable(clear):
+        return False
+    try:
+        clear(
+            session_name,
+            alert_type,
+            who_cleared="audit_watchdog:stale-alert-sweep",
+        )
+        return True
+    except TypeError:
+        try:
+            clear(session_name, alert_type)
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _sweep_stale_watchdog_alerts(*, services: Any) -> int:
+    """Close watchdog alert rows no longer counted as user-actionable."""
+
+    store = getattr(services, "msg_store", None) or getattr(
+        services, "state_store", None,
+    )
+    config = getattr(services, "config", None)
+    if store is None or config is None:
+        return 0
+    list_open = getattr(store, "open_alerts", None)
+    if not callable(list_open):
+        return 0
+    try:
+        alerts = list(list_open())
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: stale-alert sweep open_alerts failed",
+            exc_info=True,
+        )
+        return 0
+    try:
+        from pollypm.dashboard_data import dashboard_actionable_alerts
+
+        actionable = {
+            (
+                getattr(alert, "session_name", "") or "",
+                getattr(alert, "alert_type", "") or "",
+            )
+            for alert in dashboard_actionable_alerts(config, alerts)
+        }
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: stale-alert actionability filter failed",
+            exc_info=True,
+        )
+        return 0
+    cleared = 0
+    for alert in alerts:
+        alert_type = getattr(alert, "alert_type", "") or ""
+        if alert_type != WATCHDOG_ALERT_TYPE:
+            continue
+        session_name = getattr(alert, "session_name", "") or ""
+        if (session_name, alert_type) in actionable:
+            continue
+        if _clear_alert_best_effort(store, session_name, alert_type):
+            cleared += 1
+    if cleared:
+        logger.info(
+            "audit.watchdog: cleared %d stale audit_watchdog alert(s)",
+            cleared,
+        )
+    return cleared
+
+
 def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
     """Build a :class:`WatchdogConfig` from the handler payload."""
     if not isinstance(payload, dict):
@@ -3572,6 +3647,7 @@ def _scan_one_project_counters() -> dict[str, int]:
         "tier4_demoted_cleared": 0,
         "tier4_budget_exhausted": 0,
         "tier4_terminal_handoff_failed": 0,
+        "stale_alerts_cleared": 0,
     }
 
 
@@ -4090,6 +4166,16 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
             sweep_counters = {}
         for k, v in sweep_counters.items():
             totals[k] = totals.get(k, 0) + int(v)
+
+        try:
+            totals["stale_alerts_cleared"] = _sweep_stale_watchdog_alerts(
+                services=services,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "audit.watchdog: stale-alert sweep raised",
+                exc_info=True,
+            )
     finally:
         try:
             services.close()

--- a/src/pollypm/web_api/routes/alerts.py
+++ b/src/pollypm/web_api/routes/alerts.py
@@ -188,10 +188,19 @@ def list_alerts_endpoint(
 ) -> AlertsResponse:
     alerts = _read_open_alerts(config)
     if not include_operational:
-        alerts = [
-            alert for alert in alerts
-            if not is_operational_alert(alert.alert_type)
-        ]
+        try:
+            from pollypm.dashboard_data import dashboard_actionable_alerts
+
+            alerts = dashboard_actionable_alerts(config, alerts)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "alerts: actionable alert filter failed; using operational-only filter",
+                exc_info=True,
+            )
+            alerts = [
+                alert for alert in alerts
+                if not is_operational_alert(alert.alert_type)
+            ]
     total = len(alerts)
     rows = [_alert_to_response(alert) for alert in alerts[:limit]]
     return AlertsResponse(

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -177,8 +177,9 @@ class DashboardResponse(BaseModel):
     briefing: str | None = Field(
         default=None,
         description=(
-            "Optional morning-briefing narrative. Only populated when "
-            "``?include_briefing=true`` since the body can be megabytes."
+            "Optional morning-briefing narrative. Populated by default; "
+            "set ``?include_briefing=false`` only for very small polling "
+            "responses."
         ),
     )
 
@@ -346,6 +347,21 @@ def _load_dashboard_snapshot(config: Any) -> DashboardSnapshot:
     )
 
 
+def _fresh_dashboard_alert_count(config: Any) -> int | None:
+    """Return a fresh alert count so stale dashboard snapshots cannot alarm high."""
+
+    try:
+        from pollypm.dashboard_data import count_dashboard_alerts
+
+        return count_dashboard_alerts(config)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "dashboard: fresh alert-count refresh failed; using cached value",
+            exc_info=True,
+        )
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Endpoint
 # ---------------------------------------------------------------------------
@@ -389,10 +405,11 @@ async def get_dashboard_endpoint(
         Query(
             description=(
                 "Include the morning-briefing narrative in the response. "
-                "Default false — the body can be megabytes."
+                "Default true because the Home surface uses this field; "
+                "set false for tiny machine-polling responses."
             ),
         ),
-    ] = False,
+    ] = True,
 ) -> DashboardResponse:
     """GET /api/v1/dashboard per Phase 2 spec §3.1.
 
@@ -490,12 +507,25 @@ async def get_dashboard_endpoint(
     pending_plan_reviews = sum(
         1 for p in projects_view if p.pending_plan_review
     )
+    # The full snapshot is intentionally stale-while-refresh. Alert counts are
+    # volatile enough that an old-high value can alarm the Home headline, so
+    # refresh that one cheap counter only when we are serving an aged snapshot.
+    snapshot_age = time.monotonic() - snapshot.refreshed_at_monotonic
+    fresh_alert_count = (
+        _fresh_dashboard_alert_count(config)
+        if snapshot_age > 2.0
+        else None
+    )
 
     rollups = DashboardRollups(
         tracked_count=tracked_count,
         open_inbox_count=open_inbox_count,
         pending_plan_reviews=pending_plan_reviews,
-        alert_count=int(getattr(data, "alert_count", 0) or 0),
+        alert_count=int(
+            fresh_alert_count
+            if fresh_alert_count is not None
+            else (getattr(data, "alert_count", 0) or 0)
+        ),
         sweep_count_24h=int(getattr(data, "sweep_count_24h", 0) or 0),
         message_count_24h=int(getattr(data, "message_count_24h", 0) or 0),
         recovery_count_24h=int(getattr(data, "recovery_count_24h", 0) or 0),

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -1155,17 +1155,6 @@
     return count === 1 ? singular : (pluralText || singular + "s");
   }
 
-  function blockedProjectCount(data) {
-    const projects = data && Array.isArray(data.projects) ? data.projects : [];
-    return projects.filter((project) => {
-      const projectState = String(project.state || "").toLowerCase();
-      if (projectState === "blocked" || projectState === "on_hold") return true;
-      const counts = project.task_counts && typeof project.task_counts === "object"
-        ? project.task_counts : {};
-      return numeric(counts.blocked) + numeric(counts.on_hold) > 0;
-    }).length;
-  }
-
   function dashboardStatus(data) {
     if (!data || typeof data !== "object") {
       return {
@@ -1178,9 +1167,9 @@
     const rollups = data.rollups && typeof data.rollups === "object"
       ? data.rollups : {};
     const planReviews = numeric(rollups.pending_plan_reviews);
+    const inbox = numeric(rollups.open_inbox_count);
     const alerts = numeric(rollups.alert_count);
-    const blockedProjects = blockedProjectCount(data);
-    const total = planReviews + alerts + blockedProjects;
+    const total = planReviews + inbox + alerts;
     if (total === 0) {
       const sweeps = numeric(rollups.sweep_count_24h);
       const recoveries = numeric(rollups.recovery_count_24h);
@@ -1188,7 +1177,7 @@
         ? "24h: " + sweeps + " "
           + plural(sweeps, "sweep") + " / " + recoveries + " "
           + plural(recoveries, "recovery", "recoveries") + "."
-        : "No plan reviews, blockers, or alerts waiting.";
+        : "No inbox items, plan reviews, or alerts waiting.";
       return {
         title: "All handled - Polly's got it",
         detail: proof,
@@ -1206,14 +1195,14 @@
         target: "plan-review",
       };
     }
-    if (blockedProjects > 0) {
+    if (inbox > 0) {
       return {
         title: total + " " + plural(total, "thing") + " "
           + (total === 1 ? "needs" : "need") + " you",
-        detail: blockedProjects + " "
-          + plural(blockedProjects, "blocked project") + " waiting.",
-        actionLabel: "Open blocked tasks",
-        target: "blocked-tasks",
+        detail: inbox + " "
+          + plural(inbox, "inbox item") + " waiting.",
+        actionLabel: "Open inbox",
+        target: "inbox",
       };
     }
     return {
@@ -1229,13 +1218,6 @@
     if (!status) return;
     if (status.target === "plan-review") {
       selectInbox({ type: "plan_review" });
-      return;
-    }
-    if (status.target === "blocked-tasks") {
-      state.taskStatusFilter = "blocked";
-      const filter = $("task-status-filter");
-      if (filter) filter.value = state.taskStatusFilter;
-      loadSurfaces();
       return;
     }
     if (status.target === "alerts") {

--- a/tests/test_account_usage_sampler.py
+++ b/tests/test_account_usage_sampler.py
@@ -23,7 +23,6 @@ from pollypm.models import (
     RuntimeKind,
 )
 from pollypm.provider_sdk import ProviderUsageSnapshot
-from pollypm.storage.state import StateStore
 
 class _FakeTmux:
     def __init__(self) -> None:
@@ -79,8 +78,9 @@ def _config(tmp_path: Path) -> tuple[Path, PollyPMConfig]:
 
 
 def test_refresh_account_usage_persists_structured_fields(monkeypatch, tmp_path: Path) -> None:
-    config_path, config = _config(tmp_path)
+    config_path, _config_obj = _config(tmp_path)
     fake_tmux = _FakeTmux()
+    written: list[AccountUsageSample] = []
 
     monkeypatch.setattr(
         "pollypm.account_usage_sampler._build_probe_command",
@@ -99,6 +99,14 @@ def test_refresh_account_usage_persists_structured_fields(monkeypatch, tmp_path:
             period_label="current week",
         ),
     )
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler._read_cached_usage",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler._write_cached_usage",
+        lambda _config, sample: written.append(sample),
+    )
 
     sample = refresh_account_usage(
         config_path,
@@ -109,34 +117,33 @@ def test_refresh_account_usage_persists_structured_fields(monkeypatch, tmp_path:
     assert sample.remaining_pct == 79
     assert fake_tmux.created
     assert fake_tmux.killed == [fake_tmux.created[0][0]]
-
-    with StateStore(config.project.state_db) as store:
-        usage = store.get_account_usage("claude_primary")
-    assert usage is not None
-    assert usage.plan == "max"
-    assert usage.used_pct == 21
-    assert usage.remaining_pct == 79
-    assert usage.reset_at == "Apr 10 at 1am"
-    assert usage.period_label == "current week"
+    assert written == [sample]
+    assert sample.plan == "max"
+    assert sample.used_pct == 21
+    assert sample.reset_at == "Apr 10 at 1am"
+    assert sample.period_label == "current week"
 
 
 def test_refresh_account_usage_keeps_cached_shape_on_probe_failure(
     monkeypatch, tmp_path: Path,
 ) -> None:
-    config_path, config = _config(tmp_path)
-    with StateStore(config.project.state_db) as store:
-        store.upsert_account_usage(
-            account_name="claude_primary",
-            provider="claude",
-            plan="max",
-            health="healthy",
-            usage_summary="81% left this week",
-            raw_text="old",
-            used_pct=19,
-            remaining_pct=81,
-            reset_at="Apr 09 at 1am",
-            period_label="current week",
-        )
+    from pollypm.storage.records import AccountUsageRecord
+
+    config_path, _config_obj = _config(tmp_path)
+    cached = AccountUsageRecord(
+        account_name="claude_primary",
+        provider="claude",
+        plan="max",
+        health="healthy",
+        usage_summary="81% left this week",
+        raw_text="old",
+        updated_at="2026-05-30T00:00:00+00:00",
+        used_pct=19,
+        remaining_pct=81,
+        reset_at="Apr 09 at 1am",
+        period_label="current week",
+    )
+    written: list[AccountUsageSample] = []
 
     monkeypatch.setattr(
         "pollypm.account_usage_sampler.collect_account_usage_sample",
@@ -144,19 +151,22 @@ def test_refresh_account_usage_keeps_cached_shape_on_probe_failure(
             RuntimeError("Claude probe session is not authenticated.")
         ),
     )
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler._read_cached_usage",
+        lambda *_args, **_kwargs: cached,
+    )
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler._write_cached_usage",
+        lambda _config, sample: written.append(sample),
+    )
 
     sample = refresh_account_usage(config_path, "claude_primary", tmux_client=_FakeTmux())
 
     assert sample.health == "auth-broken"
     assert "usage refresh failed" in sample.usage_summary
     assert sample.remaining_pct == 81
-
-    with StateStore(config.project.state_db) as store:
-        usage = store.get_account_usage("claude_primary")
-    assert usage is not None
-    assert usage.health == "auth-broken"
-    assert usage.remaining_pct == 81
-    assert usage.plan == "max"
+    assert sample.plan == "max"
+    assert written == [sample]
 
 
 def test_refresh_all_account_usage_continues_past_single_account_failure(
@@ -255,6 +265,102 @@ def test_collect_account_usage_sample_kills_session_on_exception_path(
     )
 
 
+def test_collect_account_usage_sample_respawns_missing_probe_window(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """A vanished tmux capture target should self-heal with one fresh probe."""
+    config_path, _ = _config(tmp_path)
+    fake_tmux = _FakeTmux()
+    calls = 0
+
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler._build_probe_command",
+        lambda *_args, **_kwargs: "probe-cmd",
+    )
+
+    def _snapshot(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise subprocess.CalledProcessError(
+                1,
+                ["tmux", "capture-pane", "-t", "missing:0"],
+                stderr="can't find window: missing",
+            )
+        return ProviderUsageSnapshot(
+            plan="max",
+            health="healthy",
+            summary="77% left this week",
+            raw_text="ok",
+            used_pct=23,
+            remaining_pct=77,
+        )
+
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler.collect_usage_snapshot",
+        _snapshot,
+    )
+
+    sample = collect_account_usage_sample(
+        config_path, "claude_primary", tmux_client=fake_tmux,
+    )
+
+    assert sample.usage_summary == "77% left this week"
+    assert calls == 2
+    assert len(fake_tmux.created) == 2
+    assert fake_tmux.killed == [row[0] for row in fake_tmux.created]
+
+
+def test_refresh_account_usage_softens_missing_probe_window_summary(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Missing tmux capture targets must not leak raw command errors to Home."""
+    from pollypm.storage.records import AccountUsageRecord
+
+    config_path, _ = _config(tmp_path)
+    cached = AccountUsageRecord(
+        account_name="claude_primary",
+        provider="claude",
+        plan="max",
+        health="healthy",
+        usage_summary="81% left this week",
+        raw_text="old",
+        updated_at="2026-05-30T00:00:00+00:00",
+        used_pct=19,
+        remaining_pct=81,
+        reset_at="Jun 1",
+        period_label="current week",
+    )
+    written: list[AccountUsageSample] = []
+
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler._read_cached_usage",
+        lambda *_args, **_kwargs: cached,
+    )
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler._write_cached_usage",
+        lambda _config, sample: written.append(sample),
+    )
+    monkeypatch.setattr(
+        "pollypm.account_usage_sampler.collect_account_usage_sample",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(
+                1,
+                ["tmux", "capture-pane", "-t", "pm-usage-missing:0"],
+                stderr="can't find window: pm-usage-missing",
+            )
+        ),
+    )
+
+    sample = refresh_account_usage(config_path, "claude_primary")
+
+    assert sample.health == "healthy"
+    assert sample.remaining_pct == 81
+    assert sample.usage_summary.startswith("headroom unavailable - ")
+    assert "capture-pane" not in sample.usage_summary
+    assert written == [sample]
+
+
 def test_collect_account_usage_sample_falls_back_to_subprocess_when_kill_raises(
     monkeypatch, tmp_path: Path,
 ) -> None:
@@ -336,6 +442,10 @@ def test_sweep_orphan_usage_sessions_kills_only_pm_usage_prefix(monkeypatch) -> 
 
     def _fake_run(args, **kwargs):
         calls.append(list(args))
+        if args[:1] == ["ps"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr="",
+            )
         if args[:2] == ["tmux", "list-sessions"]:
             return subprocess.CompletedProcess(
                 args=args, returncode=0, stdout=listed, stderr="",

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -11,6 +11,8 @@ for non-faults the user already sees as yellow.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from pollypm.dashboard_data import _stuck_alert_already_user_waiting
 
 
@@ -45,6 +47,47 @@ def test_stuck_alert_already_user_waiting_handles_malformed_alert() -> None:
         "stuck_on_task:   ",
         frozenset({"polly_remote/12"}),
     )
+
+
+def test_actionable_alert_filter_drops_stale_watchdog_queue_alerts() -> None:
+    from pollypm.alert_actionability import (
+        AlertActionabilityContext,
+        is_user_actionable_alert,
+    )
+
+    context = AlertActionabilityContext(
+        known_projects=frozenset({"media", "polly_remote"}),
+        tracked_projects=frozenset({"polly_remote"}),
+        project_task_counts={
+            "media": {"queued": 4},
+            "polly_remote": {"queued": 0},
+        },
+    )
+
+    untracked_alert = SimpleNamespace(
+        session_name="audit-queue_without_motion-media-media",
+        alert_type="audit_watchdog",
+        message="Project media has 4 queued task(s) but no motion.",
+    )
+    resolved_alert = SimpleNamespace(
+        session_name="audit-queue_without_motion-polly_remote-polly_remote",
+        alert_type="audit_watchdog",
+        message="Project polly_remote has 2 queued task(s) but no motion.",
+    )
+    live_alert = SimpleNamespace(
+        session_name="audit-queue_without_motion-polly_remote-polly_remote",
+        alert_type="audit_watchdog",
+        message="Project polly_remote has 2 queued task(s) but no motion.",
+    )
+
+    assert not is_user_actionable_alert(untracked_alert, context=context)
+    assert not is_user_actionable_alert(resolved_alert, context=context)
+    live_context = AlertActionabilityContext(
+        known_projects=context.known_projects,
+        tracked_projects=context.tracked_projects,
+        project_task_counts={"polly_remote": {"queued": 2}},
+    )
+    assert is_user_actionable_alert(live_alert, context=live_context)
 
 
 def test_session_description_skips_claude_tui_bottom_bar(tmp_path) -> None:
@@ -336,72 +379,43 @@ def test_session_description_truncates_at_word_boundary(tmp_path) -> None:
     assert " " not in desc[-2:]  # ellipsis follows a complete word
 
 
-def test_briefing_pluralizes_counts_correctly(tmp_path) -> None:
-    """The morning briefing rendered ``1 project(s)`` / ``1 issue(s)``
-    when counts were exactly 1 — awkward parenthetical pluralisation
-    a user reads as a bug. Pluralise properly: ``1 project`` /
-    ``2 projects`` / ``1 issue`` / ``3 issues``.
-
-    We exercise the briefing builder via the in-process gather path
-    so the test stays focused on the prose, not the SQL plumbing.
-    """
-    # Test the inline ``_plural`` helper indirectly by exercising
-    # the gather() prose builder. We can't easily call ``_plural``
-    # in isolation since it's nested inside ``gather``; instead,
-    # construct minimal fakes that exercise each pluralisation
-    # branch and inspect the resulting briefing string.
-    from datetime import UTC, datetime
-    from pollypm.dashboard_data import CommitInfo, CompletedItem, DashboardData
-
-    now = datetime.now(UTC)
-
-    def _build_briefing(commits, completed, inbox_count) -> str:
-        """Inline copy of the briefing prose builder for unit testing.
-
-        Mirrors the production logic in ``dashboard_data.gather`` so the
-        plural-handling regression stays covered. Recoveries are not
-        surfaced in the briefing (#854): they are internal recovery-loop
-        plumbing, not user-facing activity.
-        """
-        def _plural(count: int, singular: str, plural: str | None = None) -> str:
-            word = singular if count == 1 else (plural or f"{singular}s")
-            return f"{count} {word}"
-
-        if not (commits or completed or inbox_count):
-            return ""
-        parts: list[str] = []
-        if commits:
-            projects_touched = len({c.project for c in commits})
-            parts.append(
-                f"{_plural(len(commits), 'commit')} across "
-                f"{_plural(projects_touched, 'project')}"
-            )
-        if completed:
-            parts.append(f"{_plural(len(completed), 'issue')} completed")
-        if inbox_count:
-            parts.append(
-                f"{_plural(inbox_count, 'inbox item')} waiting for you"
-            )
-        return "Last 24 hours: " + ", ".join(parts) + "."
+def test_briefing_pluralizes_counts_correctly() -> None:
+    """The Home briefing stays readable for singular and plural counts."""
+    from pollypm.dashboard_data import (
+        _build_dashboard_briefing,
+        CommitInfo,
+        CompletedItem,
+        InboxPreview,
+    )
 
     # Singular case — no parenthetical-s.
-    out = _build_briefing(
+    out = _build_dashboard_briefing(
         commits=[CommitInfo("h1", "msg", "a", 0.0, "demo")],
         completed=[CompletedItem("t", "issue", "demo", 0.0)],
         inbox_count=1,
+        recent_messages=[
+            InboxPreview(
+                sender="polly",
+                title="Approval ready: demo/1",
+                project="demo",
+                task_id="demo/1",
+                age_seconds=0.0,
+            )
+        ],
+        recovery_count_24h=1,
     )
     assert "1 commit across 1 project" in out
-    assert "1 issue completed" in out
-    assert "1 inbox item waiting" in out
-    assert out.startswith("Last 24 hours:"), f"unexpected greeting: {out!r}"
-    # Recovery counts must not surface in the user-facing briefing.
-    assert "recovery" not in out.lower()
+    assert "1 item wrapped" in out
+    assert "1 recovery handled" in out
+    assert "One thing needs you:" in out
+    assert "demo/1" not in out
+    assert out.startswith("Morning."), f"unexpected greeting: {out!r}"
     # The bare singular forms must not contain the legacy parens.
     assert "(s)" not in out
     assert "(ies)" not in out
 
     # Plural case — proper plural endings, still no parens.
-    out2 = _build_briefing(
+    out2 = _build_dashboard_briefing(
         commits=[
             CommitInfo("h1", "m", "a", 0.0, "demo"),
             CommitInfo("h2", "m", "a", 0.0, "other"),
@@ -412,13 +426,40 @@ def test_briefing_pluralizes_counts_correctly(tmp_path) -> None:
             CompletedItem("t2", "issue", "demo", 0.0),
         ],
         inbox_count=4,
+        recent_messages=[
+            InboxPreview(
+                sender="polly",
+                title="Decision ready for other/99",
+                project="other",
+                task_id="other/99",
+                age_seconds=0.0,
+            )
+        ],
+        recovery_count_24h=2,
     )
     assert "3 commits across 2 projects" in out2
-    assert "2 issues completed" in out2
+    assert "2 items wrapped" in out2
+    assert "2 recoveries handled" in out2
+    assert "First up:" in out2
     assert "4 inbox items waiting" in out2
-    assert "recovery" not in out2.lower()
+    assert "other/99" not in out2
     assert "(s)" not in out2
     assert "(ies)" not in out2
+
+
+def test_briefing_all_handled_when_no_activity() -> None:
+    from pollypm.dashboard_data import _build_dashboard_briefing
+
+    out = _build_dashboard_briefing(
+        commits=[],
+        completed=[],
+        inbox_count=0,
+        recent_messages=[],
+        recovery_count_24h=0,
+    )
+
+    assert "Quiet night" in out
+    assert "Nothing needs you" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -547,9 +547,9 @@ def test_dashboard_returns_expected_shape(
     assert body["tokens"] == {"today": 1234, "total": 98765}
     # Daemon status driven by sessions presence
     assert body["daemon_status"] == "up"
-    # Optional fields default off
+    # Large token history remains opt-in; the compact briefing is on by default.
     assert body.get("daily_tokens") is None
-    assert body.get("briefing") is None
+    assert body.get("briefing") == ""
 
 
 def test_dashboard_daemon_down_when_no_active_sessions(
@@ -658,6 +658,17 @@ def test_dashboard_include_briefing(
         "/api/v1/dashboard?include_briefing=true", headers=auth_headers,
     ).json()
     assert body["briefing"] == "Last 24 hours: 3 commits."
+
+
+def test_dashboard_can_omit_briefing(
+    client, auth_headers, patch_gather, patch_list_projects,
+):
+    patch_list_projects([_api_project("myproj")])
+    patch_gather(_make_data(briefing="Morning. All handled."))
+    body = client.get(
+        "/api/v1/dashboard?include_briefing=false", headers=auth_headers,
+    ).json()
+    assert body["briefing"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_polly_dashboard_ui.py
+++ b/tests/test_polly_dashboard_ui.py
@@ -263,6 +263,7 @@ def test_dashboard_gather_uses_rail_inbox_counter(monkeypatch, tmp_path: Path) -
     assert seen == [config]
     assert data.inbox_count == 13
     assert "13 inbox items waiting" in data.briefing
+    assert data.briefing.startswith("Morning.")
 
 
 def test_dashboard_gather_includes_cached_llm_quota_usage(
@@ -318,7 +319,10 @@ def test_dashboard_gather_includes_cached_llm_quota_usage(
     monkeypatch.setattr("pollypm.dashboard_data._recent_commits", lambda *_a, **_kw: [])
     monkeypatch.setattr("pollypm.dashboard_data._completed_issues", lambda *_a, **_kw: [])
     monkeypatch.setattr("pollypm.dashboard_data._recent_inbox_messages", lambda *_a, **_kw: [])
-    monkeypatch.setattr("pollypm.dashboard_data._count_dashboard_inbox_items", lambda _config: 0)
+    monkeypatch.setattr(
+        "pollypm.dashboard_data._count_dashboard_inbox_items",
+        lambda _config, **_kw: 0,
+    )
 
     data = gather(config, FakeStore())
 
@@ -398,7 +402,10 @@ def test_dashboard_gather_uses_bulk_heartbeat_lookup(monkeypatch) -> None:
     monkeypatch.setattr("pollypm.dashboard_data._recent_commits", lambda *_a, **_kw: [])
     monkeypatch.setattr("pollypm.dashboard_data._completed_issues", lambda *_a, **_kw: [])
     monkeypatch.setattr("pollypm.dashboard_data._recent_inbox_messages", lambda *_a, **_kw: [])
-    monkeypatch.setattr("pollypm.dashboard_data._count_dashboard_inbox_items", lambda _config: 0)
+    monkeypatch.setattr(
+        "pollypm.dashboard_data._count_dashboard_inbox_items",
+        lambda _config, **_kw: 0,
+    )
     monkeypatch.setattr("pollypm.dashboard_data._account_quota_usage", lambda *_a, **_kw: [])
     monkeypatch.setattr(
         "pollypm.dashboard_data._user_waiting_task_ids_across_projects",

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1742,7 +1742,7 @@ def test_render_dashboard_real_payload_executes() -> None:
     assert ">5<" in rendered, "tracked_count value 5 missing"
     assert "58% left this week" in rendered, "quota summary missing"
     assert "1234 today / 5678 total tokens" in rendered, "token line missing"
-    assert "5 things need you" in rendered, "lead headline missing"
+    assert "12 things need you" in rendered, "lead headline missing"
     assert 'role="button"' in rendered
     assert 'title="Open inbox"' in rendered
     assert 'title="Open alerts"' in rendered


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Fixes #2473, #2474, and #2475.
- Adds a shared user-actionable alert policy so Home, Alerts, and watchdog stale-alert cleanup agree on which alerts need the operator.
- Removes blocked/on-hold project inflation from the Home headline while keeping inbox, plan review, and alert actions counted.
- Makes the Home briefing populated by default with concise overnight copy and task-id scrubbing.
- Retries vanished Claude usage probe tmux windows once and maps missing probe target errors to a friendly Home summary.

## Tests
- `uv run --extra test pytest -q tests/test_account_usage_sampler.py tests/test_dashboard_data_alert_dedup.py tests/test_dashboard_endpoint.py::test_dashboard_returns_expected_shape tests/test_dashboard_endpoint.py::test_dashboard_include_briefing tests/test_dashboard_endpoint.py::test_dashboard_can_omit_briefing`
- `uv run --extra test pytest -q tests/test_polly_dashboard_ui.py::test_dashboard_gather_uses_rail_inbox_counter tests/test_polly_dashboard_ui.py::test_dashboard_gather_includes_cached_llm_quota_usage tests/test_polly_dashboard_ui.py::test_dashboard_gather_uses_bulk_heartbeat_lookup tests/web_api/test_web_ui.py::test_render_dashboard_real_payload_executes tests/web_api/test_web_ui.py::test_ui_empty_state_points_to_inbox_without_modal`
- `uv run --extra dev ruff check src/pollypm/account_usage_sampler.py src/pollypm/alert_actionability.py src/pollypm/dashboard_data.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py src/pollypm/web_api/routes/alerts.py src/pollypm/web_api/routes/dashboard.py tests/test_account_usage_sampler.py tests/test_dashboard_data_alert_dedup.py tests/test_dashboard_endpoint.py tests/test_polly_dashboard_ui.py tests/web_api/test_web_ui.py`
- `node --check src/pollypm/web_api/ui/app.js`
- `git diff --check`
