### PR TITLE
Fix live AskUser answer routing

### DIFF
--- a/docs/api-chat-endpoints.md
+++ b/docs/api-chat-endpoints.md
@@ -220,7 +220,7 @@ Pull a window of messages from a single session's transcript.
 | `direction` | `desc` | `desc` (newest first) or `asc`. Pagination cursors assume the same direction. |
 | `include_subagents` | `false` | When `true`, each `subagent_result` envelope's `metadata.subagent_transcript` is populated by parsing the raw Claude JSONL the parent `task-notification.output-file` points at. Paths outside the project/workspace transcript allowlist are silently skipped. Capped per envelope. (#2052) |
 | `include_thinking` | `false` | When `true`, Anthropic extended-thinking blocks are emitted as `type=thinking` envelopes alongside the normal turns. Default `false` preserves the historical envelope contract so existing clients see no new types unless they opt in. See §4 type catalog and #2082. |
-| `source` | `auto` | `auto` (JSONL with capture fallback when archive is missing or >60s stale), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). Any other value returns `422 validation_error`. |
+| `source` | `auto` | `auto` (JSONL with capture fallback when archive is missing or >60s stale, plus a live AskUserQuestion capture probe for the newest page), `jsonl` (force JSONL; 404 if absent), `capture` (force live `tmux capture-pane`). Any other value returns `422 validation_error`. |
 
 > Note: `thinking` envelopes are gated behind `?include_thinking=true`.
 > Clients that do not pass the flag will not see `type="thinking"`
@@ -362,7 +362,7 @@ It does **not** bypass pane/window validation: `409 pane_invalid`,
 | 503 | `tmux_unavailable` | tmux binary not found or unresponsive (`FileNotFoundError`, `TimeoutExpired`, `CalledProcessError`). |
 | 503 | `send_failed` | tmux `send_keys` raised a generic error (paste-buffer fail, `OSError` post-validation). |
 | 503 | `service_unavailable` | Worker session lookup failed (work-service outage). Only emitted for worker `session_name`s. |
-| 400 | `answer_to_missing` | `answer_to` id was not found in the session's recent transcript. |
+| 400 | `answer_to_missing` | `answer_to` id was not found in the session's recent transcript or live capture. |
 | 400 | `selections_no_question` | `answer_to` references a message that isn't an `ask_user` envelope. |
 | 400 | `selections_invalid` | One or more selections don't match the question's option labels. Response message includes the valid options. |
 | 400 | `invalid_request` | Catch-all for body-shape problems: missing `text` when `answer_to` is unset; `answer_to` set but no `selections`/`text`/`notes` supplied; etc. The message body identifies the specific problem. |
@@ -649,7 +649,9 @@ pane, list them via `tmux list-panes -t <window>` on the daemon host.
 ### 5.5 Answering `AskUserQuestion`
 
 The agent emitted an `ask_user` envelope (§4). In Claude Code's UI,
-the user clicks a button; in tmux, the user types the option label.
+the user clicks a button; in tmux, PollyPM either types the option
+label for JSONL-sourced questions or drives the visible TUI picker for
+capture-sourced `cap_*` questions.
 
 ```json
 {
@@ -667,20 +669,23 @@ Translation rules:
 - Multi-select `selections: ["a", "b"]` → typed as newline-separated
   labels. If your install needs a different delimiter, fall back to
   plain `text`.
+- For a live capture-sourced AskUserQuestion (`answer_to` starts
+  `cap_`), selections are translated to the option numbers/tabs needed
+  by Claude Code's visible TUI form, then submitted with Enter.
 
 If a selection label doesn't exactly match any option, the API returns
 `400 selections_invalid` with the valid labels in the response body.
 
-**AskUserQuestion answer format.** The shipped `_build_answer_text`
-(chat_send.py) joins selected option labels with newlines. If `notes`
-is provided, it's appended after another newline. The trailing newline
-is controlled by `press_enter` (default true). Example:
+**AskUserQuestion answer format.** For JSONL-sourced questions, the
+shipped `_build_answer_text` (chat_send.py) joins selected option
+labels with newlines. If `notes` is provided, it's appended after
+another newline. The trailing newline is controlled by `press_enter`
+(default true). Example:
 `selections=["A", "B"]`, `notes="extra context"`, `press_enter=true`
-produces stdin = `"A\nB\nextra context\n"`. If Claude Code's actual
-stdin parser turns out to expect something different (e.g., option
-index instead of label), file a follow-up issue rather than blocking;
-clients can also send freeform `text` instead of structured
-`selections` to test other formats.
+produces stdin = `"A\nB\nextra context\n"`. For `cap_*` questions,
+`_build_capture_answer_text` maps labels to the visible option numbers
+and tabs to Submit. Clients can also send freeform `text` instead of
+structured `selections` to test other formats.
 
 ```
 # Answer an ask_user message with a selection (positional text="" required):
