### PR TITLE
Filter low-signal activity feed plumbing

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2926,7 +2926,10 @@ paths:
         but each row includes a `summary` sentence; recovery/self-heal
         events such as `recovery.spawn` and
         `watchdog.escalation_dispatched` are rendered from structured
-        metadata into calm operator-facing prose.
+        metadata into calm operator-facing prose. Low-signal plumbing
+        events are hidden by default, but remain available through
+        `include_low_signal=true` or explicit `event_type`/`pattern`
+        searches.
       parameters:
         - in: query
           name: project
@@ -2951,6 +2954,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - in: query
+          name: include_low_signal
+          schema:
+            type: boolean
+            default: false
+          description: Include low-signal plumbing rows such as `work_db.opened`.
         - in: query
           name: limit
           schema:

--- a/src/pollypm/activity_low_signal.py
+++ b/src/pollypm/activity_low_signal.py
@@ -1,0 +1,93 @@
+"""Shared low-signal activity classification for operator-facing feeds."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+LOW_SIGNAL_ACTIVITY_KINDS: frozenset[str] = frozenset(
+    {
+        "heartbeat",
+        "lease",
+        "lease_override",
+        "scheduled",
+        "session.pause.skip",
+        "token_ledger",
+        "work_db.opened",
+    }
+)
+LOW_SIGNAL_EMPTY_ACTIVITY_KINDS: frozenset[str] = frozenset({"launch"})
+
+
+def _lower(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def activity_summary_has_content(
+    *,
+    kind: Any = None,
+    verb: Any = None,
+    actor: Any = None,
+    summary: Any = None,
+) -> bool:
+    summary_text = _lower(summary)
+    if not summary_text:
+        return False
+    kind_text = _lower(kind)
+    verb_text = _lower(verb)
+    actor_text = _lower(actor)
+    return summary_text not in {
+        kind_text,
+        verb_text,
+        actor_text,
+        f"{kind_text} on {actor_text}",
+    }
+
+
+def is_low_signal_activity(
+    *,
+    kind: Any = None,
+    verb: Any = None,
+    actor: Any = None,
+    summary: Any = None,
+) -> bool:
+    kind_text = _lower(kind)
+    verb_text = _lower(verb)
+    if (
+        kind_text in LOW_SIGNAL_ACTIVITY_KINDS
+        or verb_text in LOW_SIGNAL_ACTIVITY_KINDS
+    ):
+        return True
+    actor_text = _lower(actor)
+    if (
+        actor_text in {"operator", "scheduler"}
+        and (
+            kind_text in LOW_SIGNAL_EMPTY_ACTIVITY_KINDS
+            or verb_text in LOW_SIGNAL_EMPTY_ACTIVITY_KINDS
+        )
+        and not activity_summary_has_content(
+            kind=kind_text,
+            verb=verb_text,
+            actor=actor_text,
+            summary=summary,
+        )
+    ):
+        return True
+    return False
+
+
+def is_noise_type_filter(kind: Any = None) -> bool:
+    lowered = _lower(kind)
+    return (
+        lowered in LOW_SIGNAL_ACTIVITY_KINDS
+        or lowered in LOW_SIGNAL_EMPTY_ACTIVITY_KINDS
+    )
+
+
+__all__ = [
+    "LOW_SIGNAL_ACTIVITY_KINDS",
+    "LOW_SIGNAL_EMPTY_ACTIVITY_KINDS",
+    "activity_summary_has_content",
+    "is_low_signal_activity",
+    "is_noise_type_filter",
+]

--- a/src/pollypm/cockpit_activity.py
+++ b/src/pollypm/cockpit_activity.py
@@ -24,6 +24,11 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import DataTable, Input, Static
 
+from pollypm.activity_low_signal import (
+    LOW_SIGNAL_ACTIVITY_KINDS as _LOW_SIGNAL_ACTIVITY_KINDS,
+    LOW_SIGNAL_EMPTY_ACTIVITY_KINDS as _LOW_SIGNAL_EMPTY_ACTIVITY_KINDS,
+    is_low_signal_activity as _shared_is_low_signal_activity,
+)
 from pollypm.cockpit_alerts import _action_view_alerts
 from pollypm.cockpit_palette import _open_keyboard_help
 from pollypm.cockpit_theme import State
@@ -146,46 +151,17 @@ def _entry_search_haystack(entry) -> str:
     return " ".join(bit for bit in bits if bit).lower()
 
 
-_LOW_SIGNAL_ACTIVITY_KINDS = frozenset({
-    "heartbeat",
-    "lease",
-    "lease_override",
-    "scheduled",
-    "token_ledger",
-})
-_LOW_SIGNAL_EMPTY_ACTIVITY_KINDS = frozenset({"launch"})
-
-
-def _summary_has_content(entry) -> bool:
-    summary = (getattr(entry, "summary", "") or "").strip().lower()
-    if not summary:
-        return False
-    kind = (getattr(entry, "kind", "") or "").strip().lower()
-    verb = (getattr(entry, "verb", "") or "").strip().lower()
-    actor = (getattr(entry, "actor", "") or "").strip().lower()
-    return summary not in {kind, verb, actor, f"{kind} on {actor}"}
-
-
 def _is_low_signal_activity(entry) -> bool:
-    kind = (getattr(entry, "kind", "") or "").lower()
-    verb = (getattr(entry, "verb", "") or "").lower()
-    if kind in _LOW_SIGNAL_ACTIVITY_KINDS or verb in _LOW_SIGNAL_ACTIVITY_KINDS:
-        return True
-    actor = (getattr(entry, "actor", "") or "").lower()
-    if (
-        actor in {"operator", "scheduler"}
-        and (
-            kind in _LOW_SIGNAL_EMPTY_ACTIVITY_KINDS
-            or verb in _LOW_SIGNAL_EMPTY_ACTIVITY_KINDS
-        )
-        and not _summary_has_content(entry)
-    ):
-        return True
-    return False
+    return _shared_is_low_signal_activity(
+        kind=getattr(entry, "kind", ""),
+        verb=getattr(entry, "verb", ""),
+        actor=getattr(entry, "actor", ""),
+        summary=getattr(entry, "summary", ""),
+    )
 
 
 def _is_noise_type_filter(kind: str | None) -> bool:
-    lowered = (kind or "").lower()
+    lowered = (kind or "").strip().lower()
     return (
         lowered in _LOW_SIGNAL_ACTIVITY_KINDS
         or lowered in _LOW_SIGNAL_EMPTY_ACTIVITY_KINDS

--- a/src/pollypm/web_api/routes/activity.py
+++ b/src/pollypm/web_api/routes/activity.py
@@ -11,8 +11,12 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
+from pollypm.activity_low_signal import (
+    LOW_SIGNAL_ACTIVITY_KINDS as _LOW_SIGNAL_ACTIVITY_KINDS,
+    is_low_signal_activity,
+)
 from pollypm.audit.query import iter_recent_matching_events, resolve_target_files
-from pollypm.recovery.narration import summarize_audit_event
+from pollypm.recovery.narration import is_recovery_event, summarize_audit_event
 from pollypm.web_api.models import Event
 from pollypm.web_api.routes._deps import ConfigDep
 from pollypm.web_api.routes.audit import (
@@ -91,6 +95,15 @@ def activity_endpoint(
     safe_regex: Annotated[bool, Query()] = False,
     limit: Annotated[int, Query(ge=1, le=_GREP_LIMIT_MAX)] = _GREP_LIMIT_DEFAULT,
     deadline_seconds: Annotated[float, Query(ge=0.5, le=60.0)] = 5.0,
+    include_low_signal: Annotated[
+        bool,
+        Query(
+            description=(
+                "Include low-signal plumbing rows such as work_db.opened. "
+                "Explicit event_type or pattern searches include them too."
+            )
+        ),
+    ] = False,
 ) -> ActivityResponse:
     """Return audit events shaped for the dashboard activity rail."""
 
@@ -129,6 +142,9 @@ def activity_endpoint(
             candidates,
             limit=limit,
             project_filter=project,
+            include_low_signal=(
+                include_low_signal or bool(event_type) or bool(pattern)
+            ),
         ),
         next_cursor=None,
         _malformed_rows_skipped=(
@@ -165,10 +181,16 @@ def _compose_activity_feed(
     *,
     limit: int,
     project_filter: str | None,
+    include_low_signal: bool = False,
 ) -> list[ActivityEvent]:
     deduped: list[Event] = []
     seen: set[tuple[str, str, str, str, str, str, str]] = set()
     for event in events:
+        if not _should_include_activity_event(
+            event,
+            include_low_signal=include_low_signal,
+        ):
+            continue
         identity = _activity_event_identity(event)
         if identity in seen:
             continue
@@ -205,6 +227,26 @@ def _compose_activity_feed(
         project_filter=project_filter,
     )
     return entries[:limit]
+
+
+def _should_include_activity_event(
+    event: Event,
+    *,
+    include_low_signal: bool,
+) -> bool:
+    if include_low_signal:
+        return True
+    if is_recovery_event(event.event):
+        return True
+    if event.event == "audit.finding" or event.event.startswith("watchdog."):
+        return True
+    if event.event.strip().lower() in _LOW_SIGNAL_ACTIVITY_KINDS:
+        return False
+    return not is_low_signal_activity(
+        kind=event.event,
+        actor=event.actor,
+        summary=event.subject,
+    )
 
 
 def _activity_event_identity(
@@ -266,8 +308,6 @@ def _activity_event_from_group(group: _ActivityGroup) -> ActivityEvent:
             project=event.project,
             metadata=event.metadata or {},
         )
-    from pollypm.recovery.narration import is_recovery_event
-
     data["recovery"] = is_recovery_event(event.event)
     return ActivityEvent.model_validate(data)
 
@@ -343,8 +383,6 @@ def _apply_project_share_cap(
 
 
 def _activity_event_from_audit_event(event: Event) -> ActivityEvent:
-    from pollypm.recovery.narration import is_recovery_event
-
     data: dict[str, Any] = event.model_dump(by_alias=True)
     data["summary"] = summarize_audit_event(
         event_name=event.event,

--- a/tests/test_activity_feed_ui.py
+++ b/tests/test_activity_feed_ui.py
@@ -207,6 +207,41 @@ def test_default_activity_hides_low_signal_heartbeat_noise(
     _run(body())
 
 
+def test_default_activity_hides_work_db_and_pause_skip_plumbing(
+    activity_env, activity_app,
+) -> None:
+    """DB-open and pause-skip breadcrumbs are loaded but hidden by default."""
+    async def body() -> None:
+        entries = [
+            _make_entry(entry_id="evt:real", kind="task.done", verb="done"),
+            _make_entry(
+                entry_id="evt:db",
+                kind="work_db.opened",
+                actor="postgres",
+                verb="work_db.opened",
+                summary="work_db.opened",
+            ),
+            _make_entry(
+                entry_id="evt:pause",
+                kind="session.pause.skip",
+                actor="heartbeat",
+                verb="session.pause.skip",
+                summary="session.pause.skip",
+            ),
+        ]
+        activity_app._gather = lambda: entries  # type: ignore[method-assign]
+        async with activity_app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause()
+            assert activity_app.table.row_count == 1
+            assert "2 system noise hidden" in str(activity_app.counters.render())
+
+            await pilot.press("N")
+            await pilot.pause()
+            assert activity_app.table.row_count == 3
+
+    _run(body())
+
+
 def test_default_activity_hides_internal_scheduler_churn(
     activity_env, activity_app,
 ) -> None:

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -406,6 +406,156 @@ def test_activity_endpoint_keeps_cross_project_signal_when_one_project_is_noisy(
     assert "otherproj/1" in subjects
 
 
+def test_activity_endpoint_hides_low_signal_plumbing_by_default(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Default activity hides plumbing while keeping recovery/watchdog signal."""
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(
+                event="work_db.opened",
+                actor="postgres",
+                ts=(now - timedelta(seconds=1)).isoformat(),
+            ),
+            _make_event(
+                event="session.pause.skip",
+                actor="heartbeat",
+                ts=(now - timedelta(seconds=2)).isoformat(),
+            ),
+            _make_event(
+                event="task.created",
+                subject="myproj/1",
+                ts=(now - timedelta(seconds=3)).isoformat(),
+            ),
+            _make_event(
+                event="audit.finding",
+                status="warn",
+                ts=(now - timedelta(seconds=4)).isoformat(),
+            ),
+            _make_event(
+                event="watchdog.operator_dispatched",
+                actor="audit_watchdog",
+                ts=(now - timedelta(seconds=5)).isoformat(),
+            ),
+            _make_event(
+                event="recovery.spawn",
+                actor="supervisor",
+                ts=(now - timedelta(seconds=6)).isoformat(),
+            ),
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={"project": "myproj", "since": "24h", "limit": 10},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    event_names = [e["event"] for e in response.json()["events"]]
+    assert "work_db.opened" not in event_names
+    assert "session.pause.skip" not in event_names
+    assert event_names == [
+        "task.created",
+        "audit.finding",
+        "watchdog.operator_dispatched",
+        "recovery.spawn",
+    ]
+
+
+def test_activity_endpoint_can_include_low_signal_plumbing(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Explicit raw-feed requests can still inspect low-signal rows."""
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(
+                event="work_db.opened",
+                actor="postgres",
+                ts=(now - timedelta(seconds=1)).isoformat(),
+            ),
+            _make_event(
+                event="task.created",
+                subject="myproj/1",
+                ts=(now - timedelta(seconds=2)).isoformat(),
+            ),
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={
+            "project": "myproj",
+            "since": "24h",
+            "limit": 10,
+            "include_low_signal": "1",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert [e["event"] for e in response.json()["events"]] == [
+        "work_db.opened",
+        "task.created",
+    ]
+
+
+def test_activity_endpoint_pattern_search_includes_low_signal_rows(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    project_root: Path,
+    audit_home: Path,
+) -> None:
+    """Searching for a plumbing event is an explicit request to see it."""
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _per_project_log(project_root),
+        [
+            _make_event(
+                event="work_db.opened",
+                actor="postgres",
+                ts=now.isoformat(),
+            )
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={
+            "project": "myproj",
+            "since": "24h",
+            "limit": 10,
+            "pattern": "work_db.opened",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert [e["event"] for e in response.json()["events"]] == ["work_db.opened"]
+
+
+def test_activity_low_signal_definition_is_shared_by_web_and_tui() -> None:
+    """The web route and cockpit feed import the same low-signal kind set."""
+    from pollypm import cockpit_activity
+    from pollypm.activity_low_signal import LOW_SIGNAL_ACTIVITY_KINDS
+    from pollypm.web_api.routes import activity
+
+    assert cockpit_activity._LOW_SIGNAL_ACTIVITY_KINDS is LOW_SIGNAL_ACTIVITY_KINDS
+    assert activity._LOW_SIGNAL_ACTIVITY_KINDS is LOW_SIGNAL_ACTIVITY_KINDS
+    assert "work_db.opened" in LOW_SIGNAL_ACTIVITY_KINDS
+    assert "session.pause.skip" in LOW_SIGNAL_ACTIVITY_KINDS
+
+
 def test_grep_regex_pattern_filters_lines(
     client: TestClient,
     auth_headers: dict[str, str],


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Added a shared low-signal activity classifier for web and TUI activity surfaces.
- Hid `work_db.opened` and `session.pause.skip` from default `/api/v1/activity` responses while keeping recovery, `audit.finding`, and `watchdog.*` rows visible.
- Added the `include_low_signal` escape hatch and documented it in OpenAPI.

Fixes #2540

## Verification
- `uv run --with pytest pytest --noconftest tests/test_audit_endpoint.py -q`
- `uv run --with pytest pytest tests/test_activity_feed_ui.py -q`
- `uv run --with pytest pytest tests/test_activity_feed_ui.py::test_default_activity_hides_work_db_and_pause_skip_plumbing -q`
- `uv run --with pytest --with openapi-spec-validator pytest tests/web_api/test_openapi_conformance.py::test_contract_yaml_is_valid_openapi_31 -q`
- `uv run --with pytest --with openapi-spec-validator pytest tests/web_api/test_openapi_conformance.py::test_implementation_openapi_validates_as_31 -q`
- `uv run --with ruff ruff check src/pollypm/activity_low_signal.py src/pollypm/cockpit_activity.py src/pollypm/web_api/routes/activity.py tests/test_audit_endpoint.py tests/test_activity_feed_ui.py`
