### PR TITLE
Narrate recovery events in brief and activity

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -94,6 +94,8 @@ tags:
     description: Inbox items and threads.
   - name: Events
     description: Realtime audit-log stream.
+  - name: Activity
+    description: Operator-facing activity rows with narrated recovery events.
   - name: Audit
     description: |
       Historical audit-log queries (grep + stats). The streaming
@@ -2909,6 +2911,67 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /activity:
+    get:
+      tags: [Activity]
+      operationId: listActivity
+      summary: Recent operator-facing activity events
+      description: |
+        Returns recent audit events shaped for the dashboard activity
+        rail. The event stream is audit-backed like `/audit/grep`,
+        but each row includes a `summary` sentence; recovery/self-heal
+        events such as `recovery.spawn` and
+        `watchdog.escalation_dispatched` are rendered from structured
+        metadata into calm operator-facing prose.
+      parameters:
+        - in: query
+          name: project
+          schema: { type: string }
+          description: Scope to one project (per-project log + central tail).
+        - in: query
+          name: since
+          schema: { type: string }
+          description: ISO-8601 timestamp or shortcut like `1h`, `24h`, or `7d`.
+        - in: query
+          name: event_type
+          schema: { type: string }
+          description: Exact match on the audit `.event` field.
+        - in: query
+          name: pattern
+          schema:
+            type: string
+            maxLength: 200
+          description: Literal substring by default; regex with `safe_regex=true`.
+        - in: query
+          name: safe_regex
+          schema:
+            type: boolean
+            default: false
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+        - in: query
+          name: deadline_seconds
+          schema:
+            type: number
+            format: float
+            minimum: 0.5
+            maximum: 60.0
+            default: 5.0
+      responses:
+        "200":
+          description: Activity events with operator-facing summaries.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivityResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /audit/stats:
     get:
       tags: [Audit]
