### PR TITLE
Make AskUser decisions answerable from web chat

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -908,7 +908,10 @@ paths:
         from the normalized `events.jsonl` archive with optional tmux
         capture fallback. `source=auto` (the default) prefers the
         archive and falls back to live capture when the archive is
-        stale (>60s) or missing; `source=jsonl` forces archive reads
+        stale (>60s) or missing, except that a stale archive whose
+        newest structured envelope is an open `ask_user` is returned
+        so clients keep the answerable question id/options instead of
+        static tmux text; `source=jsonl` forces archive reads
         and 404s when the archive isn't on disk; `source=capture` is
         strict — missing windows / unavailable tmux / capture failures
         all 503 with a typed error code instead of returning an empty
@@ -975,7 +978,8 @@ paths:
             default: auto
           description: |
             Transcript source. `auto` = JSONL with capture fallback
-            when stale, `jsonl` = force archive (404 if absent),
+            when stale, preserving stale JSONL for open `ask_user`
+            envelopes; `jsonl` = force archive (404 if absent),
             `capture` = force tmux capture (503 on any failure).
       responses:
         "200":

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -504,7 +504,7 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | POST   | `/api/v1/inbox/{id}/archive` | Archive (close) the item |
 | GET    | `/api/v1/events` | SSE stream of audit-log events (`?since=&project=&event=`) |
 | GET    | `/api/v1/chat/sessions` | Discover every chat surface (operator/architect/advisor/worker) |
-| GET    | `/api/v1/chat/{session_name}/messages` | Paginated message history for one chat surface (`?since=&since_id=&limit=&direction=&source=&include_subagents=`) — `include_subagents=true` inlines the raw subagent JSONL at each `subagent_result.metadata.output_file` (allowlist-constrained, capped per envelope, #2052) |
+| GET    | `/api/v1/chat/{session_name}/messages` | Paginated message history for one chat surface (`?since=&since_id=&limit=&direction=&source=&include_subagents=`) — `source=auto` normally falls back to tmux capture for stale archives, but preserves stale JSONL when the newest structured envelope is an open `ask_user` so clients can answer it; `include_subagents=true` inlines the raw subagent JSONL at each `subagent_result.metadata.output_file` (allowlist-constrained, capped per envelope, #2052) |
 
 The OpenAPI document is the authoritative list; if anything here
 drifts, the YAML wins.

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -1625,8 +1625,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 ),
                 subject=f"{context.session_name} asked a question",
                 suggested_action=(
-                    "Open the worker pane and answer, or `pm send "
-                    f"{context.session_name} \"<answer>\"`."
+                    "Open the chat surface in the web UI and answer the "
+                    "decision card."
                 ),
             )
             api.clear_alert(context.session_name, "suspected_loop")

--- a/src/pollypm/idle_placeholders.py
+++ b/src/pollypm/idle_placeholders.py
@@ -209,6 +209,49 @@ _QUESTION_PATTERNS: tuple[str, ...] = (
 )
 
 
+def pane_shows_interactive_ask_user_question(pane_text: str) -> str | None:
+    """Return the pending AskUserQuestion prompt rendered as a TUI form.
+
+    Claude's interactive ``AskUserQuestion`` surface does not always end
+    at the empty ``❯`` prompt. It can park on a checkbox/radio menu with
+    a submit control, re-rendering the same pane indefinitely. Treat
+    that shape as an unanswered operator question so heartbeat can route
+    it to the same action-required path as prose questions.
+    """
+    if not pane_text:
+        return None
+    option_glyphs = ("☐", "☑", "○", "◉")
+    if "Submit" not in pane_text or not any(glyph in pane_text for glyph in option_glyphs):
+        return None
+
+    candidates: list[str] = []
+    for raw_line in pane_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        lower = line.lower()
+        if (
+            "bypass permissions" in lower
+            or "shift+tab to cycle" in lower
+            or "ctrl+t to" in lower
+            or line.startswith("⏵⏵")  # ⏵⏵
+        ):
+            continue
+        if set(line) <= {"─", "━", "╭", "╮", "╰", "╯", "│", "┆", " "}:  # box
+            continue
+        if "Submit" in line and any(glyph in line for glyph in option_glyphs):
+            break
+        if "?" in line and not line.startswith(("❯", "›")):
+            candidates.append(line.lstrip("⏺").strip())
+
+    if not candidates:
+        return None
+    question = candidates[-1]
+    if len(question) > 280:
+        return "…" + question[-279:]
+    return question
+
+
 def pane_ends_with_unanswered_question(pane_text: str) -> str | None:
     """Return the agent's question text iff the pane ends awaiting one.
 
@@ -235,6 +278,9 @@ def pane_ends_with_unanswered_question(pane_text: str) -> str | None:
     """
     if not pane_text:
         return None
