### PR TITLE
Synthesize captured AskUserQuestion envelopes

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -912,7 +912,10 @@ paths:
         stale (>60s) or missing, except that a stale archive whose
         newest structured envelope is an open `ask_user` is returned
         so clients keep the answerable question id/options instead of
-        static tmux text; `source=jsonl` forces archive reads
+        static tmux text. When an active AskUserQuestion form exists
+        only in tmux capture, the captured menu is synthesized as an
+        `ask_user` envelope with `metadata.questions[].options[]`.
+        `source=jsonl` forces archive reads
         and 404s when the archive isn't on disk; `source=capture` is
         strict — missing windows / unavailable tmux / capture failures
         all 503 with a typed error code instead of returning an empty
@@ -980,8 +983,10 @@ paths:
           description: |
             Transcript source. `auto` = JSONL with capture fallback
             when stale, preserving stale JSONL for open `ask_user`
-            envelopes; `jsonl` = force archive (404 if absent),
-            `capture` = force tmux capture (503 on any failure).
+            envelopes and synthesizing active captured AskUserQuestion
+            menus into `ask_user` envelopes; `jsonl` = force archive
+            (404 if absent), `capture` = force tmux capture (503 on
+            any failure).
       responses:
         "200":
           description: Page of envelopes for this surface.
@@ -4109,6 +4114,10 @@ components:
             and carry `metadata.synthetic=true` with
             `metadata.model="<synthetic>"`; clients should render them
             as notice/banner content, not as assistant speech.
+            Captured AskUserQuestion menus are also synthetic in the
+            sense that `metadata.synthetic=true`, but retain
+            `type=ask_user` and carry `metadata.questions[].options[]`
+            so clients can render and answer them normally.
 
     ChatMessagesResponse:
       type: object

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -504,7 +504,7 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | POST   | `/api/v1/inbox/{id}/archive` | Archive (close) the item |
 | GET    | `/api/v1/events` | SSE stream of audit-log events (`?since=&project=&event=`) |
 | GET    | `/api/v1/chat/sessions` | Discover every chat surface (operator/architect/advisor/worker) |
