### PR TITLE
fix(inbox): surface cancelled dependency blockers

### DIFF
--- a/docs/work-service-spec.md
+++ b/docs/work-service-spec.md
@@ -790,7 +790,7 @@ Flow templates are **immutable once a task is using them**. If the flow needs to
 - **Blocker reaches `done`**: Dependency is satisfied. Blocked task automatically unblocks (returns to `queued`).
 - **Blocker is `cancelled`**: Dependency is NOT automatically satisfied. The work service flags this to the PM/operator, who must decide: should the blocked tasks also be cancelled, or can they be unblocked now? The blocked task stays `blocked` until the PM explicitly removes the dependency or cancels it.
 
-This prevents a cancelled blocker from silently unblocking work that may no longer make sense.
+The cancelled-blocker watchdog raises a project-scoped `blocked_cancelled_blocker:<project>/<task>` alert for each affected blocked task. If the cancelled blocker was an operator/user handoff, the dependent blocked task remains visible in the default inbox so the request is preserved after cancellation. This prevents a cancelled blocker from either silently unblocking work that may no longer make sense or silently hiding the decision the operator still owes.
 
 ### ~~OQ-8: Cross-Project Dependencies~~ — RESOLVED
 

--- a/src/pollypm/plugins_builtin/core_recurring/blocked_chain.py
+++ b/src/pollypm/plugins_builtin/core_recurring/blocked_chain.py
@@ -23,9 +23,11 @@ it and decides):
   non-in-flight status. "In-flight" means ``in_progress`` / ``review`` /
   ``rework`` — actively being worked on or actively being reviewed.
   ``queued`` counts as not-in-flight: a queued blocker that itself
-  depends on stuck work is still part of a dead end. ``done`` /
-  ``cancelled`` blockers are filtered upstream by ``maybe_unblock``;
-  if any remain on the chain we still treat them as resolved.
+  depends on stuck work is still part of a dead end. ``done`` blockers
+  are filtered upstream by ``maybe_unblock``. ``cancelled`` blockers
+  are not dependency-satisfying; they emit a separate actionable
+  ``blocked_cancelled_blocker:<project>/<task>`` alert scoped to the
+  affected project so the inbox/dashboard can route it to the operator.
 
 The alert is keyed by ``session_name = blocked-<project>-<N>`` and
 ``alert_type = blocked_dead_end`` so ``upsert_alert`` dedupes across
@@ -61,11 +63,14 @@ _IN_FLIGHT_STATUSES: frozenset[str] = frozenset({
     WorkStatus.REWORK.value,
 })
 
-# Statuses that count as resolved — a blocker that's done or cancelled
-# would already have been filtered out by ``maybe_unblock``; if it
-# lingers we still treat it as not-blocking.
+# Statuses that count as resolved. ``cancelled`` is intentionally not
+# included: a cancelled prerequisite is terminal, but does not satisfy the
+# dependency. It requires a PM/operator decision.
 _RESOLVED_STATUSES: frozenset[str] = frozenset({
     WorkStatus.DONE.value,
+})
+
+_CANCELLED_STATUSES: frozenset[str] = frozenset({
     WorkStatus.CANCELLED.value,
 })
 
@@ -76,6 +81,15 @@ def blocked_dead_end_session_name(project: str, task_number: int) -> str:
 
 
 BLOCKED_DEAD_END_ALERT_TYPE = "blocked_dead_end"
+BLOCKED_CANCELLED_BLOCKER_ALERT_TYPE_PREFIX = "blocked_cancelled_blocker:"
+
+
+def blocked_cancelled_blocker_alert_type(project: str, task_number: int) -> str:
+    """Return the per-task alert_type for cancelled-blocker deadlocks."""
+    return (
+        f"{BLOCKED_CANCELLED_BLOCKER_ALERT_TYPE_PREFIX}"
+        f"{project}/{int(task_number)}"
+    )
 
 
 def _parse_iso(stamp: Any) -> datetime | None:
@@ -178,6 +192,44 @@ def _format_chain_summary(
     )
 
 