+    ask_user_question = pane_shows_interactive_ask_user_question(pane_text)
+    if ask_user_question:
+        return ask_user_question
     if not pane_shows_claude_empty_prompt(pane_text):
         return None
 
@@ -308,6 +354,7 @@ __all__ = [
     "pane_shows_codex_idle_placeholder",
     "pane_shows_claude_empty_prompt",
     "pane_shows_no_tasks_available",
+    "pane_shows_interactive_ask_user_question",
     "pane_is_idle_placeholder",
     "pane_ends_with_unanswered_question",
 ]

--- a/src/pollypm/supervisor_alerts.py
+++ b/src/pollypm/supervisor_alerts.py
@@ -285,8 +285,8 @@ def _update_alerts_snapshot_stall(
                 subject=f"{session_name} asked a question",
                 body=_question_body,
                 suggested_action=(
-                    "Open the worker pane and answer, or `pm send "
-                    f"{session_name} \"<answer>\"`."
+                    "Open the chat surface in the web UI and answer the "
+                    "decision card."
                 ),
             )
         )

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -704,6 +704,19 @@ def _load_envelopes(
         if any(env.type == MessageType.THINKING for env in envelopes):
             return envelopes, "jsonl", archive
 
+    if archive is not None and archive.exists():
+        # A stale archive can still carry the latest open AskUserQuestion
+        # tool_use while tmux capture can only see the rendered TUI menu.
+        # Prefer the structured archive in that case so clients receive
+        # the answerable ``ask_user`` id/options instead of static text.
+        envelopes = parse_events_jsonl(
+            archive,
+            actor_fallback=actor_fallback,
+            include_thinking=include_thinking,
+        )
+        if _latest_envelope_is_open_ask_user(envelopes):
+            return envelopes, "jsonl", archive
+
     captured = _capture_for_surface(surface, actor_fallback=actor_fallback)
     if captured:
         return captured, "capture", None
@@ -715,6 +728,17 @@ def _load_envelopes(
         )
         return envelopes, "jsonl", archive
     return [], None, None
+
+
+def _latest_envelope_is_open_ask_user(envelopes: list[MessageEnvelope]) -> bool:
+    for envelope in reversed(envelopes):
+        if envelope.type == MessageType.ASK_USER:
+            return True
+        if envelope.role == MessageRole.USER or envelope.type == MessageType.TOOL_RESULT:
+            return False
+        if envelope.role == MessageRole.ASSISTANT and envelope.type == MessageType.TEXT:
+            return False
+    return False
 
 
 def _capture_for_surface(

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -93,6 +93,7 @@
     auditErrors: {},
     auditLoading: {},
     surfaceMidStream: {},
+    pendingAskUser: {},
     surfaceFilter: "",
     activitySince: ACTIVITY_DEFAULT_SINCE,
     activityEntries: [],
@@ -1830,6 +1831,7 @@
       String(m.actor || ""),
       String(m.type || ""),
       String(m.text || ""),
+      JSON.stringify(m.metadata || {}),
     ]);
   }
 
@@ -1841,6 +1843,154 @@
       String(messages.length),
       messages.map(historyMessageSignature),
     ]);
