### PR TITLE
Count only operator-actionable items in the Home 'needs you' headline (#2475)

### DIFF
--- a/src/pollypm/alert_actionability.py
+++ b/src/pollypm/alert_actionability.py
@@ -20,6 +20,30 @@ _QUEUE_WITHOUT_MOTION_SESSION_PREFIX = "audit-queue_without_motion-"
 _WATCHDOG_ALERT_TYPE = "audit_watchdog"
 _QWM_PROJECT_RE = re.compile(r"\bProject\s+(?P<project>[A-Za-z0-9_.-]+)\s+has\b")
 
+# #2475 — system-internal recovery watchdog warns. Each of these alert
+# types is a mechanical recovery signal raised by the task-assignment
+# sweep that the heartbeat/cascade auto-handles (re-spawn the per-task
+# worker, refresh the plan gate, claim the queued task). They are NOT
+# operator decisions. On a live workspace the operator-Home "N things
+# need you" headline was dominated by these warns firing on stale /
+# archived / synthetic test projects (``pm_test_*``, ``ghost``,
+# ``alpha``, ``queuestorm_*``, ...) — none of which the operator can or
+# should act on. We demote a recovery warn from the operator-action
+# count when it is scoped to a project that is NOT tracked. A warn on a
+# tracked project still surfaces (the operator may legitimately want to
+# claim its queued work), so genuine operator-decision signals are
+# preserved. The session-name → project extraction mirrors the synthetic
+# scope strings the sweep writes (see
+# ``plugins_builtin/task_assignment_notify/handlers/sweep.py``):
+#   plan_missing        -> ``plan_gate-<project>``
+#   worker_session_gap  -> ``worker_session_gap-<project>``
+#   missing_task_worker -> ``missing_task_worker-<project>/<task-number>``
+_RECOVERY_WATCHDOG_SESSION_PREFIXES: dict[str, str] = {
+    "plan_missing": "plan_gate-",
+    "worker_session_gap": "worker_session_gap-",
+    "missing_task_worker": "missing_task_worker-",
+}
+
 
 @dataclass(slots=True, frozen=True)
 class AlertActionabilityContext:
@@ -108,6 +132,76 @@ def _queue_without_motion_is_stale(
     return False
 
 
+def _recovery_watchdog_project(
+    alert: object,
+    alert_type: str,
+    *,
+    known_projects: frozenset[str] | None,
+) -> str | None:
+    """Return the project a recovery-watchdog warn is scoped to, or ``None``.
+
+    The four recovery warns encode their project in a synthetic session
+    name. ``plan_missing`` / ``worker_session_gap`` carry the project key
+    directly (``plan_gate-<project>`` / ``worker_session_gap-<project>``).
+    ``missing_task_worker`` is keyed per task (``missing_task_worker-<project>/<N>``)
+    so we strip the ``/<task-number>`` tail. Project keys can themselves
+    contain hyphens, so when a ``known_projects`` set is supplied we
+    prefer the longest matching key to disambiguate.
+    """
+
+    prefix = _RECOVERY_WATCHDOG_SESSION_PREFIXES.get(alert_type)
+    if prefix is None:
+        return None
+    session_name = _text_value(alert, "session_name", "scope")
+    if not session_name.startswith(prefix):
+        return None
+    tail = session_name[len(prefix):]
+    if alert_type == "missing_task_worker":
+        # ``<project>/<task-number>`` — the project is everything before
+        # the last slash (project keys never contain a slash).
+        tail = tail.rsplit("/", 1)[0]
+    tail = tail.strip()
+    if not tail:
+        return None
+    if known_projects:
+        for project in sorted(known_projects, key=len, reverse=True):
+            if tail == project or tail.startswith(project + "-"):
+                return project
+    return tail
+
+
+def _recovery_watchdog_warn_is_self_healing(
+    alert: object,
+    alert_type: str,
+    *,
+    context: AlertActionabilityContext,
+) -> bool:
+    """Return True for a recovery warn the cascade auto-handles itself.
+
+    Today the demotion is scoped to *non-tracked* projects: a recovery
+    warn on a tracked project is left actionable (the operator may want
+    to claim its queued work), but a warn on a stale / archived /
+    synthetic test project is system-internal noise the heartbeat sweep
+    is already retrying — counting it in the operator's "N things need
+    you" headline trains the operator to ignore the number (#2475).
+    """
+
+    if alert_type not in _RECOVERY_WATCHDOG_SESSION_PREFIXES:
+        return False
+    if context.tracked_projects is None:
+        # Without a tracked-project set we cannot tell stale from live,
+        # so we keep the warn actionable rather than over-suppress.
+        return False
+    project = _recovery_watchdog_project(
+        alert,
+        alert_type,
+        known_projects=context.known_projects or context.tracked_projects,
+    )
+    if not project:
+        return False
+    return project not in context.tracked_projects
+
+
 def is_user_actionable_alert(
     alert: object,
     *,
@@ -124,6 +218,8 @@ def is_user_actionable_alert(
     if _stuck_alert_already_user_waiting(alert_type, ctx.user_waiting_task_ids):
         return False
     if _queue_without_motion_is_stale(alert, context=ctx):
+        return False
+    if _recovery_watchdog_warn_is_self_healing(alert, alert_type, context=ctx):
         return False
 
     return True

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -90,6 +90,100 @@ def test_actionable_alert_filter_drops_stale_watchdog_queue_alerts() -> None:
     assert is_user_actionable_alert(live_alert, context=live_context)
 
 
+def test_actionable_count_excludes_recovery_warns_on_untracked_projects() -> None:
+    """#2475 — the operator-Home "N things need you" headline must count
+    only operator-actionable items. System-internal recovery watchdog
+    warns (``plan_missing`` / ``worker_session_gap`` /
+    ``missing_task_worker``) firing on stale / archived / synthetic test
+    projects are recovery signals the heartbeat cascade auto-handles, so
+    they're excluded from the count. The same warns on a tracked project
+    stay actionable, and a genuine operator-decision alert is never
+    demoted.
+    """
+    from pollypm.alert_actionability import (
+        AlertActionabilityContext,
+        count_user_actionable_alerts,
+        is_user_actionable_alert,
+        user_actionable_alerts,
+    )
+
+    context = AlertActionabilityContext(
+        known_projects=frozenset(
+            {"polly_remote", "pm_test_alpha", "ghost", "queuestorm-beta"}
+        ),
+        tracked_projects=frozenset({"polly_remote"}),
+    )
+
+    # Operator-actionable: a genuine decision alert on a tracked project.
+    operator_decision = SimpleNamespace(
+        session_name="architect-polly_remote",
+        alert_type="worker_question",
+        message="Worker needs a scope call on polly_remote/14.",
+    )
+    # Operator-actionable: recovery warn, but on a TRACKED project — the
+    # operator may legitimately want to claim its queued work.
+    tracked_gap = SimpleNamespace(
+        session_name="worker_session_gap-polly_remote",
+        alert_type="worker_session_gap",
+        message="Project polly_remote has 3 queued tasks but no workers.",
+    )
+
+    # System-internal recovery noise on stale / test projects — excluded.
+    stale_plan_missing = SimpleNamespace(
+        session_name="plan_gate-pm_test_alpha",
+        alert_type="plan_missing",
+        message="Project pm_test_alpha has queued tasks but no plan.",
+    )
+    stale_worker_gap = SimpleNamespace(
+        session_name="worker_session_gap-ghost",
+        alert_type="worker_session_gap",
+        message="Project ghost has 2 queued tasks but no workers.",
+    )
+    stale_missing_worker = SimpleNamespace(
+        session_name="missing_task_worker-queuestorm-beta/7",
+        alert_type="missing_task_worker",
+        message="Task queuestorm-beta/7 is in_progress but its worker died.",
+    )
+
+    alerts = [
+        operator_decision,
+        tracked_gap,
+        stale_plan_missing,
+        stale_worker_gap,
+        stale_missing_worker,
+    ]
+
+    # Only the two tracked/operator-actionable items survive the filter.
+    assert is_user_actionable_alert(operator_decision, context=context)
+    assert is_user_actionable_alert(tracked_gap, context=context)
+    assert not is_user_actionable_alert(stale_plan_missing, context=context)
+    assert not is_user_actionable_alert(stale_worker_gap, context=context)
+    assert not is_user_actionable_alert(stale_missing_worker, context=context)
+
+    surviving = user_actionable_alerts(alerts, context=context)
+    assert surviving == [operator_decision, tracked_gap]
+    assert count_user_actionable_alerts(alerts, context=context) == 2
+
+
+def test_recovery_warn_stays_actionable_without_tracked_set() -> None:
+    """#2475 guard: with no ``tracked_projects`` set we can't tell stale
+    from live, so a recovery warn is left actionable rather than
+    over-suppressed (fail-open, not fail-closed)."""
+    from pollypm.alert_actionability import (
+        AlertActionabilityContext,
+        is_user_actionable_alert,
+    )
+
+    warn = SimpleNamespace(
+        session_name="plan_gate-ghost",
+        alert_type="plan_missing",
+        message="Project ghost has queued tasks but no plan.",
+    )
+    # No tracked_projects provided.
+    assert is_user_actionable_alert(warn, context=AlertActionabilityContext())
+    assert is_user_actionable_alert(warn)
+
+
 def test_session_description_skips_claude_tui_bottom_bar(tmp_path) -> None:
     """The polly-dashboard "Now" section was rendering every idle
     session as ``"⏵⏵ bypass permissions on (shift+tab to cycle)"`` —


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Claude
- Authoring persona: Claude Fixer (Codex usage-limited)
- Creator label: claude-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
The operator-Home "N things need you" hero (= plan reviews + inbox + `alert_count`) and the dashboard `alert_count` rollup were inflated by system-internal recovery watchdog warns — `plan_missing`, `worker_session_gap`, `missing_task_worker` — firing on stale / archived / synthetic test projects (`pm_test_*`, `ghost`, `alpha`, `queuestorm_*`). Those are mechanical recovery signals the heartbeat/cascade auto-handles, not operator decisions. This extends the shared user-actionable alert policy (`alert_actionability.py`, consumed by both `count_dashboard_alerts` for the Home rollup and `dashboard_actionable_alerts` for `/api/v1/alerts`) to demote those three recovery alert types when scoped to a **non-tracked** project. Recovery warns on tracked projects stay actionable; genuine operator-decision alerts are never demoted; fail-open when no tracked-project set is available. Mirrors the existing `queue_without_motion` stale-demotion precedent.

## Tests
- `uv run --extra test pytest -q tests/test_dashboard_data_alert_dedup.py` (26 passed; 2 new: recovery-warn exclusion on untracked projects + fail-open guard)
- `uv run --extra test pytest -q tests/web_api/test_alerts_endpoint.py tests/test_ghost_project_alerts.py tests/test_dashboard_endpoint.py tests/test_dashboard_categorization.py` (64 passed)
- `uv run --extra dev ruff check src/pollypm/alert_actionability.py tests/test_dashboard_data_alert_dedup.py` (All checks passed)

Authored by Claude (Codex usage-limited). Fixes #2475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)