### PR TITLE
Filter synthetic projects from brief liveness

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -15,6 +15,7 @@ from pollypm.config import PollyPMConfig, load_config
 from pollypm.idle_placeholders import (
     is_codex_idle_placeholder as _is_codex_idle_placeholder,
 )
+from pollypm.project_liveness import is_real_operator_project
 from pollypm.projects import project_state_db_path
 
 logger = logging.getLogger(__name__)
@@ -841,14 +842,16 @@ def _project_task_facts_for_alert_filter(
         counts_by_project: dict[str, dict[str, int]] = {}
         recent_real_work: set[str] = set()
         recent_cutoff = datetime.now(UTC) - _REAL_WORK_RECENCY_WINDOW
-        for project_key in (getattr(config, "projects", {}) or {}):
+        projects = getattr(config, "projects", {}) or {}
+        for project_key, project in projects.items():
             counts: dict[str, int] = {}
+            real_operator_project = is_real_operator_project(project_key, project)
             for task in all_tasks_for_project(grouped, config, project_key):
                 status_key = _status_key(task)
                 if not status_key:
                     continue
                 counts[status_key] = counts.get(status_key, 0) + 1
-                if status_key == "done":
+                if status_key == "done" and real_operator_project:
                     stamped = _coerce_utc_datetime(
                         getattr(task, "updated_at", None)
                         or getattr(task, "created_at", None)

--- a/src/pollypm/project_liveness.py
+++ b/src/pollypm/project_liveness.py
@@ -1,0 +1,106 @@
+"""Project classification helpers for operator-facing live surfaces."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Mapping
+
+
+_SYNTHETIC_PROJECT_KEYS = frozenset(
+    {
+        "inbox",
+        "myproj",
+        "pm_test",
+        "queuestorm",
+        "test_5_8_x",
+        "polly_e2e_proj",
+        "pollypm_cycle_ux_scratch",
+        "demo_polly",
+    }
+)
+_SYNTHETIC_PROJECT_PREFIXES = (
+    "pm_test_",
+    "pm-test-",
+    "queuestorm_",
+    "queuestorm-",
+    "pr2316_drift_",
+    "pr2316-drift-",
+    "race_proj_",
+    "race-proj-",
+    "testpause_",
+    "testpause-",
+)
+_SYNTHETIC_PATH_PREFIXES = ("/private/tmp/",)
+
+
+def _normalized_project_key(value: object) -> str:
+    text = str(value or "").strip().lower()
+    return re.sub(r"[\s-]+", "_", text)
+
+
+def project_key_looks_synthetic(project_key: object) -> bool:
+    """Return True for known harness/debris project key shapes."""
+
+    raw = str(project_key or "").strip().lower()
+    normalized = _normalized_project_key(raw)
+    if raw in _SYNTHETIC_PROJECT_KEYS or normalized in _SYNTHETIC_PROJECT_KEYS:
+        return True
+    for prefix in _SYNTHETIC_PROJECT_PREFIXES:
+        if raw.startswith(prefix) or normalized.startswith(_normalized_project_key(prefix)):
+            return True
+    return False
+
+
+def project_path_looks_synthetic(path: object) -> bool:
+    """Return True when a project root is an ephemeral test workspace."""
+
+    if not path:
+        return False
+    text = str(Path(path) if isinstance(path, str | Path) else path).strip()
+    if text == "/private/tmp":
+        return True
+    return any(text.startswith(prefix) for prefix in _SYNTHETIC_PATH_PREFIXES)
+
+
+def is_real_operator_project(
+    project_key: object,
+    project: object,
+    *,
+    default_tracked: bool = True,
+) -> bool:
+    """Return True when a project may headline operator-facing live content."""
+
+    if not getattr(project, "tracked", default_tracked):
+        return False
+    if project_key_looks_synthetic(project_key):
+        return False
+    if project_path_looks_synthetic(getattr(project, "path", None)):
+        return False
+    return True
+
+
+def real_operator_project_keys(
+    projects: Mapping[object, object],
+    *,
+    default_tracked: bool = True,
+) -> frozenset[str]:
+    """Return tracked, non-synthetic project keys."""
+
+    return frozenset(
+        str(key)
+        for key, project in projects.items()
+        if is_real_operator_project(
+            key,
+            project,
+            default_tracked=default_tracked,
+        )
+    )
+
+
+__all__ = [
+    "is_real_operator_project",
+    "project_key_looks_synthetic",
+    "project_path_looks_synthetic",
+    "real_operator_project_keys",
+]

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -313,6 +313,99 @@ def test_alert_filter_task_facts_use_recent_done_for_liveness(monkeypatch) -> No
     assert facts.project_task_counts["dormant"]["queued"] == 1
 
 
+def test_alert_filter_task_facts_excludes_synthetic_done_projects(monkeypatch) -> None:
+    """#2491 — recent done rows from test debris are not brief liveness."""
+    from pollypm import dashboard_data
+
+    now = datetime.now(UTC)
+    grouped = {
+        "pm_test_01wave_1779715196": [
+            SimpleNamespace(
+                work_status="done",
+                updated_at=now - timedelta(days=1),
+            ),
+            SimpleNamespace(
+                work_status="queued",
+                updated_at=now,
+            ),
+        ],
+        "savethenovel": [
+            SimpleNamespace(
+                work_status="done",
+                updated_at=now - timedelta(days=1),
+            )
+        ],
+    }
+    config = SimpleNamespace(
+        projects={
+            "pm_test_01wave_1779715196": SimpleNamespace(
+                tracked=True,
+                path="/private/tmp/pm_test_01wave_1779715196",
+            ),
+            "savethenovel": SimpleNamespace(
+                tracked=True,
+                path="/Users/sam/dev/savethenovel",
+            ),
+        }
+    )
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.all_tasks_grouped",
+        lambda _config: grouped,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.all_tasks_for_project",
+        lambda data, _config, key: data[key],
+    )
+
+    facts = dashboard_data._project_task_facts_for_alert_filter(
+        config,
+        [
+            SimpleNamespace(
+                session_name="worker_session_gap-pm_test_01wave_1779715196",
+                alert_type="worker_session_gap",
+            )
+        ],
+    )
+    out = dashboard_data._build_dashboard_briefing(
+        commits=[],
+        completed=[],
+        inbox_count=2,
+        recent_messages=[
+            dashboard_data.InboxPreview(
+                sender="watchdog",
+                title=(
+                    "Project pm_test_01wave_1779715196 has 1 queued "
+                    "task(s) but no claim / execution."
+                ),
+                project="pm test 01wave 1779715196",
+                task_id="pm_test_01wave_1779715196/92",
+                age_seconds=0.0,
+                project_key="pm_test_01wave_1779715196",
+            ),
+            dashboard_data.InboxPreview(
+                sender="watchdog",
+                title=(
+                    "Project savethenovel has 1 queued task(s) but no "
+                    "claim / execution."
+                ),
+                project="Save the Novel",
+                task_id="savethenovel/91",
+                age_seconds=60.0,
+                project_key="savethenovel",
+            ),
+        ],
+        recovery_count_24h=0,
+        recent_real_work_projects=facts.recent_real_work_projects,
+    )
+
+    assert facts.recent_real_work_projects == frozenset({"savethenovel"})
+    assert facts.project_task_counts["pm_test_01wave_1779715196"]["queued"] == 1
+    assert "pm_test" not in out
+    assert "pm test" not in out
+    assert "First up: Save the Novel has queued work without an active claim." in out
+
+
 def test_session_description_skips_claude_tui_bottom_bar(tmp_path) -> None:
     """The polly-dashboard "Now" section was rendering every idle
     session as ``"⏵⏵ bypass permissions on (shift+tab to cycle)"`` —

--- a/tests/test_project_liveness.py
+++ b/tests/test_project_liveness.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from pollypm.project_liveness import (
+    is_real_operator_project,
+    project_key_looks_synthetic,
+    project_path_looks_synthetic,
+    real_operator_project_keys,
+)
+
+
+def test_project_key_looks_synthetic_for_known_test_patterns() -> None:
+    assert project_key_looks_synthetic("pm_test_01wave_1779715196")
+    assert project_key_looks_synthetic("pm test 01wave 1779715196")
+    assert project_key_looks_synthetic("queuestorm_1779777233")
+    assert project_key_looks_synthetic("myproj")
+    assert project_key_looks_synthetic("inbox")
+
+
+def test_project_path_looks_synthetic_for_private_tmp_roots() -> None:
+    assert project_path_looks_synthetic(Path("/private/tmp/pm_test_01wave_1779715196"))
+    assert not project_path_looks_synthetic(Path("/Users/sam/dev/savethenovel"))
+
+
+def test_is_real_operator_project_requires_tracked_non_synthetic_project() -> None:
+    assert is_real_operator_project(
+        "savethenovel",
+        SimpleNamespace(tracked=True, path="/Users/sam/dev/savethenovel"),
+    )
+    assert not is_real_operator_project(
+        "savethenovel",
+        SimpleNamespace(tracked=False, path="/Users/sam/dev/savethenovel"),
+    )
+    assert not is_real_operator_project(
+        "pm_test_01wave_1779715196",
+        SimpleNamespace(tracked=True, path="/Users/sam/dev/pm_test_01wave_1779715196"),
+    )
+    assert not is_real_operator_project(
+        "scratch",
+        SimpleNamespace(tracked=True, path="/private/tmp/scratch"),
+    )
+
+
+def test_real_operator_project_keys_filters_config_map() -> None:
+    projects = {
+        "savethenovel": SimpleNamespace(
+            tracked=True,
+            path="/Users/sam/dev/savethenovel",
+        ),
+        "myproj": SimpleNamespace(
+            tracked=True,
+            path="/Users/sam/dev/myproj",
+        ),
+        "polly_remote": SimpleNamespace(
+            tracked=False,
+            path="/Users/sam/dev/polly_remote",
+        ),
+    }
+
+    assert real_operator_project_keys(projects) == frozenset({"savethenovel"})


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a leaf `project_liveness` helper for tracked, non-synthetic operator project classification.
- Exclude synthetic/test projects from the recent-done liveness set that feeds dashboard brief First up and recovery narration.
- Keep task counts for synthetic projects available so alert filtering can still demote them deliberately.

Fixes #2491.

## Tests
- `uv run --extra test pytest --noconftest tests/test_project_liveness.py tests/test_dashboard_data_alert_dedup.py -q`
- `uv run --extra test pytest --noconftest tests/test_dashboard_data_alert_dedup.py tests/test_dashboard_data_pg.py tests/test_polly_dashboard_ui.py tests/test_project_liveness.py -q`
- `uv run --extra dev ruff check src/pollypm/project_liveness.py src/pollypm/dashboard_data.py tests/test_project_liveness.py tests/test_dashboard_data_alert_dedup.py`
- `git diff --check`
