### PR TITLE
fix: re-exec rail daemon on code refresh

### DIFF
--- a/src/pollypm/deploy_info.py
+++ b/src/pollypm/deploy_info.py
@@ -84,6 +84,26 @@ class DeployStaleness:
     data: dict[str, object]
 
 
+@dataclass(frozen=True, slots=True)
+class RuntimeCodeFingerprint:
+    """Small runtime-code identity token for long-lived process re-exec checks."""
+
+    kind: str
+    value: str
+    package_path: str | None = None
+    source_checkout: str | None = None
+
+    @property
+    def token(self) -> str:
+        return f"{self.kind}:{self.value}"
+
+    def display(self) -> str:
+        value = self.value
+        if "sha" in self.kind and len(value) > 12:
+            value = value[:12]
+        return f"{self.kind}={value}"
+
+
 def _safe_resolve(path: Path) -> Path:
     try:
         return path.resolve()
@@ -382,6 +402,88 @@ def runtime_build_info(
             "stale_reason": reason,
         }
     )
+
+
+def runtime_code_fingerprint(
+    *,
+    package_name: str = PACKAGE_NAME,
+    import_name: str = PACKAGE_IMPORT_NAME,
+) -> RuntimeCodeFingerprint | None:
+    """Return a cheap identity token for the code this process imports.
+
+    This intentionally avoids :func:`runtime_build_info`'s package-tree
+    mtime scan so long-lived processes can call it periodically. The
+    preferred signal is the git HEAD of the imported package path, which
+    covers editable installs. Non-editable installs fall back to the
+    embedded build SHA written into shipped packages, then to a package
+    directory mtime token as a last resort.
+    """
+
+    package_path, package_file = _package_location(import_name)
+    package_version, _dist_info_path, direct_url = _distribution_info(package_name)
+    (
+        _direct_url_text,
+        direct_url_editable,
+        _direct_url_vcs,
+        direct_url_vcs_commit_id,
+        direct_url_source,
+    ) = _direct_url_fields(direct_url)
+
+    served_git_root = _git_root(package_path)
+    if served_git_root is not None:
+        served_git_sha = _git_head(served_git_root)
+        if served_git_sha:
+            return RuntimeCodeFingerprint(
+                kind="served_git_sha",
+                value=served_git_sha,
+                package_path=str(package_path) if package_path else None,
+                source_checkout=str(served_git_root),
+            )
+
+    embedded_build_info = _embedded_build_info(package_path)
+    embedded_sha = embedded_build_info.get("git_sha")
+    if embedded_sha:
+        return RuntimeCodeFingerprint(
+            kind="embedded_git_sha",
+            value=embedded_sha,
+            package_path=str(package_path) if package_path else None,
+        )
+
+    if direct_url_editable is True and direct_url_source is not None:
+        source_root = _git_root(direct_url_source)
+        if source_root is not None:
+            source_sha = _git_head(source_root)
+            if source_sha:
+                return RuntimeCodeFingerprint(
+                    kind="editable_source_git_sha",
+                    value=source_sha,
+                    package_path=str(package_path) if package_path else None,
+                    source_checkout=str(source_root),
+                )
+
+    if direct_url_vcs_commit_id:
+        return RuntimeCodeFingerprint(
+            kind="direct_url_vcs_commit_id",
+            value=direct_url_vcs_commit_id,
+            package_path=str(package_path) if package_path else None,
+        )
+
+    for candidate in (package_path, package_file):
+        if candidate is None:
+            continue
+        try:
+            stat = candidate.stat()
+        except OSError:
+            continue
+        return RuntimeCodeFingerprint(
+            kind="package_mtime_ns",
+            value=f"{candidate}:{stat.st_mtime_ns}",
+            package_path=str(package_path) if package_path else None,
+        )
+
+    if package_version:
+        return RuntimeCodeFingerprint(kind="version", value=package_version)
+    return None
 
 
 @cache