@@ -5493,6 +5556,57 @@ components:
             instead of letting the exception escape as a 500. Non-zero
             means at least one archive needs operator attention.
             (Codex round-7 finding, PR #2062.)
+
+    ActivityEvent:
+      allOf:
+        - $ref: "#/components/schemas/Event"
+        - type: object
+          required: [summary, recovery]
+          properties:
+            summary:
+              type: string
+              description: |
+                Operator-facing activity sentence. Recovery/self-heal
+                events are narrated from structured metadata instead
+                of exposing raw event ids.
+            recovery:
+              type: boolean
+              default: false
+              description: True when this row belongs to the recovery/self-heal family.
+
+    ActivityResponse:
+      type: object
+      required: [events]
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActivityEvent"
+        next_cursor:
+          type: string
+          nullable: true
+          description: Reserved for cursor-paginated variants. Always `null` today.
+        _malformed_rows_skipped:
+          type: integer
+          default: 0
+          description: Same diagnostic meaning as in `AuditGrepResponse`.
+        _pattern_timeouts:
+          type: integer
+          default: 0
+          description: Same diagnostic meaning as in `AuditGrepResponse`.
+        _truncated_by_deadline:
+          type: boolean
+          default: false
+          description: Same diagnostic meaning as in `AuditGrepResponse`.
+        _lines_scanned:
+          type: integer
+          default: 0
+          description: Same diagnostic meaning as in `AuditGrepResponse`.
+        _corrupt_archives_skipped:
+          type: integer
+          default: 0
+          minimum: 0
+          description: Same diagnostic meaning as in `AuditGrepResponse`.
 
     AuditStatsResponse:
       type: object

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -872,6 +872,17 @@ def _clean_briefing_title(title: str) -> str:
     return text.rstrip(".")
 
 
+def _recovery_narration_line(recovery_summaries: list[str] | None) -> str | None:
+    summaries: list[str] = []
+    for summary in recovery_summaries or []:
+        cleaned = re.sub(r"\s+", " ", summary or "").strip()
+        if cleaned:
+            summaries.append(cleaned)
+    if not summaries:
+        return None
+    return "While you were away, I handled this: " + " ".join(summaries[:2])
+
+
 def _build_dashboard_briefing(
     *,
     commits: list[CommitInfo],
@@ -879,6 +890,7 @@ def _build_dashboard_briefing(
     inbox_count: int,
     recent_messages: list[InboxPreview],
     recovery_count_24h: int,
+    recovery_summaries: list[str] | None = None,
 ) -> str:
     """Build the concise Home briefing from already-gathered dashboard facts."""
 
@@ -898,7 +910,10 @@ def _build_dashboard_briefing(
             + _plural(projects_touched, "project")
             + "."
         )
-    if recovery_count_24h:
+    recovery_line = _recovery_narration_line(recovery_summaries)
+    if recovery_line:
+        lines.append(recovery_line)
+    elif recovery_count_24h:
         lines.append(
             "Saved: "
             + _plural(recovery_count_24h, "recovery", "recoveries")
@@ -939,6 +954,73 @@ def _build_dashboard_briefing(
         lines.append("All handled: no inbox items waiting.")
 
     return "\n".join(lines[:6])
+
+
+def _recent_recovery_audit_narrations(
+    config: PollyPMConfig,
+    *,
+    since: str,
+    limit: int = 3,
+) -> tuple[list[str], int]:
+    """Return recent recovery/self-heal audit narration for the Home brief."""
+
+    try:
+        from pollypm.audit.log import read_events
+        from pollypm.recovery.narration import (
+            RECOVERY_BRIEF_EVENT_NAMES,
+            narrate_recovery_event,
+        )
+    except Exception:  # noqa: BLE001
+        return [], 0
+
+    events = []
+    for project_key, project in (getattr(config, "projects", {}) or {}).items():
+        if not getattr(project, "tracked", False):
+            continue
+        try:
+            rows = read_events(
+                str(project_key),
+                since=since,
+                limit=40,
+                project_path=getattr(project, "path", None),
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "dashboard_data: recovery audit read failed for %s",
+                project_key,
+                exc_info=True,
+            )
+            continue
+        events.extend(row for row in rows if row.event in RECOVERY_BRIEF_EVENT_NAMES)
+
+    events.sort(key=lambda event: event.ts, reverse=True)
+    unique_events = []
+    seen: set[tuple[str, str, str]] = set()
+    for event in events:
+        metadata = event.metadata or {}
+        dedupe_key = (
+            event.event,
+            str(metadata.get("target_session") or metadata.get("session") or event.subject),
+            str(metadata.get("finding_type") or metadata.get("reason") or ""),
+        )
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        unique_events.append(event)
+
+    narrations: list[str] = []
+    for event in unique_events[:limit]:
+        metadata = event.metadata or {}
+        sentence = narrate_recovery_event(
+            event.event,
+            metadata,
+            subject=event.subject,
+            project=event.project,
+            status=event.status,
+        )
+        if sentence:
+            narrations.append(sentence)
+    return narrations, len(unique_events)
 
 
 def _inbox_sender(task) -> str:
@@ -1235,7 +1317,14 @@ def gather(
     )
     recent_messages = _recent_inbox_messages(config)
     sweeps = sum(1 for e in day_events if e.event_type == "heartbeat")
-    recoveries = sum(1 for e in day_events if "recover" in e.event_type)
+    recovery_summaries, audit_recovery_count = _recent_recovery_audit_narrations(
+        config,
+        since=cutoff,
+    )
+    recoveries = (
+        sum(1 for e in day_events if "recover" in e.event_type)
+        + audit_recovery_count
+    )
 
     if use_pg:
         open_alerts = pg_open_alerts()
@@ -1255,6 +1344,7 @@ def gather(
         inbox_count=inbox_count,
         recent_messages=recent_messages,
         recovery_count_24h=recoveries,
+        recovery_summaries=recovery_summaries,
     )
 
     return DashboardData(

--- a/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
+++ b/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
@@ -414,13 +414,35 @@ class EventProjector:
                 raw_summary = payload.get("summary")
                 if isinstance(raw_summary, str) and raw_summary:
                     payload_summary = raw_summary
-            summary = parsed.summary or payload_summary or _fallback_summary(
-                kind, message, actor,
-            )
             severity = parsed.severity or _severity_from_message_row(row)
-            project = (
+            initial_project = (
                 parsed.project
                 or (payload.get("project") if isinstance(payload, dict) else None)
+                or _project_from_text(message)
+                or _project_from_actor(actor)
+            )
+            recovery_summary: str | None = None
+            if isinstance(payload, dict):
+                try:
+                    from pollypm.recovery.narration import narrate_recovery_event
+
+                    recovery_summary = narrate_recovery_event(
+                        kind,
+                        payload,
+                        subject=parsed.subject or row.get("sender") or None,
+                        project=initial_project,
+                        status=severity,
+                    )
+                except Exception:  # noqa: BLE001
+                    recovery_summary = None
+            summary = (
+                parsed.summary
+                or payload_summary
+                or recovery_summary
+                or _fallback_summary(kind, message, actor)
+            )
+            project = (
+                initial_project
                 or _project_from_text(summary)
                 or _project_from_text(message)
                 or _project_from_actor(actor)

--- a/src/pollypm/recovery/narration.py
+++ b/src/pollypm/recovery/narration.py
@@ -1,0 +1,324 @@
+"""Plain-language narration for recovery and self-heal audit events."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+RECOVERY_EVENT_NAMES: frozenset[str] = frozenset(
+    {
+        "heartbeat.missing",
+        "recovery.spawn",
+        "session.spawn",
+        "account.failover.proactive",
+        "account.failover.engaged",
+        "account.failover.blocked",
+        "account.failover.failed",
+        "account.failover.suppressed",
+        "watchdog.escalation_dispatched",
+        "audit.worker_lane_spawned",
+        "audit.worker_lane_failed",
+        "cockpit.session_respawned",
+    }
+)
+
+# Events worth calling out in the morning/dashboard brief. ``session.spawn``
+# is intentionally omitted because recovery relaunches emit both
+# ``recovery.spawn`` and ``session.spawn`` for the same action.
+RECOVERY_BRIEF_EVENT_NAMES: frozenset[str] = frozenset(
+    {
+        "recovery.spawn",
+        "account.failover.proactive",
+        "account.failover.engaged",
+        "watchdog.escalation_dispatched",
+        "audit.worker_lane_spawned",
+        "cockpit.session_respawned",
+    }
+)
+
+_ROLE_PREFIX_RE = re.compile(
+    r"^(?P<role>worker|architect|reviewer|operator_pm|heartbeat)[_-](?P<project>.+)$"
+)
+_TASK_REF_RE = re.compile(r"^(?P<project>[A-Za-z][A-Za-z0-9_-]*)/(?P<number>\d+)$")
+
+_FAILURE_PHRASES: dict[str, str] = {
+    "capacity_exhausted": "capacity was exhausted",
+    "capacity_low": "capacity was low",
+    "heartbeat_missing": "a heartbeat disappeared",
+    "missing_heartbeat": "a heartbeat disappeared",
+    "no_session": "a session was missing",
+    "session_missing": "a session was missing",
+    "pane_dead": "a pane stopped responding",
+    "window_missing": "a window disappeared",
+    "runtime_missing": "runtime state was missing",
+    "provider_error": "the provider failed",
+    "startup_failed": "startup failed",
+}
+
+_FINDING_PHRASES: dict[str, str] = {
+    "cancellation_churn": "repeated task cancellation",
+    "cancellation_no_promotion": "a cancelled task that needed follow-up",
+    "queue_without_motion": "queued work that had stopped moving",
+    "role_session_missing": "a missing role lane",
+    "stuck_draft": "a stuck draft",
+    "task_on_hold_stale": "stale on-hold work",
+    "task_review_stale": "stale review work",
+    "worker_session_dead_loop": "a worker session restart loop",
+}
+
+
+def is_recovery_event(event_name: str | None) -> bool:
+    """Return True when ``event_name`` belongs to the recovery/self-heal family."""
+
+    event = (event_name or "").strip()
+    if event in RECOVERY_EVENT_NAMES:
+        return True
+    return event.startswith("recovery.") or event.startswith("account.failover.")
+
+
+def narrate_recovery_event(
+    event_name: str | None,
+    metadata: Mapping[str, Any] | None = None,
+    *,
+    subject: str | None = None,
+    project: str | None = None,
+    status: str | None = None,
+) -> str | None:
+    """Render one recovery event as a calm operator-facing sentence."""
+
+    event = (event_name or "").strip()
+    if not is_recovery_event(event):
+        return None
+
+    meta = dict(metadata or {})
+    project_label = _project_label(
+        project or _text(meta, "project", "project_key")
+    )
+    event_subject = _text(meta, "subject") or subject or ""
+    session = _text(meta, "target_session", "session", "session_name") or event_subject
+    target = _session_label(
+        session,
+        role=_text(meta, "role"),
+        project=project or _text(meta, "project", "project_key"),
+    )
+    failure = _failure_label(
+        _text(meta, "failure_type", "failure_message", "reason")
+    )
+    problem = _finding_label(_text(meta, "finding_type", "rule", "reason"))
+    subject_label = _subject_label(event_subject, project=project or project_label)
+
+    if event in {"recovery.spawn", "session.spawn"}:
+        action = "restarted" if _ok_status(status) else "tried to restart"
+        if failure:
+            return _sentence(f"I {action} {target} after {failure}")
+        return _sentence(f"I {action} {target} as part of recovery")
+
+    if event == "heartbeat.missing":
+        if failure:
+            return _sentence(f"I noticed {target} was unhealthy because {failure}")
+        return _sentence(f"I noticed {target} was missing and started recovery")
+
+    if event == "watchdog.escalation_dispatched":
+        target_subject = subject_label or f"{problem} in {project_label}"
+        if problem and subject_label:
+            target_subject = f"{problem} on {subject_label}"
+        return _sentence(
+            f"I sent an unstick brief for {target_subject} so the project could keep moving"
+        )
+
+    if event == "audit.worker_lane_spawned":
+        role = _role_label(_text(meta, "role") or "worker")
+        task = _subject_label(_text(meta, "task_subject") or event_subject)
+        if task:
+            return _sentence(f"I opened a {role} lane for {task}")
+        return _sentence(f"I opened a {role} lane for {project_label}")
+
+    if event == "audit.worker_lane_failed":
+        role = _role_label(_text(meta, "role") or "worker")
+        reason = _failure_label(_text(meta, "reason")) or "the launch guard blocked it"
+        return _sentence(f"I tried to open a {role} lane for {project_label}, but {reason}")
+
+    if event in {"account.failover.proactive", "account.failover.engaged"}:
+        source = _account_label(_text(meta, "from", "previous_account"))
+        destination = _account_label(_text(meta, "to", "account"))
+        suffix = f" after {failure}" if failure else ""
+        if source and destination:
+            return _sentence(f"I moved {target} from {source} to {destination}{suffix}")
+        if destination:
+            return _sentence(f"I moved {target} to {destination}{suffix}")
+        return _sentence(f"I moved {target} to a backup account{suffix}")
+
+    if event == "account.failover.blocked":
+        reason = _failure_label(_text(meta, "reason")) or "no backup account was available"
+        return _sentence(f"I checked failover for {target}, but {reason}")
+
+    if event == "account.failover.failed":
+        reason = _failure_label(_text(meta, "last_error", "reason")) or "every backup launch failed"
+        return _sentence(f"I tried failover for {target}, but {reason}")
+
+    if event == "account.failover.suppressed":
+        reason = _failure_label(_text(meta, "reason")) or "the selected account was already active"
+        return _sentence(f"I checked failover for {target}; {reason}")
+
+    if event == "cockpit.session_respawned":
+        return _sentence(f"I restored the cockpit view for {target}")
+
+    if subject_label:
+        return _sentence(f"I handled a recovery event for {subject_label}")
+    return _sentence(f"I handled a recovery event in {project_label}")
+
+
+def summarize_audit_event(
+    *,
+    event_name: str | None,
+    subject: str | None = None,
+    actor: str | None = None,
+    status: str | None = None,
+    project: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> str:
+    """Return a user-facing summary for an audit event."""
+
+    recovery = narrate_recovery_event(
+        event_name,
+        metadata,
+        subject=subject,
+        project=project,
+        status=status,
+    )
+    if recovery:
+        return recovery
+    parts = [(event_name or "audit").strip() or "audit"]
+    if subject:
+        parts.append(_subject_label(subject, project=project) or subject)
+    if status:
+        parts.append(str(status))
+    if actor:
+        parts.append(f"by {_actor_label(actor)}")
+    return " · ".join(part for part in parts if part)
+
+
+def _text(metadata: Mapping[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = metadata.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def _ok_status(status: str | None) -> bool:
+    return (status or "ok").strip().lower() not in {"warn", "warning", "error", "failed"}
+
+
+def _sentence(text: str) -> str:
+    cleaned = re.sub(r"\s+", " ", text or "").strip()
+    if not cleaned:
+        return ""
+    return cleaned if cleaned.endswith((".", "!", "?")) else cleaned + "."
+
+
+def _humanize_token(value: str) -> str:
+    text = re.sub(r"\s+", " ", (value or "").strip())
+    if not text:
+        return ""
+    if text in _FAILURE_PHRASES:
+        return _FAILURE_PHRASES[text]
+    if text in _FINDING_PHRASES:
+        return _FINDING_PHRASES[text]
+    return text.replace("_", " ").replace("-", " ")
+
+
+def _failure_label(value: str) -> str:
+    if not value:
+        return ""
+    return _humanize_token(value)
+
+
+def _finding_label(value: str) -> str:
+    if not value:
+        return "the issue"
+    return _humanize_token(value)
+
+
+def _project_label(value: str | None) -> str:
+    text = (value or "").strip()
+    if not text:
+        return "the project"
+    return text.replace("_", " ").replace("-", " ")
+
+
+def _role_label(value: str | None) -> str:
+    text = (value or "").strip().lower()
+    if text == "operator_pm":
+        return "operator PM"
+    return text.replace("_", " ").replace("-", " ") or "worker"
+
+
+def _account_label(value: str | None) -> str:
+    text = (value or "").strip()
+    if not text:
+        return ""
+    return text.replace("_", " ").replace("-", " ") + " account"
+
+
+def _actor_label(value: str | None) -> str:
+    text = (value or "").strip()
+    if not text:
+        return "system"
+    match = _ROLE_PREFIX_RE.match(text)
+    if match:
+        return f"{_role_label(match.group('role'))} for {_project_label(match.group('project'))}"
+    return text.replace("_", " ").replace("-", " ")
+
+
+def _session_label(
+    value: str | None,
+    *,
+    role: str | None = None,
+    project: str | None = None,
+) -> str:
+    text = (value or "").strip()
+    role_text = _role_label(role) if role else ""
+    project_text = _project_label(project) if project else ""
+    match = _ROLE_PREFIX_RE.match(text)
+    if match:
+        role_text = _role_label(match.group("role"))
+        project_text = _project_label(project or match.group("project"))
+    if role_text and project_text:
+        return f"the {role_text} for {project_text}"
+    if role_text:
+        return f"the {role_text} session"
+    if text:
+        return f"the {_actor_label(text)} session"
+    if project_text:
+        return f"the project session for {project_text}"
+    return "the session"
+
+
+def _subject_label(value: str | None, *, project: str | None = None) -> str:
+    text = (value or "").strip()
+    if not text:
+        return ""
+    match = _TASK_REF_RE.match(text)
+    if match:
+        return (
+            f"task {match.group('number')} in "
+            f"{_project_label(project or match.group('project'))}"
+        )
+    role_match = _ROLE_PREFIX_RE.match(text)
+    if role_match:
+        return _session_label(text, project=project)
+    return text.replace("_", " ").replace("-", " ")
+
+
+__all__ = [
+    "RECOVERY_BRIEF_EVENT_NAMES",
+    "RECOVERY_EVENT_NAMES",
+    "is_recovery_event",
+    "narrate_recovery_event",
+    "summarize_audit_event",
+]

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -48,6 +48,7 @@ from pollypm.web_api.errors import (
     handle_validation_error,
 )
 from pollypm.web_api.routes import audit as audit_routes
+from pollypm.web_api.routes import activity as activity_routes
 from pollypm.web_api.routes import alerts as alerts_routes
 from pollypm.web_api.routes import briefings as briefings_routes
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
@@ -552,6 +553,10 @@ def create_app(
     # streaming side already ships at ``/api/v1/events`` (Phase 1 SSE);
     # we deliberately do not re-route that path here.
     app.include_router(audit_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
+    # Operator-facing activity rail. This is audit-backed like
+    # ``/audit/grep`` but adds plain-language summaries for recovery
+    # events so the UI does not expose raw internal event names.
+    app.include_router(activity_routes.router, prefix=API_V1_PREFIX, dependencies=auth_deps)
     # P2 of the chat-endpoints spec — GET /api/v1/chat/sessions and
     # GET /api/v1/chat/{session_name}/messages. Sits under the same
     # ``/chat`` prefix the P3 send endpoint shares so all

--- a/src/pollypm/web_api/routes/activity.py
+++ b/src/pollypm/web_api/routes/activity.py
@@ -1,0 +1,153 @@
+"""Activity feed endpoint backed by audit-log events."""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from pollypm.audit.query import iter_matching_events, resolve_target_files
+from pollypm.recovery.narration import summarize_audit_event
+from pollypm.web_api.errors import invalid_request
+from pollypm.web_api.models import Event
+from pollypm.web_api.routes._deps import ConfigDep
+from pollypm.web_api.routes.audit import (
+    _GREP_LIMIT_DEFAULT,
+    _GREP_LIMIT_MAX,
+    _coerce_record_to_event,
+    _compile_safe_regex_or_400,
+    _parse_since_or_400,
+    _validate_pattern_length,
+)
+
+router = APIRouter(tags=["Activity"])
+
+
+class ActivityEvent(Event):
+    """Audit event plus the operator-facing activity-feed sentence."""
+
+    summary: str
+    recovery: bool = False
+
+
+class ActivityResponse(BaseModel):
+    """Body for ``GET /api/v1/activity``."""
+
+    events: list[ActivityEvent]
+    next_cursor: str | None = None
+    malformed_rows_skipped: int = Field(default=0, alias="_malformed_rows_skipped")
+    pattern_timeouts: int = Field(default=0, alias="_pattern_timeouts")
+    truncated_by_deadline: bool = Field(
+        default=False, alias="_truncated_by_deadline"
+    )
+    lines_scanned: int = Field(default=0, alias="_lines_scanned")
+    corrupt_archives_skipped: int = Field(
+        default=0, alias="_corrupt_archives_skipped"
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+@router.get(
+    "/activity",
+    response_model=ActivityResponse,
+    response_model_by_alias=True,
+    summary="Recent operator-facing activity events",
+    operation_id="listActivity",
+)
+def activity_endpoint(
+    config: ConfigDep,
+    project: Annotated[
+        str | None,
+        Query(description="Scope to one project (per-project log + central tail)."),
+    ] = None,
+    since: Annotated[
+        str | None,
+        Query(description="ISO-8601 timestamp or shortcut (1h, 24h, 7d)."),
+    ] = None,
+    event_type: Annotated[
+        str | None,
+        Query(description="Exact match on the audit .event field."),
+    ] = None,
+    pattern: Annotated[
+        str | None,
+        Query(description="Literal substring by default; regex with safe_regex=true."),
+    ] = None,
+    safe_regex: Annotated[bool, Query()] = False,
+    limit: Annotated[int, Query(ge=1, le=_GREP_LIMIT_MAX)] = _GREP_LIMIT_DEFAULT,
+    deadline_seconds: Annotated[float, Query(ge=0.5, le=60.0)] = 5.0,
+) -> ActivityResponse:
+    """Return audit events shaped for the dashboard activity rail."""
+
+    since_dt = _parse_since_or_400(since)
+    literal: str | None = None
+    compiled: re.Pattern[str] | None = None
+    if pattern:
+        _validate_pattern_length(pattern)
+        if safe_regex:
+            compiled = _compile_safe_regex_or_400(pattern)
+        else:
+            literal = pattern
+    if safe_regex and since_dt is None:
+        raise invalid_request(
+            "'since' is required when 'safe_regex=true'",
+            hint=(
+                "Pass an ISO-8601 timestamp or shortcut (e.g. since=24h). "
+                "Regex mode walks every line in the window; bound it."
+            ),
+        )
+
+    targets = resolve_target_files(project_filter=project, config=config)
+    events: list[ActivityEvent] = []
+    malformed = 0
+    walker_stats: dict[str, int] = {}
+    for record in iter_matching_events(
+        targets=targets,
+        pattern=compiled,
+        literal=literal,
+        since=since_dt,
+        event_type=event_type,
+        stats=walker_stats,
+        bounded_regex=True,
+        deadline_s=deadline_seconds,
+    ):
+        event = _coerce_record_to_event(record)
+        if event is None:
+            malformed += 1
+            continue
+        events.append(_activity_event_from_audit_event(event))
+        if len(events) >= limit:
+            break
+
+    return ActivityResponse(
+        events=events,
+        next_cursor=None,
+        _malformed_rows_skipped=(
+            malformed + walker_stats.get("malformed_rows_skipped", 0)
+        ),
+        _pattern_timeouts=walker_stats.get("pattern_timeouts", 0),
+        _truncated_by_deadline=bool(walker_stats.get("truncated_by_deadline", 0)),
+        _lines_scanned=walker_stats.get("lines_scanned", 0),
+        _corrupt_archives_skipped=walker_stats.get("corrupt_archives_skipped", 0),
+    )
+
+
+def _activity_event_from_audit_event(event: Event) -> ActivityEvent:
+    from pollypm.recovery.narration import is_recovery_event
+
+    data: dict[str, Any] = event.model_dump(by_alias=True)
+    data["summary"] = summarize_audit_event(
+        event_name=event.event,
+        subject=event.subject,
+        actor=event.actor,
+        status=event.status,
+        project=event.project,
+        metadata=event.metadata or {},
+    )
+    data["recovery"] = is_recovery_event(event.event)
+    return ActivityEvent.model_validate(data)
+
+
+__all__ = ["ActivityEvent", "ActivityResponse", "router"]

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -1597,6 +1597,9 @@
   }
 
   function auditSummary(entry) {
+    if (entry && typeof entry.summary === "string" && entry.summary.trim()) {
+      return entry.summary.trim();
+    }
     const parts = [entry.event || "audit"];
     if (entry.subject) parts.push(entry.subject);
     if (entry.status) parts.push(entry.status);
@@ -3368,10 +3371,10 @@
     return params;
   }
 
-  function activityGrepPath() {
+  function activityFeedPath() {
     const params = activityParams();
     params.set("limit", String(ACTIVITY_LIMIT));
-    return API + "/audit/grep?" + params.toString();
+    return API + "/activity?" + params.toString();
   }
 
   function activityStatsPath() {
@@ -3393,7 +3396,7 @@
     try {
       const [grepResult, statsResult] = await Promise.allSettled([
         apiJsonOptionalWithTimeout(
-          "activity feed", activityGrepPath(), ACTIVITY_REQUEST_TIMEOUT_MS,
+          "activity feed", activityFeedPath(), ACTIVITY_REQUEST_TIMEOUT_MS,
         ),
         apiJsonOptionalWithTimeout(
           "activity stats", activityStatsPath(), ACTIVITY_STATS_REQUEST_TIMEOUT_MS,

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -212,6 +212,11 @@ def test_stats_requires_auth(client: TestClient, audit_home: Path) -> None:
     assert response.status_code == 401
 
 
+def test_activity_requires_auth(client: TestClient, audit_home: Path) -> None:
+    response = client.get("/api/v1/activity")
+    assert response.status_code == 401
+
+
 # ---------------------------------------------------------------------------
 # Grep happy paths
 # ---------------------------------------------------------------------------
@@ -244,6 +249,49 @@ def test_grep_happy_path_returns_matching_events(
     assert subjects == ["myproj/1", "myproj/2"]
     # Sanity: every event carries the canonical Event shape.
     assert all("event" in e and "actor" in e for e in body["events"])
+
+
+def test_activity_endpoint_narrates_recovery_events(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """GET /activity returns activity rows with recovery prose."""
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(
+                project="polly_remote",
+                event="recovery.spawn",
+                subject="architect_polly_remote",
+                actor="supervisor",
+                metadata={
+                    "failure_type": "capacity_exhausted",
+                    "target_session": "architect_polly_remote",
+                    "project": "polly_remote",
+                    "reason": "recovery_restart",
+                },
+            )
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={"project": "myproj", "limit": 10},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert len(body["events"]) == 1
+    event = body["events"][0]
+    assert event["event"] == "recovery.spawn"
+    assert event["recovery"] is True
+    assert event["summary"] == (
+        "I restarted the architect for polly remote after capacity was exhausted."
+    )
+    assert "architect_polly_remote" not in event["summary"]
+    assert "capacity_exhausted" not in event["summary"]
 
 
 def test_grep_regex_pattern_filters_lines(

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -556,6 +556,65 @@ def test_briefing_all_handled_when_no_activity() -> None:
     assert "Nothing needs you" in out
 
 
+def test_briefing_surfaces_recovery_narration() -> None:
+    from pollypm.dashboard_data import _build_dashboard_briefing
+
+    out = _build_dashboard_briefing(
+        commits=[],
+        completed=[],
+        inbox_count=0,
+        recent_messages=[],
+        recovery_count_24h=1,
+        recovery_summaries=[
+            "I restarted the architect for polly remote after capacity was exhausted.",
+        ],
+    )
+
+    assert "While you were away, I handled this:" in out
+    assert "I restarted the architect for polly remote" in out
+    assert "Saved:" not in out
+
+
+def test_recent_recovery_audit_narrations_reads_audit_events(monkeypatch) -> None:
+    from pollypm.dashboard_data import _recent_recovery_audit_narrations
+
+    rows = [
+        SimpleNamespace(
+            event="recovery.spawn",
+            ts="2026-05-30T10:00:00+00:00",
+            project="polly_remote",
+            subject="architect_polly_remote",
+            actor="supervisor",
+            status="ok",
+            metadata={
+                "failure_type": "capacity_exhausted",
+                "target_session": "architect_polly_remote",
+                "project": "polly_remote",
+            },
+        )
+    ]
+
+    monkeypatch.setattr("pollypm.audit.log.read_events", lambda *a, **k: rows)
+    config = SimpleNamespace(
+        projects={
+            "polly_remote": SimpleNamespace(
+                tracked=True,
+                path="/tmp/polly_remote",
+            )
+        }
+    )
+
+    narrations, count = _recent_recovery_audit_narrations(
+        config,
+        since="2026-05-30T00:00:00+00:00",
+    )
+
+    assert count == 1
+    assert narrations == [
+        "I restarted the architect for polly remote after capacity was exhausted.",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # #2308 perf — _session_description cache contract.
 #

--- a/tests/test_recovery_narration.py
+++ b/tests/test_recovery_narration.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pollypm.recovery.narration import (
+    narrate_recovery_event,
+    summarize_audit_event,
+)
+
+
+def test_recovery_spawn_narration_scrubs_session_and_failure_ids() -> None:
+    sentence = narrate_recovery_event(
+        "recovery.spawn",
+        {
+            "failure_type": "capacity_exhausted",
+            "reason": "recovery_restart",
+            "target_session": "architect_polly_remote",
+            "account": "codex_primary",
+            "provider": "codex",
+        },
+        subject="architect_polly_remote",
+        project="polly_remote",
+        status="ok",
+    )
+
+    assert sentence == (
+        "I restarted the architect for polly remote after capacity was exhausted."
+    )
+    assert "architect_polly_remote" not in sentence
+    assert "capacity_exhausted" not in sentence
+
+
+def test_watchdog_dispatch_narration_uses_finding_metadata() -> None:
+    sentence = narrate_recovery_event(
+        "watchdog.escalation_dispatched",
+        {
+            "finding_type": "stuck_draft",
+            "subject": "samblog/32",
+            "brief": "raw internal brief body",
+            "dedup_hash": "abc123",
+        },
+        project="samblog",
+        status="warn",
+    )
+
+    assert sentence == (
+        "I sent an unstick brief for a stuck draft on task 32 in samblog "
+        "so the project could keep moving."
+    )
+    assert "samblog/32" not in sentence
+    assert "dedup_hash" not in sentence
+
+
+def test_non_recovery_audit_summary_keeps_generic_shape() -> None:
+    summary = summarize_audit_event(
+        event_name="task.status_changed",
+        subject="demo/5",
+        actor="worker_demo",
+        status="ok",
+        project="demo",
+        metadata={},
+    )
+
+    assert summary == "task.status_changed · task 5 in demo · ok · by worker for demo"


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add recovery narration helpers that turn self-heal audit events into calm operator-facing sentences.
- Surface recent recovery narration in the dashboard briefing with a `While you were away, I handled this...` line.
- Add `GET /api/v1/activity` as an audit-backed activity feed with `summary` and `recovery` fields, and point the web UI activity rail at it.
- Narrate recovery-shaped rows through the existing activity-feed projector path and document the new endpoint in OpenAPI.

Fixes #2482.

## Tests
- `uv run --extra dev ruff check src/pollypm/recovery/narration.py src/pollypm/dashboard_data.py src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py src/pollypm/web_api/routes/activity.py src/pollypm/web_api/app.py tests/test_recovery_narration.py tests/test_audit_endpoint.py tests/test_dashboard_data_alert_dedup.py`
- `uv run --extra test pytest tests/test_recovery_narration.py tests/test_audit_endpoint.py tests/test_dashboard_data_alert_dedup.py -q`
- `uv run --extra dev pytest tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31 -q`
- `node --check src/pollypm/web_api/ui/app.js`
- `git diff --check`

## Notes
- The new activity endpoint is audit-backed and covers the browser dashboard activity rail. The existing Textual projector remains primarily message-store-backed; it now narrates recovery-shaped rows when they reach that path, but it does not newly ingest audit JSONL wholesale.
