### PR TITLE
Handle cockpit honesty needs-codex gaps

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -332,6 +332,10 @@ paths:
             type: string
             enum: [name, inbox_desc, recent, recent_desc, urgency]
           description: Sort projects by name, inbox count, recency, or urgency.
+        - in: query
+          name: operator
+          schema: { type: boolean, default: false }
+          description: When true, hides synthetic seed/test projects from operator-facing rails.
       responses:
         "200":
           description: All registered projects with derived state.

--- a/src/pollypm/cockpit_sections/dashboard.py
+++ b/src/pollypm/cockpit_sections/dashboard.py
@@ -24,6 +24,7 @@ from pollypm.cockpit_sections.project_dashboard import (
     _DASHBOARD_PROJECT_CACHE,
     _dashboard_project_tasks,
 )
+from pollypm.project_liveness import real_operator_project_items
 
 
 @dataclass(slots=True)
@@ -645,8 +646,12 @@ def _collect_dashboard_buckets(config, now: datetime) -> _DashboardCollection:
     all_tasks: list[tuple[str, object]] = []
     project_scorecards: list[tuple[int, str, str]] = []
     total_counts: dict[str, int] = {}
+    project_items = real_operator_project_items(
+        getattr(config, "projects", {}) or {},
+        default_tracked=False,
+    )
     live_keys: set[str] = set()
-    for project_key, project in config.projects.items():
+    for project_key, project in project_items:
         live_keys.add(project_key)
         partitioned, counts = _dashboard_project_tasks(project_key, project.path)
         project_tasks = [task for bucket in partitioned.values() for task in bucket]
@@ -956,7 +961,12 @@ def _build_dashboard(supervisor, config, config_path: Path | None = None) -> str
             lines.append(f"  ▲ {alert.session_name}: {alert.message[:55]}")
         lines.append("")
 