+def _format_blocker_label(work: Any, key: tuple[str, int]) -> str:
+    ref = f"{key[0]}/{int(key[1])}"
+    get_task = getattr(work, "get", None)
+    if not callable(get_task):
+        return ref
+    try:
+        task = get_task(ref)
+    except Exception:  # noqa: BLE001 - alert still useful with just the ref
+        return ref
+    title = str(getattr(task, "title", "") or "").strip()
+    if not title:
+        return ref
+    return f"{ref} ({title})"
+
+
+def _format_cancelled_blocker_summary(
+    *,
+    work: Any,
+    task_id: str,
+    cancelled_keys: set[tuple[str, int]],
+) -> str:
+    """Build the alert message for a chain ending at cancelled blockers."""
+    labels = [
+        _format_blocker_label(work, key)
+        for key in sorted(cancelled_keys)
+    ]
+    shown = ", ".join(labels[:4])
+    if len(labels) > 4:
+        shown += f", +{len(labels) - 4} more"
+    word = "blocker" if len(labels) == 1 else "blockers"
+    return (
+        f"Task {task_id} is blocked by cancelled dependency {word}: "
+        f"{shown}. Cancelled blockers do not auto-satisfy dependencies. "
+        "Reopen the cancelled blocker, unlink/requeue this task if the "
+        "dependency is no longer required, or cancel the dependent work."
+    )
+
+
 def _emit_alert(
     *,
     msg_store: Any,
@@ -185,16 +237,18 @@ def _emit_alert(
     project: str,
     task_number: int,
     message: str,
+    session_name: str | None = None,
+    alert_type: str = BLOCKED_DEAD_END_ALERT_TYPE,
 ) -> bool:
-    """Upsert a ``blocked_dead_end`` alert. Returns True iff a write ran."""
-    session_name = blocked_dead_end_session_name(project, task_number)
+    """Upsert a blocked-chain alert. Returns True iff a write ran."""
+    session_name = session_name or blocked_dead_end_session_name(
+        project, task_number,
+    )
     target = msg_store or state_store
     if target is None:
         return False
     try:
-        target.upsert_alert(
-            session_name, BLOCKED_DEAD_END_ALERT_TYPE, "warn", message,
-        )
+        target.upsert_alert(session_name, alert_type, "warn", message)
         return True
     except Exception:  # noqa: BLE001
         logger.debug(
@@ -244,7 +298,9 @@ def sweep_blocked_chains(
     counters = {
         "blocked_considered": 0,
         "dead_end_detected": 0,
+        "cancelled_blocker_detected": 0,
         "alerts_raised": 0,
+        "cancelled_blocker_alerts_raised": 0,
         "skipped_recent": 0,
         "skipped_in_flight_chain": 0,
         "skipped_no_blockers": 0,
@@ -287,6 +343,33 @@ def sweep_blocked_chains(
                 message=message,
             ):
                 counters["alerts_raised"] += 1
+            continue
+        cancelled_chain = {
+            key: status
+            for key, status in status_by_key.items()
+            if status in _CANCELLED_STATUSES
+        }
+        if cancelled_chain:
+            counters["dead_end_detected"] += 1
+            counters["cancelled_blocker_detected"] += 1
+            message = _format_cancelled_blocker_summary(
+                work=work,
+                task_id=task.task_id,
+                cancelled_keys=set(cancelled_chain.keys()),
+            )
+            if _emit_alert(
+                msg_store=msg_store,
+                state_store=state_store,
+                project=project,
+                task_number=task_number,
+                message=message,
+                session_name=project,
+                alert_type=blocked_cancelled_blocker_alert_type(
+                    project, task_number,
+                ),
+            ):
+                counters["alerts_raised"] += 1
+                counters["cancelled_blocker_alerts_raised"] += 1
             continue
         # Drop resolved blockers from the dead-end consideration. If
         # any remain in flight the chain is alive.
@@ -361,7 +444,9 @@ def blocked_chain_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     totals = {
         "blocked_considered": 0,
         "dead_end_detected": 0,
+        "cancelled_blocker_detected": 0,
         "alerts_raised": 0,
+        "cancelled_blocker_alerts_raised": 0,
         "skipped_recent": 0,
         "skipped_in_flight_chain": 0,
         "skipped_no_blockers": 0,

--- a/src/pollypm/work/inbox_view.py
+++ b/src/pollypm/work/inbox_view.py
@@ -11,6 +11,9 @@ A task is considered in the user's inbox when any of the following hold:
     role named "user" to the task).
   * The task's ``roles`` dict contains *any* role whose value is literally
     the string ``"user"`` (a role like ``requester=user``).
+  * The task is blocked by a cancelled dependency that itself had inbox
+    identity. This preserves cancelled operator handoffs as visible
+    downstream action instead of letting the dependent task disappear.
 
 Terminal tasks (``done`` / ``cancelled``) are always excluded.
 
@@ -271,6 +274,45 @@ def is_inbox_task_identity(
     return _current_node_is_human(task, service, flow_cache=cache)
 
 
+def _blocked_on_cancelled_inbox_dependency(
+    task: Task,
+    service: _FlowLookup,
+    *,
+    flow_cache: dict[tuple[str, int], FlowTemplate],
+) -> bool:
+    """Return True when ``task`` is blocked on a cancelled inbox handoff.
+
+    Cancelled blockers intentionally do not auto-satisfy dependencies: the PM
+    must choose whether to reopen the blocker, unlink/requeue the dependent, or
+    cancel the dependent work. If the cancelled blocker was itself an inbox row
+    (roles/user/human-node/plan-review identity), the dependent task must stay
+    visible in the user's inbox so the operator-input request is not erased by
+    the cancellation.
+    """
+    if _status_value(task) != WorkStatus.BLOCKED.value:
+        return False
+    refs = getattr(task, "blocked_by", None) or []
+    if not refs:
+        return False
+    get_task = getattr(service, "get", None)
+    if not callable(get_task):
+        return False
+    for ref in refs:
+        try:
+            project, task_number = ref
+        except (TypeError, ValueError):
+            continue
+        try:
+            blocker = get_task(f"{project}/{int(task_number)}")
+        except Exception:  # noqa: BLE001 - readonly predicate degrades hidden
+            continue
+        if _status_value(blocker) != WorkStatus.CANCELLED.value:
+            continue
+        if is_inbox_task_identity(blocker, service, flow_cache=flow_cache):
+            return True
+    return False
+
+
 def is_inbox_task(
     task: Task,
     service: _FlowLookup,
@@ -287,9 +329,15 @@ def is_inbox_task(
     snoozed, mark-read, replied to, or promoted via the API if it
     would not have appeared in the cockpit inbox.
     """
-    if getattr(task, "work_status", None) in TERMINAL_STATUSES:
+    status = getattr(task, "work_status", None)
+    if status in TERMINAL_STATUSES or _status_value(task) in {"done", "cancelled"}:
         return False
-    return is_inbox_task_identity(task, service, flow_cache=flow_cache)
+    cache = flow_cache if flow_cache is not None else {}
+    if is_inbox_task_identity(task, service, flow_cache=cache):
+        return True
+    return _blocked_on_cancelled_inbox_dependency(
+        task, service, flow_cache=cache,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -909,9 +909,11 @@ class PgWorkService:
             "WHERE role.v = 'user'"
             ") "
             "OR labels ? 'plan_review' "
-            "OR current_node_id IS NOT NULL"
+            "OR current_node_id IS NOT NULL "
+            "OR work_status = %s"
             ")"
         )
+        params.append(WorkStatus.BLOCKED.value)
 
         clause = " WHERE " + " AND ".join(where)
         order_limit = " ORDER BY updated_at DESC, project ASC, task_number DESC"

--- a/tests/test_blocked_chain_sweep.py
+++ b/tests/test_blocked_chain_sweep.py
@@ -8,13 +8,22 @@ from pollypm.work.models import WorkStatus
 
 
 class _FakeWork:
-    def __init__(self, task: SimpleNamespace) -> None:
+    def __init__(
+        self,
+        task: SimpleNamespace,
+        *,
+        tasks_by_id: dict[str, SimpleNamespace] | None = None,
+    ) -> None:
         self.task = task
+        self.tasks_by_id = dict(tasks_by_id or {})
 
     def list_tasks(self, *, work_status: str) -> list[SimpleNamespace]:
         if work_status == WorkStatus.BLOCKED.value:
             return [self.task]
         return []
+
+    def get(self, task_id: str) -> SimpleNamespace:
+        return self.tasks_by_id[task_id]
 
 
 class _FakeStore:
@@ -71,3 +80,56 @@ def test_blocked_task_with_no_blocker_rows_alerts(monkeypatch) -> None:
         ),
     ]
     assert "has no blocker dependency rows" in store.alerts[0][3]
+
+
+def test_cancelled_blocker_chain_alerts_to_project_scope(monkeypatch) -> None:
+    now = datetime(2026, 5, 29, 12, 0, tzinfo=timezone.utc)
+    task = SimpleNamespace(
+        project="demo",
+        task_number=30,
+        task_id="demo/30",
+    )
+    cancelled = SimpleNamespace(
+        project="demo",
+        task_number=26,
+        task_id="demo/26",
+        title="Needs your inputs",
+    )
+    monkeypatch.setattr(
+        blocked_chain,
+        "_blocked_since",
+        lambda *_args, **_kwargs: now - timedelta(hours=2),
+    )
+    monkeypatch.setattr(
+        blocked_chain,
+        "_walk_blocker_chain",
+        lambda *_args, **_kwargs: (
+            {("demo", 26)},
+            {("demo", 26): WorkStatus.CANCELLED.value},
+        ),
+    )
+    store = _FakeStore()
+
+    counters = blocked_chain.sweep_blocked_chains(
+        work=_FakeWork(task, tasks_by_id={"demo/26": cancelled}),
+        msg_store=store,
+        state_store=None,
+        now=now,
+        stale_threshold_seconds=3600,
+    )
+
+    assert counters["blocked_considered"] == 1
+    assert counters["dead_end_detected"] == 1
+    assert counters["cancelled_blocker_detected"] == 1
+    assert counters["alerts_raised"] == 1
+    assert counters["cancelled_blocker_alerts_raised"] == 1
+    assert store.alerts == [
+        (
+            "demo",
+            "blocked_cancelled_blocker:demo/30",
+            "warn",
+            store.alerts[0][3],
+        ),
+    ]
+    assert "demo/26 (Needs your inputs)" in store.alerts[0][3]
+    assert "do not auto-satisfy dependencies" in store.alerts[0][3]

--- a/tests/test_inbox_view_snooze.py
+++ b/tests/test_inbox_view_snooze.py
@@ -123,6 +123,15 @@ class _BulkSnoozeService:
         }
 
 
+class _DependencyService(_BulkSnoozeService):
+    def __init__(self, tasks: list[Task]) -> None:
+        super().__init__(tasks)
+        self.by_id = {task.task_id: task for task in tasks}
+
+    def get(self, task_id: str) -> Task:
+        return self.by_id[task_id]
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -210,3 +219,54 @@ def test_inbox_tasks_without_bulk_helper_returns_all_rows() -> None:
 
     result = inbox_tasks(_LegacyService(), project="demo")
     assert [t.task_id for t in result] == ["demo/1"]
+
+
+def test_inbox_tasks_surfaces_blocked_task_when_cancelled_blocker_was_user_handoff() -> None:
+    """Cancelled operator handoffs must not erase the downstream ask.
+
+    The cancelled blocker itself stays terminal/closed, but the dependent
+    blocked task remains visible in the shared inbox view so cockpit, rail,
+    dashboard counts, and API write guards agree that the user still has an
+    action to resolve.
+    """
+    blocker = _task(
+        26,
+        title="Needs your inputs",
+        current_node_id=None,
+    )
+    blocker.roles = {"requester": "user", "operator": "user"}
+    blocker.work_status = WorkStatus.CANCELLED
+    target = _task(
+        30,
+        title="Ship after inputs",
+        current_node_id=None,
+    )
+    target.roles = {}
+    target.work_status = WorkStatus.BLOCKED
+    target.blocked_by = [("demo", 26)]
+
+    result = inbox_tasks(_DependencyService([blocker, target]), project="demo")
+
+    assert [task.task_id for task in result] == ["demo/30"]
+
+
+def test_inbox_tasks_does_not_surface_blocked_task_for_ordinary_cancelled_blocker() -> None:
+    blocker = _task(
+        1,
+        title="Ordinary cancelled task",
+        current_node_id=None,
+    )
+    blocker.roles = {}
+    blocker.work_status = WorkStatus.CANCELLED
+    target = _task(
+        2,
+        title="Still blocked internally",
+        current_node_id=None,
+    )
+    target.roles = {}
+    target.work_status = WorkStatus.BLOCKED
+    target.blocked_by = [("demo", 1)]
+
+    result = inbox_tasks(_DependencyService([blocker, target]), project="demo")
+
+    assert result == []


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Detect blocked dependency chains that include a cancelled blocker and emit a project-scoped `blocked_cancelled_blocker:<project>/<task>` alert instead of treating cancelled blockers as resolved.
- Keep tasks blocked on cancelled user/operator handoff tasks visible through the shared inbox predicate so cockpit, rail, dashboard counts, and API write guards do not drop the pending operator action.
- Widen the pg inbox candidate query to include blocked rows for final canonical filtering, and document the cancelled-blocker surfacing contract.

Fixes #2532

## Tests
- `uv run --extra dev ruff check src/pollypm/work/inbox_view.py src/pollypm/work/pg_service.py src/pollypm/plugins_builtin/core_recurring/blocked_chain.py tests/test_blocked_chain_sweep.py tests/test_inbox_view_snooze.py`
- `uv run --extra test python -m pytest tests/test_blocked_chain_sweep.py tests/test_inbox_view_snooze.py -q`
- `uv run --extra test python -m pytest tests/test_dashboard_endpoint.py::test_list_projects_uses_pg_bulk_task_snapshot -q`
- `python -m compileall -q src/pollypm/work/inbox_view.py src/pollypm/work/pg_service.py src/pollypm/plugins_builtin/core_recurring/blocked_chain.py`