+  }
+
+  function askUserQuestions(message) {
+    const metadata = message && message.metadata && typeof message.metadata === "object"
+      ? message.metadata : {};
+    return Array.isArray(metadata.questions) ? metadata.questions : [];
+  }
+
+  function askUserOptionLabel(option) {
+    if (typeof option === "string") return option;
+    if (!option || typeof option !== "object") return "";
+    return String(option.label || option.value || "").trim();
+  }
+
+  function askUserOptionDescription(option) {
+    if (!option || typeof option !== "object") return "";
+    return String(option.description || option.help || "").trim();
+  }
+
+  function askUserQuestionAllowsMultiple(question) {
+    if (!question || typeof question !== "object") return false;
+    return Boolean(
+      question.multiSelect
+      || question.multi_select
+      || question.multiselect
+      || question.multiple,
+    );
+  }
+
+  function currentAskUserFromMessages(messages) {
+    for (const message of messages || []) {
+      const type = String(message && message.type || "");
+      const role = String(message && message.role || "");
+      if (type === "ask_user" && message.id) return message;
+      if (role === "user" || type === "tool_result") return null;
+      if (type === "text" && role === "assistant") return null;
+    }
+    return null;
+  }
+
+  function buildChatSendBody(name, text) {
+    const askUser = state.pendingAskUser[name];
+    if (askUser && askUser.id) {
+      return { answer_to: askUser.id, text: text };
+    }
+    return { text: text };
+  }
+
+  function askUserAnswerText(selections, notes) {
+    const picked = (selections || []).filter(Boolean);
+    const extra = String(notes || "").trim();
+    if (picked.length && extra) return picked.join(", ") + " - " + extra;
+    if (picked.length) return picked.join(", ");
+    return extra;
+  }
+
+  async function sendAskUserAnswer(name, answerTo, selections, notes) {
+    if (!name || !answerTo) return;
+    const answerText = askUserAnswerText(selections, notes);
+    if (!answerText) {
+      showToast("warn", "choose an answer first");
+      return;
+    }
+    const local = addLocalEcho(name, answerText);
+    const path = API + "/chat/" + encodeURIComponent(name) + "/send";
+    try {
+      await apiFetch(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          answer_to: answerTo,
+          selections: selections || [],
+          notes: notes || "",
+        }),
+      });
+      updateLocalEcho(name, local.id, { status: "pending" });
+      delete state.pendingAskUser[name];
+      setTimeout(() => loadHistory(name), 400);
+    } catch (err) {
+      updateLocalEcho(name, local.id, {
+        status: "failed",
+        error: err.message || String(err),
+      });
+      showToast("error", "answer failed: " + (err.message || String(err)));
+      throw err;
+    }
+  }
+
+  function askUserControlsNode(message, sessionName) {
+    const questions = askUserQuestions(message);
+    if (!questions.length || !message.id) return null;
+    const groups = [];
+    questions.forEach((question, qIndex) => {
+      const options = Array.isArray(question.options) ? question.options : [];
+      const optionNodes = [];
+      options.forEach((option) => {
+        const label = askUserOptionLabel(option);
+        if (!label) return;
+        const inputType = askUserQuestionAllowsMultiple(question)
+          ? "checkbox" : "radio";
+        const input = el("input", {
+          type: inputType,
+          name: "ask-user-" + message.id + "-" + qIndex,
+          value: label,
+          "data-ask-user-option": label,
+        });
+        const description = askUserOptionDescription(option);
+        const children = [
+          input,
+          el("span", { class: "ask-user-option-label", text: label }),
+        ];
+        if (description) {
+          children.push(el("span", {
+            class: "ask-user-option-description",
+            text: description,
+          }));
+        }
+        optionNodes.push(el("label", { class: "ask-user-option" }, children));
+      });
+      const groupChildren = [];
+      const questionText = String(question.question || "").trim();
+      if (questions.length > 1 && questionText) {
+        groupChildren.push(el("div", {
+          class: "ask-user-question",
+          text: questionText,
+        }));
+      }
+      groupChildren.push(el("div", { class: "ask-user-options" }, optionNodes));
+      groups.push(el("fieldset", { class: "ask-user-group" }, groupChildren));
+    });
+    const submit = el("button", {
+      type: "submit",
+      class: "ask-user-submit",
+      text: "Submit answer",
+    });
+    const form = el("form", {
+      class: "ask-user-card",
+      "data-answer-to": message.id,
+    }, groups.concat([submit]));
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const inputs = Array.from(
+        form.querySelectorAll("input[data-ask-user-option]:checked"),
+      );
+      const selections = inputs.map((input) => input.value).filter(Boolean);
+      sendAskUserAnswer(sessionName, message.id, selections, "").catch(() => {});
+    });
+    return form;
   }
 
   function shouldSkipHistoryRender(list, sessionName, signature) {
@@ -1855,17 +2005,20 @@
     list.dataset.historySession = sessionName;
   }
 
