### PR TITLE
fix(chat): synthesize structured ask_user envelope from AskUserQuestion capture (M5/#2476, supersedes #2485)

### DIFF
--- a/src/pollypm/web_api/chat/tmux_capture.py
+++ b/src/pollypm/web_api/chat/tmux_capture.py
@@ -10,6 +10,14 @@ Each captured line becomes one :class:`MessageEnvelope` with
 synthesized as ``cap_<hex>`` from a blake2b digest of
 ``f"{session_name}:{line_index}:{content}"`` so the same line read
 twice yields the same id (stable, sortable within a capture).
+
+When the pane is parked on an interactive ``AskUserQuestion`` TUI form
+(Claude Code's checkbox/radio menu with a ``✔ Submit`` control), the
+capture also synthesizes ONE structured ``type=ask_user`` envelope
+carrying ``metadata.questions[].options[].label`` — the exact shape
+``chat_send`` reads to validate an ``answer_to`` reply (§3.5) — so the
+web UI can render answerable options instead of raw terminal chrome,
+and the menu's own lines are dropped from the text stream.
 """
 
 from __future__ import annotations
@@ -111,8 +119,16 @@ def capture_envelopes(
         return []
     cleaned = _strip_control_codes(raw)
     ts = timestamp or _utc_now()
+    all_lines = cleaned.splitlines()
+
+    # If the pane is parked on an interactive AskUserQuestion form, the
+    # menu region is replaced by ONE structured ``ask_user`` envelope and
+    # excluded from the text stream (it's terminal chrome otherwise).
+    menu = extract_ask_user_menu(cleaned)
+    text_line_count = menu["menu_start"] if menu else len(all_lines)
+
     envelopes: list[MessageEnvelope] = []
-    for line_index, line in enumerate(cleaned.splitlines()):
+    for line_index, line in enumerate(all_lines[:text_line_count]):
         # Skip leading/trailing pure-whitespace lines but preserve internal
         # blank lines so the structure of a Claude-Code box is recognisable.
         if not line.strip() and not envelopes:
@@ -135,6 +151,14 @@ def capture_envelopes(
     # they're just visual padding at the bottom of the pane.
     while envelopes and not envelopes[-1].text.strip():
         envelopes.pop()
+
+    if menu:
+        envelopes.append(_ask_user_envelope(
+            menu,
+            session_name=session_name,
+            actor_fallback=actor_fallback,
+            ts=ts,
+        ))
     return envelopes
 
 
@@ -148,8 +172,276 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+# --------------------------------------------------------------------------
+# AskUserQuestion interactive-menu synthesis (M5 / #2476)
+# --------------------------------------------------------------------------
+# Claude Code renders an AskUserQuestion as a TUI form. The REAL on-screen
+# shape (ground truth, captured live):
+#
+#   ──────────────────────────────────────────────────────────────────────
+#   ←  ☐ Imagery medium  ☐ Hero treatment  ✔ Submit  →     <- tab-bar header
+#                                                            <- blank
+#   What medium should the imagery be? ... matches the palette —           |
+#   and the existing IMAGE_NOTES literally warn against ... clichés.       | <- prompt (wraps)
+#                                                            <- blank
+#   ❯ 1. Bespoke SVG illustration                            <- option (selected)
+#        Extend the existing book-stack.svg direction: ...   <- description (indented)
+#     2. Curated photography
+#        The original locked decision ...
+#     3. Mix of both
+#        ...
+#     4. Type something.                                     <- affordance (EXCLUDE)
+#   ──────────────────────────────────────────────────────────────────────
+#     5. Chat about this                                     <- affordance (EXCLUDE)
+#                                                            <- blank
+#   Enter to select · Tab/Arrow keys to navigate · Esc to cancel  <- footer
+#
+# The three failure modes prior attempts hit, all handled here:
+#   1. ``✔ Submit`` lives in the TOP tab-bar, with the prompt + options
+#      BELOW it (not a trailing inline submit) — detection searches for the
+#      submit line ABOVE the footer, and parsing walks DOWN from it.
+#   2. The options sit below a blank line + a multi-line WRAPPED prompt —
+#      the prompt run is skipped before option parsing begins.
+#   3. ``4. Type something.`` / ``5. Chat about this`` are NUMBERED rows,
+#      not bare lines — excluded by label after stripping the number.
+#
+# Output ``questions`` matches the §3.5 contract that ``chat_send`` reads
+# to validate an ``answer_to`` reply: ``questions[].options[].label``.
+
+_ASK_USER_FOOTER_RE = re.compile(r"enter to select.*esc to cancel", re.IGNORECASE)
+_ASK_USER_TABARROW_RE = re.compile(r"(tab\s*/\s*arrow|arrow keys|tab\b.*\barrow)", re.IGNORECASE)
+_ASK_USER_SUBMIT_RE = re.compile(r"[✔✓]\s*submit", re.IGNORECASE)
+# Numbered option row: optional selection caret (❯ › ▶ >), a number, '.' or ')',
+# then the option label.
+_ASK_USER_NUMBERED_RE = re.compile(r"^[❯❯›▶▷>\-\*\s]*?(\d{1,2})[.)]\s+(\S.*?)\s*$")
+_ASK_USER_TAB_GLYPHS = "☐☑☒✔✓◉○●◯◻◼▢▣"
+# Trailing meta-affordances Claude appends to every AskUserQuestion — never
+# real options. Matched on the label (after the leading number is stripped).
+_ASK_USER_AFFORDANCE_LABELS = frozenset({
+    "type something", "type something.",
+    "chat about this", "chat about this.",
+})
+_ASK_USER_BOX_CHARS = set("─━╌╍┄┅╭╮╰╯│┆┇┊┋" + " ←→·")
+
+
+def _ask_user_clean(line: str) -> str:
+    """ANSI-strip + drop surrounding box-border chars, collapse to core text."""
+    text = _ANSI_CSI_RE.sub("", line or "")
+    text = _C0_CTRL_RE.sub("", text)
+    text = text.strip()
+    # Strip a leading/trailing vertical box border (│ ┆) the TUI may draw.
+    if text[:1] in "│┆":
+        text = text[1:].strip()
+    if text[-1:] in "│┆":
+        text = text[:-1].strip()
+    return text
+
+
+def _ask_user_is_separator(text: str) -> bool:
+    """True for a blank line or a pure box/rule line (e.g. ───────)."""
+    if not text:
+        return True
+    return set(text) <= _ASK_USER_BOX_CHARS
+
+
+def _ask_user_is_footer(text: str) -> bool:
+    if "`" in text:
+        return False
+    low = text.lower()
+    return (
+        _ASK_USER_FOOTER_RE.search(low) is not None
+        and _ASK_USER_TABARROW_RE.search(low) is not None
+    )
+
+
+def _ask_user_is_submit(text: str) -> bool:
+    return "`" not in text and _ASK_USER_SUBMIT_RE.search(text) is not None
+
+
+def _ask_user_is_chrome_after_footer(text: str) -> bool:
+    """Lines allowed to appear AFTER the footer (else it's not the live menu)."""
+    if _ask_user_is_separator(text):
+        return True
+    low = text.lower()
+    return any(tok in low for tok in (
+        "bypass permissions", "shift+tab to cycle", "ctrl+t to", "tokens",
+        "esc to", "ctrl+o", "shift+tab",
+    ))
+
+
+def _ask_user_headers(submit_line: str) -> list[str]:
+    """Extract the per-question tab labels from the tab-bar / submit line.
+
+    "←  ☐ Imagery medium  ☐ Hero treatment  ✔ Submit  →"
+        -> ["Imagery medium", "Hero treatment"]   (Submit + arrows dropped)
+    """
+    segments = re.split(f"[{_ASK_USER_TAB_GLYPHS}]", submit_line)
+    headers: list[str] = []
+    for seg in segments:
+        label = seg.replace("←", "").replace("→", "").strip(" ·\t")
+        if not label or label.lower() == "submit":
+            continue
+        # A glyph-less single-tab form may put the whole bar in one segment;
+        # drop a trailing "Submit" token if it rode along.
+        label = re.sub(r"\s*\bsubmit\b\s*$", "", label, flags=re.IGNORECASE).strip()
+        if label:
+            headers.append(label)
+    return headers
+
+
+def extract_ask_user_menu(pane_text: str) -> dict[str, Any] | None:
+    """Parse an active AskUserQuestion TUI form out of a captured pane.
+
+    Returns ``None`` unless the pane is genuinely parked on the menu
+    (a ``Enter to select … Esc to cancel`` footer with only chrome below
+    it, and a ``✔ Submit`` line within the 80 lines above it). Otherwise
+    returns a dict::
+
+        {
+          "menu_start": int,        # first pane line of the menu box
+          "submit_index": int,
+          "footer_index": int,
+          "headers": [str, ...],    # all question tabs
+          "selected_label": str | None,
+          "questions": [            # §3.5 shape (active question only)
+            {"header": str|None, "question": str,
+             "options": [{"label": str, "description": str, "recommended": bool}, ...],
+             "multiSelect": False},
+          ],
+          "pending_questions": [str, ...],   # tabs not yet rendered
+        }
+    """
+    if not pane_text:
+        return None
+    raw_lines = pane_text.splitlines()
+    cleaned = [_ask_user_clean(ln) for ln in raw_lines]
+
+    # 1. Footer: the LAST footer line that has only chrome/blank below it.
+    footer_index: int | None = None
+    for pos in range(len(cleaned) - 1, -1, -1):
+        if not _ask_user_is_footer(cleaned[pos]):
+            continue
+        if all(_ask_user_is_chrome_after_footer(cleaned[p]) for p in range(pos + 1, len(cleaned))):
+            footer_index = pos
+            break
+    if footer_index is None:
+        return None
+
+    # 2. Submit/tab-bar line within 80 lines above the footer (nearest above).
+    submit_index: int | None = None
+    for pos in range(footer_index - 1, max(-1, footer_index - 81), -1):
+        if _ask_user_is_submit(cleaned[pos]):
+            submit_index = pos
+            break
+    if submit_index is None:
+        return None
+
+    headers = _ask_user_headers(cleaned[submit_index])
+
+    # 3. Walk DOWN from the submit line: skip blanks/separators, capture the
+    #    wrapped prompt run, then the numbered options + their descriptions.
+    prompt_parts: list[str] = []
+    options: list[dict[str, Any]] = []
+    selected_label: str | None = None
+    seen_option = False
+    cur: dict[str, Any] | None = None
+
+    def _flush() -> None:
+        nonlocal cur
+        if cur is None:
+            return
+        label = cur["label"]
+        norm = label.strip().lower()
+        if norm not in _ASK_USER_AFFORDANCE_LABELS:
+            desc = " ".join(cur["desc"]).strip()
+            options.append({
+                "label": label,
+                "description": desc,
+                "recommended": "my recommendation" in desc.lower(),
+            })
+        cur = None
+
+    for pos in range(submit_index + 1, footer_index):
+        text = cleaned[pos]
+        if _ask_user_is_separator(text):
+            continue
+        m = _ASK_USER_NUMBERED_RE.match(raw_lines[pos].rstrip())
+        if m:
+            _flush()
+            seen_option = True
+            label = m.group(2).strip()
+            cur = {"label": label, "desc": []}
+            if any(c in raw_lines[pos] for c in "❯›▶▷❯"):
+                selected_label = label
+            continue
+        # Non-numbered, non-separator line:
+        if not seen_option:
+            prompt_parts.append(text)          # part of the wrapped prompt
+        elif cur is not None:
+            cur["desc"].append(text)           # description of current option
+    _flush()
+
+    if not options:
+        return None
+
+    prompt = re.sub(r"\s+", " ", " ".join(prompt_parts)).strip()
+    active_header = headers[0] if headers else None
+    questions = [{
+        "header": active_header,
+        "question": prompt,
+        "options": options,
+        "multiSelect": False,
+    }]
+
+    # The menu box visually starts at the separator just above the tab-bar
+    # (if present), else at the tab-bar itself.
+    menu_start = submit_index
+    if menu_start > 0 and _ask_user_is_separator(cleaned[menu_start - 1]):
+        menu_start -= 1
+
+    return {
+        "menu_start": menu_start,
+        "submit_index": submit_index,
+        "footer_index": footer_index,
+        "headers": headers,
+        "selected_label": selected_label,
+        "questions": questions,
+        "pending_questions": headers[1:] if len(headers) > 1 else [],
+    }
+
+
+def _ask_user_envelope(
+    menu: dict[str, Any],
+    *,
+    session_name: str,
+    actor_fallback: str,
+    ts: str,
+) -> MessageEnvelope:
+    """Build the single structured ``ask_user`` envelope for a parsed menu."""
+    questions = menu["questions"]
+    prompt = questions[0]["question"] if questions else ""
+    env_id = synthesize_capture_id(session_name, menu["submit_index"], "ask_user:" + prompt)
+    return MessageEnvelope(
+        id=env_id,
+        ts=ts,
+        role=MessageRole.ASSISTANT,
+        actor=actor_fallback,
+        type=MessageType.ASK_USER,
+        text=prompt,
+        metadata={
+            "from_capture": True,
+            "session_name": session_name,
+            "questions": questions,
+            "headers": menu["headers"],
+            "pending_questions": menu["pending_questions"],
+            "selected_label": menu["selected_label"],
+        },
+    )
+
+
 __all__ = [
     "DEFAULT_CAPTURE_LINES",
     "capture_envelopes",
+    "extract_ask_user_menu",
     "synthesize_capture_id",
 ]

--- a/tests/test_chat_tmux_capture_askuser.py
+++ b/tests/test_chat_tmux_capture_askuser.py
@@ -1,0 +1,133 @@
+"""AskUserQuestion interactive-menu synthesis (M5 / #2476).
+
+Fixture is built from a REAL live capture of Claude Code's AskUserQuestion
+TUI form (the exact shape prior parser attempts mis-modeled): a top tab-bar
+with ``✔ Submit``, a blank line, a multi-line WRAPPED prompt, then NUMBERED
+options with indented descriptions, then numbered ``Type something.`` /
+``Chat about this`` affordances, then the footer.
+"""
+
+from __future__ import annotations
+
+from pollypm.web_api.chat.tmux_capture import (
+    capture_envelopes,
+    extract_ask_user_menu,
+)
+
+# Verbatim live capture (architect_savethenovel @ pollypm-storage-closet:8).
+REAL_PANE = """\
+  - The "plain share-button row" you mean is ShareLinks.astro on the Pledge page — four generic text buttons (Share on X / BlueSky / Facebook / Email) sitting under
+  the beautifully-set book-plate. It works, but it's the one un-editorial thing on an otherwise bespoke page.
+
+  Two decisions here are genuinely yours and they change the whole plan, so I want to lock them before I decompose — not guess and replan later.
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+←  ☐ Imagery medium  ☐ Hero treatment  ✔ Submit  →
+
+What medium should the imagery be? The original brief said 'Unsplash placeholders,' but the build pivoted to a bespoke SVG (book-stack.svg) that matches the palette —
+and the existing IMAGE_NOTES literally warn against stock 'open book on rustic table' clichés.
+
+❯ 1. Bespoke SVG illustration
+     Extend the existing book-stack.svg direction: palette-matched illustrations + textured motifs. No stock clichés, no image pipeline, light for DreamHost shared
+     hosting, fully on-brand. My recommendation — it's the most 'multi-channel delight' while protecting the editorial voice.
+  2. Curated photography
+     The original locked decision — real Unsplash photos (warm window light, book stacks, indie bookstore interiors) as annotated placeholders for S.E. to swap.
+     Warmer and more literal, but carries stock-cliché risk, asset weight, manual optimization, and credit/licensing overhead.
+  3. Mix of both
+     Bespoke SVG for decorative/hero moments where tone matters most; curated photography only where a real place earns it (e.g. a bookstore interior). More surface
+     area to build and maintain two pipelines.
+  4. Type something.
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  5. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+"""
+
+
+def test_extract_real_askuser_menu_options():
+    menu = extract_ask_user_menu(REAL_PANE)
+    assert menu is not None
+    q = menu["questions"][0]
+    labels = [o["label"] for o in q["options"]]
+    # Exactly the three real options — the numbered "Type something." / "Chat
+    # about this" affordances must be excluded.
+    assert labels == [
+        "Bespoke SVG illustration",
+        "Curated photography",
+        "Mix of both",
+    ]
+
+
+def test_extract_real_askuser_headers_and_prompt():
+    menu = extract_ask_user_menu(REAL_PANE)
+    assert menu is not None
+    # Both question tabs parsed from the top tab-bar; Submit dropped.
+    assert menu["headers"] == ["Imagery medium", "Hero treatment"]
+    assert menu["pending_questions"] == ["Hero treatment"]
+    # Wrapped prompt joined into one line.
+    q = menu["questions"][0]
+    assert q["header"] == "Imagery medium"
+    assert q["question"].startswith("What medium should the imagery be?")
+    assert "clichés." in q["question"]
+    assert "\n" not in q["question"]
+
+
+def test_extract_real_askuser_recommended_and_selected():
+    menu = extract_ask_user_menu(REAL_PANE)
+    assert menu is not None
+    opts = menu["questions"][0]["options"]
+    rec = [o for o in opts if o["recommended"]]
+    assert [o["label"] for o in rec] == ["Bespoke SVG illustration"]
+    assert menu["selected_label"] == "Bespoke SVG illustration"
+    # Descriptions captured (multi-line joined).
+    assert "book-stack.svg" in opts[0]["description"]
+
+
+def test_capture_synthesizes_one_ask_user_envelope_and_drops_chrome():
+    class FakeTmux:
+        def capture_pane(self, target, lines=3000):
+            return REAL_PANE
+
+    envs = capture_envelopes(FakeTmux(), session_name="architect_savethenovel", target="x")
+    ask = [e for e in envs if e.type.value == "ask_user"]
+    assert len(ask) == 1
+    md = ask[0].metadata
+    assert [o["label"] for o in md["questions"][0]["options"]] == [
+        "Bespoke SVG illustration",
+        "Curated photography",
+        "Mix of both",
+    ]
+    # The menu chrome must NOT also appear in the text stream …
+    text_blob = " ".join(e.text for e in envs if e.type.value == "text")
+    for chrome in ("Enter to select", "Type something", "Chat about this", "✔ Submit", "❯ 1."):
+        assert chrome not in text_blob, f"chrome leaked: {chrome!r}"
+    # … but the conversation prose above the menu is kept.
+    assert "ShareLinks" in text_blob
+
+
+def test_askuser_negatives_return_none():
+    assert extract_ask_user_menu("") is None
+    assert extract_ask_user_menu("Hello.\nI finished the task.\n> ") is None
+    # Prose that merely QUOTES the menu chrome in backticks is not a live menu.
+    assert extract_ask_user_menu(
+        "The pane shows `Enter to select ... Esc to cancel` and a `✔ Submit` bar."
+    ) is None
+
+
+def test_askuser_glyph_form_still_parses():
+    # An alternate render using a glyph option list (☐) below the tab-bar
+    # should still extract options.
+    pane = """\
+←  ☐ Pick one  ✔ Submit  →
+
+Which colour?
+
+❯ 1. Red
+  2. Blue
+  3. Type something.
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+"""
+    menu = extract_ask_user_menu(pane)
+    assert menu is not None
+    assert [o["label"] for o in menu["questions"][0]["options"]] == ["Red", "Blue"]
+    assert menu["headers"] == ["Pick one"]


### PR DESCRIPTION
## What

Synthesize a structured `ask_user` envelope when the chat capture finds the PM/Sage agent parked on an interactive **AskUserQuestion** TUI form, so the web UI renders answerable options (and `chat_send`'s `answer_to` path can validate a reply) instead of raw terminal chrome.

Fixes the M5 decision-answer blocker (#2476). **Supersedes #2485**, which mis-modeled the menu layout across 4 review rounds (latest reviews: 0 questions synthesized against the live pane).

## The real render (ground truth — what prior attempts got wrong)

```
──────────────────────────────────────────────
←  ☐ Imagery medium  ☐ Hero treatment  ✔ Submit  →     ← Submit in TOP tab-bar
                                                        ← blank
What medium should the imagery be? … matches the palette —
and the existing IMAGE_NOTES … clichés.                 ← prompt WRAPS 2 lines
                                                        ← blank
❯ 1. Bespoke SVG illustration                           ← NUMBERED options
     Extend the existing book-stack.svg … recommendation
  2. Curated photography
  3. Mix of both
  4. Type something.                                    ← NUMBERED affordances
──────────────────────────────────────────────            (must be EXCLUDED)
  5. Chat about this
Enter to select · Tab/Arrow keys to navigate · Esc to cancel   ← footer
```

Three failure modes prior attempts hit, all handled:
1. `✔ Submit` is in the **top tab-bar** with prompt + options *below* it → detection finds the submit line *above* the footer; parsing walks *down* from it.
2. Options sit below a blank line + a **wrapped multi-line prompt** → the prompt run is skipped (and joined) before option parsing.
3. `4. Type something.` / `5. Chat about this` are **numbered** rows → excluded by label.

Detection reuses the proven #2494 gate (footer + `✔ Submit` + only-chrome-after-footer, incl. the backtick guard so prose that *quotes* the chrome isn't a false positive).

## Output contract

`capture_envelopes` now emits ONE `type=ask_user` envelope with `metadata.questions[].options[].label` — the exact §3.5 shape `chat_send._ask_user_options` reads to validate an `answer_to` reply — and drops the menu's own lines from the text stream while keeping the conversation prose.

## Verified live

Against the actually-parked `architect_savethenovel` pane (`pollypm-storage-closet:8`): extracts the **3 real options** (Bespoke SVG illustration / Curated photography / Mix of both — affordances excluded), both tab headers (`Imagery medium`, `Hero treatment`), the joined prompt, the recommended + selected option; zero chrome leaks into the text stream; conversation prose kept. Negatives (empty / plain prose / backtick-quoted-chrome) return None.

New real-pane fixture test `tests/test_chat_tmux_capture_askuser.py` (6 cases). Existing `test_chat_tmux_capture.py` plain-pane tests unaffected (no menu → original path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
