### PR TITLE
Stabilize dashboard alert count on cold refresh

### DIFF
--- a/src/pollypm/web_api/dashboard_snapshot_cache.py
+++ b/src/pollypm/web_api/dashboard_snapshot_cache.py
@@ -47,6 +47,16 @@ class DashboardSnapshotCache:
             self._snapshots.clear()
             self._refreshing.clear()
 
+    def requires_sync_refresh(self, config: Any) -> bool:
+        """Return True when ``get_or_refresh`` would block on a reload."""
+        key = id(config)
+        with self._lock:
+            snapshot = self._snapshots.get(key)
+            if snapshot is None:
+                return True
+            age = time.monotonic() - snapshot.refreshed_at_monotonic
+            return age > self._max_stale_seconds
+
     async def get_or_refresh(
         self,
         config: Any,

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -424,10 +424,9 @@ async def get_dashboard_endpoint(
             hint="Drop ?project= to fetch the whole-system snapshot.",
         )
 
-    snapshot = await _get_dashboard_snapshot_cache(request).get_or_refresh(
-        config,
-        _load_dashboard_snapshot,
-    )
+    snapshot_cache = _get_dashboard_snapshot_cache(request)
+    sync_refresh_expected = snapshot_cache.requires_sync_refresh(config)
+    snapshot = await snapshot_cache.get_or_refresh(config, _load_dashboard_snapshot)
 
     # Projects view — list_projects is the authoritative cockpit row
     # builder; reuse it so the rollups derived below match the project
@@ -509,13 +508,23 @@ async def get_dashboard_endpoint(
     )
     # The full snapshot is intentionally stale-while-refresh. Alert counts are
     # volatile enough that an old-high value can alarm the Home headline, so
-    # refresh that one cheap counter only when we are serving an aged snapshot.
+    # refresh that one cheap counter when serving an aged snapshot or after a
+    # fully cold/max-stale rebuild. Updating ``data.alert_count`` keeps the
+    # just-refreshed cache from flapping back on immediate warm hits (#2504).
     snapshot_age = time.monotonic() - snapshot.refreshed_at_monotonic
     fresh_alert_count = (
         _fresh_dashboard_alert_count(config)
-        if snapshot_age > 2.0
+        if sync_refresh_expected or snapshot_age > 2.0
         else None
     )
+    if fresh_alert_count is not None:
+        try:
+            data.alert_count = int(fresh_alert_count)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "dashboard: failed to normalize cached alert_count",
+                exc_info=True,
+            )
 
     rollups = DashboardRollups(
         tracked_count=tracked_count,

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -185,6 +185,14 @@ def client(app) -> TestClient:
     return TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def patch_fresh_alert_count(monkeypatch: pytest.MonkeyPatch):
+    """Keep dashboard endpoint tests isolated from live alert storage."""
+    monkeypatch.setattr(
+        dashboard_routes, "_fresh_dashboard_alert_count", lambda _config: None,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Stub helpers
 # ---------------------------------------------------------------------------
@@ -433,6 +441,40 @@ def test_dashboard_cache_hit_skips_repeated_expensive_loads(
     assert second.status_code == 200, second.text
     assert second.json()["tokens"]["total"] == 42
     assert calls == {"list": 1, "gather": 1}
+
+
+def test_dashboard_cold_refresh_normalizes_cached_alert_count(
+    client, auth_headers, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"gather": 0, "fresh": 0}
+
+    monkeypatch.setattr(
+        dashboard_routes,
+        "list_projects",
+        lambda _config, *, operator_facing=False: [_api_project("myproj")],
+    )
+
+    def fake_gather(_config):
+        calls["gather"] += 1
+        return _make_data(alert_count=32)
+
+    def fake_fresh(_config):
+        calls["fresh"] += 1
+        return 3
+
+    monkeypatch.setattr(dashboard_routes, "_gather_dashboard", fake_gather)
+    monkeypatch.setattr(
+        dashboard_routes, "_fresh_dashboard_alert_count", fake_fresh,
+    )
+
+    first = client.get("/api/v1/dashboard", headers=auth_headers)
+    second = client.get("/api/v1/dashboard", headers=auth_headers)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["rollups"]["alert_count"] == 3
+    assert second.json()["rollups"]["alert_count"] == 3
+    assert calls == {"gather": 1, "fresh": 1}
 
 
 def test_dashboard_stale_cache_returns_while_refresh_runs(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Detects when `/api/v1/dashboard` is doing a synchronous cold/max-stale snapshot refresh.
- Normalizes that freshly cached snapshot's `alert_count` through the same fresh alert-count path used for aged warm snapshots.
- Prevents the first cold response from showing the inflated gather count and then flapping down on the next warm hit.

## Tests
- `uv run --extra test pytest --noconftest tests/test_dashboard_endpoint.py -q`
- `uv run --extra dev ruff check src/pollypm/web_api/dashboard_snapshot_cache.py src/pollypm/web_api/routes/dashboard.py tests/test_dashboard_endpoint.py`

Fixes #2504
