### PR TITLE
Fix plan-missing queue-stall watchdog invocation

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -3112,6 +3112,7 @@ class ProbeContext:
     config: WatchdogConfig
     open_tasks: Sequence[Any]
     events: Sequence[AuditEvent]
+    plan_missing_gate_closed: bool = False
 
 
 # Probe registry — public so future PRs can register new probes
@@ -3306,7 +3307,7 @@ def _queue_without_motion_probe(ctx: ProbeContext) -> list[Finding]:
     """
     if ctx.project_key in QUEUE_WITHOUT_MOTION_SUPPRESSED_PROJECTS:
         return []
-    if _has_plan_missing_auto_claim_skip(ctx):
+    if _has_plan_missing_auto_claim_skip(ctx) or ctx.plan_missing_gate_closed:
         return []
 
     cutoff = ctx.now - timedelta(
@@ -3405,7 +3406,7 @@ register_safety_net_probe(_queue_without_motion_probe)
 def _plan_missing_queue_stalled_probe(ctx: ProbeContext) -> list[Finding]:
     """Specific safety net for queued work blocked by the plan gate (#2503)."""
     skip_events = _plan_missing_skip_events(ctx)
-    if not skip_events:
+    if not skip_events and not ctx.plan_missing_gate_closed:
         return []
     if _open_plan_project_exists(ctx.open_tasks or (), project_key=ctx.project_key):
         return []
@@ -3449,6 +3450,11 @@ def _plan_missing_queue_stalled_probe(ctx: ProbeContext) -> list[Finding]:
         return []
 
     subjects_for_evidence = stale_subjects or queued_subjects
+    signal_sources: list[str] = []
+    if skip_events:
+        signal_sources.append(_AUTO_CLAIM_PLAN_MISSING_EVENT)
+    if ctx.plan_missing_gate_closed:
+        signal_sources.append("current_plan_gate_state")
     return [Finding(
         rule=RULE_PLAN_MISSING_QUEUE_STALLED,
         tier=TIER_2,
@@ -3456,8 +3462,7 @@ def _plan_missing_queue_stalled_probe(ctx: ProbeContext) -> list[Finding]:
         subject=ctx.project_key,
         message=(
             f"Project {ctx.project_key} has {len(queued_subjects)} queued "
-            "implementation task(s) that auto-claim skipped because the "
-            "approved plan is missing."
+            "implementation task(s) waiting on a missing approved plan."
         ),
         recommendation=(
             f"Dispatch the architect to start or resume planning for "
@@ -3472,6 +3477,7 @@ def _plan_missing_queue_stalled_probe(ctx: ProbeContext) -> list[Finding]:
             "skip_count": len(skip_events),
             "threshold_seconds": ctx.config.plan_missing_queue_stall_seconds,
             "detected_via": "probe",
+            "signal_sources": list(signal_sources),
         },
         evidence={
             "queued_subjects": list(subjects_for_evidence),
@@ -3482,6 +3488,8 @@ def _plan_missing_queue_stalled_probe(ctx: ProbeContext) -> list[Finding]:
             "first_skip_at": first_skip,
             "last_skip_at": last_skip,
             "threshold_seconds": ctx.config.plan_missing_queue_stall_seconds,
+            "plan_missing_gate_closed": ctx.plan_missing_gate_closed,
+            "signal_sources": list(signal_sources),
         },
     )]
 
@@ -3511,6 +3519,7 @@ def scan_events(
     state_db_probes: Sequence[Any] | None = None,
     run_safety_net_probes: bool = True,
     worker_cap_back_pressure: Mapping[str, bool] | None = None,
+    plan_missing_gate_closed: bool = False,
     stuck_draft_terminator_breadcrumbs: list[_TerminatorBreadcrumb] | None = None,
 ) -> list[Finding]:
     """Run every detection rule against ``events`` and return findings.
@@ -3562,6 +3571,11 @@ def scan_events(
             The cadence handler builds this list by probing the
             workspace + per-project state.db files for each known
             project. ``None`` disables the rule.
+        plan_missing_gate_closed: True when the cadence handler has
+            independently verified that this project has queued
+            non-bypass work and the approved-plan gate is closed. This
+            gives the plan-missing queue-stall probe a current-state
+            signal in addition to recent auto-claim skip audit events.
     """
     if config is None:
         config = WatchdogConfig()
@@ -3690,6 +3704,7 @@ def scan_events(
             config=config,
             open_tasks=tuple(open_tasks or ()),
             events=materialised,
+            plan_missing_gate_closed=bool(plan_missing_gate_closed),
         )
         findings.extend(_run_safety_net_probes(ctx))
     return _filter_dismissed_findings(
@@ -3848,6 +3863,7 @@ def scan_project(
     state_db_probes: Sequence[Any] | None = None,
     run_safety_net_probes: bool = True,
     worker_cap_back_pressure: Mapping[str, bool] | None = None,
+    plan_missing_gate_closed: bool = False,
 ) -> list[Finding]:
     """Read audit events for ``project`` and scan them.
 
@@ -3929,6 +3945,7 @@ def scan_project(
         state_db_probes=state_db_probes,
         run_safety_net_probes=run_safety_net_probes,
         worker_cap_back_pressure=worker_cap_back_pressure,
+        plan_missing_gate_closed=plan_missing_gate_closed,
         stuck_draft_terminator_breadcrumbs=pending_terminators,
     )
     if findings or pending_terminators or backfill_reclaims:

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -182,6 +182,7 @@ _OPERATOR_DISPATCHABLE_RULES: frozenset[str] = frozenset({
 
 
 logger = logging.getLogger(__name__)
+_PLAN_MISSING_QUEUE_PROBE_LOGGED: set[tuple[str, str]] = set()
 
 
 __all__ = [
@@ -715,6 +716,94 @@ def _gather_open_tasks(project_key: str, project_path: Path | None) -> list[Any]
             project_key, exc_info=True,
         )
         return []
+
+
+def _plan_missing_gate_closed_for_queued_work(
+    project_key: str,
+    project_path: Path | None,
+    open_tasks: list[Any],
+    *,
+    enforce_plan: bool,
+    plan_dir: str,
+) -> bool:
+    """Return True when current queued work is blocked by the plan gate."""
+    if not enforce_plan or project_path is None or not open_tasks:
+        return False
+    try:
+        from pollypm.plan_presence import (
+            has_acceptable_plan,
+            task_bypasses_plan_gate,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: plan-gate helper import failed", exc_info=True,
+        )
+        return False
+
+    has_queued_blocked_candidate = False
+    for task in open_tasks:
+        status = getattr(task, "work_status", None)
+        status_value = getattr(status, "value", status)
+        if status_value != "queued":
+            continue
+        if (getattr(task, "project", None) or "") != project_key:
+            continue
+        try:
+            if task_bypasses_plan_gate(task):
+                continue
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "audit.watchdog: plan-bypass probe failed for %s/%s",
+                project_key,
+                getattr(task, "task_number", "?"),
+                exc_info=True,
+            )
+            continue
+        has_queued_blocked_candidate = True
+        break
+    if not has_queued_blocked_candidate:
+        return False
+
+    try:
+        from pollypm.work import create_work_service
+
+        with create_work_service(
+            project_path=project_path,
+            project_key=project_key,
+        ) as svc:
+            return not has_acceptable_plan(
+                project_key, project_path, svc, plan_dir=plan_dir,
+            )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: plan-gate state probe failed for %s",
+            project_key, exc_info=True,
+        )
+        return False
+
+
+def _log_plan_missing_queue_probe_once(
+    project_key: str,
+    *,
+    gate_closed: bool,
+    open_task_count: int,
+    finding_count: int,
+) -> None:
+    if not gate_closed and finding_count <= 0:
+        return
+    state = "finding" if finding_count else "gate_closed_no_finding"
+    key = (project_key, state)
+    if key in _PLAN_MISSING_QUEUE_PROBE_LOGGED:
+        return
+    _PLAN_MISSING_QUEUE_PROBE_LOGGED.add(key)
+    logger.info(
+        "audit.watchdog: plan_missing_queue_stalled probe ran for %s "
+        "gate_closed=%s open_tasks=%d findings=%d",
+        project_key,
+        gate_closed,
+        open_task_count,
+        finding_count,
+    )
 
 
 def _count_work_tasks_for_project(db_path: Path, project_key: str) -> int:
@@ -3859,6 +3948,7 @@ def _scan_one_project_counters() -> dict[str, int]:
         "legacy_db_shadows_migrated": 0,
         "legacy_db_shadows_failed": 0,
         "plan_missing_churn_detected": 0,
+        "plan_missing_queue_stalled_detected": 0,
         # #1546 — new tier-1 healer counters.
         "worker_lane_spawned": 0,
         "worker_lane_failed": 0,
@@ -3950,6 +4040,8 @@ def _route_one_finding(
     if finding.rule == RULE_PLAN_MISSING_ALERT_CHURN:
         counters["plan_missing_churn_detected"] += 1
         return
+    if finding.rule == RULE_PLAN_MISSING_QUEUE_STALLED:
+        counters["plan_missing_queue_stalled_detected"] += 1
 
     # #1546 — tier-3 operator dispatchable rules route to the
     # operator inbox via ``_maybe_dispatch_to_operator``. The
@@ -4137,6 +4229,8 @@ def _scan_one_project(
     plan_missing_clears: list[_PlanMissingClear] | None = None,
     state_db_probes: list[_StateDbProbe] | None = None,
     config_path: Path | None = None,
+    enforce_plan: bool = True,
+    plan_dir: str = "docs/plan",
 ) -> dict[str, int]:
     """Scan one project and route every finding. Returns counters."""
     counters = _scan_one_project_counters()
@@ -4182,6 +4276,13 @@ def _scan_one_project(
     worker_cap_back_pressure = _gather_worker_cap_back_pressure(
         project_key, project_path, config_path,
     )
+    plan_missing_gate_closed = _plan_missing_gate_closed_for_queued_work(
+        project_key,
+        project_path,
+        open_tasks,
+        enforce_plan=enforce_plan,
+        plan_dir=plan_dir,
+    )
     try:
         findings = scan_project(
             project_key,
@@ -4197,6 +4298,7 @@ def _scan_one_project(
             plan_missing_clears=project_clears or None,
             state_db_probes=project_state_probes or None,
             worker_cap_back_pressure=worker_cap_back_pressure or None,
+            plan_missing_gate_closed=plan_missing_gate_closed,
         )
     except Exception:  # noqa: BLE001
         logger.debug(
@@ -4204,6 +4306,17 @@ def _scan_one_project(
             project_key, exc_info=True,
         )
         return counters
+
+    plan_missing_finding_count = sum(
+        1 for finding in findings
+        if finding.rule == RULE_PLAN_MISSING_QUEUE_STALLED
+    )
+    _log_plan_missing_queue_probe_once(
+        project_key,
+        gate_closed=plan_missing_gate_closed,
+        open_task_count=len(open_tasks or []),
+        finding_count=plan_missing_finding_count,
+    )
 
     # #1554 HIGH-1 — collect the root_cause_hash for every finding seen
     # this scan. The cadence-level sweep uses the union across projects
@@ -4295,6 +4408,7 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "legacy_db_shadows_migrated": 0,
         "legacy_db_shadows_failed": 0,
         "plan_missing_churn_detected": 0,
+        "plan_missing_queue_stalled_detected": 0,
         # #1546 — new tier-1 + tier-3 totals.
         "worker_lane_spawned": 0,
         "worker_lane_failed": 0,
@@ -4366,6 +4480,12 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
                 continue
             seen_projects.add(project_key)
             project_path = getattr(project, "path", None)
+            project_enforce = getattr(project, "enforce_plan", None)
+            enforce_plan = (
+                bool(project_enforce)
+                if project_enforce is not None
+                else bool(getattr(services, "enforce_plan", True))
+            )
             partial = _scan_one_project(
                 project_key=project_key,
                 project_path=Path(project_path) if project_path else None,
@@ -4378,6 +4498,10 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
                 plan_missing_clears=plan_missing_clears,
                 state_db_probes=state_db_probes,
                 config_path=config_path,
+                enforce_plan=enforce_plan,
+                plan_dir=(
+                    getattr(services, "plan_dir", "docs/plan") or "docs/plan"
+                ),
             )
             totals["projects_scanned"] += 1
             project_seen = partial.pop("_seen_root_cause_hashes", None)

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -30,6 +30,7 @@ from pollypm.audit.watchdog import (
     EVENT_HEARTBEAT_TICK,
     EVENT_STUCK_DRAFT_RECLAIMED,
     EVENT_STUCK_DRAFT_TERMINATED,
+    RULE_PLAN_MISSING_QUEUE_STALLED,
     RULE_QUEUE_WITHOUT_MOTION,
     RULE_CANCEL_NO_PROMOTION,
     RULE_CANCELLATION_CHURN,
@@ -2040,6 +2041,61 @@ def test_cadence_handler_dispatches_stuck_draft(
     ]
     assert len(dispatch_rows) == 1
     assert dispatch_rows[0]["metadata"]["finding_type"] == RULE_STUCK_DRAFT
+
+
+def test_cadence_handler_dispatches_plan_missing_stall_from_gate_state(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cadence scan does not require a recent auto-claim skip row."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    task = _StatefulTask(
+        project="savethenovel",
+        task_number=4,
+        work_status="queued",
+        created_at=now - timedelta(hours=2),
+        updated_at=now - timedelta(hours=2),
+    )
+    task.flow_template_id = "implement_module"
+
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        lambda target, brief: sent.append((target, brief)) or True,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [task],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._plan_missing_gate_closed_for_queued_work",
+        lambda *args, **kwargs: True,
+    )
+
+    store = _RecordingStore()
+    counters = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(plan_missing_queue_stall_seconds=600),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert counters["plan_missing_queue_stalled_detected"] == 1
+    assert counters["dispatches_sent"] == 1
+    assert len(sent) == 1
+    target, brief = sent[0]
+    assert target == "pollypm-storage-closet:architect-savethenovel"
+    assert RULE_PLAN_MISSING_QUEUE_STALLED in brief
+    assert "savethenovel/4" in brief
 
 
 def test_cadence_handler_dispatches_cancellation_no_promotion(

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -766,6 +766,41 @@ def test_plan_missing_queue_stall_routes_to_architect(
     assert not any(f.rule == RULE_QUEUE_WITHOUT_MOTION for f in findings)
 
 
+def test_plan_missing_queue_stall_uses_current_gate_state_without_skip_event(
+    now: datetime,
+) -> None:
+    cfg = WatchdogConfig(plan_missing_queue_stall_seconds=600)
+    queued = _StubTask(
+        project="demo",
+        task_number=4,
+        work_status_str="queued",
+        executions=[],
+        updated_at=now - timedelta(hours=2),
+        flow_template_id="implement_module",
+        roles={"worker": "worker"},
+    )
+
+    findings = scan_events(
+        [],
+        now=now,
+        config=cfg,
+        open_tasks=[queued],
+        project="demo",
+        plan_missing_gate_closed=True,
+    )
+
+    matched = [
+        f for f in findings if f.rule == RULE_PLAN_MISSING_QUEUE_STALLED
+    ]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.evidence["queued_subjects"] == ["demo/4"]
+    assert f.evidence["auto_claim_skip_count"] == 0
+    assert f.evidence["plan_missing_gate_closed"] is True
+    assert f.evidence["signal_sources"] == ["current_plan_gate_state"]
+    assert not any(f.rule == RULE_QUEUE_WITHOUT_MOTION for f in findings)
+
+
 def test_plan_missing_queue_stall_silent_when_planning_task_active(
     now: datetime,
 ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Let `plan_missing_queue_stalled` fire from current plan-gate state, not only recent `auto_claim_skipped_plan_missing` audit rows.
- Wire the recurring audit watchdog to evaluate queued non-bypass work against the approved-plan gate and pass that state into the pure probe.
- Add a low-volume diagnostic log proving the probe ran for plan-gated projects, plus pure and cadence regression coverage.

## Verification
- `uv run --extra test pytest tests/test_heartbeat_cascade_foundation.py::test_plan_missing_queue_stall_routes_to_architect tests/test_heartbeat_cascade_foundation.py::test_plan_missing_queue_stall_uses_current_gate_state_without_skip_event tests/test_heartbeat_cascade_foundation.py::test_plan_missing_queue_stall_silent_when_planning_task_active tests/test_audit_watchdog.py::test_cadence_handler_dispatches_plan_missing_stall_from_gate_state tests/test_task_assignment_recovery_audit.py::test_auto_claim_next_plan_missing_emits_skip_audit_without_claiming` - passed (5)
- `uv run --extra dev ruff check src/pollypm/audit/watchdog.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py tests/test_heartbeat_cascade_foundation.py tests/test_audit_watchdog.py` - passed
- `uv run --extra test pytest tests/test_capacity.py::TestEvaluateProactiveControllerFailover::test_selects_first_failover_under_threshold tests/test_capacity.py::TestEvaluateProactiveControllerFailover::test_all_failover_accounts_over_threshold_alerts tests/test_capacity.py::TestSelectFailoverAccount::test_selects_highest_headroom_candidate tests/test_capacity.py::TestSelectFailoverAccount::test_selects_different_provider_when_same_unavailable tests/test_supervisor.py::test_supervisor_failover_prefers_highest_headroom_candidate tests/test_supervisor.py::test_supervisor_failover_skips_pg_exhausted_account` - passed (6)
- Broader watchdog slice: `uv run --extra test pytest tests/test_heartbeat_cascade_foundation.py tests/test_task_assignment_recovery_audit.py::test_auto_claim_next_plan_missing_emits_skip_audit_without_claiming tests/test_audit_watchdog.py::test_cadence_handler_dispatches_plan_missing_stall_from_gate_state` - 58 passed, 1 pre-existing unrelated failure in `test_integration_state_db_missing_routes_to_tier1_healer` (`Unknown project: demo`).

Base confirmed before PR: branch merge-base matched `origin/main` at `72b451791421e1afd49b8c38688a53c6a09491cf`, then branch was pushed from the isolated watcher worktree.