-| GET    | `/api/v1/chat/{session_name}/messages` | Paginated message history for one chat surface (`?since=&since_id=&limit=&direction=&source=&include_subagents=`) — `source=auto` normally falls back to tmux capture for stale archives, but preserves stale JSONL when the newest structured envelope is an open `ask_user` so clients can answer it; `include_subagents=true` inlines the raw subagent JSONL at each `subagent_result.metadata.output_file` (allowlist-constrained, capped per envelope, #2052) |
+| GET    | `/api/v1/chat/{session_name}/messages` | Paginated message history for one chat surface (`?since=&since_id=&limit=&direction=&source=&include_subagents=`) — `source=auto` normally falls back to tmux capture for stale archives, but preserves stale JSONL when the newest structured envelope is an open `ask_user` so clients can answer it; active AskUserQuestion menus visible only in tmux capture are synthesized as `ask_user` envelopes with `metadata.questions[].options[]`; `include_subagents=true` inlines the raw subagent JSONL at each `subagent_result.metadata.output_file` (allowlist-constrained, capped per envelope, #2052) |
 
 The OpenAPI document is the authoritative list; if anything here
 drifts, the YAML wins.

--- a/src/pollypm/web_api/chat/tmux_capture.py
+++ b/src/pollypm/web_api/chat/tmux_capture.py
@@ -51,13 +51,33 @@ _ASK_USER_CHECKBOX_GLYPHS = frozenset({"☐", "☑"})
 _ASK_USER_ROW_RE = re.compile(
     r"^(?P<indent>\s*)(?P<glyph>[☐☑○◉◯●])\s+(?P<label>.*\S)\s*$"
 )
+_ASK_USER_NUMBERED_ROW_RE = re.compile(
+    r"^(?P<indent>\s*)(?:[❯>]\s*)?(?P<number>\d+)[.)]\s+(?P<label>.*\S)\s*$"
+)
 _ASK_USER_SUBMIT_RE = re.compile(r"\s*[✔✓]?\s*Submit\b.*$", re.IGNORECASE)
+_ASK_USER_TAB_ITEM_RE = re.compile(
+    r"(?P<glyph>[☐☑○◉◯●✔✓])\s+"
+    r"(?P<label>.*?)(?=\s+[☐☑○◉◯●✔✓]\s+|$)"
+)
+_ASK_USER_TRAILING_AFFORDANCES = frozenset({
+    "chat about this",
+    "type something.",
+    "type something",
+})
 
 
 @dataclass(frozen=True, slots=True)
 class _CapturedMenuRow:
     line_index: int
     indent: int
+    glyph: str
+    label: str
+    description: str = ""
+    is_numbered: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _CapturedTabHeader:
     glyph: str
     label: str
 
@@ -223,37 +243,39 @@ def _extract_active_ask_user_menu(
     if submit_pos is None:
         return None
 
+    menu_end_pos = _find_active_menu_end_pos(lines, submit_pos)
+    if menu_end_pos is None:
+        return None
+
+    row_search_start = max(0, submit_pos - 80)
     menu_row_positions = [
-        pos for pos in range(0, submit_pos + 1)
+        pos for pos in range(row_search_start, menu_end_pos + 1)
         if _parse_ask_user_row(lines[pos][0], lines[pos][1]) is not None
     ]
     if not menu_row_positions:
         return None
-    menu_start_pos = menu_row_positions[0]
-    for pos in reversed(menu_row_positions):
-        prior_text = lines[pos - 1][1] if pos > 0 else ""
-        if pos == 0 or _is_capture_chrome_or_blank(prior_text):
-            menu_start_pos = pos
-            break
+    rows_after_submit = [pos for pos in menu_row_positions if pos > submit_pos]
+    if rows_after_submit:
+        menu_start_pos = submit_pos
+    else:
+        menu_start_pos = menu_row_positions[0]
+        for pos in reversed(menu_row_positions):
+            prior_text = lines[pos - 1][1] if pos > 0 else ""
+            if pos == 0 or _is_capture_chrome_or_blank(prior_text):
+                menu_start_pos = pos
+                break
 
-    rows = [
-        parsed for pos in range(menu_start_pos, submit_pos + 1)
-        if (parsed := _parse_ask_user_row(lines[pos][0], lines[pos][1]))
-        is not None
-    ]
+    rows = _parse_ask_user_rows(lines, menu_start_pos, menu_end_pos)
     if not rows:
         return None
 
     prompt_pos, prompt = _find_ask_user_prompt(lines, menu_start_pos)
-    questions = _questions_from_menu_rows(rows, prompt)
+    tab_headers = _parse_ask_user_tab_headers(lines[submit_pos][1])
+    questions = _questions_from_menu_rows(rows, prompt, tab_headers=tab_headers)
     if not questions:
         return None
 
-    end_pos = submit_pos
-    while end_pos + 1 < len(lines) and _is_capture_chrome_or_blank(
-        lines[end_pos + 1][1]
-    ):
-        end_pos += 1
+    end_pos = menu_end_pos
     start_line = lines[prompt_pos][0] if prompt_pos is not None else rows[0].line_index
     digest_text = "\n".join(
         line for _idx, line in lines[menu_start_pos : end_pos + 1]
@@ -273,14 +295,62 @@ def _find_active_submit_pos(lines: list[tuple[int, str]]) -> int | None:
     for pos in range(len(lines) - 1, -1, -1):
         if "submit" not in lines[pos][1].lower():
             continue
-        if not all(_is_capture_chrome_or_blank(line) for _idx, line in lines[pos + 1:]):
+        menu_end_pos = _find_active_menu_end_pos(lines, pos)
+        if menu_end_pos is None:
             continue
-        if any(
-            any(glyph in lines[prior][1] for glyph in _ASK_USER_OPTION_GLYPHS)
-            for prior in range(max(0, pos - 80), pos + 1)
+        if not all(
+            _is_capture_chrome_or_blank(line)
+            for _idx, line in lines[menu_end_pos + 1:]
         ):
+            continue
+        if _has_ask_user_rows_near_submit(lines, pos, menu_end_pos):
             return pos
     return None
+
+
+def _find_active_menu_end_pos(
+    lines: list[tuple[int, str]],
+    submit_pos: int,
+) -> int | None:
+    """Return the last line occupied by the live menu around ``submit_pos``."""
+    end_pos = submit_pos
+    saw_row_after_submit = False
+    previous_row: _CapturedMenuRow | None = None
+
+    for pos in range(submit_pos + 1, len(lines)):
+        line_index, line = lines[pos]
+        row = _parse_ask_user_row(line_index, line)
+        if row is not None:
+            saw_row_after_submit = True
+            previous_row = row
+            end_pos = pos
+            continue
+        if (
+            saw_row_after_submit
+            and previous_row is not None
+            and _is_ask_user_continuation_line(line, previous_row.indent)
+        ):
+            end_pos = pos
+            continue
+        if _is_capture_chrome_or_blank(line) or _is_ask_user_affordance(line):
+            end_pos = pos
+            continue
+        break
+
+    return end_pos
+
+
+def _has_ask_user_rows_near_submit(
+    lines: list[tuple[int, str]],
+    submit_pos: int,
+    menu_end_pos: int,
+) -> bool:
+    window_start = max(0, submit_pos - 80)
+    window_end = min(len(lines), max(submit_pos, menu_end_pos) + 1)
+    return any(
+        _parse_ask_user_row(line_index, line) is not None
+        for line_index, line in lines[window_start:window_end]
+    )
 
 
 def _find_ask_user_prompt(
@@ -291,6 +361,8 @@ def _find_ask_user_prompt(
     for pos in range(menu_start_pos - 1, max(-1, menu_start_pos - 12), -1):
         line = _normalise_capture_menu_line(lines[pos][1])
         if not line or _is_capture_chrome_or_blank(line):
+            continue
+        if "submit" in line.lower() and _parse_ask_user_tab_headers(line):
             continue
         if _parse_ask_user_row(lines[pos][0], line) is not None:
             continue
@@ -307,7 +379,10 @@ def _find_ask_user_prompt(
 def _questions_from_menu_rows(
     rows: list[_CapturedMenuRow],
     prompt: str,
+    *,
+    tab_headers: list[_CapturedTabHeader] | None = None,
 ) -> list[dict[str, Any]]:
+    tab_header = _active_tab_header(tab_headers or [])
     grouped_questions: list[dict[str, Any]] = []
     row_to_group = set()
 
@@ -329,7 +404,7 @@ def _questions_from_menu_rows(
                 for child in child_rows
             ),
             "options": [
-                {"label": child.label, "description": ""}
+                {"label": child.label, "description": child.description}
                 for child in child_rows
             ],
         })
@@ -340,15 +415,16 @@ def _questions_from_menu_rows(
         and not _child_row_indices(rows, row_index)
     ]
     if loose_options:
+        header = tab_header.label if tab_header is not None else ""
         grouped_questions.append({
             "question": prompt or "Choose an option",
-            "header": "",
+            "header": header,
             "multiSelect": any(
                 row.glyph in _ASK_USER_CHECKBOX_GLYPHS
                 for row in loose_options
             ),
             "options": [
-                {"label": row.label, "description": ""}
+                {"label": row.label, "description": row.description}
                 for row in loose_options
             ],
         })
@@ -357,9 +433,12 @@ def _questions_from_menu_rows(
         return grouped_questions
     return [{
         "question": prompt or "Choose an option",
-        "header": "",
+        "header": tab_header.label if tab_header is not None else "",
         "multiSelect": any(row.glyph in _ASK_USER_CHECKBOX_GLYPHS for row in rows),
-        "options": [{"label": row.label, "description": ""} for row in rows],
+        "options": [
+            {"label": row.label, "description": row.description}
+            for row in rows
+        ],
     }]
 
 
@@ -368,12 +447,83 @@ def _child_row_indices(
     row_index: int,
 ) -> list[int]:
     parent = rows[row_index]
+    if parent.is_numbered:
+        return []
     children: list[int] = []
     for candidate_index, candidate in enumerate(rows[row_index + 1:], row_index + 1):
+        if candidate.is_numbered:
+            break
         if candidate.indent <= parent.indent:
             break
         children.append(candidate_index)
     return children
+
+
+def _parse_ask_user_rows(
+    lines: list[tuple[int, str]],
+    start_pos: int,
+    end_pos: int,
+) -> list[_CapturedMenuRow]:
+    rows: list[_CapturedMenuRow] = []
+    pending_description_parts: list[str] = []
+
+    for pos in range(start_pos, end_pos + 1):
+        line_index, line = lines[pos]
+        row = _parse_ask_user_row(line_index, line)
+        if row is not None:
+            if rows and pending_description_parts:
+                rows[-1] = _row_with_description(rows[-1], pending_description_parts)
+                pending_description_parts = []
+            rows.append(row)
+            continue
+
+        if not rows:
+            continue
+        if _is_ask_user_affordance(line) or _is_capture_chrome_or_blank(line):
+            if pending_description_parts:
+                rows[-1] = _row_with_description(rows[-1], pending_description_parts)
+                pending_description_parts = []
+            continue
+        if _is_ask_user_continuation_line(line, rows[-1].indent):
+            pending_description_parts.append(_normalise_capture_menu_line(line).strip())
+            continue
+        if pending_description_parts:
+            rows[-1] = _row_with_description(rows[-1], pending_description_parts)
+            pending_description_parts = []
+
+    if rows and pending_description_parts:
+        rows[-1] = _row_with_description(rows[-1], pending_description_parts)
+    return rows
+
+
+def _row_with_description(
+    row: _CapturedMenuRow,
+    parts: list[str],
+) -> _CapturedMenuRow:
+    description = " ".join(part for part in parts if part)
+    if row.description and description:
+        description = f"{row.description} {description}"
+    else:
+        description = row.description or description
+    return _CapturedMenuRow(
+        line_index=row.line_index,
+        indent=row.indent,
+        glyph=row.glyph,
+        label=row.label,
+        description=description,
+        is_numbered=row.is_numbered,
+    )
+
+
+def _active_tab_header(
+    tab_headers: list[_CapturedTabHeader],
+) -> _CapturedTabHeader | None:
+    if not tab_headers:
+        return None
+    for header in tab_headers:
+        if header.glyph != "☑":
+            return header
+    return tab_headers[0]
 
 
 def _parse_ask_user_row(
@@ -382,6 +532,17 @@ def _parse_ask_user_row(
 ) -> _CapturedMenuRow | None:
     normalised = _normalise_capture_menu_line(line)
     match = _ASK_USER_ROW_RE.match(normalised)
+    if match is not None:
+        label = _ASK_USER_SUBMIT_RE.sub("", match.group("label")).strip()
+        if not label:
+            return None
+        return _CapturedMenuRow(
+            line_index=line_index,
+            indent=len(match.group("indent").replace("\t", "    ")),
+            glyph=match.group("glyph"),
+            label=label,
+        )
+    match = _ASK_USER_NUMBERED_ROW_RE.match(normalised)
     if match is None:
         return None
     label = _ASK_USER_SUBMIT_RE.sub("", match.group("label")).strip()
@@ -390,9 +551,25 @@ def _parse_ask_user_row(
     return _CapturedMenuRow(
         line_index=line_index,
         indent=len(match.group("indent").replace("\t", "    ")),
-        glyph=match.group("glyph"),
+        glyph="○",
         label=label,
+        is_numbered=True,
     )
+
+
+def _parse_ask_user_tab_headers(line: str) -> list[_CapturedTabHeader]:
+    text = _normalise_capture_menu_line(line).strip()
+    if "submit" not in text.lower():
+        return []
+    text = text.strip("←→ ")
+    headers: list[_CapturedTabHeader] = []
+    for match in _ASK_USER_TAB_ITEM_RE.finditer(text):
+        glyph = match.group("glyph")
+        label = match.group("label").strip("←→ ").strip()
+        if not label or label.lower().startswith("submit"):
+            continue
+        headers.append(_CapturedTabHeader(glyph=glyph, label=label))
+    return headers
 
 
 def _normalise_capture_menu_line(line: str) -> str:
@@ -409,6 +586,22 @@ def _normalise_capture_menu_line(line: str) -> str:
     return text
 
 
+def _is_ask_user_continuation_line(line: str, parent_indent: int) -> bool:
+    normalised = _normalise_capture_menu_line(line)
+    if not normalised.strip():
+        return False
+    if _is_ask_user_affordance(normalised):
+        return False
+    expanded = normalised.replace("\t", "    ")
+    indent = len(expanded) - len(expanded.lstrip(" "))
+    return indent > parent_indent
+
+
+def _is_ask_user_affordance(line: str) -> bool:
+    stripped = _normalise_capture_menu_line(line).strip()
+    return stripped.lower() in _ASK_USER_TRAILING_AFFORDANCES
+
+
 def _is_capture_chrome_or_blank(line: str) -> bool:
     stripped = _normalise_capture_menu_line(line)
     if not stripped:
@@ -418,6 +611,7 @@ def _is_capture_chrome_or_blank(line: str) -> bool:
         "bypass permissions" in lower
         or "shift+tab to cycle" in lower
         or "ctrl+t to" in lower
+        or _is_ask_user_affordance(stripped)
         or stripped.startswith("⏵⏵")
     ):
         return True

--- a/src/pollypm/web_api/chat/tmux_capture.py
+++ b/src/pollypm/web_api/chat/tmux_capture.py
@@ -5,15 +5,21 @@ capture when the normalized archive is missing or stale (>60s) AND the
 tmux pane is alive. The Codex CLI doesn't write the Claude JSONL shape
 either, so Codex surfaces always land here.
 
-Each captured line becomes one :class:`MessageEnvelope` with
-``type=text`` and ``metadata.from_capture=true``. Envelope ids are
-synthesized as ``cap_<hex>`` from a blake2b digest of
+Each captured line normally becomes one :class:`MessageEnvelope` with
+``type=text`` and ``metadata.from_capture=true``. When the live pane is
+parked on Claude's interactive ``AskUserQuestion`` form, the rendered
+menu block is instead synthesized into a single ``type=ask_user``
+envelope with ``metadata.questions[].options[]`` so web clients can
+render controls against the same public chat contract.
+
+Envelope ids are synthesized as ``cap_<hex>`` from a blake2b digest of
 ``f"{session_name}:{line_index}:{content}"`` so the same line read
 twice yields the same id (stable, sortable within a capture).
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import hashlib
 import logging
 import re
@@ -40,6 +46,29 @@ DEFAULT_CAPTURE_LINES = 3000
 # as :mod:`pollypm.recovery.worker_turn_end`.
 _ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 _C0_CTRL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+_ASK_USER_OPTION_GLYPHS = frozenset({"☐", "☑", "○", "◉", "◯", "●"})
+_ASK_USER_CHECKBOX_GLYPHS = frozenset({"☐", "☑"})
+_ASK_USER_ROW_RE = re.compile(
+    r"^(?P<indent>\s*)(?P<glyph>[☐☑○◉◯●])\s+(?P<label>.*\S)\s*$"
+)
+_ASK_USER_SUBMIT_RE = re.compile(r"\s*[✔✓]?\s*Submit\b.*$", re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class _CapturedMenuRow:
+    line_index: int
+    indent: int
+    glyph: str
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class _CapturedAskUserMenu:
+    start_line_index: int
+    end_line_index: int
+    prompt: str
+    questions: list[dict[str, Any]]
+    digest_text: str
 
 
 def synthesize_capture_id(session_name: str, line_index: int, content: str) -> str:
@@ -112,10 +141,49 @@ def capture_envelopes(
     cleaned = _strip_control_codes(raw)
     ts = timestamp or _utc_now()
     envelopes: list[MessageEnvelope] = []
-    for line_index, line in enumerate(cleaned.splitlines()):
+    lines = list(enumerate(cleaned.splitlines()))
+    ask_menu: _CapturedAskUserMenu | None = None
+    if role == MessageRole.ASSISTANT:
+        ask_menu = _extract_active_ask_user_menu(lines)
+    line_pos = 0
+    while line_pos < len(lines):
+        line_index, line = lines[line_pos]
+        if ask_menu is not None and line_index == ask_menu.start_line_index:
+            envelope_id = synthesize_capture_id(
+                session_name,
+                ask_menu.start_line_index,
+                f"ask_user:{ask_menu.digest_text}",
+            )
+            envelopes.append(MessageEnvelope(
+                id=envelope_id,
+                ts=ts,
+                role=MessageRole.ASSISTANT,
+                actor=actor_fallback,
+                type=MessageType.ASK_USER,
+                text=ask_menu.prompt or "[ask_user]",
+                metadata={
+                    "from_capture": True,
+                    "synthetic": True,
+                    "session_name": session_name,
+                    "line_index": ask_menu.start_line_index,
+                    "line_start": ask_menu.start_line_index,
+                    "line_end": ask_menu.end_line_index,
+                    "tool_use_id": envelope_id,
+                    "questions": ask_menu.questions,
+                    "answered": False,
+                    "answers": None,
+                },
+            ))
+            while (
+                line_pos < len(lines)
+                and lines[line_pos][0] <= ask_menu.end_line_index
+            ):
+                line_pos += 1
+            continue
         # Skip leading/trailing pure-whitespace lines but preserve internal
         # blank lines so the structure of a Claude-Code box is recognisable.
         if not line.strip() and not envelopes:
+            line_pos += 1
             continue
         envelope_id = synthesize_capture_id(session_name, line_index, line)
         envelopes.append(MessageEnvelope(
@@ -131,11 +199,230 @@ def capture_envelopes(
                 "line_index": line_index,
             },
         ))
+        line_pos += 1
     # Drop any trailing blank lines that we appended along the way —
     # they're just visual padding at the bottom of the pane.
     while envelopes and not envelopes[-1].text.strip():
         envelopes.pop()
     return envelopes
+
+
+def _extract_active_ask_user_menu(
+    lines: list[tuple[int, str]],
+) -> _CapturedAskUserMenu | None:
+    """Return a synthetic AskUserQuestion menu parsed from the pane tail.
+
+    The capture fallback sees Claude's interactive form only as rendered
+    text. To avoid turning old scrollback menus into live controls, this
+    parser only accepts a menu whose submit line is followed by blank or
+    Claude chrome lines.
+    """
+    if not lines:
+        return None
+    submit_pos = _find_active_submit_pos(lines)
+    if submit_pos is None:
+        return None
+
+    menu_row_positions = [
+        pos for pos in range(0, submit_pos + 1)
+        if _parse_ask_user_row(lines[pos][0], lines[pos][1]) is not None
+    ]
+    if not menu_row_positions:
+        return None
+    menu_start_pos = menu_row_positions[0]
+    for pos in reversed(menu_row_positions):
+        prior_text = lines[pos - 1][1] if pos > 0 else ""
+        if pos == 0 or _is_capture_chrome_or_blank(prior_text):
+            menu_start_pos = pos
+            break
+
+    rows = [
+        parsed for pos in range(menu_start_pos, submit_pos + 1)
+        if (parsed := _parse_ask_user_row(lines[pos][0], lines[pos][1]))
+        is not None
+    ]
+    if not rows:
+        return None
+
+    prompt_pos, prompt = _find_ask_user_prompt(lines, menu_start_pos)
+    questions = _questions_from_menu_rows(rows, prompt)
+    if not questions:
+        return None
+
+    end_pos = submit_pos
+    while end_pos + 1 < len(lines) and _is_capture_chrome_or_blank(
+        lines[end_pos + 1][1]
+    ):
+        end_pos += 1
+    start_line = lines[prompt_pos][0] if prompt_pos is not None else rows[0].line_index
+    digest_text = "\n".join(
+        line for _idx, line in lines[menu_start_pos : end_pos + 1]
+    )
+    if prompt:
+        digest_text = f"{prompt}\n{digest_text}"
+    return _CapturedAskUserMenu(
+        start_line_index=start_line,
+        end_line_index=lines[end_pos][0],
+        prompt=prompt or "[ask_user]",
+        questions=questions,
+        digest_text=digest_text,
+    )
+
+
+def _find_active_submit_pos(lines: list[tuple[int, str]]) -> int | None:
+    for pos in range(len(lines) - 1, -1, -1):
+        if "submit" not in lines[pos][1].lower():
+            continue
+        if not all(_is_capture_chrome_or_blank(line) for _idx, line in lines[pos + 1:]):
+            continue
+        if any(
+            any(glyph in lines[prior][1] for glyph in _ASK_USER_OPTION_GLYPHS)
+            for prior in range(max(0, pos - 80), pos + 1)
+        ):
+            return pos
+    return None
+
+
+def _find_ask_user_prompt(
+    lines: list[tuple[int, str]],
+    menu_start_pos: int,
+) -> tuple[int | None, str]:
+    fallback: tuple[int | None, str] = (None, "")
+    for pos in range(menu_start_pos - 1, max(-1, menu_start_pos - 12), -1):
+        line = _normalise_capture_menu_line(lines[pos][1])
+        if not line or _is_capture_chrome_or_blank(line):
+            continue
+        if _parse_ask_user_row(lines[pos][0], line) is not None:
+            continue
+        line = line.lstrip("⏺").strip()
+        if not line:
+            continue
+        if fallback[1] == "":
+            fallback = (pos, line)
+        if "?" in line:
+            return pos, line
+    return fallback
+
+
+def _questions_from_menu_rows(
+    rows: list[_CapturedMenuRow],
+    prompt: str,
+) -> list[dict[str, Any]]:
+    grouped_questions: list[dict[str, Any]] = []
+    row_to_group = set()
+
+    for row_index, row in enumerate(rows):
+        child_indices = _child_row_indices(rows, row_index)
+        if not child_indices:
+            continue
+        child_rows = [rows[index] for index in child_indices]
+        row_to_group.add(row_index)
+        row_to_group.update(child_indices)
+        question_text = row.label
+        if len(rows) == len(child_rows) + 1 and prompt:
+            question_text = prompt
+        grouped_questions.append({
+            "question": question_text,
+            "header": row.label,
+            "multiSelect": any(
+                child.glyph in _ASK_USER_CHECKBOX_GLYPHS
+                for child in child_rows
+            ),
+            "options": [
+                {"label": child.label, "description": ""}
+                for child in child_rows
+            ],
+        })
+
+    loose_options = [
+        row for row_index, row in enumerate(rows)
+        if row_index not in row_to_group
+        and not _child_row_indices(rows, row_index)
+    ]
+    if loose_options:
+        grouped_questions.append({
+            "question": prompt or "Choose an option",
+            "header": "",
+            "multiSelect": any(
+                row.glyph in _ASK_USER_CHECKBOX_GLYPHS
+                for row in loose_options
+            ),
+            "options": [
+                {"label": row.label, "description": ""}
+                for row in loose_options
+            ],
+        })
+
+    if grouped_questions:
+        return grouped_questions
+    return [{
+        "question": prompt or "Choose an option",
+        "header": "",
+        "multiSelect": any(row.glyph in _ASK_USER_CHECKBOX_GLYPHS for row in rows),
+        "options": [{"label": row.label, "description": ""} for row in rows],
+    }]
+
+
+def _child_row_indices(
+    rows: list[_CapturedMenuRow],
+    row_index: int,
+) -> list[int]:
+    parent = rows[row_index]
+    children: list[int] = []
+    for candidate_index, candidate in enumerate(rows[row_index + 1:], row_index + 1):
+        if candidate.indent <= parent.indent:
+            break
+        children.append(candidate_index)
+    return children
+
+
+def _parse_ask_user_row(
+    line_index: int,
+    line: str,
+) -> _CapturedMenuRow | None:
+    normalised = _normalise_capture_menu_line(line)
+    match = _ASK_USER_ROW_RE.match(normalised)
+    if match is None:
+        return None
+    label = _ASK_USER_SUBMIT_RE.sub("", match.group("label")).strip()
+    if not label:
+        return None
+    return _CapturedMenuRow(
+        line_index=line_index,
+        indent=len(match.group("indent").replace("\t", "    ")),
+        glyph=match.group("glyph"),
+        label=label,
+    )
+
+
+def _normalise_capture_menu_line(line: str) -> str:
+    text = line.rstrip()
+    left = text.lstrip()
+    prefix = text[: len(text) - len(left)]
+    if left.startswith(("│", "┆")):
+        left = left[1:]
+        if left.startswith(" "):
+            left = left[1:]
+        text = f"{prefix}{left.rstrip()}"
+    if text.rstrip().endswith(("│", "┆")):
+        text = text.rstrip()[:-1].rstrip()
+    return text
+
+
+def _is_capture_chrome_or_blank(line: str) -> bool:
+    stripped = _normalise_capture_menu_line(line)
+    if not stripped:
+        return True
+    lower = stripped.lower()
+    if (
+        "bypass permissions" in lower
+        or "shift+tab to cycle" in lower
+        or "ctrl+t to" in lower
+        or stripped.startswith("⏵⏵")
+    ):
+        return True
+    box_chars = {"─", "━", "╭", "╮", "╰", "╯", "│", "┆", " "}
+    return set(stripped) <= box_chars
 
 
 def _strip_control_codes(text: str) -> str:

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -85,6 +85,9 @@ from pollypm.audit.log import EVENT_CHAT_SEND_FORCE_BYPASS, emit as audit_emit
 from pollypm.tmux.client import DeadPaneError, TmuxClient
 from pollypm.web_api.chat import (
     ChatSurface,
+    MessageEnvelope,
+    MessageType,
+    capture_envelopes,
     find_chat_surface,
 )
 from pollypm.web_api.errors import APIError
@@ -1067,9 +1070,7 @@ def _find_ask_user_envelope(
     # P1's envelope id is ``msg_<tool_use_id>``; the raw events.jsonl
     # only carries the bare id. Try both forms so the route accepts
     # the envelope id the GET endpoints hand out AND the raw id.
-    candidates = {answer_to}
-    if answer_to.startswith("msg_"):
-        candidates.add(answer_to[len("msg_"):])
+    candidates = _answer_to_candidates(answer_to)
     for event in events:
         event_id = _event_message_id(event)
         if event_id is None:
@@ -1077,6 +1078,61 @@ def _find_ask_user_envelope(
         if event_id in candidates:
             return event
     return None
+
+
+def _find_captured_ask_user_envelope(
+    tmux: TmuxClient,
+    *,
+    session_name: str,
+    target: str,
+    actor_fallback: str,
+    answer_to: str,
+) -> dict[str, Any] | None:
+    """Locate a synthetic ask_user envelope from the live tmux capture.
+
+    Live Claude ``AskUserQuestion`` menus can reach the web chat only
+    through tmux capture when the structured JSONL archive is absent or
+    stale. The read endpoint synthesizes those menus into ``ask_user``
+    envelopes; this mirrors that normalization so ``answer_to=<cap_* id>``
+    from the web UI is answerable through the same public POST contract.
+    """
+    candidates = _answer_to_candidates(answer_to)
+    captured = capture_envelopes(
+        tmux,
+        session_name=session_name,
+        target=target,
+        actor_fallback=actor_fallback,
+    )
+    for envelope in captured:
+        if envelope.type != MessageType.ASK_USER:
+            continue
+        ids = {envelope.id}
+        tool_use_id = envelope.metadata.get("tool_use_id")
+        if isinstance(tool_use_id, str) and tool_use_id:
+            ids.add(tool_use_id)
+        if ids & candidates:
+            return _captured_ask_user_event(envelope)
+    return None
+
+
+def _captured_ask_user_event(envelope: MessageEnvelope) -> dict[str, Any]:
+    return {
+        "id": envelope.id,
+        "event_type": "tool_call",
+        "metadata": envelope.metadata,
+        "payload": {
+            "type": "ask_user",
+            "id": envelope.metadata.get("tool_use_id") or envelope.id,
+            "questions": envelope.metadata.get("questions") or [],
+        },
+    }
+
+
+def _answer_to_candidates(answer_to: str) -> set[str]:
+    candidates = {answer_to}
+    if answer_to.startswith("msg_"):
+        candidates.add(answer_to[len("msg_"):])
+    return candidates
 
 
 def _event_message_id(event: dict[str, Any]) -> str | None:
@@ -1480,6 +1536,18 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
             raw_id = _event_message_id(ask_envelope)
             if isinstance(raw_id, str) and raw_id:
                 ask_exempt_ids.add(raw_id)
+        else:
+            ask_envelope = _find_captured_ask_user_envelope(
+                tmux,
+                session_name=session_name,
+                target=target,
+                actor_fallback=surface.persona or "agent",
+                answer_to=body.answer_to,
+            )
+            if ask_envelope is not None:
+                raw_id = _event_message_id(ask_envelope)
+                if isinstance(raw_id, str) and raw_id:
+                    ask_exempt_ids.add(raw_id)
 
     # 3. Safety gates (§4.1, §4.3) — use the exact session transcript
     # (Codex review block 3).

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -1535,6 +1535,55 @@ def test_messages_endpoint_source_auto_keeps_stale_open_ask_user_jsonl(
     assert option["label"] == "Photography"
 
 
+def test_messages_endpoint_source_capture_synthesizes_ask_user_menu(
+    client,
+    auth_headers,
+    patch_registry,
+    monkeypatch,
+):
+    patch_registry([_surface(
+        "architect_demo", SurfaceType.ARCHITECT, persona="Sage",
+        project="demo",
+    )])
+
+    class _LiveTmuxClient:
+        def capture_pane(self, target, lines=3000):  # noqa: ARG002
+            return "\n".join([
+                "⏺ I need one product direction before I queue imagery work.",
+                "",
+                "What medium should the imagery be?",
+                "",
+                "☐ Imagery medium",
+                "  ○ Bespoke SVG illustration",
+                "  ○ Photography",
+                "☐ Hero treatment        ✔ Submit",
+                "",
+                "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+            ])
+
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "_build_tmux_client",
+        lambda: _LiveTmuxClient(),
+    )
+
+    body = client.get(
+        "/api/v1/chat/architect_demo/messages?source=capture&direction=desc",
+        headers=auth_headers,
+    ).json()
+
+    assert body["transcript_source"] == "capture"
+    message = body["messages"][0]
+    assert message["type"] == "ask_user"
+    assert message["text"] == "What medium should the imagery be?"
+    assert message["metadata"]["from_capture"] is True
+    assert message["metadata"]["synthetic"] is True
+    assert message["metadata"]["questions"][0]["options"] == [
+        {"label": "Bespoke SVG illustration", "description": ""},
+        {"label": "Photography", "description": ""},
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Auth
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -79,6 +79,7 @@ class FakeTmuxClient:
     send_enter_delays: list[float] = []
     list_panes_side_effect: Exception | None = None
     list_windows_side_effect: Exception | None = None
+    capture_output: str = ""
 
     def list_windows(self, session: str) -> list[FakeWindow]:
         if self.list_windows_side_effect is not None:
@@ -91,6 +92,9 @@ class FakeTmuxClient:
         # Tests register panes by either window target ("session:window")
         # or session, depending on the call shape; check both.
         return list(self.panes_by_target.get(target, []))
+
+    def capture_pane(self, target: str, lines: int = 3000) -> str:  # noqa: ARG002
+        return self.capture_output
 
     def send_keys(
         self,
@@ -115,6 +119,7 @@ def _reset_fake_tmux():
     FakeTmuxClient.send_enter_delays = []
     FakeTmuxClient.list_panes_side_effect = None
     FakeTmuxClient.list_windows_side_effect = None
+    FakeTmuxClient.capture_output = ""
     yield
 
 
@@ -1192,6 +1197,50 @@ def test_answer_to_multiselect_newline_joined(
     assert response.status_code == 200
     _target, text, _enter = patched_tmux.send_calls[0]
     assert text == "alpha\nbravo"
+
+
+def test_answer_to_captured_ask_user_menu(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.capture_output = "\n".join([
+        "⏺ I need one product direction before I queue imagery work.",
+        "",
+        "What medium should the imagery be?",
+        "",
+        "☐ Imagery medium",
+        "  ○ Bespoke SVG illustration",
+        "  ○ Photography",
+        "☐ Hero treatment        ✔ Submit",
+    ])
+    captured = chat_send_routes.capture_envelopes(
+        patched_tmux(),
+        session_name="operator",
+        target="pollypm-test-storage-closet:pm-operator",
+    )
+    ask_id = next(env.id for env in captured if str(env.type) == "ask_user")
+
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={
+            "answer_to": ask_id,
+            "selections": ["Bespoke SVG illustration"],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.json()
+    assert patched_tmux.send_calls == [
+        (
+            "pollypm-test-storage-closet:pm-operator",
+            "Bespoke SVG illustration",
+            True,
+        ),
+    ]
 
 
 def test_answer_to_missing_returns_400(

--- a/tests/test_chat_tmux_capture.py
+++ b/tests/test_chat_tmux_capture.py
@@ -129,6 +129,54 @@ def test_capture_synthesizes_multi_question_menu_with_submit_row() -> None:
     ]
 
 
+def test_capture_synthesizes_live_numbered_ask_user_tab_menu() -> None:
+    pane_text = "\n".join([
+        "⏺ I need one product direction before I queue imagery work.",
+        "",
+        "What medium should the imagery be?",
+        "",
+        "←  ☐ Imagery medium  ☐ Hero treatment  ✔ Submit  →",
+        "❯ 1. Bespoke SVG illustration",
+        "     A one-off vector treatment tailored to this launch.",
+        "  2. Curated photography",
+        "     A tighter set of sourced photographs with captions.",
+        "Type something.",
+        "Chat about this",
+    ])
+    tmux = _StubTmuxClient(output=pane_text)
+
+    envelopes = capture_envelopes(
+        tmux,
+        session_name="architect_demo",
+        target="storage-closet:architect_demo",
+    )
+
+    ask = envelopes[-1]
+    assert ask.type == MessageType.ASK_USER
+    assert ask.text == "What medium should the imagery be?"
+    assert ask.metadata["questions"] == [
+        {
+            "question": "What medium should the imagery be?",
+            "header": "Imagery medium",
+            "multiSelect": False,
+            "options": [
+                {
+                    "label": "Bespoke SVG illustration",
+                    "description": (
+                        "A one-off vector treatment tailored to this launch."
+                    ),
+                },
+                {
+                    "label": "Curated photography",
+                    "description": (
+                        "A tighter set of sourced photographs with captions."
+                    ),
+                },
+            ],
+        }
+    ]
+
+
 def test_capture_does_not_synthesize_stale_ask_user_menu() -> None:
     pane_text = "\n".join([
         "What medium should the imagery be?",
@@ -136,6 +184,24 @@ def test_capture_does_not_synthesize_stale_ask_user_menu() -> None:
         "☐ Imagery medium",
         "  ○ Bespoke SVG illustration",
         "  ○ Photography        ✔ Submit",
+        "⏺ Continuing after the answered prompt.",
+    ])
+    tmux = _StubTmuxClient(output=pane_text)
+
+    envelopes = capture_envelopes(tmux, session_name="architect_demo", target="t")
+
+    assert all(env.type == MessageType.TEXT for env in envelopes)
+
+
+def test_capture_does_not_synthesize_stale_live_tab_menu() -> None:
+    pane_text = "\n".join([
+        "What medium should the imagery be?",
+        "",
+        "←  ☐ Imagery medium  ☐ Hero treatment  ✔ Submit  →",
+        "❯ 1. Bespoke SVG illustration",
+        "  2. Curated photography",
+        "Type something.",
+        "Chat about this",
         "⏺ Continuing after the answered prompt.",
     ])
     tmux = _StubTmuxClient(output=pane_text)

--- a/tests/test_chat_tmux_capture.py
+++ b/tests/test_chat_tmux_capture.py
@@ -59,6 +59,92 @@ def test_capture_envelopes_one_per_line() -> None:
     assert texts == ["line one", "line two", "line three"]
 
 
+def test_capture_synthesizes_active_ask_user_menu() -> None:
+    pane_text = "\n".join([
+        "⏺ I need one product direction before I queue imagery work.",
+        "",
+        "What medium should the imagery be?",
+        "",
+        "☐ Imagery medium",
+        "  ○ Bespoke SVG illustration",
+        "  ○ Photography",
+        "☐ Hero treatment        ✔ Submit",
+        "",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+    ])
+    tmux = _StubTmuxClient(output=pane_text)
+
+    envelopes = capture_envelopes(
+        tmux,
+        session_name="architect_demo",
+        target="storage-closet:architect_demo",
+    )
+
+    ask = envelopes[-1]
+    assert ask.type == MessageType.ASK_USER
+    assert ask.text == "What medium should the imagery be?"
+    assert ask.metadata["from_capture"] is True
+    assert ask.metadata["synthetic"] is True
+    assert ask.metadata["tool_use_id"] == ask.id
+    assert ask.metadata["questions"][0]["header"] == "Imagery medium"
+    assert ask.metadata["questions"][0]["options"] == [
+        {"label": "Bespoke SVG illustration", "description": ""},
+        {"label": "Photography", "description": ""},
+    ]
+    assert ask.metadata["questions"][1]["options"] == [
+        {"label": "Hero treatment", "description": ""},
+    ]
+
+
+def test_capture_synthesizes_multi_question_menu_with_submit_row() -> None:
+    pane_text = "\n".join([
+        "Choose the imagery direction.",
+        "",
+        "☐ Medium",
+        "  ○ Bespoke SVG illustration",
+        "  ○ Photography",
+        "☐ Placement",
+        "  ☐ Hero first",
+        "  ☐ Inline accents",
+        "✔ Submit",
+    ])
+    tmux = _StubTmuxClient(output=pane_text)
+
+    ask = capture_envelopes(
+        tmux,
+        session_name="architect_demo",
+        target="storage-closet:architect_demo",
+    )[0]
+
+    assert ask.type == MessageType.ASK_USER
+    assert [question["header"] for question in ask.metadata["questions"]] == [
+        "Medium",
+        "Placement",
+    ]
+    assert ask.metadata["questions"][0]["multiSelect"] is False
+    assert ask.metadata["questions"][1]["multiSelect"] is True
+    assert ask.metadata["questions"][1]["options"] == [
+        {"label": "Hero first", "description": ""},
+        {"label": "Inline accents", "description": ""},
+    ]
+
+
+def test_capture_does_not_synthesize_stale_ask_user_menu() -> None:
+    pane_text = "\n".join([
+        "What medium should the imagery be?",
+        "",
+        "☐ Imagery medium",
+        "  ○ Bespoke SVG illustration",
+        "  ○ Photography        ✔ Submit",
+        "⏺ Continuing after the answered prompt.",
+    ])
+    tmux = _StubTmuxClient(output=pane_text)
+
+    envelopes = capture_envelopes(tmux, session_name="architect_demo", target="t")
+
+    assert all(env.type == MessageType.TEXT for env in envelopes)
+
+
 def test_capture_envelope_marked_text_type_and_from_capture() -> None:
     tmux = _StubTmuxClient(output="hello world\n")
     envelopes = capture_envelopes(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Detect active Claude AskUserQuestion menu forms in live tmux capture and synthesize a public `type=ask_user` envelope with `metadata.questions[].options[]`.
- Avoid synthesizing stale menu scrollback when real content appears after the Submit line.
- Let `POST /chat/{session}/send` resolve `answer_to=cap_*` synthetic capture IDs by re-reading live capture when JSONL has no structured AskUserQuestion envelope.
- Update the chat API docs/OpenAPI for the captured-menu behavior.

Fixes #2476.

## Tests
- `uv run --extra dev ruff check src/pollypm/web_api/chat/tmux_capture.py src/pollypm/web_api/routes/chat_send.py tests/test_chat_tmux_capture.py tests/test_chat_messages_endpoint.py tests/test_chat_send_endpoint.py`
- `uv run --extra test pytest --noconftest tests/test_chat_tmux_capture.py tests/test_chat_messages_endpoint.py tests/test_chat_send_endpoint.py -q`
- `uv run --extra test pytest tests/web_api/test_web_ui.py::test_chat_history_renders_ask_user_controls_and_routes_reply -q`
- `git diff --check`

Worker also validated the OpenAPI document with `openapi_spec_validator`.

## Notes
- The capture parser is necessarily heuristic because tmux only exposes rendered text. It covers the observed glyph + Submit form shapes, including multi-question groups; future Claude TUI layout changes may need a parser update.
