### PR TITLE
Keep inbox totals aligned with materialized rows

### DIFF
--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -4034,6 +4034,7 @@ def list_inbox(
             include_drafts=include_drafts,
             limit=None,
         )
+        items = metric_items
     items.sort(key=lambda item: item.updated_at, reverse=True)
 
     cursor_idx = 0

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -2411,6 +2411,45 @@ def test_list_inbox_limit_passes_bounded_candidate_limit(
     assert svc.list_tasks_calls == 0
 
 
+def test_list_inbox_fills_page_after_false_positive_candidates(
+    client, auth_headers, monkeypatch,
+) -> None:
+    """Candidate paging must not make totals disagree with materialized rows.
+
+    The pg candidate query intentionally admits some cheap false positives
+    such as blocked tasks, then the canonical inbox predicate decides whether
+    they really belong in the inbox. If the bounded candidate page is filled
+    with false positives, the full metric scan may find a real inbox item
+    later. The response must page from that materialized full scan instead of
+    returning ``total: 1`` with ``items: []``.
+    """
+    from pollypm.work.models import WorkStatus
+
+    false_positives = [
+        _ReadInboxTask(i, title=f"Blocked non-inbox {i}", status=WorkStatus.BLOCKED)
+        for i in range(1, 12)
+    ]
+    for task in false_positives:
+        task.roles = {}
+        task.current_node_id = None
+    visible = _ReadInboxTask(30, title="Visible inbox item")
+    svc = _ReadInboxSvc([*false_positives, visible])
+    _install_read_inbox_svc(monkeypatch, svc)
+
+    response = client.get(
+        "/api/v1/inbox?project=myproj&limit=10",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [item["id"] for item in body["items"]] == ["myproj/30"]
+    assert body["total"] == 1
+    assert body["unread_count"] == 1
+    assert body["has_more"] is False
+    assert svc.list_tasks_calls == 0
+
+
 def test_inbox_detail_messages_include_reply_context(
     client, auth_headers, monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- When the bounded inbox candidate page is incomplete, page from the full materialized scan already used for exact totals.
- Prevent `GET /api/v1/inbox` from returning `total > 0` with an empty first page after false-positive SQL candidates are filtered by the canonical inbox predicate.
- Add a regression with blocked false-positive candidates before a real inbox row.

## Verification
- `uv run --with pytest pytest -q tests/test_inbox_writes_endpoint.py::test_list_inbox_fills_page_after_false_positive_candidates tests/test_inbox_writes_endpoint.py::test_list_inbox_limit_passes_bounded_candidate_limit tests/test_inbox_writes_endpoint.py::test_list_inbox_default_hides_notify_only_task_drafts tests/test_inbox_writes_endpoint.py::test_list_inbox_include_drafts_restores_notify_only_tasks tests/test_inbox_view_snooze.py::test_inbox_tasks_surfaces_blocked_task_when_cancelled_blocker_was_user_handoff tests/test_inbox_view_snooze.py::test_inbox_tasks_does_not_surface_blocked_task_for_ordinary_cancelled_blocker`
- `git diff --check`

Refs #2537
