### PR TITLE
fix: keep orphan worktree cleanup out of inbox

### DIFF
--- a/src/pollypm/alert_actionability.py
+++ b/src/pollypm/alert_actionability.py
@@ -172,6 +172,10 @@ def _worktree_state_is_stale(
     *,
     context: AlertActionabilityContext,
 ) -> bool:
+    # Orphan worktree cleanup is mechanical GC; the audit handler
+    # self-heals terminal rows and leaves non-terminal rows as FYI logs.
+    if alert_type.endswith(":orphan_branch"):
+        return True
     project = _worktree_state_project(
         alert_type,
         known_projects=context.known_projects or context.tracked_projects,

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -963,6 +963,9 @@ _BOOKKEEPING_COMMIT_RE = re.compile(
     r"^(?:journal|ledger|chore)(?:\(|:)|^journal\(48h\):",
     re.IGNORECASE,
 )
+_BRIEFING_MAINTENANCE_TITLE_PREFIXES = (
+    "Orphan worktree branch:",
+)
 
 
 def _human_project_label(value: str) -> str:
@@ -998,6 +1001,16 @@ def _briefing_message_project_key(message: object) -> str | None:
     return None
 
 
+def _briefing_message_is_operator_relevant(message: object) -> bool:
+    title = str(getattr(message, "title", "") or "").strip()
+    if any(
+        title.startswith(prefix)
+        for prefix in _BRIEFING_MAINTENANCE_TITLE_PREFIXES
+    ):
+        return False
+    return True
+
+
 def _project_is_live_for_briefing(
     project_key: str | None,
     recent_real_work_projects: frozenset[str] | None,
@@ -1015,6 +1028,8 @@ def _first_briefing_message(
     recent_real_work_projects: frozenset[str] | None,
 ) -> InboxPreview | None:
     for message in recent_messages:
+        if not _briefing_message_is_operator_relevant(message):
+            continue
         if _project_is_live_for_briefing(
             _briefing_message_project_key(message),
             recent_real_work_projects,
@@ -1092,6 +1107,8 @@ def _remaining_inbox_line(
     groups: dict[str, tuple[int, float]] = {}
     for message in recent_messages:
         if getattr(message, "task_id", None) == first_task_id:
+            continue
+        if not _briefing_message_is_operator_relevant(message):
             continue
         if not _project_is_live_for_briefing(
             _briefing_message_project_key(message),
@@ -1353,6 +1370,7 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
         inbox_tasks_for_project,
         inbox_tasks_grouped,
     )
+    from pollypm.notify_task import is_notify_only_inbox_entry
 
     now = datetime.now(UTC)
     seen_task_ids: set[str] = set()
@@ -1381,6 +1399,8 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
         project_label: str,
         project_key: str | None,
     ) -> None:
+        if is_notify_only_inbox_entry(task):
+            return
         if task.task_id in seen_task_ids:
             return
         seen_task_ids.add(task.task_id)

--- a/src/pollypm/notify_task.py
+++ b/src/pollypm/notify_task.py
@@ -52,6 +52,7 @@ _NOTIFY_TITLE_PREFIXES: tuple[str, ...] = (
     "Project: ",
     "Queued:",
     "Heartbeat:",
+    "Orphan worktree branch:",
     "URGENT:",
     "Nth ",
     "Repeated stale",

--- a/src/pollypm/plugins_builtin/core_recurring/sweeps.py
+++ b/src/pollypm/plugins_builtin/core_recurring/sweeps.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -1142,6 +1144,131 @@ def _worktree_audit_handle_dirty_stale(
     return 0, 0
 
 
+_TERMINAL_TASK_STATUS_VALUES = frozenset({"done", "cancelled"})
+_TASK_WORKTREE_BRANCH_PREFIXES = ("task/",)
+
+
+def _status_value(value: object) -> str:
+    return str(getattr(value, "value", value) or "").strip().lower()
+
+
+def _worktree_audit_task_is_terminal(work: Any, task_id: str) -> bool:
+    try:
+        task = work.get(task_id)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worktree.state_audit: could not read task %s for orphan cleanup",
+            task_id,
+            exc_info=True,
+        )
+        return False
+    return _status_value(getattr(task, "work_status", None)) in _TERMINAL_TASK_STATUS_VALUES
+
+
+def _git_for_worktree_cleanup(
+    repo_root: Path,
+    *args: str,
+    timeout: int = 300,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _remove_orphan_task_worktree(
+    *,
+    repo_root: Path,
+    wt_path: Path,
+    branch: str | None,
+) -> bool:
+    """Remove a terminal task's leftover git worktree and branch."""
+    if not wt_path.exists():
+        return True
+    result = _git_for_worktree_cleanup(
+        repo_root, "worktree", "remove", "--force", str(wt_path),
+    )
+    if result.returncode != 0 and "locked" in (result.stderr or "").lower():
+        _git_for_worktree_cleanup(repo_root, "worktree", "unlock", str(wt_path))
+        result = _git_for_worktree_cleanup(
+            repo_root, "worktree", "remove", "--force", str(wt_path),
+        )
+    if result.returncode != 0:
+        logger.warning(
+            "worktree.state_audit: failed to remove orphan task worktree %s: %s",
+            wt_path,
+            (result.stderr or result.stdout or "").strip(),
+        )
+        return False
+    _git_for_worktree_cleanup(repo_root, "worktree", "prune", timeout=60)
+    if branch and branch.startswith(_TASK_WORKTREE_BRANCH_PREFIXES):
+        _git_for_worktree_cleanup(repo_root, "branch", "-D", branch, timeout=60)
+    return True
+
+
+def _mark_orphan_worker_session_ended(work: Any, sess: Any) -> None:
+    marker = getattr(work, "mark_worker_session_ended", None)
+    if not callable(marker):
+        return
+    try:
+        marker(
+            task_project=sess.task_project,
+            task_number=int(sess.task_number),
+            ended_at=datetime.now(UTC).isoformat(),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worktree.state_audit: mark_worker_session_ended failed for %s/%s",
+            getattr(sess, "task_project", ""),
+            getattr(sess, "task_number", ""),
+            exc_info=True,
+        )
+
+
+def _close_orphan_branch_inbox_tasks(
+    work: Any,
+    *,
+    project: str,
+    dedupe_label: str,
+) -> int:
+    closed = 0
+    cancel = getattr(work, "cancel", None)
+    if not callable(cancel):
+        return closed
+    try:
+        candidates = []
+        for status in ("draft", "queued", "in_progress"):
+            candidates.extend(work.list_tasks(project=project, work_status=status))
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worktree.state_audit: orphan inbox cleanup scan failed for %s",
+            dedupe_label,
+            exc_info=True,
+        )
+        return closed
+    for task in candidates:
+        labels = getattr(task, "labels", None) or ()
+        if dedupe_label not in labels:
+            continue
+        try:
+            cancel(
+                getattr(task, "task_id"),
+                "worktree.state_audit",
+                "routine orphan worktree cleanup auto-closed",
+            )
+            closed += 1
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "worktree.state_audit: orphan inbox cleanup cancel failed for %s",
+                getattr(task, "task_id", dedupe_label),
+                exc_info=True,
+            )
+    return closed
+
+
 def _worktree_audit_handle_orphan_branch(
     *,
     classification,
@@ -1150,38 +1277,52 @@ def _worktree_audit_handle_orphan_branch(
     agent: str,
     session_key: str,
     task_id: str,
+    repo_root: Path,
     msg_store: Any,
     store: Any,
     work: Any,
-) -> tuple[int, int]:
-    """Raise the orphan-branch alert and emit the inbox task."""
+) -> tuple[int, int, int, int, int]:
+    """Self-heal terminal orphan worktrees; keep any remainder non-inbox."""
     age_days = float(classification.metadata.get("age_days", 0.0))
     alert_type = f"worktree_state:{task_id}:orphan_branch"
+    dedupe_label = f"worktree_audit:{task_id}:orphan_branch"
+    if _worktree_audit_task_is_terminal(work, task_id):
+        removed = _remove_orphan_task_worktree(
+            repo_root=repo_root,
+            wt_path=wt_path,
+            branch=classification.branch,
+        )
+        closed = _close_orphan_branch_inbox_tasks(
+            work,
+            project=sess.task_project,
+            dedupe_label=dedupe_label,
+        )
+        if removed:
+            _mark_orphan_worker_session_ended(work, sess)
+            try:
+                (msg_store or store).clear_alert(session_key, alert_type)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "worktree.state_audit: clear orphan alert failed for %s/%s",
+                    session_key,
+                    alert_type,
+                    exc_info=True,
+                )
+            return 0, 0, 1, 1, closed
+
     message = (
         f"{agent}: {wt_path} on local-only branch "
         f"{classification.branch or '(unknown)'} with no upstream "
         f"and no commit in ~{age_days:.1f}d (task {task_id}). "
-        f"Fix: push or archive the branch before the prune "
-        f"handler GCs it."
+        f"Maintenance: the prune handler will reap it once the task is terminal."
     )
     _raise_alert(msg_store or store, session_key, alert_type, "info", message)
-    body = (
-        f"Worker {agent}'s worktree for task {task_id} is on a "
-        f"local-only branch with no upstream and ~{age_days:.1f} "
-        f"days of inactivity.\n\n"
-        f"Path: {wt_path}\n\n"
-        f"Fix: push the branch, merge/abandon the task, or let "
-        f"the hourly `agent_worktree.prune` handler decide."
-    )
-    emitted = 1 if _emit_inbox_task(
+    closed = _close_orphan_branch_inbox_tasks(
         work,
-        subject=f"Orphan worktree branch: {task_id}",
-        body=body,
-        actor=agent,
-        dedupe_label=f"worktree_audit:{task_id}:orphan_branch",
         project=sess.task_project,
-    ) else 0
-    return 1, emitted
+        dedupe_label=dedupe_label,
+    )
+    return 1, 0, 0, 0, closed
 
 
 def worktree_state_audit_handler(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1235,6 +1376,8 @@ def worktree_state_audit_handler(payload: dict[str, Any]) -> dict[str, Any]:
         alerts_raised = 0
         alerts_cleared = 0
         inbox_emitted = 0
+        worktrees_pruned = 0
+        inbox_closed = 0
         LOCK_ESCALATE_SECONDS = 5 * 60
         DIRTY_STALE_SECONDS = 60 * 60
         now_epoch = _time.time()
@@ -1341,19 +1484,25 @@ def worktree_state_audit_handler(payload: dict[str, Any]) -> dict[str, Any]:
                     alerts_cleared += cleared
 
                 elif state is WorktreeState.ORPHAN_BRANCH:
-                    raised, emitted = _worktree_audit_handle_orphan_branch(
-                        classification=classification,
-                        wt_path=wt_path,
-                        sess=sess,
-                        agent=agent,
-                        session_key=session_key,
-                        task_id=task_id,
-                        msg_store=msg_store,
-                        store=store,
-                        work=work,
+                    raised, emitted, cleared, pruned, closed = (
+                        _worktree_audit_handle_orphan_branch(
+                            classification=classification,
+                            wt_path=wt_path,
+                            sess=sess,
+                            agent=agent,
+                            session_key=session_key,
+                            task_id=task_id,
+                            repo_root=project_root,
+                            msg_store=msg_store,
+                            store=store,
+                            work=work,
+                        )
                     )
                     alerts_raised += raised
                     inbox_emitted += emitted
+                    alerts_cleared += cleared
+                    worktrees_pruned += pruned
+                    inbox_closed += closed
         finally:
             closer = getattr(work, "close", None)
             if callable(closer):
@@ -1370,6 +1519,8 @@ def worktree_state_audit_handler(payload: dict[str, Any]) -> dict[str, Any]:
             "alerts_raised": alerts_raised,
             "alerts_cleared": alerts_cleared,
             "inbox_emitted": inbox_emitted,
+            "worktrees_pruned": worktrees_pruned,
+            "inbox_closed": inbox_closed,
         }
 
 def _raise_alert(

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -266,6 +266,18 @@ def test_worktree_state_demotes_tracked_project_without_recent_real_work() -> No
     assert not is_user_actionable_alert(warn, context=context)
 
 
+def test_orphan_worktree_alert_is_not_user_actionable() -> None:
+    from pollypm.alert_actionability import is_user_actionable_alert
+
+    alert = SimpleNamespace(
+        session_name="worker-russell-58",
+        alert_type="worktree_state:russell/58:orphan_branch",
+        message="Worker worktree orphan branch cleanup.",
+    )
+
+    assert not is_user_actionable_alert(alert)
+
+
 def test_alert_filter_task_facts_use_recent_done_for_liveness(monkeypatch) -> None:
     from pollypm import dashboard_data
 
@@ -997,6 +1009,39 @@ def test_briefing_first_up_skips_dormant_projects() -> None:
     assert "First up: Save the Novel has queued work without an active claim." in out
     assert "no claim / execution" not in out
     assert "open Inbox and clear that first" in out
+
+
+def test_briefing_first_up_skips_orphan_worktree_maintenance() -> None:
+    from pollypm.dashboard_data import _build_dashboard_briefing, InboxPreview
+
+    out = _build_dashboard_briefing(
+        commits=[],
+        completed=[],
+        inbox_count=2,
+        recent_messages=[
+            InboxPreview(
+                sender="worker-russell-58",
+                title="Orphan worktree branch: russell/58",
+                project="Russell",
+                task_id="russell/58",
+                age_seconds=0.0,
+                project_key="russell",
+            ),
+            InboxPreview(
+                sender="polly",
+                title="Decision needed on launch copy",
+                project="Save the Novel",
+                task_id="savethenovel/91",
+                age_seconds=60.0,
+                project_key="savethenovel",
+            ),
+        ],
+        recovery_count_24h=0,
+    )
+
+    assert "Orphan worktree branch" not in out
+    assert "a task" not in out
+    assert "First up: Decision needed on launch copy." in out
 
 
 def test_briefing_uses_generic_inbox_line_when_only_dormant_items_exist() -> None:

--- a/tests/test_notify_task.py
+++ b/tests/test_notify_task.py
@@ -161,6 +161,20 @@ class TestIsNotifyInboxTask:
                 f"title-prefix {prefix_title!r} should be filtered as a notify"
             )
 
+    def test_orphan_worktree_notice_is_notify_only(self) -> None:
+        """#2520: old orphan-worktree audit rows are maintenance FYI, not inbox work."""
+        task = _make_task(
+            title="Orphan worktree branch: russell/58",
+            labels=[
+                "audit:worktree_state",
+                "worktree_audit:russell/58:orphan_branch",
+            ],
+            flow_template_id="chat",
+            roles={"requester": "user", "actor": "worker-russell-58"},
+        )
+        assert is_notify_inbox_task(task) is True
+        assert is_notify_only_inbox_entry(task) is True
+
     def test_real_worker_assigned_task_surfaced(self) -> None:
         """The negative case: a real worker-assigned implementation task
         must still surface. ``roles.operator`` is a worker-shaped role,

--- a/tests/test_worktree_state_audit.py
+++ b/tests/test_worktree_state_audit.py
@@ -69,14 +69,30 @@ def _make_repo(root: Path) -> Path:
     return root
 
 
-def _add_worktree(repo: Path, slug: str) -> Path:
+def _add_worktree(repo: Path, slug: str, *, branch: str | None = None) -> Path:
     """Add a git worktree under ``<repo>/.claude/worktrees/agent-<slug>``."""
     worktrees_dir = repo / ".claude" / "worktrees"
     worktrees_dir.mkdir(parents=True, exist_ok=True)
     wt_path = worktrees_dir / f"agent-{slug}"
-    branch = f"audit-{slug}"
+    branch = branch or f"audit-{slug}"
     _run("git", "-C", str(repo), "worktree", "add", "-b", branch, str(wt_path))
     return wt_path
+
+
+def _add_backdated_commit(wt: Path, filename: str = "old.txt") -> None:
+    (wt / filename).write_text("old\n")
+    _run("git", "-C", str(wt), "add", filename)
+    env = os.environ.copy()
+    old_date = "2020-01-01T00:00:00"
+    env["GIT_AUTHOR_DATE"] = old_date
+    env["GIT_COMMITTER_DATE"] = old_date
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "old", "--date", old_date],
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -170,16 +186,7 @@ class TestClassifier:
         wt = _add_worktree(repo, "orphan")
         # No upstream, no remote. We need a commit older than 7 days —
         # use ``commit --date`` + ``GIT_COMMITTER_DATE`` to back-date.
-        (wt / "old.txt").write_text("old\n")
-        _run("git", "-C", str(wt), "add", "old.txt")
-        env = os.environ.copy()
-        old_date = "2020-01-01T00:00:00"
-        env["GIT_AUTHOR_DATE"] = old_date
-        env["GIT_COMMITTER_DATE"] = old_date
-        subprocess.run(
-            ["git", "-C", str(wt), "commit", "-m", "old", "--date", old_date],
-            check=True, env=env, capture_output=True, text=True,
-        )
+        _add_backdated_commit(wt)
 
         result = classify_worktree_state(wt)
         assert result.state is WorktreeState.ORPHAN_BRANCH
@@ -213,6 +220,13 @@ class _FakeSession:
     pane_id: str | None = None
     branch_name: str | None = None
     started_at: str = "2026-01-01T00:00:00Z"
+
+
+@dataclass
+class _FakeTask:
+    task_id: str
+    work_status: str
+    labels: tuple[str, ...] = ()
 
 
 class _FakeStore:
@@ -291,9 +305,13 @@ class _FakeWork:
         sessions: list[_FakeSession],
         *,
         existing_tasks: list[Any] | None = None,
+        tasks_by_id: dict[str, Any] | None = None,
     ) -> None:
         self._sessions = list(sessions)
         self.created: list[dict[str, Any]] = []
+        self.cancelled: list[tuple[str, str, str]] = []
+        self.ended_sessions: list[tuple[str, int, str]] = []
+        self._tasks_by_id = dict(tasks_by_id or {})
         # Stand-in for ``work.list_tasks`` results — keyed by status so
         # the dedupe scan can lookup draft / queued / in_progress rows.
         self._tasks_by_status: dict[str, list[Any]] = {}
@@ -303,6 +321,9 @@ class _FakeWork:
 
     def list_worker_sessions(self, *, active_only: bool = True):  # noqa: ARG002
         return list(self._sessions)
+
+    def get(self, task_id: str):
+        return self._tasks_by_id[task_id]
 
     def list_tasks(self, **kwargs: Any):
         status = kwargs.get("work_status")
@@ -319,6 +340,18 @@ class _FakeWork:
         # Mimic Task just enough — the handler doesn't read the result.
         return object()
 
+    def cancel(self, task_id: str, actor: str, reason: str):
+        self.cancelled.append((task_id, actor, reason))
+        task = self._tasks_by_id.get(task_id)
+        if task is not None:
+            setattr(task, "work_status", "cancelled")
+        return task or object()
+
+    def mark_worker_session_ended(
+        self, *, task_project: str, task_number: int, ended_at: str,
+    ) -> None:
+        self.ended_sessions.append((task_project, int(task_number), ended_at))
+
     def close(self) -> None:
         pass
 
@@ -329,6 +362,7 @@ def _invoke_handler_with_fakes(
     sessions: list[_FakeSession],
     project_root: Path,
     existing_tasks: list[Any] | None = None,
+    tasks_by_id: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], _FakeStore, _FakeWork]:
     """Run the handler with the work-service factory + ``_load_config_and_store``
     swapped for fakes. Returns (result, store, work) so assertions can
@@ -337,7 +371,11 @@ def _invoke_handler_with_fakes(
     from pollypm.plugins_builtin.core_recurring import sweeps as sweeps_module
 
     fake_store = _FakeStore()
-    fake_work = _FakeWork(sessions, existing_tasks=existing_tasks)
+    fake_work = _FakeWork(
+        sessions,
+        existing_tasks=existing_tasks,
+        tasks_by_id=tasks_by_id,
+    )
 
     @dataclass
     class _FakeProject:
@@ -526,6 +564,85 @@ class TestHandler:
         assert result["alerts_raised"] >= 1
         assert result["inbox_emitted"] == 0
         assert work.created == []
+
+    def test_terminal_orphan_branch_prunes_and_closes_prior_notification(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#2520: terminal task worktree GC is self-healing, not inbox work."""
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "orphan_terminal", branch="task/demo-12")
+        _add_backdated_commit(wt)
+        assert classify_worktree_state(wt).state is WorktreeState.ORPHAN_BRANCH
+
+        sessions = [
+            _FakeSession(
+                task_project="demo", task_number=12,
+                agent_name="worker-demo-12", worktree_path=str(wt),
+            ),
+        ]
+        prior_notice = _FakeTask(
+            task_id="demo/99",
+            work_status="draft",
+            labels=(
+                "audit:worktree_state",
+                "worktree_audit:demo/12:orphan_branch",
+            ),
+        )
+        result, _store, work = _invoke_handler_with_fakes(
+            monkeypatch,
+            sessions=sessions,
+            project_root=repo,
+            existing_tasks=[prior_notice],
+            tasks_by_id={"demo/12": _FakeTask("demo/12", "done")},
+        )
+
+        assert result["classified"].get("orphan_branch") == 1
+        assert result["worktrees_pruned"] == 1
+        assert result["inbox_closed"] == 1
+        assert result["inbox_emitted"] == 0
+        assert work.created == []
+        assert work.cancelled == [
+            (
+                "demo/99",
+                "worktree.state_audit",
+                "routine orphan worktree cleanup auto-closed",
+            )
+        ]
+        assert [(project, number) for project, number, _ in work.ended_sessions] == [
+            ("demo", 12)
+        ]
+        assert not wt.exists()
+        branches = _run("git", "-C", str(repo), "branch").stdout
+        assert "task/demo-12" not in branches
+
+    def test_nonterminal_orphan_branch_stays_out_of_inbox(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "orphan_active")
+        _add_backdated_commit(wt)
+
+        sessions = [
+            _FakeSession(
+                task_project="demo", task_number=13,
+                agent_name="worker-demo-13", worktree_path=str(wt),
+            ),
+        ]
+        result, store, work = _invoke_handler_with_fakes(
+            monkeypatch,
+            sessions=sessions,
+            project_root=repo,
+            tasks_by_id={"demo/13": _FakeTask("demo/13", "in_progress")},
+        )
+
+        assert result["classified"].get("orphan_branch") == 1
+        assert result["alerts_raised"] == 1
+        assert result["inbox_emitted"] == 0
+        assert result["worktrees_pruned"] == 0
+        assert work.created == []
+        assert wt.exists()
+        key = ("worker-demo-13", "worktree_state:demo/13:orphan_branch")
+        assert store.alerts[key]["severity"] == "info"
 
     def test_clean_after_dirty_clears_existing_alert(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Stops orphan-worktree audit rows from creating new operator inbox tasks; terminal orphan task worktrees now self-prune, unlock/retry when needed, mark the worker session ended, and auto-close prior orphan notifications.
- Classifies legacy `Orphan worktree branch:` rows as notify-only/FYI and keeps orphan branch alerts out of user-actionable alert counts.
- Keeps notify-only maintenance rows out of Home recent-message previews and skips orphan maintenance if it reaches the First-up candidate list.

## Tests
- `uv run --with pytest pytest tests/test_worktree_state_audit.py tests/test_notify_task.py tests/test_dashboard_data_alert_dedup.py -q` (`78 passed`)
- `uv run --with ruff ruff check src/pollypm/plugins_builtin/core_recurring/sweeps.py src/pollypm/dashboard_data.py src/pollypm/notify_task.py src/pollypm/alert_actionability.py tests/test_worktree_state_audit.py tests/test_notify_task.py tests/test_dashboard_data_alert_dedup.py`
- `python -m py_compile src/pollypm/plugins_builtin/core_recurring/sweeps.py src/pollypm/dashboard_data.py src/pollypm/notify_task.py src/pollypm/alert_actionability.py`

Closes #2520
