### PR TITLE
Normalize dashboard alert count before caching

### DIFF
--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -317,6 +317,38 @@ def _call_dashboard_source_pair(
     return results["projects"], results["data"]
 
 
+def _fresh_dashboard_alert_count(config: Any) -> int | None:
+    """Return a fresh alert count so stale dashboard snapshots cannot alarm high."""
+
+    try:
+        from pollypm.dashboard_data import count_dashboard_alerts
+
+        return count_dashboard_alerts(config)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "dashboard: fresh alert-count refresh failed; using cached value",
+            exc_info=True,
+        )
+        return None
+
+
+def _normalize_dashboard_alert_count(config: Any, data: Any) -> int | None:
+    """Write the liveness-filtered alert count onto dashboard data."""
+
+    fresh_alert_count = _fresh_dashboard_alert_count(config)
+    if fresh_alert_count is None:
+        return None
+    try:
+        data.alert_count = int(fresh_alert_count)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "dashboard: failed to normalize cached alert_count",
+            exc_info=True,
+        )
+        return None
+    return int(fresh_alert_count)
+
+
 def _load_dashboard_snapshot(config: Any) -> DashboardSnapshot:
     """Run the expensive dashboard load once and normalize errors."""
 
@@ -339,27 +371,13 @@ def _load_dashboard_snapshot(config: Any) -> DashboardSnapshot:
             hint="Retry shortly; check `pm doctor` for pg pool health.",
         ) from data_result
 
+    _normalize_dashboard_alert_count(config, data_result)
     return DashboardSnapshot(
         generated_at=datetime.now(timezone.utc),
         projects=tuple(projects_result),
         data=data_result,
         refreshed_at_monotonic=time.monotonic(),
     )
-
-
-def _fresh_dashboard_alert_count(config: Any) -> int | None:
-    """Return a fresh alert count so stale dashboard snapshots cannot alarm high."""
-
-    try:
-        from pollypm.dashboard_data import count_dashboard_alerts
-
-        return count_dashboard_alerts(config)
-    except Exception:  # noqa: BLE001
-        logger.debug(
-            "dashboard: fresh alert-count refresh failed; using cached value",
-            exc_info=True,
-        )
-        return None
 
 
 # ---------------------------------------------------------------------------
@@ -425,7 +443,6 @@ async def get_dashboard_endpoint(
         )
 
     snapshot_cache = _get_dashboard_snapshot_cache(request)
-    sync_refresh_expected = snapshot_cache.requires_sync_refresh(config)
     snapshot = await snapshot_cache.get_or_refresh(config, _load_dashboard_snapshot)
 
     # Projects view — list_projects is the authoritative cockpit row
@@ -506,25 +523,16 @@ async def get_dashboard_endpoint(
     pending_plan_reviews = sum(
         1 for p in projects_view if p.pending_plan_review
     )
-    # The full snapshot is intentionally stale-while-refresh. Alert counts are
-    # volatile enough that an old-high value can alarm the Home headline, so
-    # refresh that one cheap counter when serving an aged snapshot or after a
-    # fully cold/max-stale rebuild. Updating ``data.alert_count`` keeps the
-    # just-refreshed cache from flapping back on immediate warm hits (#2504).
+    # The full snapshot is intentionally stale-while-refresh. The loader
+    # normalizes alert_count before any sync/background refresh is cached; for
+    # older snapshots, refresh that one cheap counter and write it through so
+    # the Home headline does not hold an old-high value (#2504).
     snapshot_age = time.monotonic() - snapshot.refreshed_at_monotonic
     fresh_alert_count = (
-        _fresh_dashboard_alert_count(config)
-        if sync_refresh_expected or snapshot_age > 2.0
+        _normalize_dashboard_alert_count(config, data)
+        if snapshot_age > 2.0
         else None
     )
-    if fresh_alert_count is not None:
-        try:
-            data.alert_count = int(fresh_alert_count)
-        except Exception:  # noqa: BLE001
-            logger.debug(
-                "dashboard: failed to normalize cached alert_count",
-                exc_info=True,
-            )
 
     rollups = DashboardRollups(
         tracked_count=tracked_count,

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -477,6 +477,67 @@ def test_dashboard_cold_refresh_normalizes_cached_alert_count(
     assert calls == {"gather": 1, "fresh": 1}
 
 
+def test_dashboard_background_refresh_caches_normalized_alert_count(
+    app, client, auth_headers, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app.state.dashboard_snapshot_cache = dashboard_routes.DashboardSnapshotCache(
+        stale_after_seconds=0.01,
+        max_stale_seconds=5.0,
+    )
+    calls = {"gather": 0, "fresh": 0}
+    refresh_started = threading.Event()
+    release_refresh = threading.Event()
+
+    monkeypatch.setattr(
+        dashboard_routes,
+        "list_projects",
+        lambda _config, *, operator_facing=False: [_api_project("myproj")],
+    )
+
+    def fake_gather(_config):
+        calls["gather"] += 1
+        if calls["gather"] == 1:
+            return _make_data(alert_count=3, total_tokens=1)
+        refresh_started.set()
+        assert release_refresh.wait(2.0)
+        return _make_data(alert_count=31, total_tokens=2)
+
+    def fake_fresh(_config):
+        calls["fresh"] += 1
+        return 3
+
+    monkeypatch.setattr(dashboard_routes, "_gather_dashboard", fake_gather)
+    monkeypatch.setattr(
+        dashboard_routes, "_fresh_dashboard_alert_count", fake_fresh,
+    )
+
+    first = client.get("/api/v1/dashboard", headers=auth_headers)
+    assert first.status_code == 200, first.text
+    assert first.json()["rollups"]["alert_count"] == 3
+
+    time.sleep(0.03)
+    second = client.get("/api/v1/dashboard", headers=auth_headers)
+    assert second.status_code == 200, second.text
+    assert second.json()["tokens"]["total"] == 1
+    assert second.json()["rollups"]["alert_count"] == 3
+    assert refresh_started.wait(1.0)
+
+    release_refresh.set()
+    deadline = time.monotonic() + 1.0
+    body = second.json()
+    while time.monotonic() < deadline:
+        third = client.get("/api/v1/dashboard", headers=auth_headers)
+        assert third.status_code == 200, third.text
+        body = third.json()
+        if body["tokens"]["total"] == 2:
+            break
+        time.sleep(0.02)
+
+    assert body["tokens"]["total"] == 2
+    assert body["rollups"]["alert_count"] == 3
+    assert calls == {"gather": 2, "fresh": 2}
+
+
 def test_dashboard_stale_cache_returns_while_refresh_runs(
     app, client, auth_headers, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Normalize `/api/v1/dashboard` `alert_count` inside the snapshot loader before sync or background refreshes write to the cache.
- Keep the aged-snapshot write-through refresh so older cached data cannot hold an inflated headline count.
- Add regression coverage for a stale-while-refresh background rebuild that gathers raw `31` but must cache/serve demoted `3`.

## Verification
- `uv run --with pytest --with pytest-timeout pytest --noconftest tests/test_dashboard_endpoint.py -v --timeout=120` (25 passed)
- `uv run --with ruff ruff check src/pollypm/web_api/routes/dashboard.py tests/test_dashboard_endpoint.py`
- `git diff --check`

Fixes #2504