-  function historyMessageNode(message) {
+  function historyMessageNode(message, sessionName) {
     const m = message || {};
     const roleClass = "message message-role-" + (m.role || "system");
-    return el("div", { class: roleClass }, [
+    const children = [
       el("div", { class: "message-head" }, [
         el("span", { class: "message-actor", text: m.actor || m.role || "?" }),
         el("span", { class: "message-ts", text: m.ts || "" }),
         el("span", { class: "message-type", text: m.type || "" }),
       ]),
       el("div", { class: "message-text", text: m.text || "" }),
-    ]);
+    ];
+    const askControls = askUserControlsNode(m, sessionName);
+    if (askControls) children.push(askControls);
+    return el("div", { class: roleClass }, children);
   }
 
   async function loadHistory(name, opts) {
@@ -1935,6 +2088,9 @@
     $("pane-meta").textContent = meta.join(" · ");
     const rawMessages = Array.isArray(data.messages) ? data.messages : [];
     const msgs = rawMessages.slice(0, HISTORY_RENDER_LIMIT);
+    const pendingAskUser = currentAskUserFromMessages(msgs);
+    if (pendingAskUser) state.pendingAskUser[data.session_name] = pendingAskUser;
+    else delete state.pendingAskUser[data.session_name];
     const pending = reconcilePendingMessages(data.session_name, msgs);
     state.surfaceMidStream[data.session_name] = (
       msgs.length > 0 && messageLooksMidStream(msgs[0])
@@ -1958,7 +2114,7 @@
     // at the bottom (chat convention).
     const fragment = document.createDocumentFragment();
     for (let i = msgs.length - 1; i >= 0; i -= 1) {
-      fragment.appendChild(historyMessageNode(msgs[i]));
+      fragment.appendChild(historyMessageNode(msgs[i], data.session_name));
     }
     list.appendChild(fragment);
     renderLocalEchoes(data.session_name);
@@ -1986,7 +2142,7 @@
       await apiFetch(path, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: text }),
+        body: JSON.stringify(buildChatSendBody(name, text)),
       });
       updateLocalEcho(name, local.id, { status: "pending" });
       // Refresh after a short delay so the server-confirmed line can
@@ -3731,8 +3887,11 @@
     renderSurfaces: renderSurfaces,
     renderProjects: renderProjects,
     renderDashboard: renderDashboard,
+    renderHistory: renderHistory,
     renderActivity: renderActivity,
     dedupeTaskSurfaces: dedupeTaskSurfaces,
+    buildChatSendBody: buildChatSendBody,
+    currentAskUserFromMessages: currentAskUserFromMessages,
     state: state,
   };
 

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -398,6 +398,70 @@ section#message-pane {
     Monaco, Consolas, monospace;
   font-size: 12.5px;
 }
