### PR TITLE
Fix cancelled handoff inbox resolution

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2028,6 +2028,11 @@ paths:
       tags: [Inbox]
       operationId: replyInboxItem
       summary: Append a reply to an inbox thread
+      description: >
+        Appends a reply to a normal inbox thread. For inbox items whose
+        metadata has `blocked_cancelled_handoff=true`, records the reply on
+        the cancelled handoff task and clears that blocker edge through the
+        work-service dependency facade.
       requestBody:
         required: true
         content:
@@ -2036,7 +2041,7 @@ paths:
               $ref: "#/components/schemas/InboxReplyRequest"
       responses:
         "200":
-          description: Reply appended; returns the updated task detail.
+          description: Reply appended or handoff answer recorded; returns the updated task detail.
           content:
             application/json:
               schema:

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -458,6 +458,13 @@ as `approval_request` / `manual_decision`), `state` (`open`, `threaded`,
 `updated_at`, `thread_id` (nullable), `metadata` (sidecar labels),
 `messages` (`InboxMessage[]`, only on detail).
 
+When a non-terminal task is blocked by a cancelled inbox handoff,
+the item may carry `metadata.blocked_cancelled_handoff=true` plus
+`cancelled_handoff_task_id`. In that case `subject` is reframed as the
+operator's unblock action and `preview` contains the cancelled handoff
+body so the original ask remains visible even though the blocker is
+terminal.
+
 ### Event
 
 A single audit-log line. Mirrors `pollypm.audit.log.AuditEvent`.
@@ -500,7 +507,7 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | PATCH  | `/api/v1/tasks/{project}/{n}` | Partial update of mutable fields. Body accepts ONLY `labels` / `metadata` / `status` (extras like `priority` or role assignments → `422` from request validation; use `/claim` and `/reassign` for ownership changes). `status` is routed to `svc.queue`/`svc.cancel` (other statuses → 422); `labels` / `metadata` flow through `svc.update`. Status MUST NOT be combined with other fields in one body (`400 invalid_request` if both present — use separate requests). An all-`null` / empty body is rejected with `400 invalid_request` |
 | GET    | `/api/v1/inbox` | List inbox items (`?project=&type=&state=&limit=&cursor=`) |
 | GET    | `/api/v1/inbox/{id}` | Inbox item detail (with full thread messages) |
-| POST   | `/api/v1/inbox/{id}/reply` | Reply to a thread |
+| POST   | `/api/v1/inbox/{id}/reply` | Reply to a thread. For `metadata.blocked_cancelled_handoff=true` items, records the reply on the cancelled handoff and clears that blocker edge through the work-service dependency facade |
 | POST   | `/api/v1/inbox/{id}/archive` | Archive (close) the item |
 | GET    | `/api/v1/events` | SSE stream of audit-log events (`?since=&project=&event=`) |
 | GET    | `/api/v1/chat/sessions` | Discover every chat surface (operator/architect/advisor/worker) |

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -3288,7 +3288,29 @@ def reply_inbox_item(
             if not is_inbox_task(src_task, svc):
                 raise not_found(f"Inbox item not found: {item_id}")
             try:
-                svc.add_reply(item_id, body, actor=actor_name)
+                cancelled_handoff = _cancelled_handoff_blocker_for_task(
+                    src_task, svc, flow_cache={},
+                )
+                if cancelled_handoff is None:
+                    svc.add_reply(item_id, body, actor=actor_name)
+                else:
+                    blocker_id = str(getattr(cancelled_handoff, "task_id"))
+                    svc.add_reply(blocker_id, body, actor=actor_name)
+                    try:
+                        svc.add_context(
+                            item_id,
+                            actor_name,
+                            (
+                                "operator answered cancelled handoff "
+                                f"{blocker_id}; dependency cleared"
+                            ),
+                            entry_type="note",
+                        )
+                    except TaskNotFoundError as exc:
+                        raise not_found(
+                            f"Inbox item not found: {item_id}"
+                        ) from exc
+                    svc.unlink(blocker_id, item_id, "blocks")
             except TaskNotFoundError as exc:
                 raise not_found(f"Inbox item not found: {item_id}") from exc
             except WorkValidationError as exc:
@@ -4576,6 +4598,7 @@ def _task_to_inbox_item(
     item_type = inbox_item_type_for_task(task)
     body = task.description or ""
     preview = body.strip().splitlines()[0] if body.strip() else None
+    subject = task.title
     metadata: dict[str, Any] = {
         "task_id": task.task_id,
         "labels": labels,
@@ -4593,12 +4616,31 @@ def _task_to_inbox_item(
         )
         if value:
             metadata[key] = value
+    cancelled_handoff = _cancelled_handoff_blocker_for_task(
+        task, svc, flow_cache=flow_cache or {},
+    )
+    if cancelled_handoff is not None:
+        blocker_id = str(getattr(cancelled_handoff, "task_id"))
+        subject = _cancelled_handoff_unblock_subject(task, cancelled_handoff)
+        handoff_body = str(
+            getattr(cancelled_handoff, "description", "") or ""
+        ).strip()
+        preview = handoff_body or str(
+            getattr(cancelled_handoff, "title", "") or ""
+        ).strip() or preview
+        metadata.update({
+            "blocked_cancelled_handoff": True,
+            "cancelled_handoff_task_id": blocker_id,
+            "cancelled_handoff_subject": getattr(cancelled_handoff, "title", ""),
+            "blocked_task_id": task.task_id,
+            "blocked_task_subject": task.title,
+        })
     return APIInboxItem(
         id=task.task_id,
         project=task.project,
         type=item_type,
         state=state,
-        subject=task.title,
+        subject=subject,
         priority=_enum_value(getattr(task, "priority", "normal")),
         preview=preview,
         owner=_inbox_owner_for_task(task),
@@ -4607,6 +4649,65 @@ def _task_to_inbox_item(
         updated_at=task.updated_at or task.created_at or datetime.utcnow(),
         metadata=metadata,
     )
+
+
+def _cancelled_handoff_unblock_subject(task, blocker) -> str:
+    blocker_title = str(getattr(blocker, "title", "") or "").strip()
+    match = re.match(
+        r"^(?P<target>.+?)\s+needs\s+your\s+inputs?\.?$",
+        blocker_title,
+        flags=re.IGNORECASE,
+    )
+    if match is not None:
+        target = match.group("target").strip()
+    else:
+        target = str(getattr(task, "title", "") or "").strip()
+    if target:
+        return f"Provide inputs to unblock {target}"
+    return "Provide inputs to unblock this task"
+
+
+def _cancelled_handoff_blocker_for_task(
+    task,
+    svc=None,
+    *,
+    flow_cache: dict[tuple[str, int], Any],
+):
+    status = getattr(getattr(task, "work_status", None), "value", None)
+    status = status or str(getattr(task, "work_status", "") or "")
+    if status != WorkStatus.BLOCKED.value:
+        return None
+    if svc is None:
+        return None
+    get_task = getattr(svc, "get", None)
+    if not callable(get_task):
+        return None
+    for ref in getattr(task, "blocked_by", None) or []:
+        try:
+            project, number = ref
+            blocker_id = f"{project}/{int(number)}"
+        except (TypeError, ValueError):
+            continue
+        try:
+            blocker = get_task(blocker_id)
+        except Exception:  # noqa: BLE001 - readonly surfacing degrades open
+            logger.debug(
+                "inbox: cancelled handoff lookup failed for %s",
+                blocker_id,
+                exc_info=True,
+            )
+            continue
+        blocker_status = getattr(
+            getattr(blocker, "work_status", None), "value", None,
+        )
+        blocker_status = blocker_status or str(
+            getattr(blocker, "work_status", "") or ""
+        )
+        if blocker_status != WorkStatus.CANCELLED.value:
+            continue
+        if is_inbox_task_identity(blocker, svc, flow_cache=flow_cache):
+            return blocker
+    return None
 
 
 def _inbox_state_from_task(task) -> str:

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -2572,6 +2572,12 @@
     return parseTaskKey(item.task_id || metadata.task_id || item.id || "");
   }
 
+  function isBlockedCancelledHandoff(item) {
+    const metadata = item && item.metadata && typeof item.metadata === "object"
+      ? item.metadata : {};
+    return Boolean(metadata.blocked_cancelled_handoff);
+  }
+
   function disabledInboxAction(label, title) {
     const btn = el("button", {
       class: "inbox-action disabled",
@@ -2831,10 +2837,13 @@
         ]),
         el("div", { class: "inbox-thread-body", text: msg.body || "" }),
       ]));
+    const resolvesCancelledHandoff = isBlockedCancelledHandoff(detail);
     const reply = el("textarea", {
       class: "inbox-reply-input",
       rows: "3",
-      placeholder: "Reply...",
+      placeholder: resolvesCancelledHandoff
+        ? "Answer the handoff inputs..."
+        : "Reply...",
       "aria-label": "Reply to inbox item",
     });
     reply.value = state.inbox.replyDraft || "";
@@ -2844,14 +2853,16 @@
     const send = el("button", {
       class: "inbox-filter-button primary",
       type: "submit",
-      text: "Reply",
+      text: resolvesCancelledHandoff ? "Answer and unblock" : "Reply",
     });
     const actionKey = detail.id + ":reply";
     send.disabled = Boolean(state.inbox.actionInFlight[actionKey]);
     const form = el("form", { class: "inbox-reply-form" }, [reply, send]);
     form.addEventListener("submit", (ev) => {
       ev.preventDefault();
-      replyInboxItem(detail, reply.value || "");
+      replyInboxItem(detail, reply.value || "", {
+        clearSelection: resolvesCancelledHandoff,
+      });
     });
     const decisionActions = [];
     if (detail.type === "plan_review") {
@@ -2974,18 +2985,23 @@
     );
   }
 
-  async function replyInboxItem(item, body) {
+  async function replyInboxItem(item, body, options) {
     const text = String(body || "").trim();
     if (!text) return;
+    const clearSelection = Boolean(options && options.clearSelection);
     const ok = await runInboxAction(
       item,
       "reply",
       "/reply",
       { body: text, owner: OPERATOR_ACTOR },
-      {},
+      { clearSelection },
     );
     if (ok) {
       state.inbox.replyDraft = "";
+      showToast(
+        "ok",
+        clearSelection ? "answer recorded; dependency cleared" : "reply sent",
+      );
       renderInboxView();
     }
   }

--- a/tests/test_inbox_writes_endpoint.py
+++ b/tests/test_inbox_writes_endpoint.py
@@ -1243,18 +1243,21 @@ def test_membership_helper_matches_canonical_inbox_predicate() -> None:
     ``"plan_review" in lbl`` widening is what Codex round-5 caught.
     """
     from pollypm.web_api.service import _is_inbox_member
+    from pollypm.work.models import WorkStatus
 
     class _ChatWithUserRole:
         flow_template_id = "chat"
         labels: list[str] = []
         roles = {"requester": "user"}
         current_node_id = None
+        work_status = WorkStatus.IN_PROGRESS
 
     class _PlanReviewLabel:
         flow_template_id = "standard"
         labels = ["plan_review"]
         roles: dict = {}
         current_node_id = None
+        work_status = WorkStatus.IN_PROGRESS
 
     class _ChatNoUserRole:
         # Chat-flow but no user role + no current node — would have
@@ -1264,6 +1267,7 @@ def test_membership_helper_matches_canonical_inbox_predicate() -> None:
         labels: list[str] = []
         roles: dict = {}
         current_node_id = None
+        work_status = WorkStatus.IN_PROGRESS
 
     class _NearMissPlanLabel:
         # Substring would have matched the old helper; canonical
@@ -1272,12 +1276,14 @@ def test_membership_helper_matches_canonical_inbox_predicate() -> None:
         labels = ["not_plan_review"]
         roles: dict = {}
         current_node_id = None
+        work_status = WorkStatus.IN_PROGRESS
 
     class _NonInbox:
         flow_template_id = "standard"
         labels: list[str] = []
         roles: dict = {}
         current_node_id = None
+        work_status = WorkStatus.IN_PROGRESS
 
     assert _is_inbox_member(_ChatWithUserRole()) is True
     assert _is_inbox_member(_PlanReviewLabel()) is True
@@ -2205,6 +2211,184 @@ def _install_read_inbox_svc(monkeypatch, svc: _ReadInboxSvc) -> None:
     monkeypatch.setattr(
         "pollypm.work.factory.create_work_service", fake_factory,
     )
+
+
+def _blocked_cancelled_handoff_tasks(handoff_body: str):
+    from pollypm.work.models import Priority, Task, TaskType, WorkStatus
+
+    now = datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc)
+    blocker = Task(
+        project="myproj",
+        task_number=26,
+        title="Samblog Phase 0 needs your inputs",
+        type=TaskType.TASK,
+        work_status=WorkStatus.CANCELLED,
+        priority=Priority.HIGH,
+        flow_template_id="chat",
+        current_node_id=None,
+        roles={"requester": "user", "operator": "user"},
+        description=handoff_body,
+        created_at=now,
+        updated_at=now,
+        created_by="pm",
+    )
+    target = Task(
+        project="myproj",
+        task_number=30,
+        title="Execute SamBlog Phase 0 live MCP smoke test",
+        type=TaskType.TASK,
+        work_status=WorkStatus.BLOCKED,
+        priority=Priority.HIGH,
+        flow_template_id="chat",
+        current_node_id=None,
+        roles={},
+        description=(
+            "Run the smoke test once the operator provides the inputs."
+        ),
+        blocked_by=[("myproj", 26)],
+        created_at=now,
+        updated_at=now,
+        created_by="pm",
+    )
+    return blocker, target
+
+
+def test_list_inbox_reframes_blocked_cancelled_handoff(
+    client, auth_headers, monkeypatch,
+) -> None:
+    handoff_body = (
+        "1. WP core + PHP version on sam.blog\n"
+        "2. Greenlight cloning sam.blog to staging\n"
+        "3. Greenlight installing mcp-adapter on staging "
+        "(+ abilities-api if WP < 6.9)\n"
+        "4. Create a polly-mcp editor user + Application Password named "
+        "`mcp-adapter-phase-0`, delivered via 1Password\n"
+        "5. Confirm whether to repeat the smoke test on prod"
+    )
+    blocker, target = _blocked_cancelled_handoff_tasks(handoff_body)
+    svc = _ReadInboxSvc([blocker, target])
+    _install_read_inbox_svc(monkeypatch, svc)
+
+    response = client.get("/api/v1/inbox?project=myproj", headers=auth_headers)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [item["id"] for item in body["items"]] == ["myproj/30"]
+    item = body["items"][0]
+    assert item["subject"] == "Provide inputs to unblock Samblog Phase 0"
+    assert item["preview"] == handoff_body
+    assert "`mcp-adapter-phase-0`" in item["preview"]
+    assert "abilities-api if WP < 6.9" in item["preview"]
+    assert item["metadata"]["blocked_cancelled_handoff"] is True
+    assert item["metadata"]["cancelled_handoff_task_id"] == "myproj/26"
+    assert item["metadata"]["blocked_task_subject"] == (
+        "Execute SamBlog Phase 0 live MCP smoke test"
+    )
+
+
+class _ResolveCancelledHandoffSvc:
+    def __init__(self, blocker, target) -> None:
+        self.tasks = {blocker.task_id: blocker, target.task_id: target}
+        self.reply_calls: list[tuple[str, str, str]] = []
+        self.context_calls: list[tuple[str, str, str, str]] = []
+        self.unlink_calls: list[tuple[str, str, str]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, task_id):
+        from pollypm.work.service_support import TaskNotFoundError
+
+        try:
+            return self.tasks[task_id]
+        except KeyError as exc:
+            raise TaskNotFoundError(task_id) from exc
+
+    def get_flow(self, name, project=None):
+        return None
+
+    def add_reply(self, task_id, body, actor="user"):
+        from pollypm.work.models import ContextEntry
+
+        entry = ContextEntry(
+            actor=actor,
+            timestamp=datetime(2026, 6, 2, 12, 5, tzinfo=timezone.utc),
+            text=body.strip(),
+            entry_type="reply",
+        )
+        self.tasks[task_id].context.append(entry)
+        self.reply_calls.append((task_id, actor, body.strip()))
+        return entry
+
+    def add_context(self, task_id, actor, text, *, entry_type="note"):
+        from pollypm.work.models import ContextEntry
+
+        entry = ContextEntry(
+            actor=actor,
+            timestamp=datetime(2026, 6, 2, 12, 6, tzinfo=timezone.utc),
+            text=text,
+            entry_type=entry_type,
+        )
+        self.tasks[task_id].context.append(entry)
+        self.context_calls.append((task_id, actor, text, entry_type))
+        return entry
+
+    def unlink(self, from_id, to_id, kind):
+        from pollypm.work.models import WorkStatus
+
+        self.unlink_calls.append((from_id, to_id, kind))
+        blocker = self.tasks[from_id]
+        target = self.tasks[to_id]
+        ref = (blocker.project, blocker.task_number)
+        target.blocked_by = [value for value in target.blocked_by if value != ref]
+        if kind == "blocks" and target.work_status is WorkStatus.BLOCKED:
+            if not target.blocked_by:
+                target.work_status = WorkStatus.QUEUED
+
+
+def test_reply_to_blocked_cancelled_handoff_records_answer_and_unblocks(
+    config, monkeypatch,
+) -> None:
+    from pollypm.web_api import service as web_service
+
+    blocker, target = _blocked_cancelled_handoff_tasks("1. Provide staging OK")
+    svc = _ResolveCancelledHandoffSvc(blocker, target)
+
+    def fake_factory(*, config, project_key, project_path):
+        return svc
+
+    monkeypatch.setattr(
+        "pollypm.work.factory.create_work_service", fake_factory,
+    )
+
+    detail = web_service.reply_inbox_item(
+        config,
+        "myproj/30",
+        body="WP 6.8, staging OK, password in 1Password",
+        owner="operator",
+    )
+
+    assert svc.reply_calls == [
+        (
+            "myproj/26",
+            "operator",
+            "WP 6.8, staging OK, password in 1Password",
+        )
+    ]
+    assert svc.unlink_calls == [("myproj/26", "myproj/30", "blocks")]
+    assert svc.context_calls == [
+        (
+            "myproj/30",
+            "operator",
+            "operator answered cancelled handoff myproj/26; dependency cleared",
+            "note",
+        )
+    ]
+    assert detail.work_status == "queued"
+    assert detail.relationships.blocked_by == []
 
 
 def test_list_inbox_state_closed_returns_archived_task(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Reframe blocked-by-cancelled-handoff inbox rows as operator unblock actions and inline the cancelled handoff body in the preview/detail payload.
- Route replies on those rows to the cancelled handoff, add an audit breadcrumb on the blocked task, and clear the blocker edge through the work-service unlink facade.
- Update the web UI reply affordance and API docs for the answer-and-unblock behavior.

## Tests
- `uv run --extra test pytest --noconftest tests/test_inbox_writes_endpoint.py -q`
- `uv run --extra test pytest tests/test_inbox_view_snooze.py -q`
- `uv run --extra test pytest tests/web_api/test_web_ui.py -q`
- `uv run --extra dev ruff check src/pollypm/web_api/service.py tests/test_inbox_writes_endpoint.py`

Fixes #2542