### PR TITLE
Scope rail daemon fingerprint to package source

### DIFF
--- a/src/pollypm/deploy_info.py
+++ b/src/pollypm/deploy_info.py
@@ -163,6 +163,20 @@ def _git_head_time(path: Path | None) -> str | None:
     return _git_value(path, ["show", "-s", "--format=%cI", "HEAD"])
 
 
+def _git_latest_commit_for_path(git_root: Path, path: Path | None) -> str | None:
+    if path is None:
+        return None
+    root = _safe_resolve(git_root)
+    target = _safe_resolve(path)
+    if not _path_is_relative_to(target, root):
+        return None
+    rel = target.relative_to(root).as_posix() or "."
+    rc, out = _run_git(root, ["log", "-1", "--format=%H", "--", rel])
+    if rc != 0 or not out:
+        return None
+    return out
+
+
 def _iso_from_mtime(mtime: float) -> str:
     return datetime.fromtimestamp(mtime, tz=UTC).isoformat().replace("+00:00", "Z")
 
@@ -413,10 +427,11 @@ def runtime_code_fingerprint(
 
     This intentionally avoids :func:`runtime_build_info`'s package-tree
     mtime scan so long-lived processes can call it periodically. The
-    preferred signal is the git HEAD of the imported package path, which
-    covers editable installs. Non-editable installs fall back to the
-    embedded build SHA written into shipped packages, then to a package
-    directory mtime token as a last resort.
+    preferred signal is the latest git commit that touched the imported
+    package tree, which covers editable installs without forcing a
+    long-lived daemon to re-exec for docs-only commits. Non-editable
+    installs fall back to the embedded build SHA written into shipped
+    packages, then to a package directory mtime token as a last resort.
     """
 
     package_path, package_file = _package_location(import_name)
@@ -431,10 +446,10 @@ def runtime_code_fingerprint(
 
     served_git_root = _git_root(package_path)
     if served_git_root is not None:
-        served_git_sha = _git_head(served_git_root)
+        served_git_sha = _git_latest_commit_for_path(served_git_root, package_path)
         if served_git_sha:
             return RuntimeCodeFingerprint(
-                kind="served_git_sha",
+                kind="served_package_git_sha",
                 value=served_git_sha,
                 package_path=str(package_path) if package_path else None,
                 source_checkout=str(served_git_root),
@@ -452,10 +467,11 @@ def runtime_code_fingerprint(
     if direct_url_editable is True and direct_url_source is not None:
         source_root = _git_root(direct_url_source)
         if source_root is not None:
-            source_sha = _git_head(source_root)
+            source_package_root = _source_package_root(source_root, package_name)
+            source_sha = _git_latest_commit_for_path(source_root, source_package_root)
             if source_sha:
                 return RuntimeCodeFingerprint(
-                    kind="editable_source_git_sha",
+                    kind="editable_source_package_git_sha",
                     value=source_sha,
                     package_path=str(package_path) if package_path else None,
                     source_checkout=str(source_root),

--- a/tests/test_deploy_info.py
+++ b/tests/test_deploy_info.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pollypm.deploy_info as deploy_info
@@ -12,6 +13,22 @@ from pollypm.deploy_info import RuntimeBuildInfo, assess_deploy_staleness
 def _write(path: Path, body: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
 
 
 def test_assess_deploy_staleness_detects_copied_package_drift(tmp_path: Path) -> None:
@@ -113,13 +130,17 @@ def test_runtime_build_info_reads_embedded_served_git_sha(
     assert info.served_git_commit_time == "2026-05-29T12:00:00+00:00"
 
 
-def test_runtime_code_fingerprint_prefers_imported_package_git_head(
+def test_runtime_code_fingerprint_tracks_imported_package_tree_commit(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    package_path = tmp_path / "checkout" / "src" / "pollypm"
-    _write(package_path / "__init__.py", "")
     checkout = tmp_path / "checkout"
+    package_path = checkout / "src" / "pollypm"
+    _write(package_path / "__init__.py", "")
+    _git(checkout, "init")
+    _git(checkout, "config", "user.email", "codex@example.invalid")
+    _git(checkout, "config", "user.name", "Codex")
+    first_source_sha = _git_commit(checkout, "initial package")
 
     monkeypatch.setattr(
         deploy_info,
@@ -131,15 +152,29 @@ def test_runtime_code_fingerprint_prefers_imported_package_git_head(
         "_distribution_info",
         lambda _package_name: ("1", tmp_path / "pollypm-1.dist-info", None),
     )
-    monkeypatch.setattr(deploy_info, "_git_root", lambda path: checkout)
-    monkeypatch.setattr(deploy_info, "_git_head", lambda path: "abc123")
 
     fingerprint = deploy_info.runtime_code_fingerprint()
 
     assert fingerprint is not None
-    assert fingerprint.kind == "served_git_sha"
-    assert fingerprint.value == "abc123"
+    assert fingerprint.kind == "served_package_git_sha"
+    assert fingerprint.value == first_source_sha
     assert fingerprint.source_checkout == str(checkout)
+
+    _write(checkout / "docs" / "journal.md", "docs-only\n")
+    _git_commit(checkout, "docs only")
+
+    docs_fingerprint = deploy_info.runtime_code_fingerprint()
+
+    assert docs_fingerprint is not None
+    assert docs_fingerprint.value == first_source_sha
+
+    _write(package_path / "feature.py", "VALUE = 'new'\n")
+    second_source_sha = _git_commit(checkout, "package change")
+
+    source_fingerprint = deploy_info.runtime_code_fingerprint()
+
+    assert source_fingerprint is not None
+    assert source_fingerprint.value == second_source_sha
 
 
 def test_runtime_code_fingerprint_uses_embedded_sha_without_git_root(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Scope `runtime_code_fingerprint()` to the latest commit touching the imported `pollypm` package tree instead of repository `HEAD`.
- Add a git-backed regression test showing docs-only commits do not change the fingerprint while `src/pollypm` changes do.

## Tests
- `uv run --extra test python -m pytest tests/test_deploy_info.py tests/test_rail_daemon.py -q` -> 27 passed
- `uv run --extra dev ruff check src/pollypm/deploy_info.py tests/test_deploy_info.py` -> passed

Fixes #2512
