### PR TITLE
Keep blocked-cancelled alerts through stale sweep

### DIFF
--- a/src/pollypm/supervision/alert_task_lookup.py
+++ b/src/pollypm/supervision/alert_task_lookup.py
@@ -7,6 +7,8 @@ referenced task in different places:
 * ``stuck_on_task:<project>/<num>`` — task id in the ``alert_type``
   suffix.
 * ``no_session_for_assignment:<project>/<num>`` — same shape.
+* ``blocked_cancelled_blocker:<project>/<num>`` — same shape, but
+  project-scoped instead of session-scoped.
 * ``review-<project>-<num>`` — task number in the ``session_name``
   scope (the synthetic ``review_pending`` alert key from #1053).
 * ``plan_missing`` (scope: ``plan_gate-<project>``) — the task is
@@ -52,6 +54,14 @@ _REVIEW_SCOPE_RE = re.compile(r"^review-(?P<project>.+)-(?P<num>\d+)$")
 _TYPE_PREFIXES_WITH_TASK_ID: tuple[str, ...] = (
     "stuck_on_task:",
     "no_session_for_assignment:",
+    "blocked_cancelled_blocker:",
+)
+
+# Project-scoped alert families whose ``scope`` is not a launch-plan
+# session name. The generic stale-alert sweep must leave these to their
+# owner even though the task-terminal cleanup can still parse them.
+_PROJECT_SCOPED_TASK_ALERT_PREFIXES: tuple[str, ...] = (
+    "blocked_cancelled_blocker:",
 )
 
 # Alert types whose underlying task reference must come from the
@@ -135,7 +145,14 @@ def project_key_from_task_id(task_id: str) -> str:
     return task_id.split("/", 1)[0]
 
 
+def is_project_scoped_task_alert(alert_type: str) -> bool:
+    """Return True when ``alert_type`` is task-keyed but not session-keyed."""
+    alert_type = (alert_type or "").strip()
+    return alert_type.startswith(_PROJECT_SCOPED_TASK_ALERT_PREFIXES)
+
+
 __all__ = [
     "extract_task_ids",
+    "is_project_scoped_task_alert",
     "project_key_from_task_id",
 ]

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -3042,6 +3042,13 @@ class Supervisor:
 
             swept = 0
             terminal_swept = 0
+            try:
+                from pollypm.supervision.alert_task_lookup import (
+                    is_project_scoped_task_alert as _is_project_scoped_task_alert,
+                )
+            except Exception:  # noqa: BLE001
+                def _is_project_scoped_task_alert(_alert_type: str) -> bool:
+                    return False
             # Read through ``self.open_alerts()`` — the supervisor method
             # that routes to the unified ``messages`` store (#349) and
             # strips the ``[Alert]`` title tag for caller-friendly
@@ -3093,6 +3100,15 @@ class Supervisor:
                     or alert_type.startswith("no_session_for_assignment:")
                     or alert_type == "plan_missing"
                 ):
+                    continue
+                # ``blocked_chain.sweep`` emits cancelled-blocker alerts
+                # on the project scope (e.g. ``samblog``), not on a tmux
+                # launch session. That scope is intentionally absent
+                # from ``tracked``; treating it as an orphan makes the
+                # heartbeat stale sweep clear a still-live deadlock
+                # between blocked-chain cadence ticks (#2536). Terminal
+                # task cleanup above still owns the real close path.
+                if _is_project_scoped_task_alert(alert_type):
                     continue
                 if session_name in tracked:
                     window_key = expected_window_key.get(session_name)

--- a/tests/test_alert_task_lookup.py
+++ b/tests/test_alert_task_lookup.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from pollypm.supervision.alert_task_lookup import (
     extract_task_ids,
+    is_project_scoped_task_alert,
     project_key_from_task_id,
 )
 
@@ -40,6 +41,21 @@ def test_extract_no_session_for_assignment_returns_task_id() -> None:
         session_name="worker-demo",
     )
     assert candidates == ["demo/42"]
