### PR TITLE
Fix Activity feed composition

### DIFF
--- a/src/pollypm/audit/query.py
+++ b/src/pollypm/audit/query.py
@@ -893,10 +893,123 @@ def iter_matching_events(
             session.close()
 
 
+def iter_recent_matching_events(
+    *,
+    targets: Iterable[Path],
+    since: datetime,
+    pattern: re.Pattern[str] | None = None,
+    literal: str | None = None,
+    event_type: str | None,
+    stats: MutableMapping[str, int] | None = None,
+    bounded_regex: bool = False,
+    deadline_s: float | None = None,
+    per_target_limit: int | None = None,
+) -> Iterator[dict]:
+    """Stream recent parsed events newest-first for each audit target.
+
+    This is the feed-oriented sibling of :func:`iter_matching_events`.
+    It assumes audit files are append-only chronological logs, reads
+    live logs from the tail, and stops each target's chain as soon as a
+    valid row predates ``since``. That keeps recent dashboard surfaces
+    from walking all-time history before they can show current activity.
+    """
+    use_bounded_regex = (
+        bounded_regex and pattern is not None and pattern.pattern and not literal
+    )
+    session: _BoundedRegexSession | None = (
+        _BoundedRegexSession(pattern) if use_bounded_regex else None  # type: ignore[arg-type]
+    )
+    deadline_at: float | None = (
+        time.monotonic() + deadline_s
+        if deadline_s is not None and deadline_s > 0
+        else None
+    )
+    try:
+        for path in targets:
+            emitted_for_target = 0
+            stop_target = False
+            for chain_path in walk_log_chain(path):
+                if _archive_predates_since(chain_path, since):
+                    continue
+                line_stats: MutableMapping[str, int] = (
+                    stats if stats is not None else {}
+                )
+                for stripped in _iter_log_lines_newest_first(
+                    chain_path, stats=line_stats
+                ):
+                    if not stripped:
+                        continue
+                    remaining_budget: float | None = None
+                    if deadline_at is not None:
+                        remaining_budget = deadline_at - time.monotonic()
+                        if remaining_budget <= 0:
+                            if stats is not None:
+                                stats["truncated_by_deadline"] = 1
+                            return
+                    if stats is not None:
+                        stats["lines_scanned"] = (
+                            stats.get("lines_scanned", 0) + 1
+                        )
+                    try:
+                        record = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    ts_raw = record.get("ts")
+                    parsed_ts = (
+                        parse_event_ts(ts_raw) if isinstance(ts_raw, str) else None
+                    )
+                    if parsed_ts is None:
+                        if stats is not None:
+                            stats["malformed_rows_skipped"] = (
+                                stats.get("malformed_rows_skipped", 0) + 1
+                            )
+                        continue
+                    if parsed_ts < since:
+                        stop_target = True
+                        break
+                    if event_type is not None and record.get("event") != event_type:
+                        continue
+                    if literal:
+                        if literal not in stripped:
+                            continue
+                    elif session is not None:
+                        matched, timed_out = session.search(
+                            stripped, max_wall_clock_s=remaining_budget
+                        )
+                        if timed_out:
+                            if stats is not None:
+                                stats["pattern_timeouts"] = (
+                                    stats.get("pattern_timeouts", 0) + 1
+                                )
+                            continue
+                        if not matched:
+                            continue
+                    elif pattern is not None and pattern.pattern:
+                        if not pattern.search(stripped):
+                            continue
+                    yield record
+                    emitted_for_target += 1
+                    if (
+                        per_target_limit is not None
+                        and per_target_limit > 0
+                        and emitted_for_target >= per_target_limit
+                    ):
+                        stop_target = True
+                        break
+                if stop_target:
+                    break
+    finally:
+        if session is not None:
+            session.close()
+
+
 __all__ = [
     "AuditStatsAggregate",
     "aggregate_recent_stats",
     "iter_matching_events",
+    "iter_recent_matching_events",
     "open_log_lines",
     "parse_event_ts",
     "parse_since",

--- a/src/pollypm/web_api/routes/activity.py
+++ b/src/pollypm/web_api/routes/activity.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import re
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
-from pollypm.audit.query import iter_matching_events, resolve_target_files
+from pollypm.audit.query import iter_recent_matching_events, resolve_target_files
 from pollypm.recovery.narration import summarize_audit_event
-from pollypm.web_api.errors import invalid_request
 from pollypm.web_api.models import Event
 from pollypm.web_api.routes._deps import ConfigDep
 from pollypm.web_api.routes.audit import (
@@ -23,6 +25,12 @@ from pollypm.web_api.routes.audit import (
 )
 
 router = APIRouter(tags=["Activity"])
+
+_ACTIVITY_DEFAULT_SINCE = "24h"
+_ACTIVITY_PER_TARGET_MIN = 100
+_ACTIVITY_PER_TARGET_MULTIPLIER = 4
+_ACTIVITY_CROSS_PROJECT_SHARE = 0.5
+_ACTIVITY_GROUPED_EVENTS = frozenset({"watchdog.escalation_dispatched"})
 
 
 class ActivityEvent(Event):
@@ -65,7 +73,12 @@ def activity_endpoint(
     ] = None,
     since: Annotated[
         str | None,
-        Query(description="ISO-8601 timestamp or shortcut (1h, 24h, 7d)."),
+        Query(
+            description=(
+                "ISO-8601 timestamp or shortcut (1h, 24h, 7d). "
+                f"Defaults to {_ACTIVITY_DEFAULT_SINCE}."
+            )
+        ),
     ] = None,
     event_type: Annotated[
         str | None,
@@ -81,7 +94,7 @@ def activity_endpoint(
 ) -> ActivityResponse:
     """Return audit events shaped for the dashboard activity rail."""
 
-    since_dt = _parse_since_or_400(since)
+    since_dt = _parse_since_or_400(since or _ACTIVITY_DEFAULT_SINCE)
     literal: str | None = None
     compiled: re.Pattern[str] | None = None
     if pattern:
@@ -90,20 +103,11 @@ def activity_endpoint(
             compiled = _compile_safe_regex_or_400(pattern)
         else:
             literal = pattern
-    if safe_regex and since_dt is None:
-        raise invalid_request(
-            "'since' is required when 'safe_regex=true'",
-            hint=(
-                "Pass an ISO-8601 timestamp or shortcut (e.g. since=24h). "
-                "Regex mode walks every line in the window; bound it."
-            ),
-        )
-
     targets = resolve_target_files(project_filter=project, config=config)
-    events: list[ActivityEvent] = []
+    candidates: list[Event] = []
     malformed = 0
     walker_stats: dict[str, int] = {}
-    for record in iter_matching_events(
+    for record in iter_recent_matching_events(
         targets=targets,
         pattern=compiled,
         literal=literal,
@@ -112,17 +116,20 @@ def activity_endpoint(
         stats=walker_stats,
         bounded_regex=True,
         deadline_s=deadline_seconds,
+        per_target_limit=_per_target_candidate_limit(limit),
     ):
         event = _coerce_record_to_event(record)
         if event is None:
             malformed += 1
             continue
-        events.append(_activity_event_from_audit_event(event))
-        if len(events) >= limit:
-            break
+        candidates.append(event)
 
     return ActivityResponse(
-        events=events,
+        events=_compose_activity_feed(
+            candidates,
+            limit=limit,
+            project_filter=project,
+        ),
         next_cursor=None,
         _malformed_rows_skipped=(
             malformed + walker_stats.get("malformed_rows_skipped", 0)
@@ -132,6 +139,207 @@ def activity_endpoint(
         _lines_scanned=walker_stats.get("lines_scanned", 0),
         _corrupt_archives_skipped=walker_stats.get("corrupt_archives_skipped", 0),
     )
+
+
+@dataclass(slots=True)
+class _ActivityGroup:
+    representative: Event
+    count: int = 0
+    subjects: list[str] = field(default_factory=list)
+
+    def add(self, event: Event) -> None:
+        self.count += 1
+        if event.subject:
+            self.subjects.append(event.subject)
+
+
+def _per_target_candidate_limit(limit: int) -> int:
+    return min(
+        _GREP_LIMIT_MAX,
+        max(_ACTIVITY_PER_TARGET_MIN, limit * _ACTIVITY_PER_TARGET_MULTIPLIER),
+    )
+
+
+def _compose_activity_feed(
+    events: list[Event],
+    *,
+    limit: int,
+    project_filter: str | None,
+) -> list[ActivityEvent]:
+    deduped: list[Event] = []
+    seen: set[tuple[str, str, str, str, str, str, str]] = set()
+    for event in events:
+        identity = _activity_event_identity(event)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        deduped.append(event)
+
+    deduped.sort(key=_event_sort_key, reverse=True)
+
+    entries: list[ActivityEvent] = []
+    groups: dict[tuple[str, str, str, str], _ActivityGroup] = {}
+    for event in deduped:
+        group_key = _activity_group_key(event)
+        if group_key is None:
+            entries.append(_activity_event_from_audit_event(event))
+            continue
+        group = groups.get(group_key)
+        if group is None:
+            group = _ActivityGroup(representative=event)
+            groups[group_key] = group
+            group.add(event)
+            entries.append(_activity_event_from_group(group))
+            continue
+        group.add(event)
+
+    for index, entry in enumerate(entries):
+        group = groups.get(_activity_group_key(entry))
+        if group is not None and group.count > 1:
+            entries[index] = _activity_event_from_group(group)
+
+    entries.sort(key=_event_sort_key, reverse=True)
+    entries = _apply_project_share_cap(
+        entries,
+        limit=limit,
+        project_filter=project_filter,
+    )
+    return entries[:limit]
+
+
+def _activity_event_identity(
+    event: Event,
+) -> tuple[str, str, str, str, str, str, str]:
+    return (
+        event.ts.isoformat(),
+        event.project,
+        event.event,
+        event.subject,
+        event.actor,
+        event.status,
+        _metadata_fingerprint(event.metadata),
+    )
+
+
+def _metadata_fingerprint(metadata: dict[str, Any] | None) -> str:
+    try:
+        return json.dumps(metadata or {}, sort_keys=True, default=str)
+    except TypeError:
+        return repr(metadata)
+
+
+def _event_sort_key(event: Event) -> datetime:
+    return event.ts
+
+
+def _activity_group_key(event: Event) -> tuple[str, str, str, str] | None:
+    if event.event not in _ACTIVITY_GROUPED_EVENTS:
+        return None
+    metadata = event.metadata or {}
+    problem = str(
+        metadata.get("rule")
+        or metadata.get("finding_type")
+        or metadata.get("reason")
+        or ""
+    )
+    return (event.project, event.event, event.status, problem)
+
+
+def _activity_event_from_group(group: _ActivityGroup) -> ActivityEvent:
+    event = group.representative
+    data: dict[str, Any] = event.model_dump(by_alias=True)
+    metadata = dict(event.metadata or {})
+    metadata["activity_group"] = {
+        "count": group.count,
+        "event": event.event,
+        "subjects": group.subjects[:10],
+    }
+    data["metadata"] = metadata
+    if group.count > 1:
+        data["summary"] = _activity_group_summary(group)
+    else:
+        data["summary"] = summarize_audit_event(
+            event_name=event.event,
+            subject=event.subject,
+            actor=event.actor,
+            status=event.status,
+            project=event.project,
+            metadata=event.metadata or {},
+        )
+    from pollypm.recovery.narration import is_recovery_event
+
+    data["recovery"] = is_recovery_event(event.event)
+    return ActivityEvent.model_validate(data)
+
+
+def _activity_group_summary(group: _ActivityGroup) -> str:
+    event = group.representative
+    count = group.count
+    if event.event == "watchdog.escalation_dispatched":
+        problem = _plural_activity_problem(event, count)
+        project = _activity_project_label(event.project)
+        return f"I sent unstick briefs for {count} {problem} in {project}."
+    return summarize_audit_event(
+        event_name=event.event,
+        subject=event.subject,
+        actor=event.actor,
+        status=event.status,
+        project=event.project,
+        metadata=event.metadata or {},
+    )
+
+
+def _plural_activity_problem(event: Event, count: int) -> str:
+    metadata = event.metadata or {}
+    problem = str(
+        metadata.get("rule")
+        or metadata.get("finding_type")
+        or metadata.get("reason")
+        or ""
+    ).strip()
+    if problem == "stuck_draft":
+        return "stuck draft" if count == 1 else "stuck drafts"
+    if problem == "queue_without_motion":
+        return "queued work stall" if count == 1 else "queued work stalls"
+    if problem:
+        label = problem.replace("_", " ").replace("-", " ")
+        return label if count == 1 else f"{label} findings"
+    return "watchdog finding" if count == 1 else "watchdog findings"
+
+
+def _activity_project_label(project: str) -> str:
+    label = (project or "the project").strip()
+    return label.replace("_", " ").replace("-", " ")
+
+
+def _apply_project_share_cap(
+    entries: list[ActivityEvent],
+    *,
+    limit: int,
+    project_filter: str | None,
+) -> list[ActivityEvent]:
+    if project_filter or limit <= 1:
+        return entries
+    per_project_cap = max(1, int(limit * _ACTIVITY_CROSS_PROJECT_SHARE))
+    selected: list[ActivityEvent] = []
+    overflow: list[ActivityEvent] = []
+    counts: dict[str, int] = {}
+    for entry in entries:
+        project = entry.project or "workspace"
+        current = counts.get(project, 0)
+        if current < per_project_cap:
+            selected.append(entry)
+            counts[project] = current + 1
+        else:
+            overflow.append(entry)
+        if len(selected) >= limit:
+            return selected
+    for entry in overflow:
+        selected.append(entry)
+        if len(selected) >= limit:
+            break
+    selected.sort(key=_event_sort_key, reverse=True)
+    return selected
 
 
 def _activity_event_from_audit_event(event: Event) -> ActivityEvent:

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -265,6 +265,7 @@ def test_activity_endpoint_narrates_recovery_events(
                 project="polly_remote",
                 event="recovery.spawn",
                 subject="architect_polly_remote",
+                ts=datetime.now(timezone.utc).isoformat(),
                 actor="supervisor",
                 metadata={
                     "failure_type": "capacity_exhausted",
@@ -292,6 +293,117 @@ def test_activity_endpoint_narrates_recovery_events(
     )
     assert "architect_polly_remote" not in event["summary"]
     assert "capacity_exhausted" not in event["summary"]
+
+
+def test_activity_endpoint_defaults_to_recent_window(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Activity is a recent feed, not an all-time audit dump."""
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(
+                subject="myproj/old",
+                ts=(now - timedelta(days=3)).isoformat(),
+            ),
+            _make_event(
+                subject="myproj/fresh",
+                ts=(now - timedelta(minutes=5)).isoformat(),
+            ),
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={"project": "myproj", "limit": 10},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    subjects = [e["subject"] for e in response.json()["events"]]
+    assert subjects == ["myproj/fresh"]
+
+
+def test_activity_endpoint_groups_repeated_watchdog_escalations(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Repeated stuck-draft escalation rows collapse into one calm row."""
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(
+                event="watchdog.escalation_dispatched",
+                subject=f"myproj/{number}",
+                ts=(now - timedelta(minutes=number)).isoformat(),
+                metadata={"rule": "stuck_draft"},
+            )
+            for number in range(1, 4)
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={"project": "myproj", "since": "24h", "limit": 10},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    events = response.json()["events"]
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "watchdog.escalation_dispatched"
+    assert event["summary"] == "I sent unstick briefs for 3 stuck drafts in myproj."
+    assert event["metadata"]["activity_group"]["count"] == 3
+
+
+def test_activity_endpoint_keeps_cross_project_signal_when_one_project_is_noisy(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """A single target's volume must not hide recent rows from other projects."""
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(
+                event="task.created",
+                subject=f"myproj/{number}",
+                ts=(now - timedelta(seconds=number)).isoformat(),
+            )
+            for number in range(30, 0, -1)
+        ],
+    )
+    _write_jsonl(
+        _central_log(audit_home, "otherproj"),
+        [
+            _make_event(
+                project="otherproj",
+                event="task.created",
+                subject="otherproj/1",
+                ts=(now - timedelta(minutes=1)).isoformat(),
+            )
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={"since": "24h", "limit": 5},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    subjects = [e["subject"] for e in response.json()["events"]]
+    assert "otherproj/1" in subjects
 
 
 def test_grep_regex_pattern_filters_lines(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- default `/api/v1/activity` to a bounded recent window instead of all-time audit history
- read audit targets newest-first, stop each target at the recency boundary, and keep cross-project candidates before applying `limit`
- dedupe mirrored audit rows and collapse repeated `watchdog.escalation_dispatched` rows into one grouped Activity entry

Closes #2495

## Tests
- `uv run --extra test python -m pytest --noconftest tests/test_audit_endpoint.py -q`
- `uv run --extra dev python -m ruff check src/pollypm/audit/query.py src/pollypm/web_api/routes/activity.py tests/test_audit_endpoint.py`