### PR TITLE
Demote dormant recovery alerts from operator count

### DIFF
--- a/src/pollypm/alert_actionability.py
+++ b/src/pollypm/alert_actionability.py
@@ -17,24 +17,23 @@ from pollypm.cockpit_alerts import is_operational_alert
 
 _STUCK_ON_TASK_PREFIX = "stuck_on_task:"
 _QUEUE_WITHOUT_MOTION_SESSION_PREFIX = "audit-queue_without_motion-"
+_WORKTREE_STATE_PREFIX = "worktree_state:"
 _WATCHDOG_ALERT_TYPE = "audit_watchdog"
 _QWM_PROJECT_RE = re.compile(r"\bProject\s+(?P<project>[A-Za-z0-9_.-]+)\s+has\b")
 
-# #2475 — system-internal recovery watchdog warns. Each of these alert
-# types is a mechanical recovery signal raised by the task-assignment
-# sweep that the heartbeat/cascade auto-handles (re-spawn the per-task
-# worker, refresh the plan gate, claim the queued task). They are NOT
-# operator decisions. On a live workspace the operator-Home "N things
-# need you" headline was dominated by these warns firing on stale /
-# archived / synthetic test projects (``pm_test_*``, ``ghost``,
-# ``alpha``, ``queuestorm_*``, ...) — none of which the operator can or
-# should act on. We demote a recovery warn from the operator-action
-# count when it is scoped to a project that is NOT tracked. A warn on a
-# tracked project still surfaces (the operator may legitimately want to
-# claim its queued work), so genuine operator-decision signals are
-# preserved. The session-name → project extraction mirrors the synthetic
-# scope strings the sweep writes (see
-# ``plugins_builtin/task_assignment_notify/handlers/sweep.py``):
+# #2475/#2480 — system-internal recovery watchdog warns. Each of these
+# alert types is a mechanical recovery signal raised by the
+# task-assignment sweep that the heartbeat/cascade auto-handles
+# (re-spawn the per-task worker, refresh the plan gate, claim the
+# queued task). They are NOT operator decisions. The operator-Home "N
+# things need you" headline was dominated by these warns firing on
+# stale / archived / synthetic test projects (``pm_test_*``,
+# ``ghost``, ``alpha``, ``queuestorm_*``, ...) — many of which were
+# still tracked, so trackedness alone was a false liveness signal. We
+# demote a recovery warn when it is scoped to a project that is not
+# tracked OR has no recent real completed work. The session-name →
+# project extraction mirrors the synthetic scope strings the sweep
+# writes (see ``plugins_builtin/task_assignment_notify/handlers/sweep.py``):
 #   plan_missing        -> ``plan_gate-<project>``
 #   worker_session_gap  -> ``worker_session_gap-<project>``
 #   missing_task_worker -> ``missing_task_worker-<project>/<task-number>``
@@ -52,6 +51,7 @@ class AlertActionabilityContext:
     user_waiting_task_ids: frozenset[str] = frozenset()
     known_projects: frozenset[str] | None = None
     tracked_projects: frozenset[str] | None = None
+    recent_real_work_projects: frozenset[str] | None = None
     project_task_counts: Mapping[str, Mapping[str, int]] = field(default_factory=dict)
 
 