+
+
+def test_extract_blocked_cancelled_blocker_returns_task_id() -> None:
+    candidates = extract_task_ids(
+        alert_type="blocked_cancelled_blocker:samblog/30",
+        session_name="samblog",
+    )
+    assert candidates == ["samblog/30"]
+
+
+def test_blocked_cancelled_blocker_is_project_scoped() -> None:
+    assert is_project_scoped_task_alert(
+        "blocked_cancelled_blocker:samblog/30",
+    )
+    assert not is_project_scoped_task_alert("stuck_on_task:samblog/30")
 
 
 def test_extract_handles_hyphenated_project_in_alert_type_suffix() -> None:

--- a/tests/test_supervisor_alerts.py
+++ b/tests/test_supervisor_alerts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pollypm.supervisor_alerts as _supervisor_alerts
 from pollypm.models import (
@@ -638,6 +639,86 @@ def test_recovery_alert_auto_clear_skips_untracked_sessions(
         "auto-clear sweep must not touch untracked sessions; "
         "_sweep_stale_alerts owns that path"
     )
+
+
+def test_stale_alert_gc_keeps_blocked_cancelled_blocker_for_live_task(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Project-scoped blocked-chain alerts are not orphan sessions.
+
+    ``blocked_chain.sweep`` keys cancelled-blocker alerts on the project
+    scope so the dashboard can route them to the operator. The generic
+    stale-alert sweep must not clear that project scope just because it
+    is absent from the tmux launch plan while the dependent task is live.
+    """
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    alert = SimpleNamespace(
+        session_name="pollypm",
+        alert_type="blocked_cancelled_blocker:pollypm/30",
+        message="Task pollypm/30 is blocked by cancelled dependency pollypm/26.",
+    )
+    monkeypatch.setattr(supervisor, "open_alerts", lambda: [alert])
+    cleared: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        supervisor._msg_store,
+        "clear_alert",
+        lambda session_name, alert_type, *args, **kwargs: cleared.append(
+            (session_name, alert_type),
+        ),
+    )
+    lookups: list[tuple[str, str]] = []
+
+    def _live_status(project_key: str, task_id: str) -> str:
+        lookups.append((project_key, task_id))
+        return "blocked"
+
+    monkeypatch.setattr(supervisor, "_lookup_task_status", _live_status)
+
+    supervisor._sweep_stale_alerts(window_map={}, name_by_window={})
+
+    assert cleared == []
+    assert lookups == [("pollypm", "pollypm/30")]
+
+
+def test_stale_alert_gc_clears_blocked_cancelled_blocker_when_task_terminal(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """The project-scope exclusion must not bypass terminal-task cleanup."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    alert = SimpleNamespace(
+        session_name="pollypm",
+        alert_type="blocked_cancelled_blocker:pollypm/30",
+        message="Task pollypm/30 is blocked by cancelled dependency pollypm/26.",
+    )
+    monkeypatch.setattr(supervisor, "open_alerts", lambda: [alert])
+    cleared: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        supervisor._msg_store,
+        "clear_alert",
+        lambda session_name, alert_type, *args, **kwargs: cleared.append(
+            (session_name, alert_type),
+        ),
+    )
+    monkeypatch.setattr(
+        supervisor._msg_store,
+        "append_event",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_lookup_task_status",
+        lambda project_key, task_id: "done",
+    )
+
+    supervisor._sweep_stale_alerts(window_map={}, name_by_window={})
+
+    assert cleared == [("pollypm", "blocked_cancelled_blocker:pollypm/30")]
 
 
 def test_recovery_alert_auto_clear_full_lifecycle(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Teach the alert task lookup helper to parse `blocked_cancelled_blocker:<project>/<task>` as a task-referencing alert.
- Keep project-scoped blocked-cancelled alerts out of the generic heartbeat stale-alert orphan sweep while the dependent task is still live.
- Preserve terminal-task cleanup for the same alert family so completed/cancelled dependent tasks can still close the alert.

## Verification
- `uv run --with pytest pytest -q tests/test_alert_task_lookup.py tests/test_blocked_chain_sweep.py tests/test_supervisor_alerts.py::test_stale_alert_gc_keeps_blocked_cancelled_blocker_for_live_task tests/test_supervisor_alerts.py::test_stale_alert_gc_clears_blocked_cancelled_blocker_when_task_terminal`
- `git diff --check`

Refs #2536
