### PR TITLE
Bound dashboard recovery audit narration reads

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -209,6 +209,9 @@ _COMMIT_CACHE: dict[tuple[str, int], tuple[float, list["_CachedCommitRow"]]] = {
 _COMMIT_CACHE_TTL_SECONDS = 60.0
 _COMMIT_PER_PROJECT_TIMEOUT_SECONDS = 2.0
 _COMMIT_LOG_MAX_WORKERS = 8
+# Keep dashboard cold builds bounded: read_events(..., since=...) scans full
+# audit history, while read_events(..., limit=...) uses the reverse-tail path.
+_RECOVERY_AUDIT_TAIL_LIMIT_PER_PROJECT = 400
 
 
 @dataclass(slots=True, frozen=True)
@@ -1041,8 +1044,7 @@ def _recent_recovery_audit_narrations(
         try:
             rows = read_events(
                 str(project_key),
-                since=since,
-                limit=40,
+                limit=_RECOVERY_AUDIT_TAIL_LIMIT_PER_PROJECT,
                 project_path=getattr(project, "path", None),
             )
         except Exception:  # noqa: BLE001
@@ -1052,7 +1054,10 @@ def _recent_recovery_audit_narrations(
                 exc_info=True,
             )
             continue
-        events.extend(row for row in rows if row.event in RECOVERY_BRIEF_EVENT_NAMES)
+        events.extend(
+            row for row in rows
+            if row.event in RECOVERY_BRIEF_EVENT_NAMES and row.ts > since
+        )
 
     events.sort(key=lambda event: event.ts, reverse=True)
     unique_events = []

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -744,6 +744,67 @@ def test_recent_recovery_audit_narrations_reads_audit_events(monkeypatch) -> Non
     ]
 
 
+def test_recent_recovery_audit_narrations_uses_bounded_tail(
+    monkeypatch,
+) -> None:
+    from pollypm.dashboard_data import (
+        _RECOVERY_AUDIT_TAIL_LIMIT_PER_PROJECT,
+        _recent_recovery_audit_narrations,
+    )
+
+    calls: list[dict[str, object]] = []
+    rows = [
+        SimpleNamespace(
+            event="recovery.spawn",
+            ts="2026-05-29T23:00:00+00:00",
+            project="polly_remote",
+            subject="architect_polly_remote",
+            actor="supervisor",
+            status="ok",
+            metadata={"target_session": "architect_polly_remote"},
+        ),
+        SimpleNamespace(
+            event="recovery.spawn",
+            ts="2026-05-30T10:00:00+00:00",
+            project="polly_remote",
+            subject="architect_polly_remote",
+            actor="supervisor",
+            status="ok",
+            metadata={"target_session": "architect_polly_remote"},
+        ),
+    ]
+
+    def fake_read_events(*_args: object, **kwargs: object) -> list[object]:
+        calls.append(kwargs)
+        return rows
+
+    monkeypatch.setattr("pollypm.audit.log.read_events", fake_read_events)
+    config = SimpleNamespace(
+        projects={
+            "polly_remote": SimpleNamespace(
+                tracked=True,
+                path="/tmp/polly_remote",
+            )
+        }
+    )
+
+    narrations, count = _recent_recovery_audit_narrations(
+        config,
+        since="2026-05-30T00:00:00+00:00",
+    )
+
+    assert calls == [
+        {
+            "limit": _RECOVERY_AUDIT_TAIL_LIMIT_PER_PROJECT,
+            "project_path": "/tmp/polly_remote",
+        }
+    ]
+    assert count == 1
+    assert narrations == [
+        "I restarted the architect for polly remote as part of recovery.",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # #2308 perf — _session_description cache contract.
 #


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Stop the dashboard recovery narration reader from passing `since` into `read_events`, which forced full multi-MB audit-log scans on cold dashboard rebuilds.
- Read a bounded recent audit tail per tracked project and apply the 24h `since` filter locally, preserving the shipped recovery narration behavior while using the existing reverse-tail audit reader.
- Add a regression test that pins the bounded-tail call shape and keeps old rows out of the 24h narration count.

Fixes #2487.

## Tests
- `uv run --extra dev ruff check src/pollypm/dashboard_data.py tests/test_dashboard_data_alert_dedup.py`
- `uv run --extra test pytest -q tests/test_dashboard_data_alert_dedup.py::test_recent_recovery_audit_narrations_reads_audit_events tests/test_dashboard_data_alert_dedup.py::test_recent_recovery_audit_narrations_uses_bounded_tail tests/test_dashboard_data_alert_dedup.py::test_briefing_surfaces_recovery_narration`
- `git diff --check`

## Perf Evidence
Synthetic cold-read comparison over 4 project audit logs totaling 32 MB:
- Old call shape (`read_events(..., since=..., limit=40)`): p50 513.3 ms, p95 609.5 ms, max 609.5 ms.
- New bounded-tail path: p50 21.4 ms, p95 23.2 ms, max 23.2 ms.

## Notes
- The dashboard may miss a recovery narration older than the bounded tail if a project writes more than 400 audit rows after it in the same 24h window. That is an intentional dashboard-brief tradeoff: this surface needs recent human-readable examples without making cold rebuild latency proportional to full audit history.