-    project_count = len(config.projects)
+    project_count = len(
+        real_operator_project_items(
+            getattr(config, "projects", {}) or {},
+            default_tracked=False,
+        )
+    )
     project_word = "project" if project_count == 1 else "projects"
     lines.append(
         f"  {project_count} {project_word}  ·  j/k navigate  ·  S settings"

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2576,19 +2576,22 @@ class PollyCockpitApp(App[None]):
             supervisor = self.router._load_supervisor()
             config = supervisor.config
 
-            # project_count: every configured project (tracked + paused).
-            # The footer is a workspace-wide signal \u2014 filtering to
-            # tracked would hide projects the operator just paused,
-            # contradicting the "Tracked-Filter Asymmetry" memo for the
-            # rail badge.
             projects = getattr(config, "projects", {}) or {}
-            project_count = len(projects)
+            from pollypm.project_liveness import real_operator_project_items
 
-            # agent_count: every configured session row, since "agents"
-            # in the audit copy maps to the session table the supervisor
-            # launches. Live-only counts would jitter as workers restart.
+            operator_projects = real_operator_project_items(
+                projects,
+                default_tracked=False,
+            )
+            operator_project_keys = {str(key) for key, _project in operator_projects}
+            project_count = len(operator_projects)
+
             sessions = getattr(config, "sessions", {}) or {}
-            agent_count = len(sessions)
+            agent_count = 0
+            for session in sessions.values():
+                project_key = getattr(session, "project", None)
+                if project_key is None or str(project_key) in operator_project_keys:
+                    agent_count += 1
 
             # inbox_count: share the rail badge helper, but bypass the
             # state-cache snapshot so the operator-visible footer

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -15,7 +15,10 @@ from pollypm.config import PollyPMConfig, load_config
 from pollypm.idle_placeholders import (
     is_codex_idle_placeholder as _is_codex_idle_placeholder,
 )
-from pollypm.project_liveness import is_real_operator_project
+from pollypm.project_liveness import (
+    is_real_operator_project,
+    real_operator_project_items,
+)
 from pollypm.projects import project_state_db_path
 
 logger = logging.getLogger(__name__)
@@ -291,7 +294,9 @@ def _recent_commits(config: PollyPMConfig, hours: int = 24) -> list[CommitInfo]:
     now = datetime.now(UTC)
     seen: set[str] = set()
 
-    project_items = list(config.projects.items())
+    project_items = list(
+        real_operator_project_items(config.projects, default_tracked=False)
+    )
     if len(project_items) > 1:
         with ThreadPoolExecutor(
             max_workers=min(_COMMIT_LOG_MAX_WORKERS, len(project_items)),
@@ -377,7 +382,10 @@ def _completed_issues(config: PollyPMConfig, hours: int = 72) -> list[CompletedI
         now = datetime.now(UTC)
         cutoff = now - timedelta(hours=hours)
 
-        for key, project in config.projects.items():
+        for key, project in real_operator_project_items(
+            config.projects,
+            default_tracked=False,
+        ):
             completed_dir = project.path / "issues" / "05-completed"
             if not completed_dir.exists():
                 continue
@@ -684,7 +692,9 @@ def _count_inbox_tasks(config: PollyPMConfig) -> int:
     from pollypm.notify_task import is_notify_only_inbox_entry
 
     total = 0
-    for project_key, project in getattr(config, "projects", {}).items():
+    for project_key, project in real_operator_project_items(
+        getattr(config, "projects", {}) or {}
+    ):
         if not getattr(project, "tracked", False):
             continue
         total += sum(
@@ -949,6 +959,10 @@ _TASK_STALE_STATUS_RE = re.compile(
     r"has\s+been\s+at\s+status=(?P<status>[A-Za-z_]+)\b",
     re.IGNORECASE,
 )
+_BOOKKEEPING_COMMIT_RE = re.compile(
+    r"^(?:journal|ledger|chore)(?:\(|:)|^journal\(48h\):",
+    re.IGNORECASE,
+)
 
 
 def _human_project_label(value: str) -> str:
@@ -1020,6 +1034,112 @@ def _recovery_narration_line(recovery_summaries: list[str] | None) -> str | None
     return "While you were away, I handled this: " + " ".join(summaries[:2])
 
 
+def _is_bookkeeping_commit(commit: CommitInfo) -> bool:
+    return _BOOKKEEPING_COMMIT_RE.search(commit.message.strip()) is not None
+
+
+def _briefing_progress_line(commits: list[CommitInfo]) -> str | None:
+    if not commits:
+        return None
+    product_commits = [commit for commit in commits if not _is_bookkeeping_commit(commit)]
+    bookkeeping_count = len(commits) - len(product_commits)
+    counted_commits = product_commits if product_commits else commits
+    projects_touched = len({commit.project for commit in counted_commits})
+    if bookkeeping_count:
+        return (
+            "Progress: "
+            + _plural(len(product_commits), "product commit")
+            + " (+"
+            + _plural(bookkeeping_count, "bookkeeping commit")
+            + ") across "
+            + _plural(projects_touched, "project")
+            + "."
+        )
+    return (
+        "Progress: "
+        + _plural(len(product_commits), "commit")
+        + " across "
+        + _plural(projects_touched, "project")
+        + "."
+    )
+
+
+def _format_idle_age(age_seconds: float) -> str:
+    seconds = max(0, int(age_seconds))
+    days = seconds // 86400
+    hours = seconds // 3600
+    minutes = seconds // 60
+    if days:
+        return f"{days}d"
+    if hours:
+        return f"{hours}h"
+    if minutes >= 15:
+        return f"{minutes}m"
+    return ""
+
+
+def _remaining_inbox_line(
+    *,
+    first_message: InboxPreview | None,
+    inbox_count: int,
+    recent_messages: list[InboxPreview],
+    recent_real_work_projects: frozenset[str] | None,
+) -> str | None:
+    remaining_total = inbox_count - (1 if first_message is not None else 0)
+    if remaining_total <= 0:
+        return None
+    first_task_id = getattr(first_message, "task_id", None) if first_message else None
+    groups: dict[str, tuple[int, float]] = {}
+    for message in recent_messages:
+        if getattr(message, "task_id", None) == first_task_id:
+            continue
+        if not _project_is_live_for_briefing(
+            _briefing_message_project_key(message),
+            recent_real_work_projects,
+        ):
+            continue
+        label = _human_project_label(str(getattr(message, "project", "") or "Other"))
+        count, oldest = groups.get(label, (0, 0.0))
+        groups[label] = (count + 1, max(oldest, float(message.age_seconds or 0.0)))
+    if not groups:
+        return "Remaining: " + _plural(remaining_total, "other inbox item") + "."
+    parts: list[str] = []
+    covered = 0
+    for label, (count, oldest) in sorted(
+        groups.items(),
+        key=lambda item: (-item[1][0], -item[1][1], item[0].lower()),
+    )[:3]:
+        covered += count
+        age = _format_idle_age(oldest)
+        detail = f"{count}, idle {age}" if age else str(count)
+        parts.append(f"{label} ({detail})")
+    missing = max(0, remaining_total - covered)
+    if missing:
+        parts.append(_plural(missing, "other"))
+    return "Remaining: " + ", ".join(parts) + "."
+
+
+def _strain_note(
+    *,
+    account_usages: list[AccountQuotaUsage] | None,
+    recovery_count_24h: int,
+) -> str | None:
+    notes: list[str] = []
+    tight_accounts = [
+        usage for usage in (account_usages or [])
+        if int(getattr(usage, "used_pct", 0) or 0) >= 95
+    ]
+    if tight_accounts:
+        usage = tight_accounts[0]
+        limit = usage.limit_label or "limit"
+        notes.append(f"{usage.provider or usage.account_name} is near its {limit}")
+    if recovery_count_24h >= 50:
+        notes.append(f"{recovery_count_24h} recoveries in 24h")
+    if not notes:
+        return None
+    return "Health note: " + "; ".join(notes) + "."
+
+
 def _build_dashboard_briefing(
     *,
     commits: list[CommitInfo],
@@ -1029,6 +1149,7 @@ def _build_dashboard_briefing(
     recovery_count_24h: int,
     recovery_summaries: list[str] | None = None,
     recent_real_work_projects: frozenset[str] | None = None,
+    account_usages: list[AccountQuotaUsage] | None = None,
 ) -> str:
     """Build the concise Home briefing from already-gathered dashboard facts."""
 
@@ -1039,15 +1160,9 @@ def _build_dashboard_briefing(
             + _plural(len(completed), "item")
             + " wrapped in the last 72 hours."
         )
-    if commits:
-        projects_touched = len({c.project for c in commits})
-        lines.append(
-            "Progress: "
-            + _plural(len(commits), "commit")
-            + " across "
-            + _plural(projects_touched, "project")
-            + "."
-        )
+    progress_line = _briefing_progress_line(commits)
+    if progress_line:
+        lines.append(progress_line)
     recovery_line = _recovery_narration_line(recovery_summaries)
     if recovery_line:
         lines.append(recovery_line)
@@ -1057,6 +1172,12 @@ def _build_dashboard_briefing(
             + _plural(recovery_count_24h, "recovery", "recoveries")
             + " handled without handing you a mess."
         )
+    strain = _strain_note(
+        account_usages=account_usages,
+        recovery_count_24h=recovery_count_24h,
+    )
+    if strain:
+        lines.append(strain)
 
     if inbox_count:
         decision = ""
@@ -1084,6 +1205,14 @@ def _build_dashboard_briefing(
                     + _plural(inbox_count, "inbox item")
                     + " waiting; open Inbox and clear that first."
                 )
+                remaining = _remaining_inbox_line(
+                    first_message=message,
+                    inbox_count=inbox_count,
+                    recent_messages=recent_messages,
+                    recent_real_work_projects=recent_real_work_projects,
+                )
+                if remaining:
+                    lines.append(remaining)
         else:
             prefix = "One thing needs you: " if inbox_count == 1 else "Inbox needs you: "
             lines.append(
@@ -1096,7 +1225,7 @@ def _build_dashboard_briefing(
     else:
         lines.append("All handled: no inbox items waiting.")
 
-    return "\n".join(lines[:6])
+    return "\n".join(lines[:7])
 
 
 def _recent_recovery_audit_events(
@@ -1229,7 +1358,9 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
     seen_task_ids: set[str] = set()
     previews: list[InboxPreview] = []
     sources: list[tuple[str | None, str, Path, Path]] = []
-    for project_key, project in getattr(config, "projects", {}).items():
+    for project_key, project in real_operator_project_items(
+        getattr(config, "projects", {}) or {}
+    ):
         # Same tracked-only invariant as _count_inbox_tasks (cycle 86):
         # a non-tracked project's leftover state would leak stale tasks
         # into the polly-dashboard's "Recent messages" preview.
@@ -1282,6 +1413,96 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
             continue
         for task in inbox_tasks_for_project(pg_grouped, config, project_key):
             _emit_preview(task, project_label, project_key)
+    previews.sort(key=lambda item: item.age_seconds)
+    return previews[:limit]
+
+
+def _recent_pm_chat_messages(
+    config: PollyPMConfig,
+    *,
+    limit: int = 3,
+) -> list[InboxPreview]:
+    """Return latest persona-authored PM chat lines for Home previews."""
+
+    try:
+        from pollypm.web_api.chat import (
+            MessageRole,
+            MessageType,
+            SurfaceType,
+            enumerate_chat_surfaces,
+            parse_events_jsonl_tail,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+
+    projects = getattr(config, "projects", {}) or {}
+    project_items = real_operator_project_items(projects, default_tracked=False)
+    real_keys = {str(key) for key, _project in project_items}
+    project_labels = {
+        str(key): (
+            project.display_label()
+            if hasattr(project, "display_label")
+            else str(getattr(project, "name", None) or key)
+        )
+        for key, project in project_items
+    }
+    try:
+        surfaces = enumerate_chat_surfaces(
+            config,
+            work_service=None,
+            tmux_client=None,
+            include_transcripts=True,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("dashboard_data: PM chat surface enumeration failed", exc_info=True)
+        return []
+
+    previews: list[InboxPreview] = []
+    now = datetime.now(UTC)
+    wanted_types = {SurfaceType.ARCHITECT, SurfaceType.ADVISOR}
+    for surface in surfaces:
+        project_key = str(surface.project or "")
+        if surface.surface_type not in wanted_types or project_key not in real_keys:
+            continue
+        archive = surface.transcript_path
+        if archive is None or not archive.exists():
+            continue
+        try:
+            envelopes = parse_events_jsonl_tail(
+                archive,
+                limit=40,
+                actor_fallback=surface.persona or "agent",
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "dashboard_data: PM chat parse failed for %s",
+                surface.session_name,
+                exc_info=True,
+            )
+            continue
+        for envelope in reversed(envelopes):
+            if envelope.role != MessageRole.ASSISTANT or envelope.type != MessageType.TEXT:
+                continue
+            text = re.sub(r"\s+", " ", envelope.text or "").strip()
+            if not text:
+                continue
+            stamped = _coerce_utc_datetime(envelope.ts)
+            age_seconds = (
+                max(0.0, (now - stamped).total_seconds())
+                if stamped is not None
+                else 0.0
+            )
+            previews.append(
+                InboxPreview(
+                    sender=surface.persona or "PM",
+                    title=text[:80],
+                    project=project_labels.get(project_key, project_key),
+                    task_id=f"{project_key}:pm-chat",
+                    age_seconds=age_seconds,
+                    project_key=project_key,
+                )
+            )
+            break
     previews.sort(key=lambda item: item.age_seconds)
     return previews[:limit]
 
@@ -1508,7 +1729,8 @@ def gather(
         config,
         limit=max(3, inbox_count),
     )
-    recent_messages = recent_message_candidates[:3]
+    recent_pm_messages = _recent_pm_chat_messages(config, limit=3)
+    recent_messages = (recent_pm_messages + recent_message_candidates)[:3]
     sweeps = sum(1 for e in day_events if e.event_type == "heartbeat")
     recovery_events = _recent_recovery_audit_events(config, since=cutoff)
 
@@ -1548,6 +1770,7 @@ def gather(
         recovery_count_24h=recoveries,
         recovery_summaries=recovery_summaries,
         recent_real_work_projects=recent_real_work_projects,
+        account_usages=account_usages,
     )
 
     return DashboardData(

--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -335,7 +335,13 @@ def _classify_projects(ctx: RailContext) -> tuple[list[tuple[str, Any]], list[tu
             cache[project_key] = (db_mtime, git_mtime, is_active, has_working_task)
         return is_active, has_working_task
 
-    for project_key, project in getattr(config, "projects", {}).items():
+    projects = getattr(config, "projects", {}) or {}
+    from pollypm.project_liveness import real_operator_project_items
+
+    for project_key, project in real_operator_project_items(
+        projects,
+        default_tracked=False,
+    ):
         is_active, has_working_task = _project_activity(project_key, project)
         project_has_active_task[project_key] = has_working_task
         if is_active:
@@ -346,7 +352,12 @@ def _classify_projects(ctx: RailContext) -> tuple[list[tuple[str, Any]], list[tu
     # Evict stale cache entries.
     cache = getattr(router, "_project_activity_cache", None)
     if isinstance(cache, dict):
-        live_keys = set(getattr(config, "projects", {}).keys())
+        live_keys = {
+            key for key, _project in real_operator_project_items(
+                projects,
+                default_tracked=False,
+            )
+        }
         for stale_key in list(cache.keys()):
             if stale_key not in live_keys:
                 cache.pop(stale_key, None)

--- a/src/pollypm/project_liveness.py
+++ b/src/pollypm/project_liveness.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, TypeVar
 
 
 _SYNTHETIC_PROJECT_KEYS = frozenset(
     {
         "inbox",
         "myproj",
+        "smoketest",
         "pm_test",
         "queuestorm",
         "test_5_8_x",
@@ -18,6 +19,10 @@ _SYNTHETIC_PROJECT_KEYS = frozenset(
         "pollypm_cycle_ux_scratch",
         "demo_polly",
     }
+)
+_SYNTHETIC_PROJECT_RES = (
+    re.compile(r"(?:^|[-_])wave[-_]\d+$"),
+    re.compile(r"^pr\d+[-_]drift[-_].+"),
 )
 _SYNTHETIC_PROJECT_PREFIXES = (
     "pm_test_",
@@ -32,6 +37,9 @@ _SYNTHETIC_PROJECT_PREFIXES = (
     "testpause-",
 )
 _SYNTHETIC_PATH_PREFIXES = ("/private/tmp/",)
+
+_ProjectKey = TypeVar("_ProjectKey")
+_ProjectValue = TypeVar("_ProjectValue")
 
 
 def _normalized_project_key(value: object) -> str:
@@ -49,6 +57,9 @@ def project_key_looks_synthetic(project_key: object) -> bool:
     for prefix in _SYNTHETIC_PROJECT_PREFIXES:
         if raw.startswith(prefix) or normalized.startswith(_normalized_project_key(prefix)):
             return True
+    for pattern in _SYNTHETIC_PROJECT_RES:
+        if pattern.search(raw) or pattern.search(normalized):
+            return True
     return False
 
 
@@ -57,10 +68,13 @@ def project_path_looks_synthetic(path: object) -> bool:
 
     if not path:
         return False
-    text = str(Path(path) if isinstance(path, str | Path) else path).strip()
+    parsed = Path(path) if isinstance(path, str | Path) else Path(str(path))
+    text = str(parsed).strip()
     if text == "/private/tmp":
         return True
-    return any(text.startswith(prefix) for prefix in _SYNTHETIC_PATH_PREFIXES)
+    if not any(text.startswith(prefix) for prefix in _SYNTHETIC_PATH_PREFIXES):
+        return False
+    return any(project_key_looks_synthetic(part) for part in parsed.parts)
 
 
 def is_real_operator_project(
@@ -71,7 +85,7 @@ def is_real_operator_project(
 ) -> bool:
     """Return True when a project may headline operator-facing live content."""
 
-    if not getattr(project, "tracked", default_tracked):
+    if default_tracked and not getattr(project, "tracked", default_tracked):
         return False
     if project_key_looks_synthetic(project_key):
         return False
@@ -98,9 +112,38 @@ def real_operator_project_keys(
     )
 
 
+def real_operator_project_items(
+    projects: Mapping[_ProjectKey, _ProjectValue],
+    *,
+    default_tracked: bool = True,
+    fallback_to_all: bool = True,
+) -> tuple[tuple[_ProjectKey, _ProjectValue], ...]:
+    """Return tracked, non-synthetic project items for operator-facing UI.
+
+    Test and fixture-heavy workspaces can contain only synthetic keys
+    such as ``myproj``. In that case ``fallback_to_all=True`` keeps
+    the surface usable instead of rendering an empty rail.
+    """
+
+    items = tuple(projects.items())
+    real_items = tuple(
+        (key, project)
+        for key, project in items
+        if is_real_operator_project(
+            key,
+            project,
+            default_tracked=default_tracked,
+        )
+    )
+    if real_items or not fallback_to_all:
+        return real_items
+    return items
+
+
 __all__ = [
     "is_real_operator_project",
     "project_key_looks_synthetic",
     "project_path_looks_synthetic",
+    "real_operator_project_items",
     "real_operator_project_keys",
 ]

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -81,6 +81,8 @@ TAIL_READ_LIMIT_THRESHOLD = 200
 
 SourceMode = Literal["auto", "jsonl", "capture"]
 Direction = Literal["asc", "desc"]
+_PM_CHAT_SURFACE_TYPES = frozenset({SurfaceType.ARCHITECT, SurfaceType.ADVISOR})
+_PM_CHAT_DIALOGUE_TYPES = frozenset({MessageType.TEXT, MessageType.ASK_USER})
 
 
 def _is_worker_session(session_name: str) -> bool:
@@ -716,6 +718,10 @@ def _load_envelopes(
         )
         if _latest_envelope_is_open_ask_user(envelopes):
             return envelopes, "jsonl", archive
+        if _is_pm_chat_surface(surface):
+            return envelopes, "jsonl", archive
+    elif _is_pm_chat_surface(surface):
+        return [], None, None
 
     captured = _capture_for_surface(surface, actor_fallback=actor_fallback)
     if captured:
@@ -739,6 +745,46 @@ def _latest_envelope_is_open_ask_user(envelopes: list[MessageEnvelope]) -> bool:
         if envelope.role == MessageRole.ASSISTANT and envelope.type == MessageType.TEXT:
             return False
     return False
+
+
+def _is_pm_chat_surface(surface: ChatSurface) -> bool:
+    return surface.surface_type in _PM_CHAT_SURFACE_TYPES
+
+
+def _curate_pm_chat_envelopes(envelopes: list[MessageEnvelope]) -> list[MessageEnvelope]:
+    """Keep dialogue envelopes for persona chat surfaces.
+
+    JSONL carries whole text blocks and correct roles; tmux capture
+    does not. The PM chat view is the operator-facing conversation, so
+    tool calls/results and synthetic bookkeeping stay out of that feed.
+    """
+
+    curated: list[MessageEnvelope] = []
+    for envelope in envelopes:
+        if envelope.type not in _PM_CHAT_DIALOGUE_TYPES:
+            continue
+        if envelope.role not in {MessageRole.USER, MessageRole.ASSISTANT}:
+            continue
+        if not str(envelope.text or "").strip():
+            continue
+        curated.append(envelope)
+    return curated
+
+
+def _idle_pm_chat_greeting(surface: ChatSurface) -> MessageEnvelope:
+    persona = surface.persona or "Polly"
+    text = f"{persona} is standing by. Nothing needs you yet."
+    if surface.project:
+        text = f"{persona} is standing by on {surface.project}. Nothing needs you yet."
+    return MessageEnvelope(
+        id=f"idle_{surface.session_name}",
+        ts="",
+        role=MessageRole.ASSISTANT,
+        actor=persona,
+        type=MessageType.TEXT,
+        text=text,
+        metadata={"synthetic": True, "reason": "idle_persona_greeting"},
+    )
 
 
 def _capture_for_surface(
@@ -1230,6 +1276,17 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
         tail_hint=tail_hint,
         include_thinking=include_thinking,
     )
+    if (
+        _is_pm_chat_surface(surface)
+        and source != "capture"
+        and not include_subagents
+        and not include_thinking
+    ):
+        envelopes = _curate_pm_chat_envelopes(envelopes)
+        if not envelopes:
+            envelopes = [_idle_pm_chat_greeting(surface)]
+            if transcript_source is None:
+                transcript_source = "idle_greeting"
 
     post_process: Any = None
     if include_subagents:

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -829,24 +829,7 @@ def _last_assistant_open_tool_ids(
     any *other* open tool still blocks the send (Codex #2043 review
     v4 block 1).
     """
-    # Find the most-recent boundary. ``turn_end`` / ``session_state``
-    # close stale orphaned tool calls left by a prior crashed turn.
-    # Everything after that belongs to the current in-flight response.
-    boundary = -1
-    for idx in range(len(events) - 1, -1, -1):
-        event_type = events[idx].get("event_type")
-        if event_type in (
-            "user_turn",
-            "assistant_turn",
-            "turn_end",
-            "session_state",
-        ):
-            boundary = idx
-            break
-    # When no boundary exists in the tail we still scan: that's the
-    # very-long-tool-output case where the assistant_turn fell out of
-    # the 64 KiB window. Treat the whole tail as the current response.
-    span = events[boundary + 1:] if boundary >= 0 else events
+    span = _current_assistant_response_span(events)
     open_ids: set[str] = set()
     seen_results: set[str] = set()
     for event in span:
@@ -864,6 +847,62 @@ def _last_assistant_open_tool_ids(
     if exempt_tool_ids:
         unmatched -= exempt_tool_ids
     return unmatched
+
+
+def _current_assistant_response_span(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the current in-flight assistant response span from a tail read."""
+
+    # Find the most-recent boundary. ``turn_end`` / ``session_state``
+    # close stale orphaned tool calls left by a prior crashed turn.
+    # Everything after that belongs to the current in-flight response.
+    boundary = -1
+    for idx in range(len(events) - 1, -1, -1):
+        event_type = events[idx].get("event_type")
+        if event_type in (
+            "user_turn",
+            "assistant_turn",
+            "turn_end",
+            "session_state",
+        ):
+            boundary = idx
+            break
+    # When no boundary exists in the tail we still scan: that's the
+    # very-long-tool-output case where the assistant_turn fell out of
+    # the 64 KiB window. Treat the whole tail as the current response.
+    return events[boundary + 1:] if boundary >= 0 else events
+
+
+def _open_ask_user_tool_call_events(
+    events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return unmatched AskUserQuestion tool calls in the current turn."""
+
+    span = _current_assistant_response_span(events)
+    seen_results: set[str] = set()
+    for event in span:
+        if event.get("event_type") != "tool_result":
+            continue
+        payload = event.get("payload") or {}
+        tid = payload.get("tool_use_id")
+        if isinstance(tid, str) and tid:
+            seen_results.add(tid)
+
+    open_events: list[dict[str, Any]] = []
+    for event in span:
+        tool_id = _ask_user_tool_id(event)
+        if tool_id is not None and tool_id not in seen_results:
+            open_events.append(event)
+    return open_events
+
+
+def _ask_user_tool_id(event: dict[str, Any]) -> str | None:
+    if event.get("event_type") != "tool_call":
+        return None
+    payload = event.get("payload") or {}
+    if not isinstance(payload, dict) or payload.get("name") != "AskUserQuestion":
+        return None
+    tool_id = payload.get("id")
+    return tool_id if isinstance(tool_id, str) and tool_id else None
 
 
 def _is_mid_tool(
@@ -1076,7 +1115,15 @@ def _find_ask_user_envelope(
             continue
         if event_id in candidates:
             return event
+    if _is_capture_answer_id(answer_to):
+        open_asks = _open_ask_user_tool_call_events(events)
+        if len(open_asks) == 1:
+            return open_asks[0]
     return None
+
+
+def _is_capture_answer_id(answer_to: str | None) -> bool:
+    return isinstance(answer_to, str) and answer_to.startswith("cap_")
 
 
 def _event_message_id(event: dict[str, Any]) -> str | None:
@@ -1109,11 +1156,20 @@ def _ask_user_options(event: dict[str, Any]) -> list[str] | None:
     Accepts the raw events.jsonl shape too (tool_call payload for
     AskUserQuestion) so the router works pre-normalisation.
     """
+    questions = _ask_user_questions(event)
+    if questions is not None:
+        return _flatten_question_options(questions)
+    return None
+
+
+def _ask_user_questions(event: dict[str, Any]) -> list[Any] | None:
+    """Return AskUserQuestion question metadata from JSONL or capture shapes."""
+
     metadata = event.get("metadata")
     if isinstance(metadata, dict):
         questions = metadata.get("questions")
         if isinstance(questions, list):
-            return _flatten_question_options(questions)
+            return questions
     payload = event.get("payload") or {}
     if isinstance(payload, dict):
         if payload.get("name") == "AskUserQuestion":
@@ -1121,11 +1177,11 @@ def _ask_user_options(event: dict[str, Any]) -> list[str] | None:
             if isinstance(tool_input, dict):
                 questions = tool_input.get("questions")
                 if isinstance(questions, list):
-                    return _flatten_question_options(questions)
+                    return questions
         if payload.get("type") == "ask_user":
             questions = payload.get("questions")
             if isinstance(questions, list):
-                return _flatten_question_options(questions)
+                return questions
     return None
 
 
@@ -1168,6 +1224,56 @@ def _build_answer_text(selections: list[str], notes: str | None) -> str:
         else:
             body = notes
     return body
+
+
+def _build_capture_answer_text(
+    selections: list[str],
+    questions: list[Any],
+    notes: str | None,
+) -> str:
+    """Translate capture-sourced AskUserQuestion labels into TUI keystrokes.
+
+    A captured menu has a ``cap_<digest>`` envelope id, while the real
+    transcript still has the open AskUserQuestion tool_use id. For that
+    TUI path Claude expects option numbers, not option-label prose. The
+    final tab moves focus to the Submit tab; the endpoint's existing
+    ``press_enter`` then activates Submit.
+    """
+
+    if notes or not selections:
+        return _build_answer_text(selections, notes)
+
+    remaining = list(selections)
+    groups: list[str] = []
+    for question in questions:
+        if not isinstance(question, dict):
+            continue
+        raw_options = question.get("options")
+        if not isinstance(raw_options, list):
+            continue
+        labels: list[str] = []
+        for option in raw_options:
+            if isinstance(option, dict):
+                label = option.get("label")
+            else:
+                label = option
+            if isinstance(label, str) and label:
+                labels.append(label)
+        if not labels:
+            continue
+
+        digits: list[str] = []
+        for selected in list(remaining):
+            if selected not in labels:
+                continue
+            digits.append(str(labels.index(selected) + 1))
+            remaining.remove(selected)
+        if digits:
+            groups.append("".join(digits))
+
+    if remaining or not groups:
+        return _build_answer_text(selections, notes)
+    return "\t".join(groups) + "\t"
 
 
 # ---------------------------------------------------------------------------
@@ -1549,7 +1655,14 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
         if body.selections and invalid:
             raise _selections_invalid(invalid, options)
         if body.selections:
-            text_to_send = _build_answer_text(body.selections, body.notes)
+            if _is_capture_answer_id(body.answer_to):
+                text_to_send = _build_capture_answer_text(
+                    body.selections,
+                    _ask_user_questions(ask_envelope) or [],
+                    body.notes,
+                )
+            else:
+                text_to_send = _build_answer_text(body.selections, body.notes)
         elif body.text:
             text_to_send = body.text
         elif body.notes:

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -299,7 +299,7 @@ def _call_dashboard_source_pair(
         threading.Thread(
             target=_run,
             name="dashboard-list-projects",
-            args=("projects", lambda: list_projects(config)),
+            args=("projects", lambda: list_projects(config, operator_facing=True)),
             daemon=True,
         ),
         threading.Thread(

--- a/src/pollypm/web_api/routes/projects.py
+++ b/src/pollypm/web_api/routes/projects.py
@@ -77,8 +77,21 @@ def list_projects_endpoint(
         Literal["name", "inbox_desc", "recent", "recent_desc", "urgency"] | None,
         Query(description="Sort projects by name, inbox count, recency, or urgency."),
     ] = None,
+    operator: Annotated[
+        bool,
+        Query(
+            description=(
+                "When true, hides synthetic seed/test projects from "
+                "operator-facing cockpit rails."
+            ),
+        ),
+    ] = False,
 ) -> ProjectListResponse:
-    items = list_projects(config, tracked_only=bool(tracked))
+    items = list_projects(
+        config,
+        tracked_only=bool(tracked),
+        operator_facing=operator,
+    )
     needle = (q or search or "").strip().lower()
     if needle:
         items = [

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -303,7 +303,12 @@ def list_active_worker_sessions(
 # ---------------------------------------------------------------------------
 
 
-def list_projects(config: PollyPMConfig, *, tracked_only: bool = False) -> list[APIProject]:
+def list_projects(
+    config: PollyPMConfig,
+    *,
+    tracked_only: bool = False,
+    operator_facing: bool = False,
+) -> list[APIProject]:
     """Return every registered project as an :class:`APIProject`.
 
     Counts and flags are computed against the work-service so the
@@ -315,7 +320,15 @@ def list_projects(config: PollyPMConfig, *, tracked_only: bool = False) -> list[
     out: list[APIProject] = []
     snapshots = _project_task_snapshots(config)
     inbox_counts = _project_inbox_counts(config) if snapshots is not None else None
-    for key, project in config.projects.items():
+    project_items = tuple(config.projects.items())
+    if operator_facing:
+        from pollypm.project_liveness import real_operator_project_items
+
+        project_items = real_operator_project_items(
+            config.projects,
+            default_tracked=False,
+        )
+    for key, project in project_items:
         if tracked_only and not project.tracked:
             continue
         if snapshots is not None:

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -59,6 +59,7 @@
     selectedProject: null,
     projectFilter: "",
     projectSort: "urgency",
+    showTestProjects: false,
     surfaces: [],
     taskSurfaces: [],
     surfaceLoadError: null,
@@ -421,6 +422,9 @@
 
   function projectListPath() {
     const params = new URLSearchParams();
+    if (!state.showTestProjects) {
+      params.set("operator", "true");
+    }
     if (state.projectFilter.trim()) {
       params.set("q", state.projectFilter.trim());
     }
@@ -762,6 +766,14 @@
     return parts.join(" · ") || "no open work";
   }
 
+  function projectAttentionCount(project) {
+    const blocked = countFor(project, "blocked") + countFor(project, "on_hold");
+    const review = countFor(project, "review");
+    const inbox = Number(project.open_inbox_count) || 0;
+    const plan = project.pending_plan_review ? 1 : 0;
+    return blocked + review + inbox + plan;
+  }
+
   function formatShortTime(value) {
     const parsed = Date.parse(value);
     if (!Number.isFinite(parsed)) return String(value || "");
@@ -848,6 +860,30 @@
       }));
       return;
     }
+    const attentionProjects = sortProjects(
+      state.projects.filter((project) => projectAttentionCount(project) > 0),
+    );
+    const attentionTotal = attentionProjects.reduce(
+      (sum, project) => sum + projectAttentionCount(project),
+      0,
+    );
+    const triageText = attentionTotal > 0
+      ? attentionTotal + " " + plural(attentionTotal, "item")
+        + (attentionTotal === 1 ? " needs you - " : " need you - ")
+        + attentionProjects.slice(0, 3).map((project) => (
+          project.name || project.key
+        )).join(", ")
+      : "All handled - nothing needs you";
+    const triage = el("li", {
+      class: "project-triage " + (attentionTotal > 0 ? "attention" : "clear"),
+    }, [
+      el("span", { class: "project-name", text: triageText }),
+    ]);
+    if (attentionProjects[0]) {
+      triage.addEventListener("click", () => selectProject(attentionProjects[0].key));
+    }
+    list.appendChild(triage);
+
     const filter = state.projectFilter.trim().toLowerCase();
     const projects = sortProjects(
       filter
@@ -1170,7 +1206,11 @@
     const planReviews = numeric(rollups.pending_plan_reviews);
     const inbox = numeric(rollups.open_inbox_count);
     const alerts = numeric(rollups.alert_count);
-    const total = planReviews + inbox + alerts;
+    const total = planReviews + inbox;
+    const alertNote = alerts > 0
+      ? " " + alerts + " " + plural(alerts, "background alert")
+        + " being watched."
+      : "";
     if (total === 0) {
       const sweeps = numeric(rollups.sweep_count_24h);
       const recoveries = numeric(rollups.recovery_count_24h);
@@ -1178,7 +1218,8 @@
         ? "24h: " + sweeps + " "
           + plural(sweeps, "sweep") + " / " + recoveries + " "
           + plural(recoveries, "recovery", "recoveries") + "."
-        : "No inbox items, plan reviews, or alerts waiting.";
+          + alertNote
+        : "No inbox items or plan reviews waiting." + alertNote;
       return {
         title: "All handled - Polly's got it",
         detail: proof,
@@ -1191,7 +1232,7 @@
         title: total + " " + plural(total, "thing") + " "
           + (total === 1 ? "needs" : "need") + " you",
         detail: planReviews + " "
-          + plural(planReviews, "plan review") + " waiting.",
+          + plural(planReviews, "plan review") + " waiting." + alertNote,
         actionLabel: "Open plan reviews",
         target: "plan-review",
       };
@@ -1201,18 +1242,11 @@
         title: total + " " + plural(total, "thing") + " "
           + (total === 1 ? "needs" : "need") + " you",
         detail: inbox + " "
-          + plural(inbox, "inbox item") + " waiting.",
+          + plural(inbox, "inbox item") + " waiting." + alertNote,
         actionLabel: "Open inbox",
         target: "inbox",
       };
     }
-    return {
-      title: total + " " + plural(total, "thing") + " "
-        + (total === 1 ? "needs" : "need") + " you",
-      detail: alerts + " " + plural(alerts, "alert") + " waiting.",
-      actionLabel: "Open alerts",
-      target: "alerts",
-    };
   }
 
   function runDashboardStatusAction(status) {
@@ -3255,19 +3289,19 @@
     }
     if (typeof rollups.alert_count === "number") {
       cards.push(buildCard(
-        "alerts",
+        "watching",
         rollups.alert_count,
-        rollups.alert_count > 0 ? "rollup-blocked" : "",
+        rollups.alert_count > 0 ? "rollup-working" : "",
         // alert_count is intentionally global per DashboardRollups
         // docstring — never appears in scoped_fields, so no tag.
         false,
         dashboardCardAction({
-          label: "alerts",
+          label: "watching",
           value: rollups.alert_count,
           target: "alerts",
-          detail: "Opens the current alert list.",
+          detail: "Opens background alerts and recovery notes.",
         }, data),
-        "Open alerts",
+        "Open background alerts",
       ));
     }
 
@@ -3797,6 +3831,15 @@
         state.projectSort = sort.value || "urgency";
         renderProjects();
         loadSurfaces();
+      });
+    }
+    const showTests = $("project-show-tests");
+    if (showTests) {
+      showTests.checked = state.showTestProjects;
+      showTests.addEventListener("change", () => {
+        state.showTestProjects = Boolean(showTests.checked);
+        loadSurfaces();
+        pollDashboard();
       });
     }
   }

--- a/src/pollypm/web_api/ui/index.html
+++ b/src/pollypm/web_api/ui/index.html
@@ -41,6 +41,10 @@
         <option value="name">Name</option>
         <option value="inbox_desc">Inbox</option>
       </select>
+      <label class="rail-toggle" title="Show seed and harness projects">
+        <input id="project-show-tests" type="checkbox" />
+        <span>Tests</span>
+      </label>
     </div>
     <ul id="project-list" class="project-list">
       <li class="project-empty">loading…</li>

--- a/src/pollypm/web_api/ui/styles.css
+++ b/src/pollypm/web_api/ui/styles.css
@@ -144,6 +144,24 @@ aside#dashboard-rail {
   gap: 6px;
   padding: 0 12px 8px;
 }
+.rail-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  min-height: 31px;
+  padding: 0 8px;
+  border: 1px solid var(--border-line);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+}
+.rail-toggle input {
+  margin: 0;
+}
 
 .surface-filter-wrap {
   display: flex;
@@ -205,6 +223,18 @@ aside#dashboard-rail {
   color: var(--text-muted);
   cursor: default;
   font-style: italic;
+}
+.project-list li.project-triage {
+  background: transparent;
+  border-color: var(--border-line);
+  cursor: default;
+}
+.project-list li.project-triage.attention {
+  border-color: var(--waiting);
+  cursor: pointer;
+}
+.project-list li.project-triage.clear .project-name {
+  color: var(--text-muted);
 }
 .project-name {
   color: var(--text-heading);

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -798,6 +798,66 @@ def test_messages_endpoint_empty_when_no_transcript_yet(
     assert "transcript_path" not in body
 
 
+def test_pm_messages_auto_prefers_stale_jsonl_and_filters_tool_plumbing(
+    client, auth_headers, patch_registry, patch_parser, monkeypatch, tmp_path,
+):
+    archive = tmp_path / "events.jsonl"
+    archive.write_text("placeholder")
+    patch_registry([_surface(
+        "architect_myproj", SurfaceType.ARCHITECT,
+        persona="Sage", project="myproj", transcript_path=archive,
+        present=True,
+    )])
+    patch_parser({archive: [
+        _env("assistant", role=MessageRole.ASSISTANT, actor="Sage",
+             type_=MessageType.TEXT, text="The pitch draft is ready."),
+        _env("tool", role=MessageRole.TOOL, actor="tool",
+             type_=MessageType.TOOL_RESULT, text="Bash(cd /tmp && cat x)"),
+        _env("user", role=MessageRole.USER, actor="user",
+             type_=MessageType.TEXT, text="Ship it."),
+    ]})
+    monkeypatch.setattr(chat_messages_routes, "is_archive_stale", lambda *_a, **_kw: True)
+
+    body = client.get(
+        "/api/v1/chat/architect_myproj/messages?direction=asc",
+        headers=auth_headers,
+    ).json()
+
+    assert body["transcript_source"] == "jsonl"
+    assert [(m["role"], m["type"], m["text"]) for m in body["messages"]] == [
+        ("assistant", "text", "The pitch draft is ready."),
+        ("user", "text", "Ship it."),
+    ]
+    assert "Bash(" not in str(body["messages"])
+
+
+def test_pm_messages_idle_surface_returns_persona_greeting_not_tui_capture(
+    client, auth_headers, patch_registry, monkeypatch,
+):
+    patch_registry([_surface(
+        "architect_myproj", SurfaceType.ARCHITECT,
+        persona="Sage", project="myproj", transcript_path=None,
+        present=True,
+    )])
+
+    def _capture_should_not_run(*_args, **_kwargs):
+        raise AssertionError("PM auto history must not scrape tmux capture")
+
+    monkeypatch.setattr(chat_messages_routes, "capture_envelopes", _capture_should_not_run)
+    body = client.get(
+        "/api/v1/chat/architect_myproj/messages",
+        headers=auth_headers,
+    ).json()
+
+    assert body["transcript_source"] == "idle_greeting"
+    assert len(body["messages"]) == 1
+    message = body["messages"][0]
+    assert message["actor"] == "Sage"
+    assert message["role"] == "assistant"
+    assert "standing by on myproj" in message["text"]
+    assert "Try how do I log an error" not in message["text"]
+
+
 # ---------------------------------------------------------------------------
 # Pagination + filtering
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -1717,6 +1717,74 @@ def test_answer_to_msg_envelope_id_resolves(
     assert response.status_code == 200, response.json()
 
 
+def test_answer_to_capture_id_exempts_current_open_ask_user_tool(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """M5/#2501 — capture ids are not the JSONL AskUserQuestion tool id.
+
+    The GET messages capture fallback synthesizes ``cap_<digest>`` ids
+    for a live TUI menu. The strict mid-tool gate must exempt the real
+    open AskUserQuestion ``tool_use_id`` in events.jsonl, not the
+    synthetic capture id, or every answer returns ``unsafe_mid_tool``.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-capture-ask", [
+        {"event_type": "user_turn", "payload": {"text": "pick"}},
+        _ask_user_event(message_id="toolu_ask", options=["alpha", "bravo"]),
+    ], cwd=workspace_root)
+
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "cap_deadbeef", "selections": ["bravo"]},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.json()
+    assert patched_tmux.send_calls == [
+        ("pollypm-test-storage-closet:pm-operator", "2\t", True),
+    ]
+
+
+def test_answer_to_capture_id_still_blocks_unrelated_open_tool(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-capture-mixed", [
+        {"event_type": "user_turn", "payload": {"text": "pick"}},
+        _ask_user_event(message_id="toolu_ask", options=["alpha"]),
+        {
+            "event_type": "tool_call",
+            "payload": {
+                "type": "tool_use",
+                "id": "toolu_bash_open",
+                "name": "Bash",
+                "input": {"command": "sleep 5"},
+            },
+        },
+    ], cwd=workspace_root)
+
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "cap_deadbeef", "selections": ["alpha"]},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 409, response.json()
+    assert response.json()["error"]["code"] == "unsafe_mid_tool"
+
+
 # ---------------------------------------------------------------------------
 # Codex #2043 review v4 — narrow tmux validation errors
 # ---------------------------------------------------------------------------
@@ -1979,6 +2047,24 @@ def test_build_answer_text_with_notes() -> None:
 
 def test_build_answer_text_notes_only() -> None:
     assert chat_send_routes._build_answer_text([], "just notes") == "just notes"
+
+
+def test_build_capture_answer_text_maps_labels_to_numbers_and_submit() -> None:
+    questions = [
+        {
+            "question": "Q1",
+            "options": [{"label": "alpha"}, {"label": "bravo"}],
+        },
+        {
+            "question": "Q2",
+            "options": [{"label": "plain"}, {"label": "bold"}],
+        },
+    ]
+
+    assert (
+        chat_send_routes._build_capture_answer_text(["bravo", "bold"], questions, None)
+        == "2\t2\t"
+    )
 
 
 def test_read_events_tail_handles_truncated_first_line(tmp_path: Path) -> None:

--- a/tests/test_cockpit_footer_status_wiring.py
+++ b/tests/test_cockpit_footer_status_wiring.py
@@ -23,6 +23,7 @@ can stub the router / hint widget without spinning up Textual.
 from __future__ import annotations
 
 import re
+from types import SimpleNamespace
 
 from pollypm.cockpit_ui import FooterStateSnapshot, PollyCockpitApp
 
@@ -312,6 +313,48 @@ def test_resolve_footer_state_returns_snapshot_with_expected_counts(
     assert snapshot.inbox_count == 11
     # Stub store reports no heartbeat → no alert chunk.
     assert snapshot.alert is None
+
+
+def test_resolve_footer_state_filters_synthetic_projects_and_agents(
+    monkeypatch,
+) -> None:
+    real_project = SimpleNamespace(
+        tracked=True,
+        path="/Users/sam/dev/savethenovel",
+    )
+    synthetic_project = SimpleNamespace(
+        tracked=True,
+        path="/Users/sam/dev/pm-test-01wave-1779715196",
+    )
+    paused_project = SimpleNamespace(
+        tracked=False,
+        path="/Users/sam/dev/real-paused",
+    )
+    projects = {
+        "savethenovel": real_project,
+        "real-paused": paused_project,
+        "pm-test-01wave-1779715196": synthetic_project,
+    }
+    sessions = {
+        "architect_savethenovel": SimpleNamespace(project="savethenovel"),
+        "architect_paused": SimpleNamespace(project="real-paused"),
+        "architect_pm_test": SimpleNamespace(project="pm-test-01wave-1779715196"),
+        "operator": SimpleNamespace(project=None),
+    }
+    app, _hint = _build_app(
+        projects=projects,
+        sessions=sessions,
+        inbox_count=0,
+        hint_width=120,
+        monkeypatch=monkeypatch,
+        seed_footer_state=False,
+    )
+
+    snapshot = app._resolve_footer_state()
+
+    assert isinstance(snapshot, FooterStateSnapshot)
+    assert snapshot.project_count == 2
+    assert snapshot.agent_count == 3
 
 
 def test_resolve_footer_state_bypasses_state_cache(monkeypatch) -> None:

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -417,6 +417,57 @@ def test_build_items_keeps_projects_section_when_empty(
     assert keys.index("inbox") < keys.index("projects_root") < keys.index("settings")
 
 
+def test_project_rows_hide_seed_harness_projects_when_real_projects_exist(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    real = KnownProject(
+        key="savethenovel",
+        path=tmp_path / "savethenovel",
+        name="Save the Novel",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+    synthetic = KnownProject(
+        key="pm-test-01wave-1779715196",
+        path=tmp_path / "pm-test-01wave-1779715196",
+        name="PM Test 01",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+    real.path.mkdir()
+    synthetic.path.mkdir()
+    config = _FakeConfig(
+        tmp_path,
+        projects={
+            "savethenovel": real,
+            "pm-test-01wave-1779715196": synthetic,
+        },
+    )
+
+    class _Router:
+        _project_activity_cache: dict = {}
+
+        def _session_state(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            return "idle"
+
+    monkeypatch.setattr(
+        "pollypm.work.task_state.project_activity",
+        lambda **_kwargs: (True, False),
+    )
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "active_task_numbers",
+        lambda project, *, config=None: [],
+    )
+    ctx = RailContext(router=_Router(), config=config, launches=[])
+
+    rows = core_rail_items_plugin._project_rows(ctx)
+    keys = [row.key for row in rows]
+
+    assert "project:savethenovel" in keys
+    assert "project:pm-test-01wave-1779715196" not in keys
+
+
 def test_russell_rail_entry_hidden_when_reviewer_session_unconfigured(
     monkeypatch, tmp_path: Path,
 ) -> None:

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -763,6 +763,167 @@ def test_briefing_pluralizes_counts_correctly() -> None:
     assert "(ies)" not in out2
 
 
+def test_briefing_splits_bookkeeping_commits_from_product_progress() -> None:
+    from pollypm.dashboard_data import _build_dashboard_briefing, CommitInfo
+
+    out = _build_dashboard_briefing(
+        commits=[
+            CommitInfo("h1", "journal(48h): cycle 42", "a", 0.0, "pollypm"),
+            CommitInfo("h2", "ledger: sync loop", "a", 0.0, "pollypm"),
+            CommitInfo("h3", "fix(chat): clean PM transcript", "a", 0.0, "savethenovel"),
+        ],
+        completed=[],
+        inbox_count=0,
+        recent_messages=[],
+        recovery_count_24h=0,
+    )
+
+    assert "Progress: 1 product commit (+2 bookkeeping commits) across 1 project." in out
+    assert "3 commits across" not in out
+
+
+def test_briefing_decomposes_remaining_inbox_projects() -> None:
+    from pollypm.dashboard_data import _build_dashboard_briefing, InboxPreview
+
+    out = _build_dashboard_briefing(
+        commits=[],
+        completed=[],
+        inbox_count=5,
+        recent_messages=[
+            InboxPreview(
+                sender="polly",
+                title="Project savethenovel has 1 queued task but no claim / execution.",
+                project="Save the Novel",
+                task_id="savethenovel/1",
+                age_seconds=3600,
+                project_key="savethenovel",
+            ),
+            InboxPreview(
+                sender="polly",
+                title="Russell needs a decision",
+                project="russell",
+                task_id="russell/2",
+                age_seconds=22 * 3600,
+                project_key="russell",
+            ),
+            InboxPreview(
+                sender="polly",
+                title="Russell still needs a decision",
+                project="russell",
+                task_id="russell/3",
+                age_seconds=20 * 3600,
+                project_key="russell",
+            ),
+            InboxPreview(
+                sender="polly",
+                title="Russell follow-up",
+                project="russell",
+                task_id="russell/4",
+                age_seconds=18 * 3600,
+                project_key="russell",
+            ),
+            InboxPreview(
+                sender="polly",
+                title="Itsalive deploy check",
+                project="itsalive",
+                task_id="itsalive/5",
+                age_seconds=3600,
+                project_key="itsalive",
+            ),
+        ],
+        recovery_count_24h=0,
+    )
+
+    assert "First up: Save the Novel has queued work without an active claim." in out
+    assert "Remaining: russell (3, idle 22h), itsalive (1, idle 1h)." in out
+
+
+def test_briefing_flags_capacity_and_recovery_strain() -> None:
+    from pollypm.dashboard_data import (
+        _build_dashboard_briefing,
+        AccountQuotaUsage,
+    )
+
+    out = _build_dashboard_briefing(
+        commits=[],
+        completed=[],
+        inbox_count=0,
+        recent_messages=[],
+        recovery_count_24h=76,
+        account_usages=[
+            AccountQuotaUsage(
+                account_name="claude_main",
+                provider="Anthropic",
+                email="sam@example.com",
+                used_pct=96,
+                summary="4% left",
+                severity="critical",
+                limit_label="weekly limit",
+            )
+        ],
+    )
+
+    assert "Health note: Anthropic is near its weekly limit; 76 recoveries in 24h." in out
+
+
+def test_recent_pm_chat_messages_surface_persona_jsonl_line(
+    monkeypatch, tmp_path,
+) -> None:
+    from pollypm.dashboard_data import _recent_pm_chat_messages
+    from pollypm.web_api.chat import MessageEnvelope, MessageRole, MessageType, SurfaceType
+
+    archive = tmp_path / "events.jsonl"
+    archive.write_text("placeholder")
+    project = SimpleNamespace(
+        tracked=True,
+        path="/Users/sam/dev/savethenovel",
+        display_label=lambda: "Save the Novel",
+    )
+    config = SimpleNamespace(projects={"savethenovel": project})
+    surface = SimpleNamespace(
+        surface_type=SurfaceType.ARCHITECT,
+        project="savethenovel",
+        transcript_path=archive,
+        persona="Sage",
+        session_name="architect_savethenovel",
+    )
+    monkeypatch.setattr(
+        "pollypm.web_api.chat.enumerate_chat_surfaces",
+        lambda *_args, **_kwargs: [surface],
+    )
+    monkeypatch.setattr(
+        "pollypm.web_api.chat.parse_events_jsonl_tail",
+        lambda *_args, **_kwargs: [
+            MessageEnvelope(
+                id="tool",
+                ts="2026-05-30T10:00:00Z",
+                role=MessageRole.TOOL,
+                actor="tool",
+                type=MessageType.TOOL_RESULT,
+                text="Bash(cd /tmp && cat x)",
+            ),
+            MessageEnvelope(
+                id="sage",
+                ts="2026-05-30T10:01:00Z",
+                role=MessageRole.ASSISTANT,
+                actor="Sage",
+                type=MessageType.TEXT,
+                text="I have the next outline ready for your review.",
+            ),
+        ],
+    )
+
+    rows = _recent_pm_chat_messages(config)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.sender == "Sage"
+    assert row.project == "Save the Novel"
+    assert row.task_id == "savethenovel:pm-chat"
+    assert row.title == "I have the next outline ready for your review."
+    assert "Bash(" not in row.title
+
+
 def test_briefing_all_handled_when_no_activity() -> None:
     from pollypm.dashboard_data import _build_dashboard_briefing
 

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -369,7 +369,8 @@ def test_dashboard_loads_projects_and_gather_concurrently(
     project_started = threading.Event()
     gather_started = threading.Event()
 
-    def fake_list_projects(_config):
+    def fake_list_projects(_config, *, operator_facing: bool = False):
+        assert operator_facing is True
         project_started.set()
         assert gather_started.wait(1.0)
         return [_api_project("myproj")]
@@ -413,7 +414,8 @@ def test_dashboard_cache_hit_skips_repeated_expensive_loads(
 ) -> None:
     calls = {"list": 0, "gather": 0}
 
-    def fake_list_projects(_config):
+    def fake_list_projects(_config, *, operator_facing: bool = False):
+        assert operator_facing is True
         calls["list"] += 1
         return [_api_project("myproj")]
 
@@ -443,7 +445,8 @@ def test_dashboard_stale_cache_returns_while_refresh_runs(
     refresh_started = threading.Event()
     release_refresh = threading.Event()
 
-    def fake_list_projects(_config):
+    def fake_list_projects(_config, *, operator_facing: bool = False):
+        assert operator_facing is True
         return [_api_project("myproj")]
 
     def fake_gather(_config):

--- a/tests/test_project_liveness.py
+++ b/tests/test_project_liveness.py
@@ -7,6 +7,7 @@ from pollypm.project_liveness import (
     is_real_operator_project,
     project_key_looks_synthetic,
     project_path_looks_synthetic,
+    real_operator_project_items,
     real_operator_project_keys,
 )
 
@@ -14,8 +15,11 @@ from pollypm.project_liveness import (
 def test_project_key_looks_synthetic_for_known_test_patterns() -> None:
     assert project_key_looks_synthetic("pm_test_01wave_1779715196")
     assert project_key_looks_synthetic("pm test 01wave 1779715196")
+    assert project_key_looks_synthetic("load-wave-1779715196")
+    assert project_key_looks_synthetic("pr2498-drift-17797201")
     assert project_key_looks_synthetic("queuestorm_1779777233")
     assert project_key_looks_synthetic("myproj")
+    assert project_key_looks_synthetic("smoketest")
     assert project_key_looks_synthetic("inbox")
 
 
@@ -33,13 +37,18 @@ def test_is_real_operator_project_requires_tracked_non_synthetic_project() -> No
         "savethenovel",
         SimpleNamespace(tracked=False, path="/Users/sam/dev/savethenovel"),
     )
+    assert is_real_operator_project(
+        "savethenovel",
+        SimpleNamespace(tracked=False, path="/Users/sam/dev/savethenovel"),
+        default_tracked=False,
+    )
     assert not is_real_operator_project(
         "pm_test_01wave_1779715196",
         SimpleNamespace(tracked=True, path="/Users/sam/dev/pm_test_01wave_1779715196"),
     )
     assert not is_real_operator_project(
         "scratch",
-        SimpleNamespace(tracked=True, path="/private/tmp/scratch"),
+        SimpleNamespace(tracked=True, path="/private/tmp/pm_test_01wave_1779715196"),
     )
 
 
@@ -60,3 +69,19 @@ def test_real_operator_project_keys_filters_config_map() -> None:
     }
 
     assert real_operator_project_keys(projects) == frozenset({"savethenovel"})
+
+
+def test_real_operator_project_items_falls_back_when_only_synthetic() -> None:
+    projects = {
+        "myproj": SimpleNamespace(tracked=True, path="/Users/sam/dev/myproj"),
+        "pm_test_01wave_1779715196": SimpleNamespace(
+            tracked=True,
+            path="/Users/sam/dev/pm_test_01wave_1779715196",
+        ),
+    }
+
+    assert [key for key, _project in real_operator_project_items(projects)] == [
+        "myproj",
+        "pm_test_01wave_1779715196",
+    ]
+    assert real_operator_project_items(projects, fallback_to_all=False) == ()

--- a/tests/web_api/test_endpoints.py
+++ b/tests/web_api/test_endpoints.py
@@ -86,6 +86,49 @@ def test_list_projects_tracked_filter(api_config, client, auth_headers) -> None:
     assert keys == ["myproj"]
 
 
+def test_list_projects_operator_filter_hides_seed_harness_projects(
+    api_config, client, auth_headers, project_root
+) -> None:
+    from pollypm.models import KnownProject, ProjectKind
+
+    real_root = project_root.parent / "savethenovel"
+    seed_root = project_root.parent / "pm-test-01wave-1779715196"
+    paused_root = project_root.parent / "real-paused"
+    real_root.mkdir()
+    seed_root.mkdir()
+    paused_root.mkdir()
+    (real_root / ".pollypm").mkdir()
+    (seed_root / ".pollypm").mkdir()
+    (paused_root / ".pollypm").mkdir()
+    api_config.projects["savethenovel"] = KnownProject(
+        key="savethenovel",
+        path=real_root,
+        name="Save the Novel",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+    api_config.projects["real-paused"] = KnownProject(
+        key="real-paused",
+        path=paused_root,
+        name="Real Paused",
+        tracked=False,
+        kind=ProjectKind.GIT,
+    )
+    api_config.projects["pm-test-01wave-1779715196"] = KnownProject(
+        key="pm-test-01wave-1779715196",
+        path=seed_root,
+        name="PM Test",
+        tracked=True,
+        kind=ProjectKind.GIT,
+    )
+
+    response = client.get("/api/v1/projects?operator=true", headers=auth_headers)
+
+    assert response.status_code == 200
+    keys = [item["key"] for item in response.json()["items"]]
+    assert keys == ["savethenovel", "real-paused"]
+
+
 def test_project_metrics_normalize_last_activity_at(api_config) -> None:
     from pollypm.web_api import service as api_service
 

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1174,7 +1174,7 @@ def test_ui_app_js_has_alerts_panel_hooks(client: TestClient) -> None:
         "/doctor/run",
         "session-drift",
         "Run session drift",
-        "Open alerts",
+        "Open background alerts",
     ):
         assert expected in body
 
@@ -1849,7 +1849,7 @@ def test_render_dashboard_real_payload_executes() -> None:
     Asserts the rendered DOM contains:
     - the inbox count + label
     - the plan-reviews count + label
-    - the alert count + ``alerts`` label
+    - the alert count + ``watching`` label
     - the daemon ``up`` status + label
     - the activity sweeps/msgs label
     - the active-sessions count
@@ -1904,7 +1904,7 @@ def test_render_dashboard_real_payload_executes() -> None:
         "Claude headroom",
         "inbox",
         "plan reviews",
-        "alerts",
+        "watching",
         "activity (24h)",
         "daemon",
         "active sessions",
@@ -1926,16 +1926,16 @@ def test_render_dashboard_real_payload_executes() -> None:
     assert ">5<" in rendered, "tracked_count value 5 missing"
     assert "58% left this week" in rendered, "quota summary missing"
     assert "1234 today / 5678 total tokens" in rendered, "token line missing"
-    assert "12 things need you" in rendered, "lead headline missing"
+    assert "9 things need you" in rendered, "lead headline missing"
+    assert "3 background alerts being watched" in rendered
     assert 'role="button"' in rendered
     assert 'title="Open inbox"' in rendered
-    assert 'title="Open alerts"' in rendered
+    assert 'title="Open background alerts"' in rendered
 
-    # Color-coding contract: daemon=up → rollup-working; alert_count>0
-    # → rollup-blocked. Pin these too so a future restyle that drops
+    # Color-coding contract: daemon=up and alert_count>0 both use
+    # the working/watching treatment. Pin this so a future restyle that drops
     # the class hooks fails loudly.
     assert "rollup-working" in rendered
-    assert "rollup-blocked" in rendered
 
 
 def test_render_dashboard_daemon_down_uses_blocked_class() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Fixes PM/Sage chat reads for architect/advisor surfaces to prefer structured JSONL, filter tool plumbing from the default PM chat view, and show a persona idle greeting instead of stale TUI capture.
- Filters synthetic seed/harness projects out of operator-facing cockpit, dashboard, rail, footer, and web project surfaces while preserving real paused projects.
- Makes Home/Dashboard status copy more honest: background alerts no longer inflate “needs you,” progress splits product vs bookkeeping commits, remaining inbox work is decomposed, and capacity/recovery strain is called out.
- Fixes capture-sourced AskUserQuestion answers: `cap_…` answer ids now resolve to the current open AskUserQuestion tool call for the strict mid-tool exemption, and capture-sourced selections are sent as option numbers with a final Tab-to-Submit sequence.

## Issues
- Closes #2497
- Closes #2498
- Closes #2499
- Closes #2501

## Tests
- `uv run --extra test pytest --noconftest tests/test_chat_send_endpoint.py tests/test_project_liveness.py tests/test_chat_messages_endpoint.py -q`
- `uv run --extra test pytest tests/test_project_liveness.py tests/test_chat_messages_endpoint.py::test_pm_messages_auto_prefers_stale_jsonl_and_filters_tool_plumbing tests/test_chat_messages_endpoint.py::test_pm_messages_idle_surface_returns_persona_greeting_not_tui_capture tests/web_api/test_endpoints.py::test_list_projects_operator_filter_hides_seed_harness_projects tests/test_core_rail_items.py::test_project_rows_hide_seed_harness_projects_when_real_projects_exist tests/test_cockpit_footer_status_wiring.py::test_resolve_footer_state_filters_synthetic_projects_and_agents tests/test_dashboard_data_alert_dedup.py::test_briefing_splits_bookkeeping_commits_from_product_progress tests/test_dashboard_data_alert_dedup.py::test_briefing_decomposes_remaining_inbox_projects tests/test_dashboard_data_alert_dedup.py::test_briefing_flags_capacity_and_recovery_strain tests/test_dashboard_data_alert_dedup.py::test_recent_pm_chat_messages_surface_persona_jsonl_line tests/web_api/test_web_ui.py::test_render_dashboard_real_payload_executes -q`
- `uv run --extra dev ruff check src/pollypm/web_api/routes/chat_send.py tests/test_chat_send_endpoint.py src/pollypm/project_liveness.py src/pollypm/web_api/routes/chat_messages.py src/pollypm/dashboard_data.py src/pollypm/cockpit_sections/dashboard.py src/pollypm/plugins_builtin/core_rail_items/plugin.py src/pollypm/web_api/routes/dashboard.py src/pollypm/web_api/routes/projects.py src/pollypm/web_api/service.py tests/test_chat_messages_endpoint.py tests/test_cockpit_footer_status_wiring.py tests/test_dashboard_data_alert_dedup.py tests/test_project_liveness.py tests/web_api/test_endpoints.py tests/web_api/test_web_ui.py tests/test_dashboard_endpoint.py`

## Notes
- A broader web/API rerun still has an existing `test_list_projects_search_sort_and_activity` failure where seeded PG inbox counts are not reflected in `sort=inbox_desc`; the new operator filter test passes.
- A broad Ruff run including `src/pollypm/cockpit_ui.py` reports existing import-order/unused-import noise in that module; the scoped changed-file Ruff pass above is clean.
- The capture AskUserQuestion delivery change is covered with mocked tmux router tests; I did not have a live Claude AskUserQuestion pane available inside this isolated worktree.
