### PR TITLE
Cap watchdog audit scan memory

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -157,6 +157,12 @@ the requested window boundary is reached. Rotated `.gz` archives remain visible
 to the reader for dedupe windows, but they are streamed rather than loaded into
 one large in-memory list.
 
+The cadence path also narrows the read to event names consumed by the watchdog
+detectors and caps each per-project scan at `scan_event_limit` events (default
+`10000`). This keeps a bursty audit tail from making the long-lived daemon hold
+allocator arenas after one sweep; in an event storm the newest matching rows win
+and the next cadence tick gets another bounded slice.
+
 | Rule | Detects | Default threshold | Operator response |
 |---|---|---|---|
 | `orphan_marker` | `marker.created` without matching `marker.released` and without a terminal task transition. | `window_seconds=1800` | Inspect the worker pane; resume it or transition/cancel the task so cleanup can release the marker. |

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -15,6 +15,7 @@ import logging
 import os
 import shutil
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1054,9 +1055,13 @@ def _audit_obj_matches(
     project: str,
     since: str | None,
     event: str | None,
+    event_names: frozenset[str] | None = None,
 ) -> bool:
     """Apply the read_events filters to a decoded audit object."""
-    if event is not None and obj.get("event") != event:
+    obj_event = obj.get("event")
+    if event is not None and obj_event != event:
+        return False
+    if event_names is not None and obj_event not in event_names:
         return False
     if since is not None:
         ts = str(obj.get("ts", ""))
@@ -1147,21 +1152,46 @@ def _read_events_limited_tail(
     *,
     limit: int,
     event: str | None,
+    event_names: frozenset[str] | None,
 ) -> list[AuditEvent]:
     """Read the newest ``limit`` matching rows without scanning history."""
     if limit <= 0:
         return []
     events: list[AuditEvent] = []
     for path in _walk_log_chain(live):
-        for obj in _iter_log_lines_reverse(path):
-            if not _audit_obj_matches(
-                obj, project=project, since=None, event=event
-            ):
-                continue
-            events.append(AuditEvent.from_dict(obj))
-            if len(events) >= limit:
-                events.sort(key=lambda e: e.ts)
-                return events
+        remaining = limit - len(events)
+        if remaining <= 0:
+            break
+        if path.suffix == ".gz":
+            archive_matches: deque[AuditEvent] = deque(maxlen=remaining)
+            for obj in _iter_log_lines(path):
+                if not _audit_obj_matches(
+                    obj,
+                    project=project,
+                    since=None,
+                    event=event,
+                    event_names=event_names,
+                ):
+                    continue
+                archive_matches.append(AuditEvent.from_dict(obj))
+            events.extend(archive_matches)
+        else:
+            for obj in _iter_log_lines_reverse(path):
+                if not _audit_obj_matches(
+                    obj,
+                    project=project,
+                    since=None,
+                    event=event,
+                    event_names=event_names,
+                ):
+                    continue
+                events.append(AuditEvent.from_dict(obj))
+                if len(events) >= limit:
+                    events.sort(key=lambda e: e.ts)
+                    return events
+        if len(events) >= limit:
+            events.sort(key=lambda e: e.ts)
+            return events
     events.sort(key=lambda e: e.ts)
     return events
 
@@ -1190,6 +1220,7 @@ def _read_events_since_tail(
     since: str,
     limit: int | None,
     event: str | None,
+    event_names: frozenset[str] | None,
 ) -> list[AuditEvent]:
     """Read rows newer than ``since`` without scanning full audit history.
 
@@ -1206,18 +1237,35 @@ def _read_events_since_tail(
 
     events: list[AuditEvent] = []
     for path in _walk_log_chain(live):
+        remaining = (
+            None
+            if limit is None or limit < 0
+            else max(0, limit - len(events))
+        )
+        if remaining == 0:
+            break
         stop_chain = False
         if path.suffix == ".gz":
             saw_cutoff = False
+            archive_matches: list[AuditEvent] | deque[AuditEvent]
+            if remaining is None:
+                archive_matches = []
+            else:
+                archive_matches = deque(maxlen=remaining)
             for obj in _iter_log_lines(path):
                 if _audit_obj_at_or_before_since(obj, since):
                     saw_cutoff = True
                     continue
                 if not _audit_obj_matches(
-                    obj, project=project, since=since, event=event,
+                    obj,
+                    project=project,
+                    since=since,
+                    event=event,
+                    event_names=event_names,
                 ):
                     continue
-                events.append(AuditEvent.from_dict(obj))
+                archive_matches.append(AuditEvent.from_dict(obj))
+            events.extend(archive_matches)
             if saw_cutoff:
                 stop_chain = True
         else:
@@ -1226,7 +1274,11 @@ def _read_events_since_tail(
                     stop_chain = True
                     break
                 if not _audit_obj_matches(
-                    obj, project=project, since=since, event=event,
+                    obj,
+                    project=project,
+                    since=since,
+                    event=event,
+                    event_names=event_names,
                 ):
                     continue
                 events.append(AuditEvent.from_dict(obj))
@@ -1247,6 +1299,7 @@ def read_events(
     since: str | None = None,
     limit: int | None = None,
     event: str | None = None,
+    event_names: Iterable[str] | None = None,
     project_path: Path | str | None = None,
 ) -> list[AuditEvent]:
     """Read recent audit events for ``project``.
