### PR TITLE
Fix duplicate unstick recovery notes in morning brief

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -1307,7 +1307,10 @@ def _recovery_audit_narrations_from_events(
     recent_real_work_projects: frozenset[str] | None,
 ) -> list[str]:
     try:
-        from pollypm.recovery.narration import narrate_recovery_event
+        from pollypm.recovery.narration import (
+            narrate_recovery_event,
+            narrate_watchdog_escalation_group,
+        )
     except Exception:  # noqa: BLE001
         return []
 
@@ -1319,18 +1322,60 @@ def _recovery_audit_narrations_from_events(
         )
     ]
     narrations: list[str] = []
-    for event in live_events[:limit]:
+    for group in _group_recovery_brief_events(live_events)[:limit]:
+        event = group[0]
         metadata = event.metadata or {}
-        sentence = narrate_recovery_event(
-            event.event,
-            metadata,
-            subject=event.subject,
-            project=event.project,
-            status=event.status,
-        )
+        if event.event == "watchdog.escalation_dispatched" and len(group) > 1:
+            sentence = narrate_watchdog_escalation_group(
+                (
+                    str((group_event.metadata or {}).get("finding_type") or "")
+                    for group_event in group
+                ),
+                subject=str(metadata.get("subject") or event.subject or ""),
+                project=str(event.project or ""),
+            )
+        else:
+            sentence = narrate_recovery_event(
+                event.event,
+                metadata,
+                subject=event.subject,
+                project=event.project,
+                status=event.status,
+            )
         if sentence:
             narrations.append(sentence)
     return narrations
