### PR TITLE
Bound watchdog audit log window reads

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -29,16 +29,20 @@ errors after logging a warning.
 
 ## Rotation And Retention
 
-There is no automatic rotation for audit JSONL files today. The
-[log rotation work in PR #1384](https://github.com/samhotchkiss/pollypm/pull/1384)
-covers `~/.pollypm/*.log` process logs such as `errors.log`,
-`cockpit_debug.log`, `rail_daemon.log`, and `phantom_client.log`; it does not
-cover `~/.pollypm/audit/*.jsonl` or `<project>/.pollypm/audit.jsonl`.
+Audit JSONL files rotate automatically during writes. Before appending, the
+writer checks the live file against the `[audit] rotate_size_mb` threshold
+(default `50`) and gzips oversized files to timestamped siblings such as
+`audit.jsonl.<epoch>.gz`. The next event starts a fresh live file. Rotation is
+best-effort: a failed rotate logs and the append still proceeds.
+
+The `[audit] retention_count` setting controls how many gzipped rotations are
+kept beside each audit file (default `4`). Older archives beyond the cap are
+pruned oldest-first. Set `[audit] disable_rotation = true` only as a temporary
+incident-debugging escape hatch; otherwise the audit corpus can grow without a
+bound.
 
 The `[events] audit_retention_days` setting applies to database `messages`
-rows categorized as audit events, not to these JSONL files. Until a dedicated
-audit-log rotation pass lands, operators should archive or truncate audit JSONL
-files manually after preserving any incident window they still need.
+rows categorized as audit events, not to these JSONL files.
 
 ## Event Schema
 
@@ -144,9 +148,14 @@ current work-service factory and DB-resolution model.
 
 The audit watchdog is registered by the built-in core recurring plugin as
 `audit.watchdog` on an `@every 5m` schedule. The handler emits a
-`heartbeat.tick`, reads each known project's audit log, runs pure detectors in
-`pollypm.audit.watchdog`, emits `audit.finding` for every finding, and upserts
-an alert keyed by `(rule, project, subject)`.
+`heartbeat.tick`, reads a bounded recent window from each known project's audit
+log, runs pure detectors in `pollypm.audit.watchdog`, emits `audit.finding` for
+every finding, and upserts an alert keyed by `(rule, project, subject)`.
+
+`read_events(..., since=...)` tails the live JSONL newest-first and stops once
+the requested window boundary is reached. Rotated `.gz` archives remain visible
+to the reader for dedupe windows, but they are streamed rather than loaded into
+one large in-memory list.
 
 | Rule | Detects | Default threshold | Operator response |
 |---|---|---|---|
@@ -264,8 +273,11 @@ gzip -c ~/.pollypm/audit/<project>.jsonl > ~/Desktop/<project>-audit.jsonl.gz
 : > ~/.pollypm/audit/<project>.jsonl
 ```
 
-Prefer truncation over deletion when a process may be tailing the file. No
-clear subcommand exists under `pm audit` today.
+Prefer truncation over deletion when a process may be tailing the file. Manual
+archival is rarely needed now that `[audit] rotate_size_mb` and
+`retention_count` bound the live corpus; use it only when you need to preserve
+or export a specific incident window. No clear subcommand exists under
+`pm audit` today.
 
 ## Contributor Surface
 

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -1166,6 +1166,81 @@ def _read_events_limited_tail(
     return events
 
 
+def _audit_obj_at_or_before_since(obj: dict[str, Any], since: str) -> bool:
+    """Return true when ``obj`` proves older rows can be skipped."""
+    ts = str(obj.get("ts", ""))
+    return bool(ts) and ts <= since
+
+
+def _trim_events_to_limit(
+    events: list[AuditEvent],
+    *,
+    limit: int | None,
+) -> list[AuditEvent]:
+    events.sort(key=lambda e: e.ts)
+    if limit is not None and limit >= 0:
+        return events[-limit:] if limit else []
+    return events
+
+
+def _read_events_since_tail(
+    live: Path,
+    project: str,
+    *,
+    since: str,
+    limit: int | None,
+    event: str | None,
+) -> list[AuditEvent]:
+    """Read rows newer than ``since`` without scanning full audit history.
+
+    Watchdog callers query small recent windows every few minutes. A
+    forward full-corpus scan makes that cadence proportional to all audit
+    history and can transiently materialize hundreds of MB. Audit writers
+    append chronological JSONL, so the live file can be read newest-first
+    and stopped as soon as the first row at or before ``since`` appears.
+    Gzipped rotations are streamed forward so recent archives remain
+    visible without building an in-memory copy of the archive.
+    """
+    if limit == 0:
+        return []
+
+    events: list[AuditEvent] = []
+    for path in _walk_log_chain(live):
+        stop_chain = False
+        if path.suffix == ".gz":
+            saw_cutoff = False
+            for obj in _iter_log_lines(path):
+                if _audit_obj_at_or_before_since(obj, since):
+                    saw_cutoff = True
+                    continue
+                if not _audit_obj_matches(
+                    obj, project=project, since=since, event=event,
+                ):
+                    continue
+                events.append(AuditEvent.from_dict(obj))
+            if saw_cutoff:
+                stop_chain = True
+        else:
+            for obj in _iter_live_log_lines_reverse(path):
+                if _audit_obj_at_or_before_since(obj, since):
+                    stop_chain = True
+                    break
+                if not _audit_obj_matches(
+                    obj, project=project, since=since, event=event,
+                ):
+                    continue
+                events.append(AuditEvent.from_dict(obj))
+                if limit is not None and limit >= 0 and len(events) >= limit:
+                    return _trim_events_to_limit(events, limit=limit)
+
+        if limit is not None and limit >= 0 and len(events) >= limit:
+            return _trim_events_to_limit(events, limit=limit)
+        if stop_chain:
+            break
+
+    return _trim_events_to_limit(events, limit=limit)
+
+
 def read_events(
     project: str,
     *,
@@ -1204,15 +1279,21 @@ def read_events(
 
     Returns a list (not a generator) because typical callers want
     to count / slice / re-iterate. Limited tail reads skip the
-    full-history scan when no ``since`` filter is present; other
-    shapes keep the chronological full scan so rotated logs and
-    dedupe windows remain authoritative.
+    full-history scan when no ``since`` filter is present. ``since``
+    reads use a bounded newest-first live tail plus streaming archive
+    fallback so recurring watchdog sweeps stay proportional to their
+    lookback window rather than total audit history.
     """
     per_project = project_log_path(project_path)
     if per_project is not None and per_project.exists():
         live = per_project
     else:
         live = central_log_path(project)
+
+    if since is not None:
+        return _read_events_since_tail(
+            live, project, since=since, limit=limit, event=event,
+        )
 
     if limit is not None and limit >= 0 and since is None:
         return _read_events_limited_tail(

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -69,7 +69,11 @@ def test_emit_writes_to_central_tail(tmp_path: Path) -> None:
 
     central = central_log_path("demo")
     assert central.exists(), "central tail should be created on first emit"
-    lines = [l for l in central.read_text(encoding="utf-8").splitlines() if l.strip()]
+    lines = [
+        line
+        for line in central.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
     assert len(lines) == 1
     record = json.loads(lines[0])
     assert record["event"] == EVENT_TASK_CREATED
@@ -129,9 +133,13 @@ def test_emit_appends_multiple_events_in_order(tmp_path: Path) -> None:
         )
 
     central = central_log_path("multi")
-    lines = [l for l in central.read_text(encoding="utf-8").splitlines() if l.strip()]
+    lines = [
+        line
+        for line in central.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
     assert len(lines) == 5
-    decoded = [json.loads(l) for l in lines]
+    decoded = [json.loads(line) for line in lines]
     assert [r["metadata"]["i"] for r in decoded] == [0, 1, 2, 3, 4]
     # All distinct timestamps OR equal-but-ordered — either way, the
     # append order is preserved.
@@ -448,7 +456,9 @@ def test_rotation_fires_when_size_exceeds_threshold(
     # original 20-event payload.
     assert audit_path.exists()
     live_lines = [
-        l for l in audit_path.read_text(encoding="utf-8").splitlines() if l.strip()
+        line
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
     ]
     assert len(live_lines) < 20
 
@@ -503,9 +513,9 @@ def test_rotation_archives_contain_pre_rotation_events(
 
     # Plus whatever is in the live file currently.
     live_subjects = [
-        json.loads(l)["subject"]
-        for l in audit_path.read_text(encoding="utf-8").splitlines()
-        if l.strip()
+        json.loads(line)["subject"]
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
     ]
     # With retention=50 no archive can have been pruned, so every
     # subject we emitted must appear somewhere (archives + live).
@@ -560,10 +570,12 @@ def test_rotation_retention_prunes_old_archives(
         project_path=project_root,
     )
     final_lines = [
-        l for l in audit_path.read_text(encoding="utf-8").splitlines() if l.strip()
+        line
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
     ]
     assert any(
-        json.loads(l)["subject"] == "retproj/final" for l in final_lines
+        json.loads(line)["subject"] == "retproj/final" for line in final_lines
     ), "post-rotation append must still land in the live file"
 
 
@@ -609,9 +621,11 @@ def test_rotation_failure_does_not_break_append(
     )
 
     lines = [
-        l for l in audit_path.read_text(encoding="utf-8").splitlines() if l.strip()
+        line
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
     ]
-    subjects = [json.loads(l)["subject"] for l in lines]
+    subjects = [json.loads(line)["subject"] for line in lines]
     assert "failproj/after-failure" in subjects, (
         "audit append must succeed even when rotation fails"
     )
@@ -647,7 +661,9 @@ def test_rotation_disabled_via_env(
     )
     # All 20 lines should be in the live file because nothing rotated.
     lines = [
-        l for l in audit_path.read_text(encoding="utf-8").splitlines() if l.strip()
+        line
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
     ]
     assert len(lines) == 20
 
@@ -771,6 +787,78 @@ def test_read_events_limit_uses_live_tail_without_full_scan(
         "tailfast/198",
         "tailfast/199",
     ]
+
+
+def test_read_events_since_uses_live_tail_without_full_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Watchdog sweeps query recent windows with ``since``.
+
+    That path must not walk a large live audit log from the head just to
+    discard old rows. It should read newest-first and stop at the first
+    row outside the requested window.
+    """
+    import pollypm.audit.log as log_mod
+
+    project_root = tmp_path / "sincefast"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    rows = []
+    for i in range(500):
+        rows.append(json.dumps({
+            "schema": SCHEMA_VERSION,
+            "ts": f"2026-05-30T00:{i // 60:02d}:{i % 60:02d}+00:00",
+            "project": "sincefast",
+            "event": "task.status_changed",
+            "subject": f"sincefast/old-{i}",
+            "actor": "test",
+            "status": "ok",
+            "metadata": {"padding": "x" * 64},
+        }))
+    for i in range(3):
+        rows.append(json.dumps({
+            "schema": SCHEMA_VERSION,
+            "ts": f"2026-05-31T10:00:0{i}+00:00",
+            "project": "sincefast",
+            "event": "task.status_changed",
+            "subject": f"sincefast/recent-{i}",
+            "actor": "test",
+            "status": "ok",
+            "metadata": {},
+        }))
+    audit_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    def fail_forward_scan(_path):
+        raise AssertionError("since read should not scan from file head")
+
+    decode_calls = 0
+    original_decode = log_mod._decode_audit_line
+
+    def counting_decode(raw):
+        nonlocal decode_calls
+        decode_calls += 1
+        return original_decode(raw)
+
+    monkeypatch.setattr(log_mod, "_TAIL_READ_CHUNK_BYTES", 256)
+    monkeypatch.setattr(log_mod, "_iter_log_lines", fail_forward_scan)
+    monkeypatch.setattr(log_mod, "_decode_audit_line", counting_decode)
+
+    events = log_mod.read_events(
+        "sincefast",
+        project_path=project_root,
+        since="2026-05-31T09:59:59+00:00",
+    )
+
+    assert [event.subject for event in events] == [
+        "sincefast/recent-0",
+        "sincefast/recent-1",
+        "sincefast/recent-2",
+    ]
+    assert decode_calls < 20, (
+        "since reads should stop at the recent-window boundary, not "
+        "decode the full historical corpus"
+    )
 
 
 def test_read_events_chains_live_and_gz_in_chronological_order(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Make `read_events(..., since=...)` use a newest-first live JSONL tail and stop at the requested window boundary instead of scanning the full audit corpus.
- Keep rotated `.gz` audit archives visible for dedupe/throttle windows while streaming them forward rather than materializing each archive as one list.
- Update audit-log docs to describe current `[audit]` rotation/retention knobs and the watchdog bounded-window read behavior.

Fixes #2522.

## Tests
- `uv run --extra dev ruff check src/pollypm/audit/log.py tests/test_audit_log.py`
- `uv run --extra test pytest -q tests/test_audit_log.py::test_read_events_since_uses_live_tail_without_full_scan tests/test_audit_log.py::test_read_events_walks_gz_archives_after_rotation tests/test_audit_log.py::test_read_events_walks_gz_archives_for_central_tail`
- `HOME=<isolated> uv run --extra test pytest -q tests/test_audit_watchdog.py::test_cadence_handler_dispatches_eligible_finding tests/test_audit_watchdog.py::test_was_recently_dispatched_true_after_emit tests/test_audit_watchdog.py::test_was_recently_dispatched_expires_after_window`
- `HOME=<isolated> uv run --extra test pytest -q tests/test_audit_watchdog.py` (135 passed)
- `git diff --check`

## Notes
- A non-isolated watchdog run resolved tier-4 promotion accounting to `/Users/sam/dev/.pollypm/state.db`, whose existing local promotion history caused synthetic dispatch tests to route to tier 4. Re-running the suite with an isolated `HOME` and config avoided operator-state leakage and passed.