@@ -1272,6 +1325,8 @@ def read_events(
     Filters apply in order:
 
     * ``event``: only events matching this exact name.
+    * ``event_names``: only events whose name appears in this set. Mutually
+      exclusive with ``event``.
     * ``since``: only events with ``ts > since``. Compare as
       strings — ISO-8601 UTC sorts lexicographically.
     * ``limit``: keep at most the last N matching events
@@ -1284,6 +1339,12 @@ def read_events(
     fallback so recurring watchdog sweeps stay proportional to their
     lookback window rather than total audit history.
     """
+    if event is not None and event_names is not None:
+        raise ValueError("read_events accepts only one of event or event_names")
+    event_name_set: frozenset[str] | None = None
+    if event_names is not None:
+        event_name_set = frozenset(str(name) for name in event_names if name)
+
     per_project = project_log_path(project_path)
     if per_project is not None and per_project.exists():
         live = per_project
@@ -1292,12 +1353,21 @@ def read_events(
 
     if since is not None:
         return _read_events_since_tail(
-            live, project, since=since, limit=limit, event=event,
+            live,
+            project,
+            since=since,
+            limit=limit,
+            event=event,
+            event_names=event_name_set,
         )
 
     if limit is not None and limit >= 0 and since is None:
         return _read_events_limited_tail(
-            live, project, limit=limit, event=event
+            live,
+            project,
+            limit=limit,
+            event=event,
+            event_names=event_name_set,
         )
 
     # ``_walk_log_chain`` yields live first then archives newest-first.
@@ -1312,7 +1382,11 @@ def read_events(
         bucket: list[AuditEvent] = []
         for obj in _iter_log_lines(path):
             if not _audit_obj_matches(
-                obj, project=project, since=since, event=event
+                obj,
+                project=project,
+                since=since,
+                event=event,
+                event_names=event_name_set,
             ):
                 continue
             bucket.append(AuditEvent.from_dict(obj))

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -452,6 +452,11 @@ class WatchdogConfig:
     # for this many seconds fires a tier-2 finding routed to the
     # operator leg.
     queue_motion_threshold_seconds: int = QUEUE_MOTION_THRESHOLD_SECONDS
+    # Hard ceiling for the audit-event objects materialized by one
+    # project scan. Detector reads are time-windowed first; this caps
+    # pathological bursts inside that window so the long-lived daemon
+    # cannot retain allocator arenas after a huge sweep.
+    scan_event_limit: int = 10_000
 
 
 @dataclass(slots=True, frozen=True)
@@ -3162,6 +3167,21 @@ _QUEUE_MOTION_EVENTS: frozenset[str] = frozenset({
     EVENT_WORKER_HEARTBEAT,
 })
 _AUTO_CLAIM_PLAN_MISSING_EVENT = "auto_claim_skipped_plan_missing"
+_WATCHDOG_SCAN_EVENT_NAMES: frozenset[str] = frozenset({
+    EVENT_MARKER_CREATED,
+    EVENT_MARKER_RELEASED,
+    EVENT_MARKER_LEAKED,
+    EVENT_TASK_CREATED,
+    EVENT_TASK_STATUS_CHANGED,
+    EVENT_WORKER_HEARTBEAT,
+    EVENT_WORKER_SESSION_REAPED,
+    EVENT_AUDIT_FINDING,
+    EVENT_AUDIT_FINDING_DISMISSED,
+    EVENT_STUCK_DRAFT_TERMINATED,
+    EVENT_STUCK_DRAFT_RECLAIMED,
+    _AUTO_CLAIM_PLAN_MISSING_EVENT,
+    *_QUEUE_MOTION_EVENTS,
+})
 
 
 _QUEUE_WITHOUT_MOTION_TITLE_RE = re.compile(
@@ -3741,6 +3761,7 @@ def _merge_central_stuck_draft_signals(
     project: str,
     since: str,
     project_path: Path | str | None,
+    limit: int | None,
 ) -> list[AuditEvent]:
     """Merge durable central stuck_draft signal rows into project readback.
 
@@ -3766,6 +3787,7 @@ def _merge_central_stuck_draft_signals(
                 project,
                 since=since,
                 event=event_name,
+                limit=limit,
                 project_path=None,
             )
         except Exception:  # noqa: BLE001
@@ -3900,9 +3922,12 @@ def scan_project(
     since = (
         resolved_now - timedelta(seconds=config.window_seconds * 2)
     ).isoformat()
+    scan_event_limit = max(1, int(config.scan_event_limit))
     events = read_events(
         project,
         since=since,
+        limit=scan_event_limit,
+        event_names=_WATCHDOG_SCAN_EVENT_NAMES,
         project_path=project_path,
     )
     events = _merge_central_stuck_draft_signals(
@@ -3910,6 +3935,7 @@ def scan_project(
         project=project,
         since=since,
         project_path=project_path,
+        limit=scan_event_limit,
     )
     backfill_reclaims = _stuck_draft_reclaim_backfill_candidates(
         events,
@@ -4298,6 +4324,7 @@ def was_recently_dispatched(
             project,
             since=cutoff,
             event=EVENT_WATCHDOG_ESCALATION_DISPATCHED,
+            limit=1000,
             project_path=project_path,
         )
     except Exception:  # noqa: BLE001 — never block dispatch on read failure
@@ -4394,6 +4421,7 @@ def was_recently_operator_dispatched(
             project,
             since=cutoff,
             event=EVENT_WATCHDOG_OPERATOR_DISPATCHED,
+            limit=1000,
             project_path=project_path,
         )
     except Exception:  # noqa: BLE001

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -327,6 +327,7 @@ def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
         "progress_stale_seconds",
         "on_hold_stale_seconds",
         "rework_stale_seconds",
+        "scan_event_limit",
     ):
         raw = payload.get(field_name)
         if raw is None:

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -861,6 +861,71 @@ def test_read_events_since_uses_live_tail_without_full_scan(
     )
 
 
+def test_read_events_since_accepts_event_name_set(tmp_path: Path) -> None:
+    """Watchdog scans can exclude audit rows their detectors never read."""
+    project_root = tmp_path / "eventset"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    rows = [
+        {
+            "schema": SCHEMA_VERSION,
+            "ts": "2026-05-31T10:00:00+00:00",
+            "project": "eventset",
+            "event": "heartbeat.tick",
+            "subject": "audit_watchdog",
+            "actor": "test",
+            "status": "ok",
+            "metadata": {"padding": "x" * 1024},
+        },
+        {
+            "schema": SCHEMA_VERSION,
+            "ts": "2026-05-31T10:00:01+00:00",
+            "project": "eventset",
+            "event": EVENT_TASK_CREATED,
+            "subject": "eventset/1",
+            "actor": "test",
+            "status": "ok",
+            "metadata": {},
+        },
+        {
+            "schema": SCHEMA_VERSION,
+            "ts": "2026-05-31T10:00:02+00:00",
+            "project": "eventset",
+            "event": "worker.heartbeat",
+            "subject": "eventset/1",
+            "actor": "test",
+            "status": "ok",
+            "metadata": {},
+        },
+    ]
+    audit_path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+    events = read_events(
+        "eventset",
+        project_path=project_root,
+        since="2026-05-31T09:59:59+00:00",
+        event_names={EVENT_TASK_CREATED, "worker.heartbeat"},
+    )
+
+    assert [event.event for event in events] == [
+        EVENT_TASK_CREATED,
+        "worker.heartbeat",
+    ]
+
+
+def test_read_events_rejects_event_and_event_name_set() -> None:
+    with pytest.raises(ValueError, match="only one of event or event_names"):
+        read_events(
+            "demo",
+            event=EVENT_TASK_CREATED,
+            event_names={EVENT_TASK_STATUS_CHANGED},
+        )
+
+
 def test_read_events_chains_live_and_gz_in_chronological_order(
     tmp_path: Path,
 ) -> None:
@@ -942,6 +1007,48 @@ def test_read_events_walks_gz_archives_for_central_tail(
         since="2026-05-01T00:00:00+00:00",
     )
     assert [e.subject for e in events] == ["centralgz/finding-Z"]
+
+
+def test_read_events_since_limit_keeps_newest_gz_rows(
+    tmp_path: Path,
+) -> None:
+    """Limited archive fallback must not require retaining every match."""
+    import gzip as _gz
+
+    project_root = tmp_path / "gzlimit"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+    gz_archive = audit_path.with_suffix(audit_path.suffix + ".1700000002.gz")
+
+    with _gz.open(gz_archive, "wt", encoding="utf-8") as fh:
+        for i in range(20):
+            fh.write(json.dumps({
+                "schema": SCHEMA_VERSION,
+                "ts": f"2026-05-31T10:00:{i:02d}+00:00",
+                "project": "gzlimit",
+                "event": EVENT_TASK_STATUS_CHANGED,
+                "subject": f"gzlimit/{i}",
+                "actor": "test",
+                "status": "ok",
+                "metadata": {"to": "queued"},
+            }) + "\n")
+    audit_path.touch()
+
+    events = read_events(
+        "gzlimit",
+        project_path=project_root,
+        since="2026-05-31T09:59:59+00:00",
+        event_names={EVENT_TASK_STATUS_CHANGED},
+        limit=5,
+    )
+
+    assert [event.subject for event in events] == [
+        "gzlimit/15",
+        "gzlimit/16",
+        "gzlimit/17",
+        "gzlimit/18",
+        "gzlimit/19",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -1308,6 +1308,33 @@ def test_scan_project_against_empty_log_returns_no_findings(now: datetime) -> No
     assert findings == []
 
 
+def test_scan_project_filters_and_caps_audit_read(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cadence path should not materialize unrelated audit rows."""
+    import pollypm.audit.log as log_mod
+
+    calls: list[dict[str, object]] = []
+
+    def fake_read_events(*args: object, **kwargs: object) -> list[AuditEvent]:
+        calls.append(dict(kwargs))
+        return []
+
+    monkeypatch.setattr(log_mod, "read_events", fake_read_events)
+
+    config = WatchdogConfig(scan_event_limit=7)
+    assert scan_project("demo", now=now, config=config) == []
+
+    assert calls
+    first = calls[0]
+    assert first["limit"] == 7
+    event_names = first["event_names"]
+    assert isinstance(event_names, frozenset)
+    assert EVENT_TASK_CREATED in event_names
+    assert EVENT_TASK_STATUS_CHANGED in event_names
+    assert EVENT_HEARTBEAT_TICK not in event_names
+
+
 def test_scan_project_against_synthetic_log(now: datetime, tmp_path: Path) -> None:
     """Write events through ``emit`` then read via ``scan_project``.
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Add an `event_names` filter to audit `read_events` so watchdog scans skip audit rows that no detector consumes.
- Cap each per-project watchdog scan with `scan_event_limit` and keep limited `.gz` archive fallbacks bounded with a deque instead of retaining every matching row.
- Document the watchdog scan cap and add regressions for event-set reads, limited archive reads, and the cadence scan callsite.

## Safety
The detector contract stays in `pollypm.audit.watchdog`; the cadence handler still passes a materialized event list to the same pure detectors. The change reduces the input set before materialization and bounds pathological bursts, with newest matching rows winning if the cap is hit. Dispatch throttle reads are also capped to keep repeated finding routing from building large per-finding lists.

## Verification
- `tmp_home=$(mktemp -d); HOME="$tmp_home" uv run --extra dev ruff check src/pollypm/audit/log.py src/pollypm/audit/watchdog.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py tests/test_audit_log.py tests/test_audit_watchdog.py`
- `tmp_home=$(mktemp -d); HOME="$tmp_home" uv run --extra test pytest -q tests/test_audit_log.py::test_read_events_since_uses_live_tail_without_full_scan tests/test_audit_log.py::test_read_events_since_accepts_event_name_set tests/test_audit_log.py::test_read_events_since_limit_keeps_newest_gz_rows tests/test_audit_watchdog.py::test_scan_project_filters_and_caps_audit_read tests/test_audit_watchdog.py::test_cadence_handler_dispatches_stuck_draft`
- `tmp_home=$(mktemp -d); HOME="$tmp_home" uv run --extra test pytest -q tests/test_audit_log.py tests/test_audit_watchdog.py` (166 passed)
- `git diff --check`

Refs #2522