--- a/src/pollypm/rail_daemon.py
+++ b/src/pollypm/rail_daemon.py
@@ -94,6 +94,10 @@ def _acquire_lifetime_lock(lock_path: Path) -> int | None:
     except OSError as exc:
         logger.warning("rail_daemon: could not open lock file %s: %s", lock_path, exc)
         return None
+    try:
+        os.set_inheritable(fd, False)
+    except OSError:
+        pass
 
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -128,6 +132,10 @@ _LIFETIME_LOCK_FD: int | None = None
 _SIGTERM_WATCHDOG_GRACE: float = 2.0
 
 
+class _ReexecFailed(RuntimeError):
+    """Raised when a stale-code re-exec could not replace this process."""
+
+
 def _claim_pid_file(pid_path: Path) -> bool:
     """Atomically write our PID iff no live daemon already holds the file.
 
@@ -157,6 +165,12 @@ def _claim_pid_file(pid_path: Path) -> bool:
 
     if pid_path.exists():
         existing = _read_existing_pid()
+        if existing == os.getpid():
+            # ``os.execv`` preserves the PID. A daemon that re-execed
+            # itself for a code bump starts with its own PID already in
+            # the file; accepting that claim avoids a false duplicate
+            # while the lifetime flock still prevents any second daemon.
+            return True
         if existing <= 0:
             # Another daemon may have won O_EXCL and not written its PID
             # bytes yet. Give that tiny critical section a chance to
@@ -198,6 +212,102 @@ def _claim_pid_file(pid_path: Path) -> bool:
     finally:
         os.close(fd)
     return True
+
+
+def _current_runtime_code_fingerprint():
+    """Return the current import-code fingerprint, or ``None`` if unknown."""
+    try:
+        from pollypm.deploy_info import runtime_code_fingerprint
+
+        return runtime_code_fingerprint()
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "rail_daemon: runtime code fingerprint check failed",
+            exc_info=True,
+        )
+        return None
+
+
+def _fingerprint_display(fingerprint: object | None) -> str:
+    if fingerprint is None:
+        return "unknown"
+    display = getattr(fingerprint, "display", None)
+    if callable(display):
+        try:
+            return str(display())
+        except Exception:  # noqa: BLE001
+            pass
+    kind = getattr(fingerprint, "kind", "unknown")
+    value = getattr(fingerprint, "value", "")
+    if isinstance(value, str) and "sha" in str(kind) and len(value) > 12:
+        value = value[:12]
+    return f"{kind}={value}"
+
+
+def _runtime_code_changed(
+    boot_fingerprint: object | None,
+    current_fingerprint: object | None,
+) -> bool:
+    """True when comparable runtime-code fingerprints differ."""
+    if boot_fingerprint is None or current_fingerprint is None:
+        return False
+    boot_kind = getattr(boot_fingerprint, "kind", None)
+    current_kind = getattr(current_fingerprint, "kind", None)
+    if boot_kind != current_kind:
+        logger.debug(
+            "rail_daemon: code fingerprint kind changed (%s -> %s); "
+            "skipping re-exec until the signal is comparable",
+            boot_kind, current_kind,
+        )
+        return False
+    boot_token = getattr(boot_fingerprint, "token", None)
+    current_token = getattr(current_fingerprint, "token", None)
+    if boot_token is None:
+        boot_token = f"{boot_kind}:{getattr(boot_fingerprint, 'value', '')}"
+    if current_token is None:
+        current_token = f"{current_kind}:{getattr(current_fingerprint, 'value', '')}"
+    return str(boot_token) != str(current_token)
+
+
+def _reexec_argv() -> list[str]:
+    argv = list(sys.argv)
+    if not argv:
+        argv = ["-m", "pollypm.rail_daemon"]
+    return [sys.executable, *argv]
+
+
+def _reexec_for_runtime_code_change(
+    rail: object,
+    *,
+    boot_fingerprint: object | None,
+    current_fingerprint: object | None,
+) -> None:
+    """Stop the rail and replace this process with a fresh interpreter."""
+    logger.warning(
+        "rail_daemon: runtime code changed (%s -> %s); "
+        "stopping rail and re-execing",
+        _fingerprint_display(boot_fingerprint),
+        _fingerprint_display(current_fingerprint),
+    )
+    try:
+        stop = getattr(rail, "stop", None)
+        if callable(stop):
+            stop()
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "rail_daemon: rail.stop() raised before code-refresh re-exec; "
+            "continuing with exec so the next boot can recover orphaned jobs",
+        )
+
+    argv = _reexec_argv()
+    try:
+        os.execv(sys.executable, argv)
+    except OSError as exc:
+        logger.exception(
+            "rail_daemon: re-exec failed after runtime code change; "
+            "exiting so the external supervisor can revive a fresh daemon",
+        )
+        raise _ReexecFailed(str(exc)) from exc
 
 
 def _pid_alive(pid: int) -> bool:
@@ -325,6 +435,7 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
         logger.error("rail_daemon: supervisor has no core_rail attribute")
         pid_path.unlink(missing_ok=True)
         return 2
+    boot_fingerprint = _current_runtime_code_fingerprint()
 
     stopping = {"flag": False, "deadline": 0.0}
 
@@ -429,8 +540,9 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
     _crash_loop_file(pollypm_home).unlink(missing_ok=True)
 
     logger.info(
-        "rail_daemon: started (pid=%d, poll=%.1fs) — heartbeat rail live",
-        os.getpid(), poll_interval,
+        "rail_daemon: started (pid=%d, poll=%.1fs, code=%s) — "
+        "heartbeat rail live",
+        os.getpid(), poll_interval, _fingerprint_display(boot_fingerprint),
     )
 
     # The rail's internal ticker thread does the work; we just keep
@@ -443,6 +555,16 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
     while not stopping["flag"]:
         slice_s = min(0.5, max(0.0, deadline - time.monotonic()))
         if slice_s <= 0:
+            current_fingerprint = _current_runtime_code_fingerprint()
+            if _runtime_code_changed(boot_fingerprint, current_fingerprint):
+                try:
+                    _reexec_for_runtime_code_change(
+                        rail,
+                        boot_fingerprint=boot_fingerprint,
+                        current_fingerprint=current_fingerprint,
+                    )
+                except _ReexecFailed:
+                    return 4
             deadline = time.monotonic() + poll_interval
             continue
         time.sleep(slice_s)

--- a/tests/test_deploy_info.py
+++ b/tests/test_deploy_info.py
@@ -113,6 +113,65 @@ def test_runtime_build_info_reads_embedded_served_git_sha(
     assert info.served_git_commit_time == "2026-05-29T12:00:00+00:00"
 
 
+def test_runtime_code_fingerprint_prefers_imported_package_git_head(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    package_path = tmp_path / "checkout" / "src" / "pollypm"
+    _write(package_path / "__init__.py", "")
+    checkout = tmp_path / "checkout"
+
+    monkeypatch.setattr(
+        deploy_info,
+        "_package_location",
+        lambda _import_name: (package_path, package_path / "__init__.py"),
+    )
+    monkeypatch.setattr(
+        deploy_info,
+        "_distribution_info",
+        lambda _package_name: ("1", tmp_path / "pollypm-1.dist-info", None),
+    )
+    monkeypatch.setattr(deploy_info, "_git_root", lambda path: checkout)
+    monkeypatch.setattr(deploy_info, "_git_head", lambda path: "abc123")
+
+    fingerprint = deploy_info.runtime_code_fingerprint()
+
+    assert fingerprint is not None
+    assert fingerprint.kind == "served_git_sha"
+    assert fingerprint.value == "abc123"
+    assert fingerprint.source_checkout == str(checkout)
+
+
+def test_runtime_code_fingerprint_uses_embedded_sha_without_git_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    package_path = tmp_path / "tool" / "pollypm"
+    _write(package_path / "__init__.py", "")
+    _write(
+        package_path / deploy_info.BUILD_INFO_FILENAME,
+        json.dumps({"git_sha": "embedded-sha"}),
+    )
+
+    monkeypatch.setattr(
+        deploy_info,
+        "_package_location",
+        lambda _import_name: (package_path, package_path / "__init__.py"),
+    )
+    monkeypatch.setattr(
+        deploy_info,
+        "_distribution_info",
+        lambda _package_name: ("1", tmp_path / "pollypm-1.dist-info", None),
+    )
+    monkeypatch.setattr(deploy_info, "_git_root", lambda path: None)
+
+    fingerprint = deploy_info.runtime_code_fingerprint()
+
+    assert fingerprint is not None
+    assert fingerprint.kind == "embedded_git_sha"
+    assert fingerprint.value == "embedded-sha"
+
+
 def test_runtime_build_info_flags_stale_when_embedded_sha_differs_from_source(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_rail_daemon.py
+++ b/tests/test_rail_daemon.py
@@ -14,7 +14,6 @@ import signal
 import subprocess
 import sys
 import textwrap
-import time
 from pathlib import Path
 
 import pytest
@@ -25,6 +24,7 @@ from pollypm.rail_daemon import (
     _lock_file,
     _pid_alive,
     _pid_file,
+    _runtime_code_changed,
 )
 
 
@@ -51,10 +51,26 @@ def test_claim_pid_file_fresh(tmp_path: Path):
 
 def test_claim_pid_file_rejects_live_owner(tmp_path: Path):
     pid_path = tmp_path / "rail_daemon.pid"
-    # Simulate an already-running daemon owning the file.
+    owner = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        # Simulate another live daemon owning the file.
+        pid_path.write_text(str(owner.pid))
+        assert _claim_pid_file(pid_path) is False
+        # The file must be untouched — we reject without stomping.
+        assert pid_path.read_text().strip() == str(owner.pid)
+    finally:
+        owner.terminate()
+        try:
+            owner.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            owner.kill()
+            owner.wait(timeout=2.0)
+
+
+def test_claim_pid_file_accepts_self_pid_for_reexec(tmp_path: Path):
+    pid_path = tmp_path / "rail_daemon.pid"
     pid_path.write_text(str(os.getpid()))
-    assert _claim_pid_file(pid_path) is False
-    # The file must be untouched — we reject without stomping.
+    assert _claim_pid_file(pid_path) is True
     assert pid_path.read_text().strip() == str(os.getpid())
 
 
@@ -88,6 +104,32 @@ def test_claim_pid_file_creates_parent_dir(tmp_path: Path):
     pid_path = tmp_path / "new_subdir" / "rail_daemon.pid"
     assert _claim_pid_file(pid_path) is True
     assert pid_path.exists()
+
+
+class _Fingerprint:
+    def __init__(self, kind: str, value: str) -> None:
+        self.kind = kind
+        self.value = value
+        self.token = f"{kind}:{value}"
+
+
+def test_runtime_code_changed_detects_comparable_value_change() -> None:
+    assert _runtime_code_changed(
+        _Fingerprint("served_git_sha", "old"),
+        _Fingerprint("served_git_sha", "new"),
+    )
+
+
+def test_runtime_code_changed_ignores_unknown_or_incomparable_values() -> None:
+    assert not _runtime_code_changed(None, _Fingerprint("served_git_sha", "new"))
+    assert not _runtime_code_changed(
+        _Fingerprint("served_git_sha", "old"),
+        _Fingerprint("package_mtime_ns", "new"),
+    )
+    assert not _runtime_code_changed(
+        _Fingerprint("served_git_sha", "same"),
+        _Fingerprint("served_git_sha", "same"),
+    )
 
 
 # --- Lifetime flock (#1586) ------------------------------------------------


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- add a lightweight runtime code fingerprint for long-lived processes without scanning the whole package tree
- have rail_daemon log its booted code fingerprint and re-exec itself when the installed/editable code fingerprint changes
- preserve the existing PID across exec while reacquiring the lifetime flock, so pm up/cockpit supervision still sees one daemon

## Verification
- uv run --extra dev ruff check src/pollypm/deploy_info.py src/pollypm/rail_daemon.py tests/test_rail_daemon.py tests/test_deploy_info.py
- uv run --extra test pytest -q tests/test_rail_daemon.py tests/test_deploy_info.py

Fixes #2510