### PR TITLE
fix(blocked-chain): walk task blocker fields

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/blocked_chain.py
+++ b/src/pollypm/plugins_builtin/core_recurring/blocked_chain.py
@@ -128,6 +128,7 @@ def _walk_blocker_chain(
     *,
     project: str,
     task_number: int,
+    root_task: Any | None = None,
 ) -> tuple[set[tuple[str, int]], dict[tuple[str, int], str]]:
     """Walk the recursive ``blocked_by`` chain.
 
@@ -144,6 +145,7 @@ def _walk_blocker_chain(
         work,
         project_key=project,
         task_number=task_number,
+        root_task=root_task,
     )
 
 
@@ -234,6 +236,7 @@ def _emit_alert(
     *,
     msg_store: Any,
     state_store: Any,
+    config: Any | None = None,
     project: str,
     task_number: int,
     message: str,
@@ -244,16 +247,63 @@ def _emit_alert(
     session_name = session_name or blocked_dead_end_session_name(
         project, task_number,
     )
-    target = msg_store or state_store
-    if target is None:
+    if msg_store is not None:
+        try:
+            msg_store.upsert_alert(session_name, alert_type, "warn", message)
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "blocked_chain.sweep: msg_store upsert_alert failed for %s/%d",
+                project, task_number, exc_info=True,
+            )
+
+    if _upsert_pg_alert(
+        config=config,
+        session_name=session_name,
+        alert_type=alert_type,
+        message=message,
+    ):
+        return True
+
+    if state_store is None:
         return False
     try:
-        target.upsert_alert(session_name, alert_type, "warn", message)
+        state_store.upsert_alert(session_name, alert_type, "warn", message)
         return True
     except Exception:  # noqa: BLE001
         logger.debug(
-            "blocked_chain.sweep: upsert_alert failed for %s/%d",
+            "blocked_chain.sweep: state_store upsert_alert failed for %s/%d",
             project, task_number, exc_info=True,
+        )
+        return False
+
+
+def _upsert_pg_alert(
+    *,
+    config: Any | None,
+    session_name: str,
+    alert_type: str,
+    message: str,
+) -> bool:
+    storage = getattr(config, "storage", None)
+    backend = str(getattr(storage, "backend", "") or "").lower()
+    if backend != "postgres":
+        return False
+    try:
+        from pollypm.storage.pg_alerts import upsert_alert
+
+        upsert_alert(
+            session_name,
+            alert_type,
+            "warn",
+            message,
+            config=config,
+        )
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "blocked_chain.sweep: pg_alerts upsert_alert failed for %s/%s",
+            session_name, alert_type, exc_info=True,
         )
         return False
 
@@ -286,6 +336,7 @@ def sweep_blocked_chains(
     work: Any,
     msg_store: Any,
     state_store: Any,
+    config: Any | None = None,
     now: datetime,
     stale_threshold_seconds: int = DEFAULT_STALE_THRESHOLD_SECONDS,
 ) -> dict[str, int]:
@@ -324,7 +375,10 @@ def sweep_blocked_chains(
             counters["skipped_recent"] += 1
             continue
         visited, status_by_key = _walk_blocker_chain(
-            work, project=project, task_number=task_number,
+            work,
+            project=project,
+            task_number=task_number,
+            root_task=task,
         )
         if not visited:
             counters["dead_end_detected"] += 1
@@ -338,6 +392,7 @@ def sweep_blocked_chains(
             if _emit_alert(
                 msg_store=msg_store,
                 state_store=state_store,
+                config=config,
                 project=project,
                 task_number=task_number,
                 message=message,
@@ -360,6 +415,7 @@ def sweep_blocked_chains(
             if _emit_alert(
                 msg_store=msg_store,
                 state_store=state_store,
+                config=config,
                 project=project,
                 task_number=task_number,
                 message=message,
@@ -395,6 +451,7 @@ def sweep_blocked_chains(
         if _emit_alert(
             msg_store=msg_store,
             state_store=state_store,
+            config=config,
             project=project,
             task_number=task_number,
             message=message,
@@ -460,6 +517,7 @@ def blocked_chain_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
                 work=services.work_service,
                 msg_store=services.msg_store,
                 state_store=services.state_store,
+                config=services.config,
                 now=now,
                 stale_threshold_seconds=stale_threshold_seconds,
             )
@@ -476,6 +534,7 @@ def blocked_chain_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
                     work=project_work,
                     msg_store=services.msg_store,
                     state_store=services.state_store,
+                    config=services.config,
                     now=now,
                     stale_threshold_seconds=stale_threshold_seconds,
                 )

--- a/src/pollypm/work/task_state.py
+++ b/src/pollypm/work/task_state.py
@@ -175,13 +175,103 @@ def blocked_since_stamp_for_service(
     )
 
 
+def _coerce_task_ref(raw: Any) -> tuple[str, int] | None:
+    if isinstance(raw, str):
+        project, sep, number = raw.rpartition("/")
+        if sep and project and number.isdigit():
+            return project, int(number)
+        return None
+    if isinstance(raw, (tuple, list)) and len(raw) == 2:
+        project, number = raw
+        try:
+            return str(project), int(number)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _task_status_value(task: Any) -> str:
+    status = getattr(task, "work_status", "")
+    return str(getattr(status, "value", status) or "")
+
+
+def _task_blockers(task: Any) -> list[tuple[str, int]]:
+    refs: list[tuple[str, int]] = []
+    for raw in getattr(task, "blocked_by", None) or ():
+        ref = _coerce_task_ref(raw)
+        if ref is not None:
+            refs.append(ref)
+    return refs
+
+
+def _task_id(project_key: str, task_number: int) -> str:
+    return f"{project_key}/{int(task_number)}"
+
+
+def _service_blocker_chain_statuses(
+    work: Any,
+    *,
+    project_key: str,
+    task_number: int,
+    root_task: Any | None = None,
+) -> tuple[set[tuple[str, int]], dict[tuple[str, int], str]] | None:
+    """Walk blockers through the public work-service Task surface.
+
+    ``Task.blocked_by`` is the same representation rendered by
+    ``pm task get`` and hydrated by ``PgWorkService.list_tasks``. Use it
+    before falling back to the legacy SQLite row probe so PG-backed and
+    field-hydrated blockers do not look like missing dependency rows.
+    """
+    get_task = getattr(work, "get", None)
+    if not callable(get_task):
+        return None
+
+    origin = (str(project_key), int(task_number))
+    if root_task is None:
+        try:
+            root_task = get_task(_task_id(*origin))
+        except Exception:  # noqa: BLE001 - caller can try the row probe
+            return None
+
+    visited: set[tuple[str, int]] = set()
+    status_by_key: dict[tuple[str, int], str] = {}
+    stack = list(reversed(_task_blockers(root_task)))
+
+    while stack:
+        key = stack.pop()
+        if key == origin or key in visited:
+            continue
+        visited.add(key)
+        try:
+            blocker = get_task(_task_id(*key))
+        except Exception:  # noqa: BLE001 - missing row is unresolved
+            status_by_key[key] = ""
+            continue
+        status_by_key[key] = _task_status_value(blocker)
+        for blocker_key in reversed(_task_blockers(blocker)):
+            if blocker_key != origin and blocker_key not in visited:
+                stack.append(blocker_key)
+
+    return visited, status_by_key
+
+
 def blocker_chain_for_service(
     work: Any,
     *,
     project_key: str,
     task_number: int,
+    root_task: Any | None = None,
 ) -> tuple[set[tuple[str, int]], dict[tuple[str, int], str]]:
     """Return recursive blocker keys and statuses from a work service."""
+    task_surface = _service_blocker_chain_statuses(
+        work,
+        project_key=project_key,
+        task_number=task_number,
+        root_task=root_task,
+    )
+    if task_surface is not None:
+        return task_surface
+
     conn = getattr(work, "_conn", None)
     if conn is None:
         return set(), {}

--- a/tests/test_blocked_chain_sweep.py
+++ b/tests/test_blocked_chain_sweep.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Any
 
 from pollypm.plugins_builtin.core_recurring import blocked_chain
 from pollypm.work.models import WorkStatus
@@ -16,6 +17,7 @@ class _FakeWork:
     ) -> None:
         self.task = task
         self.tasks_by_id = dict(tasks_by_id or {})
+        self.tasks_by_id.setdefault(task.task_id, task)
 
     def list_tasks(self, *, work_status: str) -> list[SimpleNamespace]:
         if work_status == WorkStatus.BLOCKED.value:
@@ -133,3 +135,102 @@ def test_cancelled_blocker_chain_alerts_to_project_scope(monkeypatch) -> None:
     ]
     assert "demo/26 (Needs your inputs)" in store.alerts[0][3]
     assert "do not auto-satisfy dependencies" in store.alerts[0][3]
+
+
+def test_field_based_cancelled_blocker_chain_alerts(monkeypatch) -> None:
+    now = datetime(2026, 5, 29, 12, 0, tzinfo=timezone.utc)
+    task = SimpleNamespace(
+        project="demo",
+        task_number=30,
+        task_id="demo/30",
+        blocked_by=[("demo", 26)],
+    )
+    cancelled = SimpleNamespace(
+        project="demo",
+        task_number=26,
+        task_id="demo/26",
+        title="Needs your inputs",
+        work_status=WorkStatus.CANCELLED,
+        blocked_by=[],
+    )
+    monkeypatch.setattr(
+        blocked_chain,
+        "_blocked_since",
+        lambda *_args, **_kwargs: now - timedelta(hours=2),
+    )
+    store = _FakeStore()
+
+    counters = blocked_chain.sweep_blocked_chains(
+        work=_FakeWork(task, tasks_by_id={"demo/26": cancelled}),
+        msg_store=store,
+        state_store=None,
+        now=now,
+        stale_threshold_seconds=3600,
+    )
+
+    assert counters["blocked_considered"] == 1
+    assert counters["dead_end_detected"] == 1
+    assert counters["cancelled_blocker_detected"] >= 1
+    assert counters["alerts_raised"] == 1
+    assert counters["cancelled_blocker_alerts_raised"] == 1
+    assert store.alerts == [
+        (
+            "demo",
+            "blocked_cancelled_blocker:demo/30",
+            "warn",
+            store.alerts[0][3],
+        ),
+    ]
+    assert "demo/26 (Needs your inputs)" in store.alerts[0][3]
+
+
+def test_emit_alert_uses_pg_facade_before_legacy_state_store(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_pg_upsert_alert(
+        session_name: str,
+        alert_type: str,
+        severity: str,
+        message: str,
+        *,
+        config: object,
+    ) -> None:
+        calls.append(
+            {
+                "session_name": session_name,
+                "alert_type": alert_type,
+                "severity": severity,
+                "message": message,
+                "config": config,
+            }
+        )
+
+    monkeypatch.setattr(
+        "pollypm.storage.pg_alerts.upsert_alert",
+        _fake_pg_upsert_alert,
+    )
+    config = SimpleNamespace(storage=SimpleNamespace(backend="postgres"))
+    legacy_store = _FakeStore()
+
+    emitted = blocked_chain._emit_alert(
+        msg_store=None,
+        state_store=legacy_store,
+        config=config,
+        project="demo",
+        task_number=30,
+        message="blocked by cancelled dependency",
+        session_name="demo",
+        alert_type="blocked_cancelled_blocker:demo/30",
+    )
+
+    assert emitted is True
+    assert calls == [
+        {
+            "session_name": "demo",
+            "alert_type": "blocked_cancelled_blocker:demo/30",
+            "severity": "warn",
+            "message": "blocked by cancelled dependency",
+            "config": config,
+        }
+    ]
+    assert legacy_store.alerts == []


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Walk blocked dependency chains through the work-service `Task.blocked_by` surface used by `pm task get`, so PG-backed/field-hydrated blockers are visible to `blocked_chain.sweep`.
- Preserve the legacy SQLite row probe as a fallback when a service cannot expose tasks.
- Route blocked-chain alert writes to the unified message store first, then the PG alert facade before falling back to legacy `StateStore`, so operator-facing `open_alerts()` sees emitted alerts.
- Add regression coverage for field-based cancelled blockers and PG-facade alert fallback.

Fixes #2534

## Tests
- `uv run --extra dev ruff check src/pollypm/work/task_state.py src/pollypm/plugins_builtin/core_recurring/blocked_chain.py tests/test_blocked_chain_sweep.py`
- `uv run --extra test python -m pytest tests/test_blocked_chain_sweep.py -q`
- `uv run --extra test python -m pytest tests/test_inbox_view_snooze.py -q`
- `uv run --extra test python -m pytest tests/test_blocked_chain_sweep.py tests/test_inbox_view_snooze.py -q`
- `python -m compileall -q src/pollypm/work/task_state.py src/pollypm/plugins_builtin/core_recurring/blocked_chain.py tests/test_blocked_chain_sweep.py`