@@ -699,10 +704,13 @@ always included in the GET response (phase 1 has no
 silently if the user might wonder why the conversation "jumps" —
 render at least a horizontal rule.
 
-### 5.7 Stale JSONL → tmux capture fallback
+### 5.7 Live tmux capture fallback
 
 The JSONL exists but hasn't been written for >60s and the tmux pane is
-live — usually means Claude Code hasn't flushed mid-stream.
+live — usually means Claude Code hasn't flushed mid-stream. The same
+capture path is also used when the newest default `source=auto` page
+sees a live AskUserQuestion form in the pane before the corresponding
+`tool_use` has flushed to JSONL.
 
 **Behavior (under `source=auto`):** fall back to
 `tmux capture-pane -p -S -3000`. Each captured line becomes one
@@ -712,7 +720,9 @@ synthetic (`cap_<hash>`), stable across reads.
 Source-mode behavior:
 
 - `source=auto` (default): JSONL archive first, capture-pane fallback
-  on stale/missing. Fail-soft — returns empty `messages` if both fail.
+  on stale/missing, and for the newest page when a live AskUserQuestion
+  menu is visible but not yet flushed to JSONL. Fail-soft — returns
+  empty `messages` if both fail.
 - `source=jsonl` (explicit): JSONL only. Returns `404 archive_missing`
   if absent, `503 archive_unreadable` on read failure.
 - `source=capture` (explicit): tmux capture only. Returns
@@ -767,9 +777,10 @@ ingestor used for Claude:
 - The route's source selection in
   `chat_messages.py::_load_envelopes` is **provider-agnostic**. It
   prefers the JSONL archive under `source=auto` and only falls
-  through to `tmux capture-pane` when the archive is stale or
-  unreadable (the §5.7 staleness rule). There is no `provider ==
-  "codex"` short-circuit.
+  through to `tmux capture-pane` when the archive is stale/unreadable
+  or when the live AskUserQuestion probe finds an answerable menu (the
+  §5.7 fallback rule). There is no `provider == "codex"`
+  short-circuit.
 - The capture-pane fallback is therefore a freshness safety net for
   **any** provider whose ingestor lags the live pane — not a
   provider-specific code path.

--- a/src/pollypm/web_api/routes/chat_messages.py
+++ b/src/pollypm/web_api/routes/chat_messages.py
@@ -77,6 +77,7 @@ MAX_MESSAGE_LIMIT = 500
 # file. The forward parser stays authoritative for ``asc``, cursor
 # paging, and the strict ``source=jsonl`` validation path.
 TAIL_READ_LIMIT_THRESHOLD = 200
+LIVE_ASK_USER_CAPTURE_LINES = 240
 
 
 SourceMode = Literal["auto", "jsonl", "capture"]
@@ -579,6 +580,7 @@ def _load_envelopes(
     source: SourceMode,
     tail_hint: int | None = None,
     include_thinking: bool = False,
+    probe_live_ask_user: bool = False,
 ) -> tuple[list[MessageEnvelope], str | None, Path | None]:
     """Return ``(envelopes, transcript_source, transcript_path)``.
 
@@ -603,6 +605,11 @@ def _load_envelopes(
     are dropped at parse time. The parser caches separately for each
     flag value, so a default-False request never sees a thinking-True
     cache hit and vice versa.
+
+    ``probe_live_ask_user`` lets the default latest-page UI poll detect
+    Claude Code's active AskUserQuestion TUI form before the tool_use is
+    flushed to JSONL. The probe is a small live capture and only wins
+    when it parses a structured open ask_user envelope.
     """
     archive = surface.transcript_path
     actor_fallback = surface.persona or "agent"
@@ -661,6 +668,15 @@ def _load_envelopes(
                 include_thinking=include_thinking,
             )
         if envelopes:
+            if _latest_envelope_is_open_ask_user(envelopes):
+                return envelopes, "jsonl", archive
+            captured_ask = _live_capture_open_ask_user(
+                surface,
+                actor_fallback=actor_fallback,
+                enabled=probe_live_ask_user,
+            )
+            if captured_ask:
+                return captured_ask, "capture", None
             return envelopes, "jsonl", archive
         # Empty result on a fresh (non-stale) archive could be a
         # legitimately empty transcript OR an unreadable archive whose
@@ -686,6 +702,13 @@ def _load_envelopes(
                 exc_info=True,
             )
         else:
+            captured_ask = _live_capture_open_ask_user(
+                surface,
+                actor_fallback=actor_fallback,
+                enabled=probe_live_ask_user,
+            )
+            if captured_ask:
+                return captured_ask, "capture", None
             return strict_envelopes, "jsonl", archive
 
     # Stale or missing archive (or unreadable archive in the auto
@@ -747,6 +770,24 @@ def _latest_envelope_is_open_ask_user(envelopes: list[MessageEnvelope]) -> bool:
     return False
 
 
+def _live_capture_open_ask_user(
+    surface: ChatSurface,
+    *,
+    actor_fallback: str,
+    enabled: bool,
+) -> list[MessageEnvelope]:
+    if not enabled:
+        return []
+    captured = _capture_for_surface(
+        surface,
+        actor_fallback=actor_fallback,
+        lines=LIVE_ASK_USER_CAPTURE_LINES,
+    )
+    if _latest_envelope_is_open_ask_user(captured):
+        return captured
+    return []
+
+
 def _is_pm_chat_surface(surface: ChatSurface) -> bool:
     return surface.surface_type in _PM_CHAT_SURFACE_TYPES
 
@@ -792,6 +833,7 @@ def _capture_for_surface(
     *,
     actor_fallback: str,
     strict: bool = False,
+    lines: int = 3000,
 ) -> list[MessageEnvelope]:
     """Capture the surface's tmux pane into envelopes.
 
@@ -824,6 +866,7 @@ def _capture_for_surface(
             session_name=surface.session_name,
             target=target,
             actor_fallback=actor_fallback,
+            lines=lines,
             strict=strict,
         )
     except APIError:
@@ -1215,8 +1258,9 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
     source: Annotated[SourceMode, Query(
         description=(
             "Transcript source: 'auto' (jsonl with capture fallback when "
-            f">{int(STALE_THRESHOLD_SECONDS)}s stale), 'jsonl' (force "
-            "JSONL, 404 if absent), 'capture' (force tmux capture)."
+            f">{int(STALE_THRESHOLD_SECONDS)}s stale or when the latest "
+            "page has a live AskUserQuestion menu), 'jsonl' (force JSONL, "
+            "404 if absent), 'capture' (force tmux capture)."
         ),
     )] = "auto",
     include_subagents: Annotated[bool, Query(
@@ -1275,6 +1319,13 @@ def get_chat_messages_endpoint(  # noqa: PLR0913 — query surface mirrors spec 
         source=source,
         tail_hint=tail_hint,
         include_thinking=include_thinking,
+        probe_live_ask_user=(
+            source == "auto"
+            and direction == "desc"
+            and since_id is None
+            and not include_subagents
+            and not include_thinking
+        ),
     )
     if (
         _is_pm_chat_surface(surface)

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -85,6 +85,9 @@ from pollypm.audit.log import EVENT_CHAT_SEND_FORCE_BYPASS, emit as audit_emit
 from pollypm.tmux.client import DeadPaneError, TmuxClient
 from pollypm.web_api.chat import (
     ChatSurface,
+    MessageEnvelope,
+    MessageType,
+    capture_envelopes,
     find_chat_surface,
 )
 from pollypm.web_api.errors import APIError
@@ -1122,6 +1125,39 @@ def _find_ask_user_envelope(
     return None
 
 
+def _find_live_capture_ask_user_envelope(
+    tmux: Any,
+    *,
+    session_name: str,
+    target: str,
+    actor_fallback: str,
+    answer_to: str,
+) -> dict[str, Any] | None:
+    """Locate a live capture-sourced ask_user envelope matching ``answer_to``."""
+
+    if not _is_capture_answer_id(answer_to):
+        return None
+    envelopes = capture_envelopes(
+        tmux,
+        session_name=session_name,
+        target=target,
+        actor_fallback=actor_fallback,
+    )
+    for envelope in reversed(envelopes):
+        if envelope.type == MessageType.ASK_USER and envelope.id == answer_to:
+            return _capture_envelope_event(envelope)
+    return None
+
+
+def _capture_envelope_event(envelope: MessageEnvelope) -> dict[str, Any]:
+    metadata = dict(envelope.metadata or {})
+    return {
+        "event_type": "capture_ask_user",
+        "id": envelope.id,
+        "metadata": metadata,
+    }
+
+
 def _is_capture_answer_id(answer_to: str | None) -> bool:
     return isinstance(answer_to, str) and answer_to.startswith("cap_")
 
@@ -1561,6 +1597,7 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
     if needs_transcript:
         events_path, resolution = _resolve_session_events(surface, project_root)
     ask_envelope: dict[str, Any] | None = None
+    ask_envelope_from_capture = False
     ask_exempt_ids: set[str] = set()
     transcript_unavailable_detail: str | None = None
     if body.answer_to is not None:
@@ -1586,6 +1623,15 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
             raw_id = _event_message_id(ask_envelope)
             if isinstance(raw_id, str) and raw_id:
                 ask_exempt_ids.add(raw_id)
+        elif _is_capture_answer_id(body.answer_to):
+            ask_envelope = _find_live_capture_ask_user_envelope(
+                tmux,
+                session_name=session_name,
+                target=target,
+                actor_fallback=surface.persona or "agent",
+                answer_to=body.answer_to,
+            )
+            ask_envelope_from_capture = ask_envelope is not None
 
     # 3. Safety gates (§4.1, §4.3) — use the exact session transcript
     # (Codex review block 3).
@@ -1601,7 +1647,7 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
                 exempt_tool_ids=ask_exempt_ids,
             )
     else:
-        if resolution == "absent_but_others_exist":
+        if resolution == "absent_but_others_exist" and not ask_envelope_from_capture:
             # Strict and loose both require an exact transcript
             # mapping. Other transcripts exist for the project but
             # none fingerprints to this surface — the operator is

--- a/tests/test_chat_messages_endpoint.py
+++ b/tests/test_chat_messages_endpoint.py
@@ -1524,6 +1524,57 @@ def test_messages_endpoint_source_auto_prefers_jsonl(
     assert body["messages"][0]["id"] == "a"
 
 
+def test_messages_endpoint_source_auto_prefers_live_ask_user_capture(
+    client,
+    auth_headers,
+    patch_registry,
+    patch_parser,
+    patch_capture,
+    monkeypatch,
+    tmp_path,
+):
+    archive = tmp_path / "events.jsonl"
+    archive.write_text("x")
+    monkeypatch.setattr(
+        chat_messages_routes,
+        "is_archive_stale",
+        lambda path, **kw: False,
+    )
+    patch_registry([_surface(
+        "architect_demo", SurfaceType.ARCHITECT, persona="Sage",
+        project="demo", transcript_path=archive, present=True,
+    )])
+    patch_parser({archive: [
+        _env("msg_text", actor="Sage", text="I need a choice."),
+    ]})
+    patch_capture([
+        _env("cap_text", actor="Sage", text="I need a choice."),
+        _env(
+            "cap_live_ask",
+            actor="Sage",
+            type_=MessageType.ASK_USER,
+            text="Which option?",
+            metadata={
+                "from_capture": True,
+                "questions": [{
+                    "question": "Which option?",
+                    "options": [{"label": "alpha"}, {"label": "bravo"}],
+                }],
+            },
+        ),
+    ])
+
+    body = client.get(
+        "/api/v1/chat/architect_demo/messages?source=auto&direction=desc",
+        headers=auth_headers,
+    ).json()
+
+    assert body["transcript_source"] == "capture"
+    assert body["messages"][0]["id"] == "cap_live_ask"
+    assert body["messages"][0]["type"] == "ask_user"
+    assert body["messages"][0]["metadata"]["questions"][0]["options"][1]["label"] == "bravo"
+
+
 def test_messages_endpoint_source_auto_falls_back_when_stale(
     client, auth_headers, patch_registry, patch_capture, monkeypatch, tmp_path,
 ):

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -77,6 +77,8 @@ class FakeTmuxClient:
     send_side_effect: Exception | None = None
     send_calls: list[tuple[str, str, bool]] = []
     send_enter_delays: list[float] = []
+    captures_by_target: dict[str, str] = {}
+    capture_calls: list[tuple[str, int]] = []
     list_panes_side_effect: Exception | None = None
     list_windows_side_effect: Exception | None = None
 
@@ -91,6 +93,10 @@ class FakeTmuxClient:
         # Tests register panes by either window target ("session:window")
         # or session, depending on the call shape; check both.
         return list(self.panes_by_target.get(target, []))
+
+    def capture_pane(self, target: str, lines: int = 3000) -> str:
+        self.capture_calls.append((target, lines))
+        return self.captures_by_target.get(target, "")
 
     def send_keys(
         self,
@@ -113,6 +119,8 @@ def _reset_fake_tmux():
     FakeTmuxClient.send_side_effect = None
     FakeTmuxClient.send_calls = []
     FakeTmuxClient.send_enter_delays = []
+    FakeTmuxClient.captures_by_target = {}
+    FakeTmuxClient.capture_calls = []
     FakeTmuxClient.list_panes_side_effect = None
     FakeTmuxClient.list_windows_side_effect = None
     yield
@@ -1108,6 +1116,38 @@ def _ask_user_event(
     }
 
 
+LIVE_ASK_USER_PANE = """\
+Ready to choose.
+──────────────────────────────────────────────────────────────────────────────
+←  ☐ Pick one  ✔ Submit  →
+
+Which option should I use?
+
+❯ 1. alpha
+  2. bravo
+  3. Type something.
+──────────────────────────────────────────────────────────────────────────────
+  4. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+"""
+
+
+def _capture_ask_user_id(session_name: str, pane_text: str) -> str:
+    class OneShotCapture:
+        def capture_pane(self, target: str, lines: int = 3000) -> str:  # noqa: ARG002
+            return pane_text
+
+    envelopes = chat_send_routes.capture_envelopes(
+        OneShotCapture(),
+        session_name=session_name,
+        target="x",
+    )
+    ask = [env for env in envelopes if env.type == chat_send_routes.MessageType.ASK_USER]
+    assert len(ask) == 1
+    return ask[0].id
+
+
 def test_answer_to_selections_happy_path(
     client: TestClient,
     auth_headers: dict[str, str],
@@ -1783,6 +1823,73 @@ def test_answer_to_capture_id_still_blocks_unrelated_open_tool(
 
     assert response.status_code == 409, response.json()
     assert response.json()["error"]["code"] == "unsafe_mid_tool"
+
+
+def test_answer_to_live_capture_id_works_before_tool_use_flush(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """M5/#2518 — answer a visible AskUserQuestion not yet flushed to JSONL."""
+
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-live-ask", [
+        {"event_type": "assistant_turn", "payload": {"text": "I need a choice"}},
+    ], cwd=workspace_root)
+    target = "pollypm-test-storage-closet:pm-operator"
+    patched_tmux.captures_by_target[target] = LIVE_ASK_USER_PANE
+    answer_to = _capture_ask_user_id("operator", LIVE_ASK_USER_PANE)
+
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": answer_to, "selections": ["bravo"]},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.json()
+    assert patched_tmux.send_calls == [(target, "2\t", True)]
+    assert patched_tmux.capture_calls == [(target, 3000)]
+
+
+def test_answer_to_live_capture_id_still_blocks_unrelated_open_tool(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-live-ask-with-tool", [
+        {"event_type": "user_turn", "payload": {"text": "do work"}},
+        {
+            "event_type": "tool_call",
+            "payload": {
+                "type": "tool_use",
+                "id": "toolu_bash_open",
+                "name": "Bash",
+                "input": {"command": "sleep 5"},
+            },
+        },
+    ], cwd=workspace_root)
+    target = "pollypm-test-storage-closet:pm-operator"
+    patched_tmux.captures_by_target[target] = LIVE_ASK_USER_PANE
+    answer_to = _capture_ask_user_id("operator", LIVE_ASK_USER_PANE)
+
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": answer_to, "selections": ["alpha"]},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 409, response.json()
+    assert response.json()["error"]["code"] == "unsafe_mid_tool"
+    assert patched_tmux.send_calls == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Exposes a visible live AskUserQuestion through `GET /messages?source=auto` when JSONL is fresh but the `tool_use` has not flushed yet.
- Lets `POST /chat/{session}/send` resolve `cap_*` AskUser ids from the live pane and route selections through the existing TUI-number translation.
- Keeps unrelated open transcript tools as a blocker, and updates the chat endpoint docs for the live capture path.

Fixes #2518

## Verification
- `uv run --extra test pytest --noconftest tests/test_chat_send_endpoint.py tests/test_chat_messages_endpoint.py -q` -> 151 passed
- `uv run --extra dev ruff check src/pollypm/web_api/routes/chat_send.py src/pollypm/web_api/routes/chat_messages.py tests/test_chat_send_endpoint.py tests/test_chat_messages_endpoint.py` -> All checks passed
- `git diff --check` -> clean

## Safety
The answer path stays inside the chat API facade: UI receives public `ask_user` envelopes, send validates public `answer_to` + `selections`, and storage remains behind existing transcript/session helpers. Live capture only wins when it parses a structured open AskUserQuestion, and strict mid-tool protection still blocks if the transcript shows another open tool.