+.ask-user-card {
+  margin-top: 10px;
+  padding: 10px;
+  background: var(--bg-panel);
+  border: 1px solid rgba(255, 204, 102, 0.35);
+  border-radius: 6px;
+}
+.ask-user-group {
+  margin: 0 0 8px;
+  padding: 0;
+  border: 0;
+}
+.ask-user-question {
+  margin: 0 0 6px;
+  color: var(--text-label);
+  font-size: 12px;
+  font-weight: 600;
+}
+.ask-user-options {
+  display: grid;
+  gap: 6px;
+}
+.ask-user-option {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 4px 8px;
+  align-items: start;
+  padding: 7px 8px;
+  background: var(--bg-row);
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.ask-user-option:hover {
+  border-color: rgba(91, 138, 255, 0.7);
+}
+.ask-user-option input {
+  margin-top: 2px;
+}
+.ask-user-option-label {
+  color: var(--text-body);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+.ask-user-option-description {
+  grid-column: 2;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.ask-user-submit {
+  margin-top: 2px;
+  padding: 7px 12px;
+  background: var(--info);
+  color: var(--text-heading-bright);
+  border: 0;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.ask-user-submit:hover {
+  background: #4a78e0;
+}
 
 .task-detail {
   background: var(--bg-row);

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -1487,6 +1487,54 @@ def test_messages_endpoint_source_auto_falls_back_when_stale(
     assert body["messages"][0]["id"] == "cap_1"
 
 
+def test_messages_endpoint_source_auto_keeps_stale_open_ask_user_jsonl(
+    client,
+    auth_headers,
+    patch_registry,
+    patch_parser,
+    patch_capture,
+    monkeypatch,
+    tmp_path,
+):
+    archive = tmp_path / "events.jsonl"
+    archive.write_text("x")
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "is_archive_stale",
+        lambda path, **kw: True,
+    )
+    patch_registry([_surface(
+        "architect_demo", SurfaceType.ARCHITECT, persona="Sage",
+        project="demo", transcript_path=archive,
+    )])
+    ask_user = _env(
+        "msg_toolu_ask",
+        actor="Sage",
+        type_=MessageType.ASK_USER,
+        text="What medium should the imagery be?",
+        metadata={
+            "tool_use_id": "toolu_ask",
+            "questions": [{
+                "question": "What medium should the imagery be?",
+                "options": [{"label": "Photography"}],
+            }],
+        },
+    )
+    patch_parser({archive: [ask_user]})
+    patch_capture([_env("cap_1", text="static rendered menu")])
+
+    body = client.get(
+        "/api/v1/chat/architect_demo/messages?source=auto",
+        headers=auth_headers,
+    ).json()
+
+    assert body["transcript_source"] == "jsonl"
+    assert body["messages"][0]["id"] == "msg_toolu_ask"
+    assert body["messages"][0]["type"] == "ask_user"
+    option = body["messages"][0]["metadata"]["questions"][0]["options"][0]
+    assert option["label"] == "Photography"
+
+
 # ---------------------------------------------------------------------------
 # Auth
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -981,6 +981,46 @@ def test_local_heartbeat_backend_marks_waiting_on_user_for_question() -> None:
     assert api.cursor_updates[-1]["verdict"] == "blocked"
 
 
+def test_same_snapshot_interactive_ask_user_menu_routes_operator_question() -> None:
+    pane_text = "\n".join([
+        "⏺ I need one product direction before I queue imagery work.",
+        "",
+        "What medium should the imagery be?",
+        "",
+        "☐ Imagery medium",
+        "  ○ Bespoke SVG",
+        "  ○ Photography",
+        "☐ Hero treatment        ✔ Submit",
+    ])
+    context = _context(
+        session_name="architect_demo",
+        role="architect",
+        pane_text=pane_text,
+        transcript_delta="",
+        snapshot_hash="ask-user-menu",
+        previous_snapshot_hash="ask-user-menu",
+    )
+    api = FakeHeartbeatAPI(
+        [context],
+        hashes={"architect_demo": [
+            "ask-user-menu",
+            "ask-user-menu",
+            "ask-user-menu",
+        ]},
+    )
+
+    alerts = LocalHeartbeatBackend()._handle_same_snapshot_stall(
+        api,
+        context,
+        mechanical_only=False,
+    )
+
+    assert alerts == ["worker_question"]
+    alert = api.alerts[("architect_demo", "worker_question")]
+    assert "architect architect_demo is waiting" in alert.message
+    assert "What medium should the imagery be?" in alert.message
+
+
 def test_local_heartbeat_backend_recovers_missing_window() -> None:
     api = FakeHeartbeatAPI([_context(window_present=False, pane_text="", transcript_delta="")])
 

--- a/tests/test_supervisor_alerts.py
+++ b/tests/test_supervisor_alerts.py
@@ -1034,6 +1034,40 @@ def test_no_tasks_available_does_not_match_when_followed_by_real_output() -> Non
     assert pane_shows_no_tasks_available(pane_text) is False
 
 
+def test_interactive_ask_user_menu_is_unanswered_question() -> None:
+    """Claude's AskUserQuestion menu can park on a TUI form instead of an
+    empty prompt. The heartbeat question detector must still classify it
+    as awaiting the operator, otherwise the session looks healthy while
+    work is wedged.
+    """
+    from pollypm.idle_placeholders import (
+        pane_ends_with_unanswered_question,
+        pane_shows_interactive_ask_user_question,
+    )
+
+    pane_text = "\n".join([
+        "⏺ I need one product direction before I queue imagery work.",
+        "",
+        "What medium should the imagery be?",
+        "",
+        "☐ Imagery medium",
+        "  ○ Bespoke SVG",
+        "  ○ Photography",
+        "☐ Hero treatment        ✔ Submit",
+        "",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+    ])
+
+    assert (
+        pane_shows_interactive_ask_user_question(pane_text)
+        == "What medium should the imagery be?"
+    )
+    assert (
+        pane_ends_with_unanswered_question(pane_text)
+        == "What medium should the imagery be?"
+    )
+
+
 def test_default_recovery_policy_classifies_no_tasks_pane_as_healthy() -> None:
     """End-to-end #1084 contract: a worker whose last reply is
     ``No tasks available.`` short-circuits to ``HEALTHY`` even when the

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1374,6 +1374,139 @@ process.stdout.write(elements["dashboard-rollups"].innerHTML);
     return proc.stdout
 
 
+def _node_render_chat_history(payload: dict, reply_text: str = "") -> dict:
+    """Render chat history under node and inspect AskUserQuestion state."""
+    node_bin = shutil.which("node")
+    if node_bin is None:
+        pytest.skip("node binary not available; cannot run executable JS harness")
+    app_js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "pollypm"
+        / "web_api"
+        / "ui"
+        / "app.js"
+    )
+    harness = r"""
+const fs = require("fs");
+const path = process.argv[1];
+const payload = JSON.parse(process.argv[2]);
+const replyText = process.argv[3] || "";
+
+function makeNode(tag) {
+  const node = {
+    tagName: (tag || "div").toUpperCase(),
+    children: [],
+    attrs: {},
+    className: "",
+    textContent: "",
+    dataset: {},
+    style: {},
+  };
+  Object.defineProperty(node, "innerHTML", {
+    get() {
+      function escapeText(s) {
+        return String(s)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+      }
+      function render(n) {
+        if (n.__text != null) return escapeText(n.__text);
+        const tag = n.tagName.toLowerCase();
+        const inner = n.textContent && n.children.length === 0
+          ? escapeText(n.textContent)
+          : n.children.map(render).join("");
+        if (tag === "fragment") return inner;
+        const parts = [];
+        for (const k of Object.keys(n.attrs)) {
+          parts.push(k + '="' + n.attrs[k] + '"');
+        }
+        if (n.className) parts.push('class="' + n.className + '"');
+        const open = parts.length
+          ? "<" + tag + " " + parts.join(" ") + ">"
+          : "<" + tag + ">";
+        return open + inner + "</" + tag + ">";
+      }
+      return node.children.map(render).join("");
+    },
+    set(v) {
+      if (v === "") node.children = [];
+    },
+  });
+  node.setAttribute = function (k, v) { node.attrs[k] = v; };
+  node.appendChild = function (child) { node.children.push(child); return child; };
+  node.removeChild = function (child) {
+    node.children = node.children.filter((c) => c !== child);
+    return child;
+  };
+  node.querySelector = function () { return null; };
+  node.querySelectorAll = function () { return []; };
+  node.addEventListener = function () {};
+  return node;
+}
+
+const elements = {
+  "dashboard-rollups": makeNode("div"),
+  "surface-list": makeNode("ul"),
+  "message-list": makeNode("div"),
+  "send-input": makeNode("input"),
+  "send-button": makeNode("button"),
+  "send-form": makeNode("form"),
+  "pane-title": makeNode("div"),
+  "pane-meta": makeNode("div"),
+  "conn-status": makeNode("div"),
+  "layout": makeNode("div"),
+};
+
+global.document = {
+  getElementById: (id) => elements[id] || null,
+  createElement: (tag) => makeNode(tag),
+  createDocumentFragment: () => makeNode("fragment"),
+  createTextNode: (text) => {
+    const n = makeNode("span");
+    n.__text = text;
+    return n;
+  },
+  addEventListener: function () {},
+  readyState: "complete",
+  body: makeNode("body"),
+};
+global.window = {};
+global.setInterval = function () { return 0; };
+global.clearInterval = function () {};
+global.setTimeout = function () { return 0; };
+global.fetch = function () { return Promise.reject(new Error("no network")); };
+
+const source = fs.readFileSync(path, "utf8");
+// eslint-disable-next-line no-eval
+eval(source);
+
+global.window.PollyPM.renderHistory(payload);
+const body = replyText
+  ? global.window.PollyPM.buildChatSendBody(payload.session_name, replyText)
+  : null;
+process.stdout.write(JSON.stringify({
+  html: elements["message-list"].innerHTML,
+  pendingAskUser: global.window.PollyPM.state.pendingAskUser[payload.session_name],
+  body: body,
+}));
+"""
+    proc = subprocess.run(
+        [node_bin, "-e", harness, str(app_js_path), json.dumps(payload), reply_text],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"node harness failed (rc={proc.returncode}):\n"
+            f"STDOUT: {proc.stdout}\nSTDERR: {proc.stderr}"
+        )
+    return json.loads(proc.stdout)
+
+
 def _node_render_surface_rail(payload: dict) -> dict:
     """Render the left rail under node and optionally select a task."""
     node_bin = shutil.which("node")
@@ -1657,6 +1790,57 @@ def test_task_detail_surfaces_cancel_and_reopen_actions() -> None:
         "selectTask": "myproj/9",
     })
     assert "Reopen" in cancelled["messages"]
+
+
+def test_chat_history_renders_ask_user_controls_and_routes_reply() -> None:
+    payload = {
+        "session_name": "architect_demo",
+        "surface_type": "architect",
+        "transcript_source": "events_jsonl",
+        "messages": [
+            {
+                "id": "msg_toolu_ask",
+                "ts": "2026-05-30T10:00:00Z",
+                "role": "assistant",
+                "actor": "Sage",
+                "type": "ask_user",
+                "text": "What medium should the imagery be?",
+                "metadata": {
+                    "tool_use_id": "toolu_ask",
+                    "questions": [
+                        {
+                            "question": "What medium should the imagery be?",
+                            "multiSelect": False,
+                            "options": [
+                                {
+                                    "label": "Bespoke SVG",
+                                    "description": "Custom illustration.",
+                                },
+                                {
+                                    "label": "Photography",
+                                    "description": "Use sourced photos.",
+                                },
+                            ],
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+    rendered = _node_render_chat_history(payload, "Use photography")
+
+    html = rendered["html"]
+    assert "ask-user-card" in html
+    assert 'data-answer-to="msg_toolu_ask"' in html
+    assert "Bespoke SVG" in html
+    assert "Photography" in html
+    assert "Submit answer" in html
+    assert rendered["pendingAskUser"]["id"] == "msg_toolu_ask"
+    assert rendered["body"] == {
+        "answer_to": "msg_toolu_ask",
+        "text": "Use photography",
+    }
 
 
 def test_render_dashboard_real_payload_executes() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Fixes #2476.
- Keeps stale JSONL as the chat history source when the newest structured envelope is an open `ask_user`, so the web UI receives the answerable id/options instead of static tmux capture text.
- Renders `ask_user` questions as web chat decision controls and routes free-text replies through `answer_to` while an open question is pending.
- Detects stable Claude interactive AskUserQuestion menu panes as unanswered operator questions, so heartbeat/cascade raises the existing action-required `worker_question` path instead of treating the session as healthy idle.
- Updates docs for the `source=auto` AskUserQuestion exception.

## Tests
- `uv run --extra test pytest -q tests/test_chat_messages_endpoint.py::test_messages_endpoint_source_auto_keeps_stale_open_ask_user_jsonl tests/web_api/test_web_ui.py::test_chat_history_renders_ask_user_controls_and_routes_reply tests/test_supervisor_alerts.py::test_interactive_ask_user_menu_is_unanswered_question tests/test_heartbeat_plugin_api.py::test_same_snapshot_interactive_ask_user_menu_routes_operator_question tests/test_chat_send_endpoint.py::test_answer_to_unmatched_ask_user_does_not_409_mid_tool tests/test_chat_send_endpoint.py::test_answer_to_freeform_text_allowed tests/test_chat_transcripts.py::test_ask_user_question_emits_ask_user_envelope`
- `uv run --extra dev ruff check src/pollypm/web_api/routes/chat_messages.py src/pollypm/idle_placeholders.py src/pollypm/heartbeats/local.py src/pollypm/supervisor_alerts.py`
- `node --check src/pollypm/web_api/ui/app.js`
- `git diff --check origin/main...HEAD`
