### PR TITLE
Fix plan-gated queue stalls

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -111,6 +111,7 @@ __all__ = [
     "RULE_PLAN_REVIEW_BYPASSED_APPROVAL",
     "RULE_LEGACY_DB_SHADOW",
     "RULE_PLAN_MISSING_ALERT_CHURN",
+    "RULE_PLAN_MISSING_QUEUE_STALLED",
     "RULE_REJECTION_LOOP",
     "RULE_STATE_DB_MISSING",
     "RULE_QUEUE_WITHOUT_MOTION",
@@ -226,6 +227,11 @@ RULE_LEGACY_DB_SHADOW = "legacy_db_shadow"
 # in the cockpit. Threshold defaults to >=3 clear events on the same
 # ``plan_gate-<project>`` scope inside ``plan_missing_churn_window_seconds``.
 RULE_PLAN_MISSING_ALERT_CHURN = "plan_missing_alert_churn"
+# #2503 — plan-gated queued implementation work must not silently rot
+# after auto-claim proves the queue cannot dispatch it. This is distinct
+# from the alert-churn canary above: the alert can be stable while the
+# architect still thinks it handed work to an executable queue.
+RULE_PLAN_MISSING_QUEUE_STALLED = "plan_missing_queue_stalled"
 # #1546 — heartbeat-cascade foundation. Three new rules:
 #
 # * ``rejection_loop`` — fires when a task accumulates K=3+ consecutive
@@ -433,6 +439,10 @@ class WatchdogConfig:
     # place, never closes-and-reopens).
     plan_missing_churn_window_seconds: int = 600
     plan_missing_churn_threshold: int = 3
+    # #2503 — when auto-claim keeps skipping queued implementation work
+    # because the approved-plan gate is closed, route structured evidence
+    # to the architect instead of waiting for a human hand-claim.
+    plan_missing_queue_stall_seconds: int = QUEUE_MOTION_THRESHOLD_SECONDS
     # #1546 — rejection-loop detector. K=3 consecutive rejections at
     # the same review node inside W=2h with clustered reject reasons.
     rejection_loop_threshold: int = REJECTION_LOOP_THRESHOLD
@@ -3150,6 +3160,7 @@ _QUEUE_MOTION_EVENTS: frozenset[str] = frozenset({
     "execution.completed",
     EVENT_WORKER_HEARTBEAT,
 })
+_AUTO_CLAIM_PLAN_MISSING_EVENT = "auto_claim_skipped_plan_missing"
 
 
 _QUEUE_WITHOUT_MOTION_TITLE_RE = re.compile(
@@ -3181,6 +3192,61 @@ def _task_label_set(task: Any) -> set[str]:
     except TypeError:
         return set()
     return out
+
+
+def _task_flow_template(task: Any) -> str:
+    return _task_scalar_value(task, "flow_template_id")
+
+
+def _task_subject(task: Any) -> str:
+    project = _task_scalar_value(task, "project")
+    task_number = getattr(task, "task_number", None)
+    if project and task_number is not None:
+        return f"{project}/{task_number}"
+    return _task_scalar_value(task, "task_id")
+
+
+def _open_plan_project_exists(
+    tasks: Sequence[Any],
+    *,
+    project_key: str,
+) -> bool:
+    for task in tasks:
+        if _task_scalar_value(task, "project") != project_key:
+            continue
+        if _task_flow_template(task) != "plan_project":
+            continue
+        if _task_status_value(task) in _TERMINAL_TASK_STATES:
+            continue
+        return True
+    return False
+
+
+def _plan_gate_blocks_task(task: Any) -> bool:
+    try:
+        from pollypm.plan_presence import task_bypasses_plan_gate
+
+        return not task_bypasses_plan_gate(task)
+    except Exception:  # noqa: BLE001
+        flow_id = _task_flow_template(task)
+        if flow_id in {"plan_project", "critique_flow"}:
+            return False
+        return "bypass_plan_gate" not in _task_label_set(task)
+
+
+def _plan_missing_skip_events(ctx: ProbeContext) -> list[AuditEvent]:
+    events: list[AuditEvent] = []
+    for ev in ctx.events or ():
+        if ev.event != _AUTO_CLAIM_PLAN_MISSING_EVENT:
+            continue
+        if ev.project and ev.project != ctx.project_key:
+            continue
+        events.append(ev)
+    return events
+
+
+def _has_plan_missing_auto_claim_skip(ctx: ProbeContext) -> bool:
+    return bool(_plan_missing_skip_events(ctx))
 
 
 def _is_unactioned_queue_without_motion_task(
@@ -3239,6 +3305,8 @@ def _queue_without_motion_probe(ctx: ProbeContext) -> list[Finding]:
     timestamp so the prompt builder can hand structured signal upward.
     """
     if ctx.project_key in QUEUE_WITHOUT_MOTION_SUPPRESSED_PROJECTS:
+        return []
+    if _has_plan_missing_auto_claim_skip(ctx):
         return []
 
     cutoff = ctx.now - timedelta(
@@ -3332,6 +3400,93 @@ def _queue_without_motion_probe(ctx: ProbeContext) -> list[Finding]:
 
 # Register the one shipped probe on import.
 register_safety_net_probe(_queue_without_motion_probe)
+
+
+def _plan_missing_queue_stalled_probe(ctx: ProbeContext) -> list[Finding]:
+    """Specific safety net for queued work blocked by the plan gate (#2503)."""
+    skip_events = _plan_missing_skip_events(ctx)
+    if not skip_events:
+        return []
+    if _open_plan_project_exists(ctx.open_tasks or (), project_key=ctx.project_key):
+        return []
+
+    cutoff = ctx.now - timedelta(
+        seconds=ctx.config.plan_missing_queue_stall_seconds,
+    )
+    queued_subjects: list[str] = []
+    stale_subjects: list[str] = []
+    queued_last_updated: dict[str, str] = {}
+    for task in ctx.open_tasks or ():
+        if _task_status_value(task) != "queued":
+            continue
+        if _task_scalar_value(task, "project") != ctx.project_key:
+            continue
+        if not _plan_gate_blocks_task(task):
+            continue
+        subject = _task_subject(task)
+        if not subject:
+            continue
+        queued_subjects.append(subject)
+        stamp = _coerce_datetime(
+            getattr(task, "updated_at", None) or getattr(task, "created_at", None)
+        )
+        if stamp is not None:
+            queued_last_updated[subject] = stamp.isoformat()
+            if stamp <= cutoff:
+                stale_subjects.append(subject)
+
+    if not queued_subjects:
+        return []
+
+    skip_times = [
+        parsed for ev in skip_events
+        if (parsed := _parse_iso(ev.ts)) is not None
+    ]
+    first_skip = min(skip_times).isoformat() if skip_times else None
+    last_skip = max(skip_times).isoformat() if skip_times else None
+    has_old_skip = any(ts <= cutoff for ts in skip_times)
+    if not stale_subjects and not has_old_skip:
+        return []
+
+    subjects_for_evidence = stale_subjects or queued_subjects
+    return [Finding(
+        rule=RULE_PLAN_MISSING_QUEUE_STALLED,
+        tier=TIER_2,
+        project=ctx.project_key,
+        subject=ctx.project_key,
+        message=(
+            f"Project {ctx.project_key} has {len(queued_subjects)} queued "
+            "implementation task(s) that auto-claim skipped because the "
+            "approved plan is missing."
+        ),
+        recommendation=(
+            f"Dispatch the architect to start or resume planning for "
+            f"{ctx.project_key}; do not report worker handoff until the "
+            "plan gate is open or the tasks carry an explicit bypass."
+        ),
+        metadata={
+            "queued_count": len(queued_subjects),
+            "stale_queued_count": len(stale_subjects),
+            "first_skip_at": first_skip,
+            "last_skip_at": last_skip,
+            "skip_count": len(skip_events),
+            "threshold_seconds": ctx.config.plan_missing_queue_stall_seconds,
+            "detected_via": "probe",
+        },
+        evidence={
+            "queued_subjects": list(subjects_for_evidence),
+            "all_queued_subjects": list(queued_subjects),
+            "queued_last_updated": dict(queued_last_updated),
+            "auto_claim_skip_event": _AUTO_CLAIM_PLAN_MISSING_EVENT,
+            "auto_claim_skip_count": len(skip_events),
+            "first_skip_at": first_skip,
+            "last_skip_at": last_skip,
+            "threshold_seconds": ctx.config.plan_missing_queue_stall_seconds,
+        },
+    )]
+
+
+register_safety_net_probe(_plan_missing_queue_stalled_probe)
 
 
 # ---------------------------------------------------------------------------
@@ -4960,6 +5115,47 @@ def _brief_worker_session_dead_loop(
     return lines
 
 
+def _brief_plan_missing_queue_stalled(
+    finding: Finding,
+    meta: dict,
+) -> list[str]:
+    """Brief body for plan-gated queued work that cannot auto-claim."""
+    evidence = finding.evidence or {}
+    queued = evidence.get("queued_subjects") or []
+    first_skip = evidence.get("first_skip_at") or meta.get("first_skip_at")
+    last_skip = evidence.get("last_skip_at") or meta.get("last_skip_at")
+    threshold = evidence.get("threshold_seconds") or meta.get("threshold_seconds")
+    skip_count = evidence.get("auto_claim_skip_count") or meta.get("skip_count")
+    lines: list[str] = []
+    lines.append("Stuck for: plan-gate auto-claim stall")
+    lines.append("Observed evidence:")
+    if queued:
+        lines.append(f"- Queued implementation task(s): {', '.join(map(str, queued))}")
+    if skip_count:
+        lines.append(
+            f"- Auto-claim skipped on missing approved plan {skip_count} time(s)."
+        )
+    if first_skip or last_skip:
+        lines.append(f"- First skip: {first_skip or 'unknown'}")
+        lines.append(f"- Last skip: {last_skip or 'unknown'}")
+    if threshold:
+        lines.append(f"- Stall threshold: {threshold} seconds")
+    lines.append("")
+    lines.append(
+        "ACTION REQUIRED: make the queue claimable before reporting handoff. "
+        f"Start or resume planning for {finding.project} with "
+        f"`pm project plan {finding.project}` if no active plan_project task "
+        "exists. If the tasks are intentionally emergency work, update them "
+        "with the explicit `bypass_plan_gate` label and cite why."
+    )
+    lines.append(
+        "End this turn after the state-changing command has succeeded. "
+        "Do not reply that you are standing by while worker auto-claim is "
+        "still skipping on plan_missing."
+    )
+    return lines
+
+
 def _brief_fallback(finding: Finding) -> list[str]:
     """Generic brief body for rules without a tailored template.
 
@@ -5064,6 +5260,8 @@ def format_unstick_brief(
         lines.extend(_brief_rejection_loop(finding, meta))
     elif finding.rule == RULE_WORKER_SESSION_DEAD_LOOP:
         lines.extend(_brief_worker_session_dead_loop(finding, subject, meta))
+    elif finding.rule == RULE_PLAN_MISSING_QUEUE_STALLED:
+        lines.extend(_brief_plan_missing_queue_stalled(finding, meta))
     else:
         lines.extend(_brief_fallback(finding))
     body = "\n".join(lines)

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -46,6 +46,7 @@ from pollypm.audit.watchdog import (
     RULE_DUPLICATE_ADVISOR_TASKS,
     RULE_LEGACY_DB_SHADOW,
     RULE_PLAN_MISSING_ALERT_CHURN,
+    RULE_PLAN_MISSING_QUEUE_STALLED,
     RULE_PLAN_REVIEW_BYPASSED_APPROVAL,
     RULE_PLAN_REVIEW_MISSING,
     RULE_QUEUE_WITHOUT_MOTION,
@@ -165,6 +166,9 @@ _DISPATCHABLE_RULES: frozenset[str] = frozenset({
     RULE_TASK_ON_HOLD_STALE,
     # #1546 — rejection-loop detector → tier-2 PM dispatch.
     RULE_REJECTION_LOOP,
+    # #2503 — plan-gated queued work has already proven it cannot
+    # auto-claim; hand the recovery back to the architect, not Sam.
+    RULE_PLAN_MISSING_QUEUE_STALLED,
 })
 
 # #1546 — rules whose finding routes to the operator (tier-3) leg by

--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -21,6 +21,8 @@ Decision rule for every incoming request:
 - Planning, deciding, coordinating, reviewing, or answering architecture questions is your job; handle it directly and produce the plan, decision, review, or answer.
 
 Aside from trivial surgical edits, the only files you author are planning/coordination artifacts under `docs/` and inbox/decision content. If you catch yourself opening editors across multiple product source files — pages, components, application code — stop and decompose the work instead.
+
+Before you tell the operator that delegated work has been handed off, confirm the queued tasks are actually claimable. If `pm task list` / alerts show `plan_missing` or `auto_claim_skipped_plan_missing`, start or resume planning first (`pm project plan <project>` or the active `plan_project` task) and do not report worker handoff until the plan gate is open. Use `bypass_plan_gate` only for explicit emergency/operator-bypass work and cite why.
 </ad_hoc_requests>
 
 <principles>

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -160,7 +160,11 @@ def _unavailable_account_names(config: object) -> frozenset[str]:
     so per-task worker spawn skips the same accounts the control-plane
     failover skips. Reads ``account_runtime`` from the project state DB
     and consults ``is_account_runtime_unavailable`` (auth_broken,
-    auth-broken, exhausted, provider_outage, blocked).
+    auth-broken, exhausted, provider_outage, blocked). Also treats
+    known-low remaining usage as unavailable for new worker launches so
+    a fresh task does not pin itself to an account with only a few
+    percent of weekly budget left when a healthier failover account is
+    configured (#2503).
 
     Returns an empty frozenset when the state DB is unreachable so a
     transient store error does not block all worker launches — the
@@ -177,6 +181,32 @@ def _unavailable_account_names(config: object) -> frozenset[str]:
             runtime = get_account_runtime(name)
             if runtime is not None and is_account_runtime_unavailable(runtime.status):
                 unavailable.add(name)
+        try:
+            from pollypm.capacity import (
+                FAILOVER_TRIGGERS,
+                PROACTIVE_ROLLOVER_THRESHOLD_PCT,
+                probe_capacity,
+            )
+
+            for name in accounts:
+                if name in unavailable:
+                    continue
+                probe = probe_capacity(config, None, name)
+                if probe.state in FAILOVER_TRIGGERS:
+                    unavailable.add(name)
+                    continue
+                remaining = probe.remaining_pct
+                if (
+                    remaining is not None
+                    and remaining <= PROACTIVE_ROLLOVER_THRESHOLD_PCT
+                ):
+                    unavailable.add(name)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "worker launch: account-usage filter failed; "
+                "falling back to runtime-only availability",
+                exc_info=True,
+            )
         return frozenset(unavailable)
     except Exception:  # noqa: BLE001
         logger.exception("worker launch: account-runtime filter failed; allowing all")

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -48,6 +48,7 @@ from pollypm.audit.watchdog import (
     RULE_LEGACY_DB_SHADOW,
     RULE_ORPHAN_MARKER,
     RULE_PLAN_MISSING_ALERT_CHURN,
+    RULE_PLAN_MISSING_QUEUE_STALLED,
     RULE_PLAN_REVIEW_MISSING,
     RULE_QUEUE_WITHOUT_MOTION,
     RULE_REJECTION_LOOP,
@@ -120,6 +121,7 @@ class _StubTask:
     description: str | None = None
     labels: tuple[str, ...] = ()
     kind: str | None = None
+    flow_template_id: str | None = None
 
     @property
     def work_status(self) -> _StubStatus:
@@ -150,6 +152,7 @@ def test_existing_rules_carry_expected_tiers(now: datetime) -> None:
         RULE_TASK_PROGRESS_STALE: TIER_2,
         RULE_TASK_ON_HOLD_STALE: TIER_2,
         RULE_WORKER_SESSION_DEAD_LOOP: TIER_2,
+        RULE_PLAN_MISSING_QUEUE_STALLED: TIER_2,
         # Observe-only canaries.
         RULE_ORPHAN_MARKER: TIER_TERMINAL,
         RULE_PLAN_MISSING_ALERT_CHURN: TIER_TERMINAL,
@@ -721,6 +724,92 @@ def test_queue_without_motion_disabled_when_probe_flag_off(
         run_safety_net_probes=False,
     )
     assert not any(f.rule == RULE_QUEUE_WITHOUT_MOTION for f in findings)
+
+
+def test_plan_missing_queue_stall_routes_to_architect(
+    now: datetime,
+) -> None:
+    cfg = WatchdogConfig(plan_missing_queue_stall_seconds=600)
+    queued = _StubTask(
+        project="demo",
+        task_number=4,
+        work_status_str="queued",
+        executions=[],
+        updated_at=now - timedelta(hours=2),
+        flow_template_id="implement_module",
+        roles={"worker": "worker"},
+    )
+    events = [
+        AuditEvent(
+            ts=(now - timedelta(minutes=10)).isoformat(),
+            project="demo",
+            event="auto_claim_skipped_plan_missing",
+            subject="demo/4",
+            actor="auto_claim_sweep",
+            status="warn",
+            metadata={"task_id": "demo/4"},
+        ),
+    ]
+
+    findings = scan_events(
+        events, now=now, config=cfg, open_tasks=[queued], project="demo",
+    )
+
+    matched = [
+        f for f in findings if f.rule == RULE_PLAN_MISSING_QUEUE_STALLED
+    ]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.tier == TIER_2
+    assert f.evidence["queued_subjects"] == ["demo/4"]
+    assert f.evidence["auto_claim_skip_count"] == 1
+    assert not any(f.rule == RULE_QUEUE_WITHOUT_MOTION for f in findings)
+
+
+def test_plan_missing_queue_stall_silent_when_planning_task_active(
+    now: datetime,
+) -> None:
+    cfg = WatchdogConfig(plan_missing_queue_stall_seconds=600)
+    queued = _StubTask(
+        project="demo",
+        task_number=4,
+        work_status_str="queued",
+        executions=[],
+        updated_at=now - timedelta(hours=2),
+        flow_template_id="implement_module",
+    )
+    plan_task = _StubTask(
+        project="demo",
+        task_number=9,
+        work_status_str="in_progress",
+        executions=[],
+        updated_at=now - timedelta(minutes=5),
+        flow_template_id="plan_project",
+        roles={"architect": "architect"},
+    )
+    events = [
+        AuditEvent(
+            ts=(now - timedelta(minutes=10)).isoformat(),
+            project="demo",
+            event="auto_claim_skipped_plan_missing",
+            subject="demo/4",
+            actor="auto_claim_sweep",
+            status="warn",
+            metadata={"task_id": "demo/4"},
+        ),
+    ]
+
+    findings = scan_events(
+        events,
+        now=now,
+        config=cfg,
+        open_tasks=[queued, plan_task],
+        project="demo",
+    )
+
+    assert not any(
+        f.rule == RULE_PLAN_MISSING_QUEUE_STALLED for f in findings
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1487,6 +1576,18 @@ def _representative_findings_for_lint() -> list[Finding]:
                 "window_seconds": REJECTION_LOOP_WINDOW_SECONDS,
             },
         ),
+        Finding(
+            rule=RULE_PLAN_MISSING_QUEUE_STALLED,
+            tier=TIER_2,
+            project="demo",
+            subject="demo",
+            metadata={"skip_count": 2, "threshold_seconds": 1800},
+            evidence={
+                "queued_subjects": ["demo/6"],
+                "auto_claim_skip_count": 2,
+                "threshold_seconds": 1800,
+            },
+        ),
     ]
 
 
@@ -1792,3 +1893,43 @@ def test_integration_rejection_loop_dispatches_via_architect(
     # The structural-loop framing must mention generating hypotheses
     # fresh — the issue's evidence-not-hypotheses principle.
     assert "fresh from the evidence" in brief
+
+
+def test_integration_plan_missing_queue_stall_dispatches_via_architect(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as cadence_mod
+
+    sent: list[tuple[str, str]] = []
+
+    def _stub_send(target: str, brief: str) -> bool:
+        sent.append((target, brief))
+        return True
+
+    monkeypatch.setattr(cadence_mod, "_send_brief_to_architect", _stub_send)
+
+    finding = Finding(
+        rule=RULE_PLAN_MISSING_QUEUE_STALLED,
+        tier=TIER_2,
+        project="demo",
+        subject="demo",
+        evidence={
+            "queued_subjects": ["demo/4"],
+            "auto_claim_skip_count": 3,
+            "threshold_seconds": 1800,
+        },
+    )
+    outcome = cadence_mod._maybe_dispatch_to_architect(
+        finding,
+        project_path=None,
+        storage_closet_name="pollypm-storage-closet",
+        now=now,
+    )
+
+    assert outcome == "dispatched"
+    assert len(sent) == 1
+    target, brief = sent[0]
+    assert target == "pollypm-storage-closet:architect-demo"
+    assert "plan_missing_queue_stalled" in brief
+    assert "demo/4" in brief
+    assert "make the queue claimable" in brief

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -9,6 +9,7 @@ import sqlite3
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
@@ -1028,6 +1029,56 @@ class TestWorkerLaunchBundleAccountFilter:
                 status="auth-broken",
                 reason="legacy hyphen form",
             )
+
+        manager = SessionManager(
+            mock_tmux,
+            mock_svc,
+            tmp_project,
+            config=config,
+            session_service=MagicMock(),
+        )
+
+        worktree_path = tmp_project / ".pollypm" / "worktrees" / "proj-1"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+        (_cmd, _prov, account_name, _fresh, _home) = manager._worker_launch_bundle(
+            worktree_path=worktree_path,
+            agent_name="claude_main",
+            window_name="task-proj-1",
+            project="proj",
+        )
+
+        assert account_name == "claude_backup"
+
+    def test_worker_launch_bundle_skips_low_remaining_primary(
+        self, monkeypatch, mock_tmux, mock_svc, tmp_project, tmp_path,
+    ):
+        """Known-low usage is treated like a soft failover condition for
+        fresh worker launches, so a task does not pin to a nearly
+        exhausted account when a healthier failover account exists."""
+        primary_home = tmp_path / "claude-main-home"
+        fallback_home = tmp_path / "claude-backup-home"
+        config = self._multi_account_config(
+            tmp_project, primary_home=primary_home, fallback_home=fallback_home,
+        )
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_accounts.get_account_runtime",
+            lambda _name: None,
+        )
+
+        def fake_usage(name: str):
+            remaining = 5 if name == "claude_main" else 80
+            return SimpleNamespace(
+                health="healthy",
+                usage_summary=f"{remaining}% left this week",
+                remaining_pct=remaining,
+                used_pct=100 - remaining,
+            )
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_accounts.get_account_usage",
+            fake_usage,
+        )
 
         manager = SessionManager(
             mock_tmux,


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Adds a `plan_missing_queue_stalled` watchdog rule for queued, plan-gated work that auto-claim is skipping because no approved plan is claimable.
- Routes that finding to the architect path with a targeted recovery brief instead of leaving only a generic queue stall/operator path.
- Skips known-low or exhausted accounts for fresh worker launches when a healthier failover account is configured.
- Updates the architect profile to forbid reporting handoff while the plan gate is still closed.

## Tests
- `uv run --extra test pytest tests/test_heartbeat_cascade_foundation.py::test_plan_missing_queue_stall_routes_to_architect tests/test_heartbeat_cascade_foundation.py::test_plan_missing_queue_stall_silent_when_planning_task_active tests/test_heartbeat_cascade_foundation.py::test_format_unstick_brief_no_solution_menu_language tests/test_heartbeat_cascade_foundation.py::test_integration_plan_missing_queue_stall_dispatches_via_architect tests/test_session_manager.py::TestWorkerLaunchBundleAccountFilter::test_worker_launch_bundle_skips_low_remaining_primary tests/test_session_manager.py::TestWorkerLaunchBundleAccountFilter::test_worker_launch_bundle_keeps_healthy_primary -q`
- `uv run --extra dev ruff check src/pollypm/audit/watchdog.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py src/pollypm/work/session_manager.py tests/test_heartbeat_cascade_foundation.py`
- `uv run --extra dev ruff check tests/test_session_manager.py --ignore F401`

## Notes
- A broader two-file pytest run under `uv` reported 122 passed / 4 failed on current main-adjacent code. The failures were outside this diff: state-db healer config setup, stale Claude argv model expectation, and two existing StateStore-vs-PG runtime-account tests.

Fixes #2503