+
+
+def _group_recovery_brief_events(events: list[object]) -> list[list[object]]:
+    grouped: list[list[object]] = []
+    group_indexes: dict[tuple[str, str, str], int] = {}
+    for event in events:
+        key = _recovery_brief_group_key(event)
+        index = group_indexes.get(key)
+        if index is None:
+            group_indexes[key] = len(grouped)
+            grouped.append([event])
+        else:
+            grouped[index].append(event)
+    return grouped
+
+
+def _recovery_brief_group_key(event: object) -> tuple[str, str, str]:
+    metadata = getattr(event, "metadata", None) or {}
+    event_name = str(getattr(event, "event", "") or "")
+    project = str(getattr(event, "project", "") or "")
+    if event_name == "watchdog.escalation_dispatched":
+        subject = str(metadata.get("subject") or getattr(event, "subject", "") or "")
+        return (event_name, project, subject)
+    subject = str(
+        metadata.get("target_session")
+        or metadata.get("session")
+        or getattr(event, "subject", "")
+        or ""
+    )
+    problem = str(metadata.get("finding_type") or metadata.get("reason") or "")
+    return (event_name, subject, problem)
 
 
 def _recent_recovery_audit_narrations(

--- a/src/pollypm/recovery/narration.py
+++ b/src/pollypm/recovery/narration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from typing import Any, Mapping
 
 
@@ -64,7 +65,14 @@ _FINDING_PHRASES: dict[str, str] = {
     "stuck_draft": "a stuck draft",
     "task_on_hold_stale": "stale on-hold work",
     "task_review_stale": "stale review work",
+    "task_rework_stale": "stale rework",
     "worker_session_dead_loop": "a worker session restart loop",
+}
+
+_BRIEF_GROUP_FINDING_PHRASES: dict[str, str] = {
+    "task_on_hold_stale": "stale on-hold work",
+    "task_review_stale": "stale review",
+    "task_rework_stale": "stale rework",
 }
 
 
@@ -169,6 +177,32 @@ def narrate_recovery_event(
     return _sentence(f"I handled a recovery event in {project_label}")
 
 
+def narrate_watchdog_escalation_group(
+    finding_types: Iterable[str],
+    *,
+    subject: str | None,
+    project: str | None,
+) -> str:
+    """Render grouped same-subject watchdog dispatches for the morning brief."""
+
+    findings = _unique_text(finding_types)
+    if len(findings) <= 1:
+        metadata = {"finding_type": findings[0]} if findings else {}
+        return narrate_recovery_event(
+            "watchdog.escalation_dispatched",
+            metadata,
+            subject=subject,
+            project=project,
+            status="ok",
+        ) or ""
+
+    problem = _combined_brief_finding_label(findings)
+    target = _subject_label(subject, project=project) or f"work in {_project_label(project)}"
+    return _sentence(
+        f"I sent unstick briefs for {problem} on {target} so the project could keep moving"
+    )
+
+
 def summarize_audit_event(
     *,
     event_name: str | None,
@@ -242,6 +276,52 @@ def _finding_label(value: str) -> str:
     if not value:
         return "the issue"
     return _humanize_token(value)
+
+
+def _brief_group_finding_label(value: str) -> str:
+    text = re.sub(r"\s+", " ", (value or "").strip())
+    if not text:
+        return "the issue"
+    if text in _BRIEF_GROUP_FINDING_PHRASES:
+        return _BRIEF_GROUP_FINDING_PHRASES[text]
+    return _finding_label(text)
+
+
+def _unique_text(values: Iterable[str]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = re.sub(r"\s+", " ", (value or "").strip())
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        unique.append(text)
+    return unique
+
+
+def _combined_brief_finding_label(values: Iterable[str]) -> str:
+    labels = _unique_text(_brief_group_finding_label(value) for value in values)
+    if not labels:
+        return "the issue"
+    if len(labels) == 1:
+        return labels[0]
+    if all(label.startswith("stale ") for label in labels):
+        stale_bits = [
+            label.removeprefix("stale ").removesuffix(" work")
+            for label in labels
+        ]
+        return "stale " + _join_words(stale_bits)
+    return _join_words(labels)
+
+
+def _join_words(values: list[str]) -> str:
+    if not values:
+        return ""
+    if len(values) == 1:
+        return values[0]
+    if len(values) == 2:
+        return f"{values[0]} and {values[1]}"
+    return ", ".join(values[:-1]) + f", and {values[-1]}"
 
 
 def _project_label(value: str | None) -> str:
@@ -320,5 +400,6 @@ __all__ = [
     "RECOVERY_EVENT_NAMES",
     "is_recovery_event",
     "narrate_recovery_event",
+    "narrate_watchdog_escalation_group",
     "summarize_audit_event",
 ]

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -970,6 +970,58 @@ def test_briefing_surfaces_recovery_narration() -> None:
     assert "Saved:" not in out
 
 
+def test_briefing_merges_same_task_unstick_recovery_narrations() -> None:
+    from pollypm.dashboard_data import (
+        _build_dashboard_briefing,
+        _recovery_audit_narrations_from_events,
+    )
+
+    events = [
+        SimpleNamespace(
+            event="watchdog.escalation_dispatched",
+            metadata={
+                "finding_type": "task_review_stale",
+                "subject": "itsalive/55",
+            },
+            subject="itsalive/55",
+            project="itsalive",
+            status="warn",
+        ),
+        SimpleNamespace(
+            event="watchdog.escalation_dispatched",
+            metadata={
+                "finding_type": "task_rework_stale",
+                "subject": "itsalive/55",
+            },
+            subject="itsalive/55",
+            project="itsalive",
+            status="warn",
+        ),
+    ]
+
+    summaries = _recovery_audit_narrations_from_events(
+        events,
+        limit=3,
+        recent_real_work_projects=frozenset({"itsalive"}),
+    )
+    out = _build_dashboard_briefing(
+        commits=[],
+        completed=[],
+        inbox_count=0,
+        recent_messages=[],
+        recovery_count_24h=2,
+        recovery_summaries=summaries,
+    )
+
+    assert summaries == [
+        "I sent unstick briefs for stale review and rework on task 55 in itsalive "
+        "so the project could keep moving.",
+    ]
+    assert out.count("task 55") == 1
+    assert "stale review and rework" in out
+    assert "task rework stale" not in out
+
+
 def test_briefing_first_up_skips_dormant_projects() -> None:
     from pollypm.dashboard_data import _build_dashboard_briefing, InboxPreview
 

--- a/tests/test_recovery_narration.py
+++ b/tests/test_recovery_narration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pollypm.recovery.narration import (
     narrate_recovery_event,
+    narrate_watchdog_escalation_group,
     summarize_audit_event,
 )
 
@@ -47,6 +48,21 @@ def test_watchdog_dispatch_narration_uses_finding_metadata() -> None:
     )
     assert "samblog/32" not in sentence
     assert "dedup_hash" not in sentence
+
+
+def test_watchdog_dispatch_group_merges_same_task_recovery_reasons() -> None:
+    sentence = narrate_watchdog_escalation_group(
+        ["task_review_stale", "task_rework_stale"],
+        subject="itsalive/55",
+        project="itsalive",
+    )
+
+    assert sentence == (
+        "I sent unstick briefs for stale review and rework on task 55 in itsalive "
+        "so the project could keep moving."
+    )
+    assert "task_review_stale" not in sentence
+    assert "task_rework_stale" not in sentence
 
 
 def test_non_recovery_audit_summary_keeps_generic_shape() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Group same-task watchdog unstick dispatches before rendering morning-brief recovery narration.
- Merge stale review/rework finding labels into one operator-facing sentence so task-level recovery appears once.
- Preserve existing recovery narration for unrelated events and single watchdog dispatches.

## Tests
- `uv run --extra test pytest tests/test_recovery_narration.py tests/test_dashboard_data_alert_dedup.py -q`
- `uv run --extra test pytest tests/test_recovery_narration.py::test_watchdog_dispatch_group_merges_same_task_recovery_reasons tests/test_dashboard_data_alert_dedup.py::test_briefing_merges_same_task_unstick_recovery_narrations -q`
- `uv run --extra dev ruff check src/pollypm/recovery/narration.py src/pollypm/dashboard_data.py tests/test_recovery_narration.py tests/test_dashboard_data_alert_dedup.py`
- `git diff --check`

Fixes #2527.
