### PR TITLE
Fix dashboard cold-miss alert count response

### DIFF
--- a/src/pollypm/web_api/dashboard_snapshot_cache.py
+++ b/src/pollypm/web_api/dashboard_snapshot_cache.py
@@ -21,6 +21,7 @@ class DashboardSnapshot:
     projects: tuple[Any, ...]
     data: Any
     refreshed_at_monotonic: float
+    normalized_alert_count: int | None = None
 
 
 class DashboardSnapshotCache:

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -371,12 +371,16 @@ def _load_dashboard_snapshot(config: Any) -> DashboardSnapshot:
             hint="Retry shortly; check `pm doctor` for pg pool health.",
         ) from data_result
 
-    _normalize_dashboard_alert_count(config, data_result)
+    normalized_alert_count = _normalize_dashboard_alert_count(
+        config,
+        data_result,
+    )
     return DashboardSnapshot(
         generated_at=datetime.now(timezone.utc),
         projects=tuple(projects_result),
         data=data_result,
         refreshed_at_monotonic=time.monotonic(),
+        normalized_alert_count=normalized_alert_count,
     )
 
 
@@ -528,11 +532,12 @@ async def get_dashboard_endpoint(
     # older snapshots, refresh that one cheap counter and write it through so
     # the Home headline does not hold an old-high value (#2504).
     snapshot_age = time.monotonic() - snapshot.refreshed_at_monotonic
-    fresh_alert_count = (
-        _normalize_dashboard_alert_count(config, data)
-        if snapshot_age > 2.0
-        else None
-    )
+    if snapshot_age > 2.0:
+        fresh_alert_count = _normalize_dashboard_alert_count(config, data)
+    else:
+        # Prefer the loader's explicit normalized value so the sync
+        # cache-miss response cannot fall back to the raw gathered count.
+        fresh_alert_count = snapshot.normalized_alert_count
 
     rollups = DashboardRollups(
         tracked_count=tracked_count,

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -475,6 +476,37 @@ def test_dashboard_cold_refresh_normalizes_cached_alert_count(
     assert first.json()["rollups"]["alert_count"] == 3
     assert second.json()["rollups"]["alert_count"] == 3
     assert calls == {"gather": 1, "fresh": 1}
+
+
+def test_dashboard_cache_miss_response_uses_snapshot_normalized_alert_count(
+    app, client, auth_headers, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"load": 0}
+
+    def fake_load_dashboard_snapshot(_config):
+        calls["load"] += 1
+        return dashboard_routes.DashboardSnapshot(
+            generated_at=datetime.now(timezone.utc),
+            projects=(_api_project("myproj"),),
+            data=_make_data(alert_count=29),
+            refreshed_at_monotonic=time.monotonic(),
+            normalized_alert_count=3,
+        )
+
+    monkeypatch.setattr(
+        dashboard_routes,
+        "_load_dashboard_snapshot",
+        fake_load_dashboard_snapshot,
+    )
+
+    first = client.get("/api/v1/dashboard", headers=auth_headers)
+    second = client.get("/api/v1/dashboard", headers=auth_headers)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["rollups"]["alert_count"] == 3
+    assert second.json()["rollups"]["alert_count"] == 3
+    assert calls == {"load": 1}
 
 
 def test_dashboard_background_refresh_caches_normalized_alert_count(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Carry the liveness-normalized dashboard `alert_count` as an explicit snapshot value when the dashboard snapshot is loaded.
- Have `/api/v1/dashboard` prefer that normalized snapshot value for fresh cache hits, including the synchronous cold cache-miss response, while preserving the existing aged-snapshot write-through refresh.
- Add a regression test where the snapshot data still contains a raw high alert count but the response must serve the normalized count immediately.

## Verification
- `uv run --with pytest --with pytest-timeout pytest --noconftest tests/test_dashboard_endpoint.py -v --timeout=120` (26 passed)
- `uv run --with ruff ruff check src/pollypm/web_api/routes/dashboard.py src/pollypm/web_api/dashboard_snapshot_cache.py tests/test_dashboard_endpoint.py`
- `git diff --check`

Fixes #2504