@@ -122,7 +122,7 @@ def _queue_without_motion_is_stale(
     if not project:
         return False
 
-    if context.tracked_projects is not None and project not in context.tracked_projects:
+    if _project_is_inactive_for_operator_count(project, context=context):
         return True
 
     counts = context.project_task_counts.get(project)
@@ -130,6 +130,55 @@ def _queue_without_motion_is_stale(
         return True
 
     return False
+
+
+def _worktree_state_project(
+    alert_type: str,
+    *,
+    known_projects: frozenset[str] | None,
+) -> str | None:
+    if not alert_type.startswith(_WORKTREE_STATE_PREFIX):
+        return None
+    tail = alert_type[len(_WORKTREE_STATE_PREFIX):].strip()
+    if not tail:
+        return None
+    # Production shape is ``worktree_state:<project>/<task>:<reason>``.
+    if "/" in tail:
+        return tail.split("/", 1)[0].strip() or None
+    if known_projects:
+        for project in sorted(known_projects, key=len, reverse=True):
+            if tail == project or tail.startswith(project + ":"):
+                return project
+    return tail.split(":", 1)[0].strip() or None
+
+
+def _project_is_inactive_for_operator_count(
+    project: str,
+    *,
+    context: AlertActionabilityContext,
+) -> bool:
+    if context.tracked_projects is not None and project not in context.tracked_projects:
+        return True
+    if (
+        context.recent_real_work_projects is not None
+        and project not in context.recent_real_work_projects
+    ):
+        return True
+    return False
+
+
+def _worktree_state_is_stale(
+    alert_type: str,
+    *,
+    context: AlertActionabilityContext,
+) -> bool:
+    project = _worktree_state_project(
+        alert_type,
+        known_projects=context.known_projects or context.tracked_projects,
+    )
+    if not project:
+        return False
+    return _project_is_inactive_for_operator_count(project, context=context)
 
 
 def _recovery_watchdog_project(
@@ -178,19 +227,20 @@ def _recovery_watchdog_warn_is_self_healing(
 ) -> bool:
     """Return True for a recovery warn the cascade auto-handles itself.
 
-    Today the demotion is scoped to *non-tracked* projects: a recovery
-    warn on a tracked project is left actionable (the operator may want
-    to claim its queued work), but a warn on a stale / archived /
-    synthetic test project is system-internal noise the heartbeat sweep
-    is already retrying — counting it in the operator's "N things need
-    you" headline trains the operator to ignore the number (#2475).
+    A recovery warn on a stale / archived / synthetic project is
+    system-internal noise the heartbeat sweep is already retrying.
+    Counting it in the operator's "N things need you" headline trains
+    the operator to ignore the number (#2475/#2480). Trackedness is not
+    enough: watchdog churn can keep a dead tracked project looking
+    freshly touched, so callers may also pass the set of projects with
+    recent real ``done`` work.
     """
 
     if alert_type not in _RECOVERY_WATCHDOG_SESSION_PREFIXES:
         return False
-    if context.tracked_projects is None:
-        # Without a tracked-project set we cannot tell stale from live,
-        # so we keep the warn actionable rather than over-suppress.
+    if context.tracked_projects is None and context.recent_real_work_projects is None:
+        # Without any liveness facts we cannot tell stale from live, so
+        # keep the warn actionable rather than over-suppress.
         return False
     project = _recovery_watchdog_project(
         alert,
@@ -199,7 +249,7 @@ def _recovery_watchdog_warn_is_self_healing(
     )
     if not project:
         return False
-    return project not in context.tracked_projects
+    return _project_is_inactive_for_operator_count(project, context=context)
 
 
 def is_user_actionable_alert(
@@ -220,6 +270,8 @@ def is_user_actionable_alert(
     if _queue_without_motion_is_stale(alert, context=ctx):
         return False
     if _recovery_watchdog_warn_is_self_healing(alert, alert_type, context=ctx):
+        return False
+    if _worktree_state_is_stale(alert_type, context=ctx):
         return False
 
     return True

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -761,19 +761,68 @@ def _known_project_keys(config: PollyPMConfig) -> frozenset[str]:
     return frozenset((getattr(config, "projects", {}) or {}).keys())
 
 
-def _project_task_counts_for_alert_filter(
+_REAL_WORK_RECENCY_WINDOW = timedelta(days=7)
+_RECOVERY_ALERT_TYPES_FOR_LIVENESS = frozenset({
+    "plan_missing",
+    "worker_session_gap",
+    "missing_task_worker",
+})
+
+
+@dataclass(slots=True, frozen=True)
+class _AlertProjectTaskFacts:
+    project_task_counts: dict[str, dict[str, int]]
+    recent_real_work_projects: frozenset[str] | None
+
+
+def _status_key(task: object) -> str:
+    status = getattr(task, "work_status", "") or ""
+    status_value = getattr(status, "value", status)
+    return str(status_value or "")
+
+
+def _coerce_utc_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _alert_filter_needs_project_task_facts(open_alerts: list[object]) -> bool:
+    for alert in open_alerts:
+        session_name = str(getattr(alert, "session_name", "") or "")
+        if session_name.startswith("audit-queue_without_motion-"):
+            return True
+        alert_type = str(getattr(alert, "alert_type", "") or "")
+        if alert_type in _RECOVERY_ALERT_TYPES_FOR_LIVENESS:
+            return True
+        if alert_type.startswith("worktree_state:"):
+            return True
+    return False
+
+
+def _project_task_facts_for_alert_filter(
     config: PollyPMConfig,
     open_alerts: list[object],
-) -> dict[str, dict[str, int]]:
-    """Return per-project work-status counts only when alert policy needs them."""
+) -> _AlertProjectTaskFacts:
+    """Return per-project task facts only when alert policy needs them."""
 
-    if not any(
-        str(getattr(alert, "session_name", "") or "").startswith(
-            "audit-queue_without_motion-"
-        )
-        for alert in open_alerts
-    ):
-        return {}
+    if not _alert_filter_needs_project_task_facts(open_alerts):
+        return _AlertProjectTaskFacts({}, None)
     try:
         from pollypm.cockpit_pg_aggregates import (
             all_tasks_for_project,
@@ -782,25 +831,35 @@ def _project_task_counts_for_alert_filter(
 
         grouped = all_tasks_grouped(config)
         if grouped is None:
-            return {}
+            return _AlertProjectTaskFacts({}, None)
         counts_by_project: dict[str, dict[str, int]] = {}
+        recent_real_work: set[str] = set()
+        recent_cutoff = datetime.now(UTC) - _REAL_WORK_RECENCY_WINDOW
         for project_key in (getattr(config, "projects", {}) or {}):
             counts: dict[str, int] = {}
             for task in all_tasks_for_project(grouped, config, project_key):
-                status = getattr(task, "work_status", "") or ""
-                status_value = getattr(status, "value", status)
-                status_key = str(status_value or "")
+                status_key = _status_key(task)
                 if not status_key:
                     continue
                 counts[status_key] = counts.get(status_key, 0) + 1
+                if status_key == "done":
+                    stamped = _coerce_utc_datetime(
+                        getattr(task, "updated_at", None)
+                        or getattr(task, "created_at", None)
+                    )
+                    if stamped is None or stamped >= recent_cutoff:
+                        recent_real_work.add(project_key)
             counts_by_project[project_key] = counts
-        return counts_by_project
+        return _AlertProjectTaskFacts(
+            counts_by_project,
+            frozenset(recent_real_work),
+        )
     except Exception:  # noqa: BLE001
         logger.debug(
-            "dashboard_data: project task counts for alert filter failed",
+            "dashboard_data: project task facts for alert filter failed",
             exc_info=True,
         )
-        return {}
+        return _AlertProjectTaskFacts({}, None)
 
 
 def dashboard_actionable_alerts(
@@ -825,14 +884,16 @@ def dashboard_actionable_alerts(
                 exc_info=True,
             )
             user_waiting_task_ids = frozenset()
+    project_task_facts = _project_task_facts_for_alert_filter(
+        config,
+        open_alerts,
+    )
     context = AlertActionabilityContext(
         user_waiting_task_ids=frozenset(user_waiting_task_ids),
         known_projects=_known_project_keys(config),
         tracked_projects=_tracked_project_keys(config),
-        project_task_counts=_project_task_counts_for_alert_filter(
-            config,
-            open_alerts,
-        ),
+        recent_real_work_projects=project_task_facts.recent_real_work_projects,
+        project_task_counts=project_task_facts.project_task_counts,
     )
     return user_actionable_alerts(open_alerts, context=context)
 

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -11,6 +11,7 @@ for non-faults the user already sees as yellow.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 from pollypm.dashboard_data import _stuck_alert_already_user_waiting
@@ -182,6 +183,134 @@ def test_recovery_warn_stays_actionable_without_tracked_set() -> None:
     # No tracked_projects provided.
     assert is_user_actionable_alert(warn, context=AlertActionabilityContext())
     assert is_user_actionable_alert(warn)
+
+
+def test_recovery_warn_demotes_tracked_but_dormant_project() -> None:
+    """#2480 — trackedness is not a liveness signal.
+
+    A dead project can remain ``tracked=True`` while watchdog churn keeps
+    touching its tasks. Recovery/hygiene warns on such projects should
+    not inflate the operator "needs you" headline unless the project has
+    recent real completed work.
+    """
+    from pollypm.alert_actionability import (
+        AlertActionabilityContext,
+        is_user_actionable_alert,
+    )
+
+    context = AlertActionabilityContext(
+        known_projects=frozenset({"polly_remote", "savethenovel"}),
+        tracked_projects=frozenset({"polly_remote", "savethenovel"}),
+        recent_real_work_projects=frozenset({"savethenovel"}),
+    )
+
+    dormant_recovery_warn = SimpleNamespace(
+        session_name="worker_session_gap-polly_remote",
+        alert_type="worker_session_gap",
+        message="Project polly_remote has 3 queued tasks but no workers.",
+    )
+    active_recovery_warn = SimpleNamespace(
+        session_name="worker_session_gap-savethenovel",
+        alert_type="worker_session_gap",
+        message="Project savethenovel has 2 queued tasks but no workers.",
+    )
+    operator_decision = SimpleNamespace(
+        session_name="architect-polly_remote",
+        alert_type="worker_question",
+        message="Worker needs a scope call.",
+    )
+
+    assert not is_user_actionable_alert(dormant_recovery_warn, context=context)
+    assert is_user_actionable_alert(active_recovery_warn, context=context)
+    assert is_user_actionable_alert(operator_decision, context=context)
+
+
+def test_queue_without_motion_demotes_tracked_project_without_recent_real_work() -> None:
+    from pollypm.alert_actionability import (
+        AlertActionabilityContext,
+        is_user_actionable_alert,
+    )
+
+    context = AlertActionabilityContext(
+        known_projects=frozenset({"polly_remote"}),
+        tracked_projects=frozenset({"polly_remote"}),
+        recent_real_work_projects=frozenset(),
+        project_task_counts={"polly_remote": {"queued": 12}},
+    )
+    qwm_alert = SimpleNamespace(
+        session_name="audit-queue_without_motion-polly_remote-polly_remote",
+        alert_type="audit_watchdog",
+        message="Project polly_remote has 12 queued task(s) but no motion.",
+    )
+
+    assert not is_user_actionable_alert(qwm_alert, context=context)
+
+
+def test_worktree_state_demotes_tracked_project_without_recent_real_work() -> None:
+    from pollypm.alert_actionability import (
+        AlertActionabilityContext,
+        is_user_actionable_alert,
+    )
+
+    context = AlertActionabilityContext(
+        known_projects=frozenset({"polly_remote"}),
+        tracked_projects=frozenset({"polly_remote"}),
+        recent_real_work_projects=frozenset(),
+    )
+    warn = SimpleNamespace(
+        session_name="worker-polly_remote-9",
+        alert_type="worktree_state:polly_remote/9:dirty_stale",
+        message="Worker worktree has stale dirty changes.",
+    )
+
+    assert not is_user_actionable_alert(warn, context=context)
+
+
+def test_alert_filter_task_facts_use_recent_done_for_liveness(monkeypatch) -> None:
+    from pollypm import dashboard_data
+
+    now = datetime.now(UTC)
+    grouped = {
+        "active": [
+            SimpleNamespace(
+                work_status="done",
+                updated_at=now - timedelta(days=1),
+            )
+        ],
+        "dormant": [
+            SimpleNamespace(
+                work_status="done",
+                updated_at=now - timedelta(days=14),
+            ),
+            SimpleNamespace(
+                work_status="queued",
+                updated_at=now,
+            ),
+        ],
+    }
+    config = SimpleNamespace(projects={"active": object(), "dormant": object()})
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.all_tasks_grouped",
+        lambda _config: grouped,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.all_tasks_for_project",
+        lambda data, _config, key: data[key],
+    )
+
+    facts = dashboard_data._project_task_facts_for_alert_filter(
+        config,
+        [
+            SimpleNamespace(
+                session_name="worker_session_gap-active",
+                alert_type="worker_session_gap",
+            )
+        ],
+    )
+
+    assert facts.recent_real_work_projects == frozenset({"active"})
+    assert facts.project_task_counts["dormant"]["queued"] == 1
 
 
 def test_session_description_skips_claude_tui_bottom_bar(tmp_path) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add recent-real-work liveness to the shared alert actionability context so tracked-but-dormant projects stop inflating the operator count.
- Demote queue-without-motion, task-assignment recovery warns, and stale worktree-state hygiene alerts when the scoped project is untracked or lacks recent done work.
- Keep genuine operator-decision alerts actionable and compute the liveness facts from the existing dashboard PG aggregate path.

Fixes #2480.

## Tests
- `uv run --extra test pytest -q tests/test_dashboard_data_alert_dedup.py -q`
- `uv run --extra dev ruff check src/pollypm/alert_actionability.py src/pollypm/dashboard_data.py tests/test_dashboard_data_alert_dedup.py`
- `git diff --check`

## Notes
- This intentionally does not archive/untrack the dead-project census set; the source issue marks that as a Sam-steered hygiene action.
