### PR TITLE
Surface parked AskUserQuestion panes in inbox

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/sweeps.py
+++ b/src/pollypm/plugins_builtin/core_recurring/sweeps.py
@@ -728,6 +728,11 @@ def _pane_text_classify_body(
                         session_name=session_name,
                         rule_name=rule_name,
                         pane_text=pane_text,
+                        project_key=_pane_pattern_project_key(
+                            services=services,
+                            handle=handle,
+                            session_name=session_name,
+                        ),
                         state_store=state_store,
                         msg_store=msg_store,
                     )
@@ -802,24 +807,88 @@ def _emit_context_truncated_audit_event(
         return False
 
 
+def _pane_pattern_project_key(
+    *,
+    services: Any,
+    handle: Any,
+    session_name: str,
+) -> str:
+    """Best-effort project routing for pane-pattern inbox rows."""
+    try:
+        from pollypm.work.task_state import parse_task_window_name
+
+        parsed = parse_task_window_name(session_name)
+    except Exception:  # noqa: BLE001
+        parsed = None
+    if parsed is not None:
+        project_key, _task_number = parsed
+        if project_key:
+            return str(project_key)
+
+    config = getattr(services, "config", None)
+    sessions = getattr(config, "sessions", None) or {}
+    session_cfg = sessions.get(session_name)
+    if session_cfg is None:
+        window_name = getattr(handle, "window_name", "") or ""
+        session_cfg = next(
+            (
+                candidate for candidate in sessions.values()
+                if getattr(candidate, "window_name", None) == window_name
+                or getattr(candidate, "name", None) == session_name
+            ),
+            None,
+        )
+    if session_cfg is not None:
+        project_key = str(getattr(session_cfg, "project", "") or "")
+        if project_key:
+            return project_key
+
+    projects = getattr(config, "projects", None) or {}
+    cwd = getattr(handle, "cwd", "") or ""
+    if cwd:
+        try:
+            cwd_path = Path(cwd).resolve()
+        except (OSError, RuntimeError):
+            cwd_path = Path(cwd)
+        for key, project in projects.items():
+            project_path_raw = getattr(project, "path", None)
+            if project_path_raw is None:
+                continue
+            try:
+                project_path = Path(project_path_raw).resolve()
+            except (OSError, RuntimeError):
+                project_path = Path(project_path_raw)
+            try:
+                cwd_path.relative_to(project_path)
+            except ValueError:
+                continue
+            return str(key)
+
+    return "inbox"
+
+
 def _emit_pane_pattern_inbox_item(
     *,
     work_service: Any,
     session_name: str,
     rule_name: str,
     pane_text: str,
+    project_key: str = "inbox",
     state_store: Any = None,
     msg_store: Any = None,
 ) -> bool:
     """Create a user-visible inbox task for a matched pane pattern."""
     dedupe_label = f"pane_pattern:{rule_name}:{session_name}"
+    target_project = project_key if rule_name == "ask_user_decision" else "inbox"
 
     try:
         list_fn = getattr(work_service, "list_tasks", None)
         if callable(list_fn):
             for status in ("queued", "in_progress", "draft", "review"):
                 try:
-                    tasks = list_fn(work_status=status, project="inbox")
+                    tasks = list_fn(
+                        work_status=status, project=target_project,
+                    )
                 except TypeError:
                     tasks = list_fn(work_status=status)
                 for task in tasks or []:
@@ -840,6 +909,11 @@ def _emit_pane_pattern_inbox_item(
         "permission_prompt": (
             f"Session '{session_name}' is waiting on a permission "
             f"prompt — approval needed"
+        ),
+        "ask_user_decision": (
+            f"{target_project} PM is waiting on a decision from you"
+            if target_project != "inbox"
+            else f"Session '{session_name}' is waiting on a decision from you"
         ),
     }
     title = title_map.get(
@@ -873,10 +947,18 @@ def _emit_pane_pattern_inbox_item(
             "the prompt, or",
             f"- Auto-accept: `pm send {session_name} 1`.",
         ])
+    elif rule_name == "ask_user_decision":
+        body_parts.extend([
+            "- Open the agent session from the cockpit or chat surface "
+            "and answer the interactive decision prompt.",
+            "- This is a visibility backstop: PollyPM detected the "
+            "AskUserQuestion chrome, but did not parse the options for "
+            "in-UI answering.",
+        ])
     body_parts.extend([
         "",
         f"Alert type: `pane:{rule_name}`. This inbox item was emitted "
-        "by the pane-text classifier (issue #250).",
+        "by the pane-text classifier (issues #250/#2493).",
     ])
     body = "\n".join(body_parts)
 
@@ -886,22 +968,35 @@ def _emit_pane_pattern_inbox_item(
         f"session:{session_name}",
         dedupe_label,
     ]
+    if rule_name == "ask_user_decision":
+        labels.append("ask_user_decision")
+
+    is_ask_user_decision = rule_name == "ask_user_decision"
 
     try:
-        # Pane-pattern findings (zombie sessions, idle prompts, …) go
-        # to Polly to recover, not to the user. Activity-event tier on
-        # the user-facing surface.
+        # Most pane-pattern findings go to Polly to recover. The
+        # AskUserQuestion backstop is different: it is explicitly a
+        # human decision visibility row when structured option capture
+        # failed, so it is routed to the user inbox.
         inbox_task = work_service.create(
             title=title,
             description=body,
             type="task",
-            project="inbox",
+            project=target_project,
             flow_template="chat",
-            roles={"requester": session_name, "operator": "polly"},
+            roles=(
+                {"requester": "user", "actor": session_name}
+                if is_ask_user_decision
+                else {"requester": session_name, "operator": "polly"}
+            ),
             priority="normal",
             created_by=session_name,
             labels=labels,
-            kind=InboxItemKind.ACTIVITY_EVENT.value,
+            kind=(
+                InboxItemKind.PM_QUESTION_UNANSWERED.value
+                if is_ask_user_decision
+                else InboxItemKind.ACTIVITY_EVENT.value
+            ),
         )
     except Exception:  # noqa: BLE001
         logger.debug(

--- a/src/pollypm/recovery/pane_patterns.py
+++ b/src/pollypm/recovery/pane_patterns.py
@@ -36,7 +36,12 @@ Rules (see issue #250 for the full spec):
    prompt ("Do you want to proceed?"). User-actionable: the handler
    emits an inbox task so Sam can approve.
 
-4. ``theme_trust_modal`` — the post-launch "Select a theme" /
+4. ``ask_user_decision`` — Claude Code is parked on an interactive
+   AskUserQuestion decision menu. User-actionable: the handler emits
+   an inbox task so the operator can see that the agent is waiting,
+   even when the option parser cannot model the menu yet.
+
+5. ``theme_trust_modal`` — the post-launch "Select a theme" /
    "Do you trust this workspace?" modals that ``_stabilize_claude_launch``
    is supposed to auto-dismiss but sometimes leaks. Detection only
    in this PR; the send-keys auto-dismiss is in the follow-up.
@@ -230,6 +235,87 @@ def _match_permission_prompt(pane_text: str) -> bool:
     return _PERMISSION_RE.search(pane_text) is not None
 
 
+# AskUserQuestion menus are not ordinary yes/no permission prompts. Claude
+# renders them as a Submit tab/row plus a keyboard footer. We deliberately
+# detect only the chrome, not the option labels, so this remains a visibility
+# backstop when the richer capture parser cannot understand the menu shape.
+_ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_ASK_USER_SUBMIT_RE = re.compile(r"(?:^|\s)[✔✓]\s*Submit\b", re.IGNORECASE)
+_ASK_USER_TAB_ARROW_RE = re.compile(
+    r"(?:tab\s*/\s*arrow|tab\b.*\barrow)",
+    re.IGNORECASE,
+)
+_ASK_USER_CHROME_LINES = (
+    "bypass permissions",
+    "shift+tab to cycle",
+    "ctrl+t to",
+    "tokens",
+    "chat about this",
+    "type something",
+)
+
+
+def _normalise_ask_user_line(line: str) -> str:
+    text = _ANSI_CSI_RE.sub("", line or "").rstrip()
+    stripped = text.strip()
+    if stripped.startswith(("│", "┆")):
+        stripped = stripped[1:].strip()
+    if stripped.endswith(("│", "┆")):
+        stripped = stripped[:-1].strip()
+    return stripped
+
+
+def _is_ask_user_footer_line(line: str) -> bool:
+    text = _normalise_ask_user_line(line)
+    if "`" in text:
+        return False
+    lower = text.lower()
+    return (
+        "enter to select" in lower
+        and "esc to cancel" in lower
+        and _ASK_USER_TAB_ARROW_RE.search(lower) is not None
+    )
+
+
+def _is_ask_user_submit_line(line: str) -> bool:
+    text = _normalise_ask_user_line(line)
+    if "`" in text:
+        return False
+    return _ASK_USER_SUBMIT_RE.search(text) is not None
+
+
+def _is_ask_user_trailing_chrome(line: str) -> bool:
+    text = _normalise_ask_user_line(line)
+    if not text:
+        return True
+    lower = text.lower()
+    if any(token in lower for token in _ASK_USER_CHROME_LINES):
+        return True
+    box_chars = {"─", "━", "╭", "╮", "╰", "╯", "│", "┆", " "}
+    return set(text) <= box_chars
+
+
+def _match_ask_user_decision(pane_text: str) -> bool:
+    if not pane_text:
+        return False
+    lines = pane_text.splitlines()
+    for footer_pos in range(len(lines) - 1, -1, -1):
+        if not _is_ask_user_footer_line(lines[footer_pos]):
+            continue
+        if not all(
+            _is_ask_user_trailing_chrome(line)
+            for line in lines[footer_pos + 1 :]
+        ):
+            continue
+        start = max(0, footer_pos - 80)
+        if any(
+            _is_ask_user_submit_line(lines[pos])
+            for pos in range(start, footer_pos + 1)
+        ):
+            return True
+    return False
+
+
 # Theme / trust / bypass post-launch modals. ``_stabilize_claude_launch``
 # is supposed to catch these but occasionally they leak (race on the
 # initial render, provider restart, etc.). Detection only — the
@@ -272,7 +358,7 @@ def _match_theme_trust_modal(pane_text: str) -> bool:
 # Order matters — ``classify_pane`` returns hits in declaration order so
 # a single-classification caller can take the first element. Priority is:
 # context_full (most actionable) → stuck_on_error → permission_prompt →
-# theme_trust_modal (most often self-heals).
+# ask_user_decision → theme_trust_modal (most often self-heals).
 RULES: list[ClassifierRule] = [
     ClassifierRule(
         name="context_full",
@@ -290,6 +376,11 @@ RULES: list[ClassifierRule] = [
         severity="warn",
     ),
     ClassifierRule(
+        name="ask_user_decision",
+        matcher=_match_ask_user_decision,
+        severity="warn",
+    ),
+    ClassifierRule(
         name="theme_trust_modal",
         matcher=_match_theme_trust_modal,
         severity="warn",
@@ -302,6 +393,7 @@ RULES: list[ClassifierRule] = [
 # Membership is data so a follow-up can promote / demote a rule without
 # touching the wiring layer.
 USER_VISIBLE_RULES: frozenset[str] = frozenset({
+    "ask_user_decision",
     "context_full",
     "permission_prompt",
 })

--- a/tests/test_pane_patterns.py
+++ b/tests/test_pane_patterns.py
@@ -189,6 +189,36 @@ Both are reasonable; let's discuss in the meeting.
 """
 
 
+ASK_USER_DECISION_POSITIVE = """
+⏺ I need one product direction before I queue imagery work.
+
+What medium should the imagery be?
+
+☐ Imagery medium
+  ○ Bespoke SVG illustration
+  ○ Photography
+←  ☐ Imagery medium  ☐ Hero treatment  ✔ Submit  →
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+"""
+
+ASK_USER_DECISION_PROSE_NEGATIVE = """
+The issue says the pane shows the `✔ Submit` tab-bar /
+`Enter to select · Tab/Arrow keys to navigate · Esc to cancel` footer.
+This is prose in a bug report, not a live menu.
+"""
+
+ASK_USER_DECISION_STALE_NEGATIVE = """
+What medium should the imagery be?
+
+☐ Imagery medium
+  ○ Bespoke SVG illustration
+  ○ Photography
+✔ Submit
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+⏺ Continuing after the answered prompt.
+"""
+
+
 THEME_TRUST_POSITIVE = """
 ╭──────────────────────────────────────────────╮
 │  Select a theme                              │
@@ -320,6 +350,21 @@ class TestClassifyPane:
         # only cue ("and tell Claude" / "esc to interrupt" / etc.).
         assert "permission_prompt" not in classify_pane(
             PERMISSION_PROMPT_BARE_MENU_NEGATIVE,
+        )
+
+    def test_ask_user_decision_positive(self) -> None:
+        assert "ask_user_decision" in classify_pane(
+            ASK_USER_DECISION_POSITIVE,
+        )
+
+    def test_ask_user_decision_prose_negative(self) -> None:
+        assert "ask_user_decision" not in classify_pane(
+            ASK_USER_DECISION_PROSE_NEGATIVE,
+        )
+
+    def test_ask_user_decision_stale_negative(self) -> None:
+        assert "ask_user_decision" not in classify_pane(
+            ASK_USER_DECISION_STALE_NEGATIVE,
         )
 
     def test_theme_trust_modal_positive_theme(self) -> None:
@@ -517,6 +562,43 @@ class TestPaneClassifyHandler:
         # must not duplicate it.
         result2 = pane_text_classify_handler({})
         # Alert is already open; counter only ticks on first-fire.
+        assert result2["alerts_raised"] == 0
+        assert result2["inbox_items_emitted"] == 0
+        assert svc.sent == []
+
+    def test_ask_user_decision_emits_user_routed_project_inbox_task(
+        self, tmp_path, monkeypatch, pg_work_service,
+    ) -> None:
+        from pollypm.inbox.kind import InboxItemKind
+
+        store = StateStore(tmp_path / "state.db")
+        work = pg_work_service
+        svc = FakeSessionService(
+            handles=[FakeHandle("task-demo-7")],
+            captures={"task-demo-7": ASK_USER_DECISION_POSITIVE},
+        )
+        _patch_resolver(monkeypatch, tmp_path, svc, store, work_service=work)
+
+        result = pane_text_classify_handler({})
+
+        assert result["outcome"] == "swept"
+        assert result["alerts_raised"] == 1
+        assert result["match_counts"]["ask_user_decision"] == 1
+        assert result["inbox_items_emitted"] == 1
+
+        tasks = work.list_tasks(project="demo", work_status="draft")
+        task = next(
+            task for task in tasks
+            if "pane_pattern:ask_user_decision:task-demo-7"
+            in (getattr(task, "labels", None) or [])
+        )
+        assert task.kind is InboxItemKind.PM_QUESTION_UNANSWERED
+        assert task.roles["requester"] == "user"
+        assert task.roles["actor"] == "task-demo-7"
+        assert task.title == "demo PM is waiting on a decision from you"
+        assert "did not parse the options" in task.description
+
+        result2 = pane_text_classify_handler({})
         assert result2["alerts_raised"] == 0
         assert result2["inbox_items_emitted"] == 0
         assert svc.sent == []


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add a pane-text `ask_user_decision` detector for live Claude AskUserQuestion chrome (`✔ Submit` plus `Enter to select · Tab/Arrow keys to navigate · Esc to cancel`).
- Route that detector through the existing pane classifier to emit a deduped, user-routed `pm_question_unanswered` inbox task in the owning project.
- Cover live-menu detection, prose/stale false positives, and the emitted task's project, kind, roles, and dedupe label.

Fixes #2493.

## Verification
- `uv run --extra dev ruff check src/pollypm/recovery/pane_patterns.py src/pollypm/plugins_builtin/core_recurring/sweeps.py tests/test_pane_patterns.py`
- `uv run --extra test pytest tests/test_pane_patterns.py -q`
- `uv run --extra test pytest tests/test_inbox_predicates.py -q`
- `git diff --check origin/main...HEAD`
- Read-only live sanity: captured `pollypm-storage-closet:architect-savethenovel` and confirmed `classify_pane(...)` reports `ask_user_decision` while the pane is parked on the AskUserQuestion footer. I did not run the live emitter or write to the production inbox.
