### PR TITLE
Gate task assignment sweeps by recent real work

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -16,8 +16,12 @@ from pollypm.idle_placeholders import (
     is_codex_idle_placeholder as _is_codex_idle_placeholder,
 )
 from pollypm.project_liveness import (
+    RECENT_REAL_WORK_WINDOW,
+    coerce_utc_datetime as _coerce_utc_datetime,
     is_real_operator_project,
     real_operator_project_items,
+    task_is_recent_done_work,
+    task_status_key,
 )
 from pollypm.projects import project_state_db_path
 
@@ -776,7 +780,6 @@ def _known_project_keys(config: PollyPMConfig) -> frozenset[str]:
     return frozenset((getattr(config, "projects", {}) or {}).keys())
 
 
-_REAL_WORK_RECENCY_WINDOW = timedelta(days=7)
 _RECOVERY_ALERT_TYPES_FOR_LIVENESS = frozenset({
     "plan_missing",
     "worker_session_gap",
@@ -788,33 +791,6 @@ _RECOVERY_ALERT_TYPES_FOR_LIVENESS = frozenset({
 class _AlertProjectTaskFacts:
     project_task_counts: dict[str, dict[str, int]]
     recent_real_work_projects: frozenset[str] | None
-
-
-def _status_key(task: object) -> str:
-    status = getattr(task, "work_status", "") or ""
-    status_value = getattr(status, "value", status)
-    return str(status_value or "")
-
-
-def _coerce_utc_datetime(value: object) -> datetime | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        if value.tzinfo is None:
-            return value.replace(tzinfo=UTC)
-        return value.astimezone(UTC)
-    text = str(value).strip()
-    if not text:
-        return None
-    if text.endswith("Z"):
-        text = text[:-1] + "+00:00"
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
 
 
 def _alert_filter_needs_project_task_facts(open_alerts: list[object]) -> bool:
@@ -851,23 +827,21 @@ def _project_task_facts_for_alert_filter(
             return _AlertProjectTaskFacts({}, None)
         counts_by_project: dict[str, dict[str, int]] = {}
         recent_real_work: set[str] = set()
-        recent_cutoff = datetime.now(UTC) - _REAL_WORK_RECENCY_WINDOW
+        recent_cutoff = datetime.now(UTC) - RECENT_REAL_WORK_WINDOW
         projects = getattr(config, "projects", {}) or {}
         for project_key, project in projects.items():
             counts: dict[str, int] = {}
             real_operator_project = is_real_operator_project(project_key, project)
             for task in all_tasks_for_project(grouped, config, project_key):
-                status_key = _status_key(task)
+                status_key = task_status_key(task)
                 if not status_key:
                     continue
                 counts[status_key] = counts.get(status_key, 0) + 1
-                if status_key == "done" and real_operator_project:
-                    stamped = _coerce_utc_datetime(
-                        getattr(task, "updated_at", None)
-                        or getattr(task, "created_at", None)
-                    )
-                    if stamped is None or stamped >= recent_cutoff:
-                        recent_real_work.add(project_key)
+                if real_operator_project and task_is_recent_done_work(
+                    task,
+                    cutoff=recent_cutoff,
+                ):
+                    recent_real_work.add(project_key)
             counts_by_project[project_key] = counts
         return _AlertProjectTaskFacts(
             counts_by_project,

--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -52,6 +52,7 @@ from pollypm.plan_presence import (
     has_acceptable_plan,
     task_bypasses_plan_gate,
 )
+from pollypm.project_liveness import recent_real_work_project_keys
 from pollypm.plugins_builtin.task_assignment_notify.resolver import (
     SWEEPER_COOLDOWN_SECONDS,
     _known_project_keys,
@@ -148,6 +149,73 @@ _IDLE_GATED_STATUSES = frozenset(_ACTIVE_WORKER_STATUSES)
 
 _TMUX_WINDOW_PROBE_UNAVAILABLE_COUNTS: dict[tuple[str, int], int] = {}
 _TMUX_WINDOW_PROBE_UNAVAILABLE_ALERTED: set[tuple[str, int]] = set()
+
+
+def _recent_real_work_project_keys_for_sweep(
+    services: Any,
+) -> frozenset[str] | None:
+    """Return the #2483 recent-real-work liveness set for sweep gating.
+
+    ``None`` means the workspace facts could not be loaded, so callers
+    fail open and preserve the old sweep behavior. A concrete empty set
+    means liveness was computed and no registered project has recent real
+    completed work.
+    """
+
+    config = getattr(services, "config", None)
+    if config is None:
+        return None
+    projects = getattr(config, "projects", {}) or {}
+    if not projects:
+        return None
+    try:
+        from pollypm.cockpit_pg_aggregates import (
+            all_tasks_for_project,
+            all_tasks_grouped,
+        )
+
+        grouped = all_tasks_grouped(config)
+        if grouped is None:
+            return None
+        return recent_real_work_project_keys(
+            projects,
+            lambda project_key: all_tasks_for_project(grouped, config, project_key),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "task_assignment sweep: recent real-work liveness lookup failed",
+            exc_info=True,
+        )
+        return None
+
+
+def _project_is_live_for_sweep(
+    project_key: str | None,
+    recent_real_work_projects: frozenset[str] | None,
+) -> bool:
+    if recent_real_work_projects is None:
+        return True
+    if not project_key:
+        return True
+    return project_key in recent_real_work_projects
+
+
+def _known_projects_for_sweep(
+    services: Any,
+    *,
+    recent_real_work_projects: frozenset[str] | None,
+) -> tuple[Any, ...]:
+    projects = tuple(getattr(services, "known_projects", ()) or ())
+    if recent_real_work_projects is None:
+        return projects
+    return tuple(
+        project
+        for project in projects
+        if _project_is_live_for_sweep(
+            getattr(project, "key", None),
+            recent_real_work_projects,
+        )
+    )
 
 
 def _build_event_for_task(work_service: Any, task: Any) -> TaskAssignmentEvent | None:
@@ -761,7 +829,11 @@ def _count_queued_tasks_for_project(
     return total
 
 
-def _sweep_worker_session_gaps(services: Any) -> dict[str, int]:
+def _sweep_worker_session_gaps(
+    services: Any,
+    *,
+    recent_real_work_projects: frozenset[str] | None = None,
+) -> dict[str, int]:
     """Emit ``worker_session_gap`` alerts for projects with queued tasks
     and no worker session. Auto-clears stale alerts.
 
@@ -769,7 +841,14 @@ def _sweep_worker_session_gaps(services: Any) -> dict[str, int]:
     the sweep's by-outcome tally.
     """
     summary = {"emitted": 0, "cleared": 0}
-    known = list(getattr(services, "known_projects", ()) or ())
+    if recent_real_work_projects is None:
+        recent_real_work_projects = _recent_real_work_project_keys_for_sweep(services)
+    known = list(
+        _known_projects_for_sweep(
+            services,
+            recent_real_work_projects=recent_real_work_projects,
+        )
+    )
     if not known:
         return summary
     window_names = _storage_closet_window_names(services)
@@ -917,7 +996,11 @@ def _list_active_worker_tasks(work: Any, project_key: str | None) -> list[Any]:
     return out
 
 
-def _sweep_missing_task_workers(services: Any) -> dict[str, int]:
+def _sweep_missing_task_workers(
+    services: Any,
+    *,
+    recent_real_work_projects: frozenset[str] | None = None,
+) -> dict[str, int]:
     """Emit ``missing_task_worker`` alerts for stuck-with-no-worker tasks.
 
     #1070 — detection-only counterpart to ``_recover_dead_claims``.
@@ -939,6 +1022,8 @@ def _sweep_missing_task_workers(services: Any) -> dict[str, int]:
     if window_names is None:
         # Can't enumerate sessions — bail rather than emit false positives.
         return summary
+    if recent_real_work_projects is None:
+        recent_real_work_projects = _recent_real_work_project_keys_for_sweep(services)
 
     def _check_task(project_key: str, task: Any) -> None:
         roles = getattr(task, "roles", {}) or {}
@@ -977,7 +1062,12 @@ def _sweep_missing_task_workers(services: Any) -> dict[str, int]:
     # workspace tasks without a project key have no per-task window
     # naming convention to check against.
     workspace_work = getattr(services, "work_service", None)
-    known = list(getattr(services, "known_projects", ()) or ())
+    known = list(
+        _known_projects_for_sweep(
+            services,
+            recent_real_work_projects=recent_real_work_projects,
+        )
+    )
     if workspace_work is not None and known:
         for project in known:
             project_key = getattr(project, "key", None)
@@ -1189,6 +1279,7 @@ def _sweep_work_service(
     review_pending_tasks: set[tuple[str, int]] | None = None,
     project_path: Any = None,
     project: Any = None,
+    recent_real_work_projects: frozenset[str] | None = None,
 ) -> None:
     """Run one sweep pass over a single work-service DB.
 
@@ -1221,7 +1312,10 @@ def _sweep_work_service(
     # ``auto_claim_skipped_plan_missing`` outcome on the same task.
     known_by_key: dict[str, Any] = {}
     if project is None and project_path is None:
-        for known in getattr(services, "known_projects", ()) or ():
+        for known in _known_projects_for_sweep(
+            services,
+            recent_real_work_projects=recent_real_work_projects,
+        ):
             known_key = getattr(known, "key", None)
             if known_key:
                 known_by_key[known_key] = known
@@ -1242,6 +1336,15 @@ def _sweep_work_service(
             # ``review`` is by definition work-for-the-human and should
             # be visible. Tracked so the post-sweep clearing pass can
             # close alerts whose task transitioned out of ``review``.
+            task_project_key = str(getattr(task, "project", "") or "")
+            if not _project_is_live_for_sweep(
+                task_project_key,
+                recent_real_work_projects,
+            ):
+                by_outcome["skipped_dormant_project"] = (
+                    by_outcome.get("skipped_dormant_project", 0) + 1
+                )
+                continue
             if (
                 review_pending_tasks is not None
                 and status == WorkStatus.REVIEW.value
@@ -2543,7 +2646,11 @@ def _wire_session_manager(svc: Any, project_root: Path, services: Any) -> None:
         )
 
 
-def _precompute_plan_missing_projects(services: Any) -> dict[str, str | None]:
+def _precompute_plan_missing_projects(
+    services: Any,
+    *,
+    recent_real_work_projects: frozenset[str] | None = None,
+) -> dict[str, str | None]:
     """Return a mapping of plan-gated project keys → an example queued task_id.
 
     #1524 — computed up front from the canonical workspace DB so the
@@ -2562,7 +2669,12 @@ def _precompute_plan_missing_projects(services: Any) -> dict[str, str | None]:
         global_enforce = bool(getattr(services, "enforce_plan", True))
         if not global_enforce:
             return {}
-        known = list(getattr(services, "known_projects", ()) or ())
+        known = list(
+            _known_projects_for_sweep(
+                services,
+                recent_real_work_projects=recent_real_work_projects,
+            )
+        )
         if not known:
             return {}
         plan_dir = getattr(services, "plan_dir", "docs/plan") or "docs/plan"
@@ -2711,6 +2823,7 @@ def _sweep_workspace_root(
     plan_missing_projects: set,
     plan_decisions: dict,
     review_pending_tasks: set,
+    recent_real_work_projects: frozenset[str] | None,
 ) -> dict[str, Any] | None:
     """Pass 1: workspace-root DB sweep.
 
@@ -2730,6 +2843,7 @@ def _sweep_workspace_root(
                 plan_decisions=plan_decisions,
                 review_pending_tasks=review_pending_tasks,
                 project_path=None,
+                recent_real_work_projects=recent_real_work_projects,
             )
         finally:
             _close_quietly(workspace_work)
@@ -2742,10 +2856,17 @@ def _sweep_workspace_root(
 
 
 def _sweep_workspace_per_project(
-    *, services: Any, totals: dict, plan_missing_projects: set,
+    *,
+    services: Any,
+    totals: dict,
+    plan_missing_projects: set,
+    recent_real_work_projects: frozenset[str] | None,
 ) -> None:
     """Open the workspace DB once per registered project and run auto-claim."""
-    for project in services.known_projects:
+    for project in _known_projects_for_sweep(
+        services,
+        recent_real_work_projects=recent_real_work_projects,
+    ):
         if not _auto_claim_enabled_for_project(services, project):
             continue
         workspace_project_work = _open_workspace_project_work_service(
@@ -2775,11 +2896,15 @@ def _sweep_per_project_dbs(
     plan_missing_projects: set,
     plan_decisions: dict,
     review_pending_tasks: set,
+    recent_real_work_projects: frozenset[str] | None,
 ) -> tuple[int, int]:
     """Pass 2: per-project DB sweep. Returns ``(scanned, skipped)``."""
     projects_scanned = 0
     projects_skipped = 0
-    for project in services.known_projects:
+    for project in _known_projects_for_sweep(
+        services,
+        recent_real_work_projects=recent_real_work_projects,
+    ):
         project_key = getattr(project, "key", None)
         project_work = _open_project_work_service(project, services)
         if project_work is None:
@@ -2798,6 +2923,7 @@ def _sweep_per_project_dbs(
                 review_pending_tasks=review_pending_tasks,
                 project_path=getattr(project, "path", None),
                 project=project,
+                recent_real_work_projects=recent_real_work_projects,
             )
             # #768: auto-claim runs after the regular sweep body so
             # dead-window recovery has the most-recent state to work
@@ -2829,7 +2955,10 @@ def _sweep_per_project_dbs(
 
 
 def _sweep_recovery_passes(
-    *, services: Any, config_path: Path | None,
+    *,
+    services: Any,
+    config_path: Path | None,
+    recent_real_work_projects: frozenset[str] | None,
 ) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
     """End-of-tick recovery passes.
 
@@ -2855,7 +2984,10 @@ def _sweep_recovery_passes(
 
     worker_gap_summary = {"emitted": 0, "cleared": 0}
     try:
-        worker_gap_summary = _sweep_worker_session_gaps(services)
+        worker_gap_summary = _sweep_worker_session_gaps(
+            services,
+            recent_real_work_projects=recent_real_work_projects,
+        )
     except Exception:  # noqa: BLE001
         logger.debug(
             "task_assignment sweep: worker_session_gap pass failed",
@@ -2864,7 +2996,10 @@ def _sweep_recovery_passes(
 
     missing_worker_summary = {"emitted": 0, "cleared": 0, "considered": 0}
     try:
-        missing_worker_summary = _sweep_missing_task_workers(services)
+        missing_worker_summary = _sweep_missing_task_workers(
+            services,
+            recent_real_work_projects=recent_real_work_projects,
+        )
     except Exception:  # noqa: BLE001
         logger.debug(
             "task_assignment sweep: missing_task_worker pass failed",
@@ -2893,10 +3028,14 @@ def _task_assignment_sweep_body(
 
     totals: dict[str, Any] = {"considered": 0, "by_outcome": {}}
     alerted_pairs: set[tuple[str, str]] = set()
+    recent_real_work_projects = _recent_real_work_project_keys_for_sweep(services)
     # #1524 — pre-compute the set of projects that are plan-gated this
     # tick so the emit/clear decision is deterministic across the
     # workspace pass + per-project pass.
-    precomputed_missing = _precompute_plan_missing_projects(services)
+    precomputed_missing = _precompute_plan_missing_projects(
+        services,
+        recent_real_work_projects=recent_real_work_projects,
+    )
     plan_missing_projects: set[str] = set(precomputed_missing.keys())
     plan_decisions: dict[str, bool] = {}
     # Seed the per-tick gate cache with the precomputed answers so the
@@ -2933,6 +3072,7 @@ def _task_assignment_sweep_body(
         plan_missing_projects=plan_missing_projects,
         plan_decisions=plan_decisions,
         review_pending_tasks=review_pending_tasks,
+        recent_real_work_projects=recent_real_work_projects,
     )
     if short_circuit is not None:
         return short_circuit
@@ -2941,6 +3081,7 @@ def _task_assignment_sweep_body(
         services=services,
         totals=totals,
         plan_missing_projects=plan_missing_projects,
+        recent_real_work_projects=recent_real_work_projects,
     )
 
     projects_scanned, projects_skipped = _sweep_per_project_dbs(
@@ -2951,6 +3092,7 @@ def _task_assignment_sweep_body(
         plan_missing_projects=plan_missing_projects,
         plan_decisions=plan_decisions,
         review_pending_tasks=review_pending_tasks,
+        recent_real_work_projects=recent_real_work_projects,
     )
 
     # #1053: clear stale ``review_pending`` alerts.
@@ -2959,7 +3101,11 @@ def _task_assignment_sweep_body(
     )
 
     spawn_summary, worker_gap_summary, missing_worker_summary = (
-        _sweep_recovery_passes(services=services, config_path=config_path)
+        _sweep_recovery_passes(
+            services=services,
+            config_path=config_path,
+            recent_real_work_projects=recent_real_work_projects,
+        )
     )
 
     return {

--- a/src/pollypm/project_liveness.py
+++ b/src/pollypm/project_liveness.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import re
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Mapping, TypeVar
+from typing import Callable, Iterable, Mapping, TypeVar
 
 
 _SYNTHETIC_PROJECT_KEYS = frozenset(
@@ -37,6 +38,7 @@ _SYNTHETIC_PROJECT_PREFIXES = (
     "testpause-",
 )
 _SYNTHETIC_PATH_PREFIXES = ("/private/tmp/",)
+RECENT_REAL_WORK_WINDOW = timedelta(days=7)
 
 _ProjectKey = TypeVar("_ProjectKey")
 _ProjectValue = TypeVar("_ProjectValue")
@@ -94,6 +96,84 @@ def is_real_operator_project(
     return True
 
 
+def task_status_key(task: object) -> str:
+    """Return a task's work-status value as a plain string."""
+
+    status = getattr(task, "work_status", "") or ""
+    status_value = getattr(status, "value", status)
+    return str(status_value or "")
+
+
+def coerce_utc_datetime(value: object) -> datetime | None:
+    """Coerce an ISO/datetime value to UTC, returning ``None`` on parse failure."""
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def task_is_recent_done_work(
+    task: object,
+    *,
+    cutoff: datetime,
+) -> bool:
+    """Return True when ``task`` is recently completed real work."""
+
+    if task_status_key(task) != "done":
+        return False
+    stamped = coerce_utc_datetime(
+        getattr(task, "updated_at", None) or getattr(task, "created_at", None)
+    )
+    return stamped is None or stamped >= cutoff
+
+
+def recent_real_work_project_keys(
+    projects: Mapping[object, object],
+    tasks_for_project: Callable[[object], Iterable[object]],
+    *,
+    now: datetime | None = None,
+    recency_window: timedelta = RECENT_REAL_WORK_WINDOW,
+) -> frozenset[str]:
+    """Return real operator projects with recent completed task work.
+
+    This is the liveness signal used by operator-facing alert demotion
+    and sweep-side watchdog gating. It intentionally ignores queued /
+    recently touched rows because watchdog sweeps themselves can refresh
+    those timestamps.
+    """
+
+    current = now or datetime.now(UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=UTC)
+    else:
+        current = current.astimezone(UTC)
+    cutoff = current - recency_window
+    recent: set[str] = set()
+    for project_key, project in projects.items():
+        if not is_real_operator_project(project_key, project):
+            continue
+        for task in tasks_for_project(project_key):
+            if task_is_recent_done_work(task, cutoff=cutoff):
+                recent.add(str(project_key))
+                break
+    return frozenset(recent)
+
+
 def real_operator_project_keys(
     projects: Mapping[object, object],
     *,
@@ -141,9 +221,14 @@ def real_operator_project_items(
 
 
 __all__ = [
+    "RECENT_REAL_WORK_WINDOW",
+    "coerce_utc_datetime",
     "is_real_operator_project",
     "project_key_looks_synthetic",
     "project_path_looks_synthetic",
     "real_operator_project_items",
     "real_operator_project_keys",
+    "recent_real_work_project_keys",
+    "task_is_recent_done_work",
+    "task_status_key",
 ]

--- a/tests/test_missing_task_worker.py
+++ b/tests/test_missing_task_worker.py
@@ -438,3 +438,45 @@ def test_multiple_missing_workers_each_get_their_own_alert(
         "missing_task_worker-polly_remote/13",
         "missing_task_worker-polly_remote/14",
     }
+
+
+def test_liveness_gate_skips_dormant_project_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2530: dormant projects are not scanned for missing workers."""
+    live_project = _FakeProject(key="polly_remote")
+    dormant_project = _FakeProject(key="pm_test_01wave_1779715196")
+    store = _FakeStore()
+    services = _build_services(
+        windows=[],
+        known_projects=(live_project, dormant_project),
+        store=store,
+    )
+    opened: list[str] = []
+
+    def _opener(project: _FakeProject, _services: Any) -> _FakeWorkService:
+        opened.append(project.key)
+        return _FakeWorkService(
+            [
+                _make_task(
+                    project=project.key,
+                    task_number=1,
+                    work_status=WorkStatus.IN_PROGRESS.value,
+                ),
+            ],
+            is_workspace=False,
+        )
+
+    monkeypatch.setattr(sweep_mod, "_open_project_work_service", _opener)
+
+    summary = _sweep_missing_task_workers(
+        services,
+        recent_real_work_projects=frozenset({"polly_remote"}),
+    )
+
+    assert opened == ["polly_remote"]
+    assert summary["emitted"] == 1
+    assert summary["considered"] == 1
+    assert {row[0] for row in store.upserts} == {
+        "missing_task_worker-polly_remote/1",
+    }

--- a/tests/test_project_liveness.py
+++ b/tests/test_project_liveness.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
 from pollypm.project_liveness import (
+    coerce_utc_datetime,
     is_real_operator_project,
     project_key_looks_synthetic,
     project_path_looks_synthetic,
     real_operator_project_items,
     real_operator_project_keys,
+    recent_real_work_project_keys,
+    task_is_recent_done_work,
 )
 
 
@@ -85,3 +89,72 @@ def test_real_operator_project_items_falls_back_when_only_synthetic() -> None:
         "pm_test_01wave_1779715196",
     ]
     assert real_operator_project_items(projects, fallback_to_all=False) == ()
+
+
+def test_recent_real_work_project_keys_use_recent_done_real_projects() -> None:
+    now = datetime(2026, 6, 1, tzinfo=UTC)
+    projects = {
+        "active": SimpleNamespace(tracked=True, path="/Users/sam/dev/active"),
+        "dormant": SimpleNamespace(tracked=True, path="/Users/sam/dev/dormant"),
+        "queued_only": SimpleNamespace(tracked=True, path="/Users/sam/dev/queued"),
+        "pm_test_01wave_1779715196": SimpleNamespace(
+            tracked=True,
+            path="/private/tmp/pm_test_01wave_1779715196",
+        ),
+    }
+    tasks = {
+        "active": [
+            SimpleNamespace(
+                work_status="done",
+                updated_at=now - timedelta(days=1),
+            ),
+        ],
+        "dormant": [
+            SimpleNamespace(
+                work_status="done",
+                updated_at=now - timedelta(days=14),
+            ),
+        ],
+        "queued_only": [
+            SimpleNamespace(
+                work_status="queued",
+                updated_at=now,
+            ),
+        ],
+        "pm_test_01wave_1779715196": [
+            SimpleNamespace(
+                work_status="done",
+                updated_at=now - timedelta(days=1),
+            ),
+        ],
+    }
+
+    assert recent_real_work_project_keys(
+        projects,
+        lambda key: tasks[key],
+        now=now,
+    ) == frozenset({"active"})
+
+
+def test_task_is_recent_done_work_treats_missing_timestamp_as_live() -> None:
+    cutoff = datetime(2026, 5, 25, tzinfo=UTC)
+    assert task_is_recent_done_work(
+        SimpleNamespace(work_status="done", updated_at=None, created_at=None),
+        cutoff=cutoff,
+    )
+    assert not task_is_recent_done_work(
+        SimpleNamespace(work_status="queued", updated_at=None, created_at=None),
+        cutoff=cutoff,
+    )
+
+
+def test_coerce_utc_datetime_handles_z_suffix_and_naive_values() -> None:
+    assert coerce_utc_datetime("2026-06-01T12:00:00Z") == datetime(
+        2026,
+        6,
+        1,
+        12,
+        0,
+        tzinfo=UTC,
+    )
+    assert coerce_utc_datetime(datetime(2026, 6, 1, 12, 0)).tzinfo is UTC

--- a/tests/test_task_assignment_recovery_audit.py
+++ b/tests/test_task_assignment_recovery_audit.py
@@ -8,6 +8,7 @@ from pollypm.plugins_builtin.task_assignment_notify.handlers import sweep as swe
 from pollypm.plugins_builtin.task_assignment_notify.handlers.sweep import (
     _auto_claim_next,
     _recover_dead_claims,
+    _sweep_workspace_per_project,
 )
 from pollypm.work.models import WorkStatus
 
@@ -119,6 +120,65 @@ def _write_pause_marker(base_dir: Path, names: list[str]) -> None:
 def _reset_tmux_probe_tracking() -> None:
     sweep_mod._TMUX_WINDOW_PROBE_UNAVAILABLE_COUNTS.clear()
     sweep_mod._TMUX_WINDOW_PROBE_UNAVAILABLE_ALERTED.clear()
+
+
+class _ClosableWork:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_auto_claim_workspace_pass_skips_dormant_projects(monkeypatch) -> None:
+    """#2530: auto-claim enumeration is liveness-gated before DB work."""
+    live = SimpleNamespace(key="savethenovel", auto_claim=None)
+    dormant = SimpleNamespace(key="pm_test_01wave_1779715196", auto_claim=None)
+    services = SimpleNamespace(
+        auto_claim=True,
+        known_projects=(live, dormant),
+    )
+    opened: list[str] = []
+    recovered: list[str] = []
+    claimed: list[str] = []
+    work_by_project: dict[str, _ClosableWork] = {}
+
+    def _open(project, _services):
+        opened.append(project.key)
+        work = _ClosableWork()
+        work_by_project[project.key] = work
+        return work
+
+    monkeypatch.setattr(
+        sweep_mod,
+        "_open_workspace_project_work_service",
+        _open,
+    )
+    monkeypatch.setattr(
+        sweep_mod,
+        "_recover_dead_claims",
+        lambda _services, _work, project, _totals: recovered.append(project.key),
+    )
+    monkeypatch.setattr(
+        sweep_mod,
+        "_auto_claim_next",
+        lambda _services, _work, project, _totals, **_kwargs: claimed.append(
+            project.key
+        ),
+    )
+
+    _sweep_workspace_per_project(
+        services=services,
+        totals={"by_outcome": {}},
+        plan_missing_projects=set(),
+        recent_real_work_projects=frozenset({"savethenovel"}),
+    )
+
+    assert opened == ["savethenovel"]
+    assert recovered == ["savethenovel"]
+    assert claimed == ["savethenovel"]
+    assert work_by_project["savethenovel"].closed
+
 
 def test_recover_dead_claims_emits_task_reclaimed_audit(
     monkeypatch,

--- a/tests/test_worker_session_gap.py
+++ b/tests/test_worker_session_gap.py
@@ -13,7 +13,6 @@ contract without spinning up real tmux sessions or DBs.
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -373,3 +372,35 @@ def test_no_known_projects_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     assert summary == {"emitted": 0, "cleared": 0}
     assert store.upserts == []
     assert store.clears == []
+
+
+def test_liveness_gate_skips_dormant_project_gap_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2530: queued tasks in dormant projects do not refresh gap alerts."""
+    live_project = _FakeProject(key="polly_remote")
+    dormant_project = _FakeProject(key="pm_test_01wave_1779715196")
+    store = _FakeStore()
+    services = _build_services(
+        windows=[],
+        known_projects=(live_project, dormant_project),
+        store=store,
+    )
+    opened: list[str] = []
+
+    def _opener(project: _FakeProject, _services: Any) -> _FakeWorkService:
+        opened.append(project.key)
+        return _FakeWorkService({project.key: 3})
+
+    monkeypatch.setattr(sweep_mod, "_open_project_work_service", _opener)
+
+    summary = _sweep_worker_session_gaps(
+        services,
+        recent_real_work_projects=frozenset({"polly_remote"}),
+    )
+
+    assert opened == ["polly_remote"]
+    assert summary == {"emitted": 1, "cleared": 0}
+    assert [row[0] for row in store.upserts] == [
+        "worker_session_gap-polly_remote",
+    ]


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Extract the #2483 recent-real-work liveness predicate into `project_liveness` so dashboard counts and sweep gating share the same definition.
- Gate task-assignment project enumeration for plan-missing precompute, workspace/per-project auto-claim, worker-session-gap, and missing-task-worker sweeps.
- Keep the sweep fail-open when liveness facts cannot be loaded, but skip dormant projects when a concrete recent-real-work set is available.

Fixes #2530

## Tests
- `uv run --extra test python -m pytest -q tests/test_project_liveness.py tests/test_dashboard_data_alert_dedup.py::test_alert_filter_task_facts_use_recent_done_for_liveness tests/test_dashboard_data_alert_dedup.py::test_alert_filter_task_facts_excludes_synthetic_done_projects tests/test_missing_task_worker.py::test_liveness_gate_skips_dormant_project_db tests/test_worker_session_gap.py::test_liveness_gate_skips_dormant_project_gap_scan tests/test_task_assignment_recovery_audit.py::test_auto_claim_workspace_pass_skips_dormant_projects` (13 passed)
- `uv run --extra dev python -m ruff check src/pollypm/project_liveness.py src/pollypm/dashboard_data.py src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py tests/test_project_liveness.py tests/test_missing_task_worker.py tests/test_worker_session_gap.py tests/test_task_assignment_recovery_audit.py`

## Notes
- A broader intermediate run including `tests/test_task_assignment_fanout_recovery.py` hit existing failures in that module; spot-checking `tests/test_task_assignment_fanout_recovery.py::TestPerProjectFanout::test_sweeper_opens_multiple_per_project_dbs` on `origin/main` reproduces the same failure.
