### PR TITLE
Fix home briefing handoff naming

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -175,6 +175,7 @@ class InboxPreview:
     task_id: str
     age_seconds: float
     project_key: str | None = None
+    allow_dormant_briefing: bool = False
 
 
 @dataclass(slots=True)
@@ -1007,7 +1008,7 @@ def _first_briefing_message(
         if _project_is_live_for_briefing(
             _briefing_message_project_key(message),
             recent_real_work_projects,
-        ):
+        ) or bool(getattr(message, "allow_dormant_briefing", False)):
             return message
     return None
 
@@ -1131,6 +1132,18 @@ def _strain_note(
     return "Health note: " + "; ".join(notes) + "."
 
 
+def _briefing_greeting(generated_at: datetime | None = None) -> str:
+    clock = generated_at or datetime.now(UTC)
+    hour = int(getattr(clock, "hour", 0) or 0)
+    if 5 <= hour < 12:
+        return "Morning. Here's the overnight read."
+    if 12 <= hour < 17:
+        return "Afternoon. Here's where things stand."
+    if 17 <= hour < 24:
+        return "Evening. Here's where things stand."
+    return "Morning. Here's where things stand."
+
+
 def _build_dashboard_briefing(
     *,
     commits: list[CommitInfo],
@@ -1141,10 +1154,11 @@ def _build_dashboard_briefing(
     recovery_summaries: list[str] | None = None,
     recent_real_work_projects: frozenset[str] | None = None,
     account_usages: list[AccountQuotaUsage] | None = None,
+    generated_at: datetime | None = None,
 ) -> str:
     """Build the concise Home briefing from already-gathered dashboard facts."""
 
-    lines: list[str] = ["Morning. Here's the overnight read."]
+    lines: list[str] = [_briefing_greeting(generated_at)]
     if completed:
         lines.append(
             "Shipped: "
@@ -1390,6 +1404,10 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
         inbox_tasks_grouped,
     )
     from pollypm.notify_task import is_notify_only_inbox_entry
+    from pollypm.work.inbox_view import (
+        cancelled_handoff_blocker_for_task,
+        cancelled_handoff_unblock_subject,
+    )
 
     now = datetime.now(UTC)
     seen_task_ids: set[str] = set()
@@ -1412,6 +1430,34 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
     pg_grouped = inbox_tasks_grouped(config)
     if pg_grouped is None:
         return []
+    handoff_svc: object | None = None
+    handoff_flow_cache: dict[tuple[str, int], object] = {}
+
+    def _handoff_subject(task: object) -> str | None:
+        nonlocal handoff_svc
+        status = getattr(getattr(task, "work_status", None), "value", None)
+        status = status or str(getattr(task, "work_status", "") or "")
+        if status != "blocked" or not getattr(task, "blocked_by", None):
+            return None
+        if handoff_svc is None:
+            try:
+                from pollypm.work.pg_service import PgWorkService
+
+                handoff_svc = PgWorkService(config=config)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "dashboard_data: cancelled handoff preview lookup unavailable",
+                    exc_info=True,
+                )
+                return None
+        blocker = cancelled_handoff_blocker_for_task(
+            task,
+            handoff_svc,
+            flow_cache=handoff_flow_cache,  # type: ignore[arg-type]
+        )
+        if blocker is None:
+            return None
+        return cancelled_handoff_unblock_subject(task, blocker)
 
     def _emit_preview(
         task: object,
@@ -1434,24 +1480,38 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
                 )
             except (ValueError, TypeError):
                 age_seconds = 0.0
+        handoff_subject = _handoff_subject(task)
         previews.append(
             InboxPreview(
                 sender=_inbox_sender(task),
-                title=(getattr(task, "title", "") or "(untitled)")[:80],
+                title=(
+                    handoff_subject
+                    or getattr(task, "title", "")
+                    or "(untitled)"
+                )[:80],
                 project=project_label,
                 task_id=task.task_id,
                 age_seconds=age_seconds,
                 project_key=project_key,
+                allow_dormant_briefing=handoff_subject is not None,
             )
         )
 
     # Single in-memory partition + emit; no per-source DB opens.
-    for project_key, project_label, _db_path, _project_path in sources:
-        if not project_key:
-            # workspace-root source has no task rows under pg.
-            continue
-        for task in inbox_tasks_for_project(pg_grouped, config, project_key):
-            _emit_preview(task, project_label, project_key)
+    try:
+        for project_key, project_label, _db_path, _project_path in sources:
+            if not project_key:
+                # workspace-root source has no task rows under pg.
+                continue
+            for task in inbox_tasks_for_project(pg_grouped, config, project_key):
+                _emit_preview(task, project_label, project_key)
+    finally:
+        close = getattr(handoff_svc, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:  # noqa: BLE001
+                pass
     previews.sort(key=lambda item: item.age_seconds)
     return previews[:limit]
 
@@ -1801,6 +1861,17 @@ def gather(
         user_waiting_task_ids=user_waiting,
         project_task_facts=project_task_facts,
     )
+    briefing_generated_at = now
+    try:
+        from pollypm.tz import get_timezone
+
+        config_tz = getattr(getattr(config, "pollypm", None), "timezone", "") or ""
+        briefing_generated_at = now.astimezone(get_timezone(config_tz))
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "dashboard_data.gather: local briefing clock resolution failed",
+            exc_info=True,
+        )
     briefing = _build_dashboard_briefing(
         commits=commits,
         completed=completed,
@@ -1810,6 +1881,7 @@ def gather(
         recovery_summaries=recovery_summaries,
         recent_real_work_projects=recent_real_work_projects,
         account_usages=account_usages,
+        generated_at=briefing_generated_at,
     )
 
     return DashboardData(

--- a/src/pollypm/web_api/service.py
+++ b/src/pollypm/web_api/service.py
@@ -35,6 +35,8 @@ from pollypm.models import KnownProject
 from pollypm.notify_task import is_notify_only_inbox_entry
 from pollypm.work import inbox_snooze as _inbox_snooze
 from pollypm.work.inbox_view import (
+    cancelled_handoff_blocker_for_task,
+    cancelled_handoff_unblock_subject,
     inbox_item_type_for_task,
     inbox_state_for_task,
     inbox_task_matches_type,
@@ -3288,7 +3290,7 @@ def reply_inbox_item(
             if not is_inbox_task(src_task, svc):
                 raise not_found(f"Inbox item not found: {item_id}")
             try:
-                cancelled_handoff = _cancelled_handoff_blocker_for_task(
+                cancelled_handoff = cancelled_handoff_blocker_for_task(
                     src_task, svc, flow_cache={},
                 )
                 if cancelled_handoff is None:
@@ -4616,12 +4618,12 @@ def _task_to_inbox_item(
         )
         if value:
             metadata[key] = value
-    cancelled_handoff = _cancelled_handoff_blocker_for_task(
+    cancelled_handoff = cancelled_handoff_blocker_for_task(
         task, svc, flow_cache=flow_cache or {},
     )
     if cancelled_handoff is not None:
         blocker_id = str(getattr(cancelled_handoff, "task_id"))
-        subject = _cancelled_handoff_unblock_subject(task, cancelled_handoff)
+        subject = cancelled_handoff_unblock_subject(task, cancelled_handoff)
         handoff_body = str(
             getattr(cancelled_handoff, "description", "") or ""
         ).strip()
@@ -4649,65 +4651,6 @@ def _task_to_inbox_item(
         updated_at=task.updated_at or task.created_at or datetime.utcnow(),
         metadata=metadata,
     )
-
-
-def _cancelled_handoff_unblock_subject(task, blocker) -> str:
-    blocker_title = str(getattr(blocker, "title", "") or "").strip()
-    match = re.match(
-        r"^(?P<target>.+?)\s+needs\s+your\s+inputs?\.?$",
-        blocker_title,
-        flags=re.IGNORECASE,
-    )
-    if match is not None:
-        target = match.group("target").strip()
-    else:
-        target = str(getattr(task, "title", "") or "").strip()
-    if target:
-        return f"Provide inputs to unblock {target}"
-    return "Provide inputs to unblock this task"
-
-
-def _cancelled_handoff_blocker_for_task(
-    task,
-    svc=None,
-    *,
-    flow_cache: dict[tuple[str, int], Any],
-):
-    status = getattr(getattr(task, "work_status", None), "value", None)
-    status = status or str(getattr(task, "work_status", "") or "")
-    if status != WorkStatus.BLOCKED.value:
-        return None
-    if svc is None:
-        return None
-    get_task = getattr(svc, "get", None)
-    if not callable(get_task):
-        return None
-    for ref in getattr(task, "blocked_by", None) or []:
-        try:
-            project, number = ref
-            blocker_id = f"{project}/{int(number)}"
-        except (TypeError, ValueError):
-            continue
-        try:
-            blocker = get_task(blocker_id)
-        except Exception:  # noqa: BLE001 - readonly surfacing degrades open
-            logger.debug(
-                "inbox: cancelled handoff lookup failed for %s",
-                blocker_id,
-                exc_info=True,
-            )
-            continue
-        blocker_status = getattr(
-            getattr(blocker, "work_status", None), "value", None,
-        )
-        blocker_status = blocker_status or str(
-            getattr(blocker, "work_status", "") or ""
-        )
-        if blocker_status != WorkStatus.CANCELLED.value:
-            continue
-        if is_inbox_task_identity(blocker, svc, flow_cache=flow_cache):
-            return blocker
-    return None
 
 
 def _inbox_state_from_task(task) -> str:

--- a/src/pollypm/work/inbox_view.py
+++ b/src/pollypm/work/inbox_view.py
@@ -23,6 +23,8 @@ autoreview), then by priority descending, then by ``updated_at`` descending.
 
 from __future__ import annotations
 
+import logging
+import re
 from datetime import datetime, timezone
 from typing import Iterable, Protocol
 
@@ -36,6 +38,8 @@ from pollypm.work.models import (
     TERMINAL_STATUSES,
     WorkStatus,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -289,28 +293,64 @@ def _blocked_on_cancelled_inbox_dependency(
     visible in the user's inbox so the operator-input request is not erased by
     the cancellation.
     """
+    return cancelled_handoff_blocker_for_task(
+        task, service, flow_cache=flow_cache,
+    ) is not None
+
+
+def cancelled_handoff_unblock_subject(task: object, blocker: object) -> str:
+    blocker_title = str(getattr(blocker, "title", "") or "").strip()
+    match = re.match(
+        r"^(?P<target>.+?)\s+needs\s+your\s+inputs?\.?$",
+        blocker_title,
+        flags=re.IGNORECASE,
+    )
+    if match is not None:
+        target = match.group("target").strip()
+    else:
+        target = str(getattr(task, "title", "") or "").strip()
+    if target:
+        return f"Provide inputs to unblock {target}"
+    return "Provide inputs to unblock this task"
+
+
+def cancelled_handoff_blocker_for_task(
+    task: object,
+    service: _FlowLookup | None,
+    *,
+    flow_cache: dict[tuple[str, int], FlowTemplate] | None = None,
+) -> object | None:
     if _status_value(task) != WorkStatus.BLOCKED.value:
-        return False
+        return None
+    if service is None:
+        return None
     refs = getattr(task, "blocked_by", None) or []
     if not refs:
-        return False
+        return None
     get_task = getattr(service, "get", None)
     if not callable(get_task):
-        return False
+        return None
+    cache = flow_cache if flow_cache is not None else {}
     for ref in refs:
         try:
             project, task_number = ref
+            blocker_id = f"{project}/{int(task_number)}"
         except (TypeError, ValueError):
             continue
         try:
-            blocker = get_task(f"{project}/{int(task_number)}")
+            blocker = get_task(blocker_id)
         except Exception:  # noqa: BLE001 - readonly predicate degrades hidden
+            logger.debug(
+                "inbox_view: cancelled handoff lookup failed for %s",
+                blocker_id,
+                exc_info=True,
+            )
             continue
         if _status_value(blocker) != WorkStatus.CANCELLED.value:
             continue
-        if is_inbox_task_identity(blocker, service, flow_cache=flow_cache):
-            return True
-    return False
+        if is_inbox_task_identity(blocker, service, flow_cache=cache):
+            return blocker
+    return None
 
 
 def is_inbox_task(

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -12,6 +12,7 @@ for non-faults the user already sees as yellow.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from types import SimpleNamespace
 
 from pollypm.dashboard_data import _stuck_alert_already_user_waiting
@@ -731,6 +732,7 @@ def test_briefing_pluralizes_counts_correctly() -> None:
             )
         ],
         recovery_count_24h=1,
+        generated_at=datetime(2026, 6, 2, 8, 0, tzinfo=UTC),
     )
     assert "1 commit across 1 project" in out
     assert "1 item wrapped" in out
@@ -773,6 +775,37 @@ def test_briefing_pluralizes_counts_correctly() -> None:
     assert "other/99" not in out2
     assert "(s)" not in out2
     assert "(ies)" not in out2
+
+
+def test_briefing_greeting_tracks_generated_time() -> None:
+    from pollypm.dashboard_data import _build_dashboard_briefing
+
+    base = {
+        "commits": [],
+        "completed": [],
+        "inbox_count": 0,
+        "recent_messages": [],
+        "recovery_count_24h": 0,
+    }
+
+    morning = _build_dashboard_briefing(
+        **base,
+        generated_at=datetime(2026, 6, 2, 8, 0, tzinfo=UTC),
+    )
+    afternoon = _build_dashboard_briefing(
+        **base,
+        generated_at=datetime(2026, 6, 2, 14, 0, tzinfo=UTC),
+    )
+    evening = _build_dashboard_briefing(
+        **base,
+        generated_at=datetime(2026, 6, 2, 17, 36, tzinfo=UTC),
+    )
+
+    assert morning.startswith("Morning. Here's the overnight read.")
+    assert afternoon.startswith("Afternoon. Here's where things stand.")
+    assert evening.startswith("Evening. Here's where things stand.")
+    assert "overnight read" not in afternoon
+    assert "overnight read" not in evening
 
 
 def test_briefing_splits_bookkeeping_commits_from_product_progress() -> None:
@@ -1063,6 +1096,37 @@ def test_briefing_first_up_skips_dormant_projects() -> None:
     assert "open Inbox and clear that first" in out
 
 
+def test_briefing_names_dormant_operator_blocked_handoff() -> None:
+    from pollypm.dashboard_data import _build_dashboard_briefing, InboxPreview
+
+    out = _build_dashboard_briefing(
+        commits=[],
+        completed=[],
+        inbox_count=1,
+        recent_messages=[
+            InboxPreview(
+                sender="polly",
+                title="Provide inputs to unblock Samblog Phase 0",
+                project="Samblog",
+                task_id="samblog/30",
+                age_seconds=3600.0,
+                project_key="samblog",
+                allow_dormant_briefing=True,
+            )
+        ],
+        recovery_count_24h=0,
+        recent_real_work_projects=frozenset({"savethenovel"}),
+        generated_at=datetime(2026, 6, 2, 17, 36, tzinfo=UTC),
+    )
+
+    assert out.startswith("Evening. Here's where things stand.")
+    assert (
+        "One thing needs you: Provide inputs to unblock Samblog Phase 0. "
+        "Open Inbox and clear that first."
+    ) in out
+    assert "1 inbox item waiting" not in out
+
+
 def test_briefing_first_up_skips_orphan_worktree_maintenance() -> None:
     from pollypm.dashboard_data import _build_dashboard_briefing, InboxPreview
 
@@ -1123,6 +1187,83 @@ def test_briefing_uses_generic_inbox_line_when_only_dormant_items_exist() -> Non
     assert "pm test" not in out
     assert "status=in_progress" not in out
     assert "One thing needs you: 1 inbox item waiting." in out
+
+
+def test_recent_inbox_messages_reframes_cancelled_handoff_preview(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    from pollypm.dashboard_data import _recent_inbox_messages
+
+    now = datetime(2026, 6, 2, 12, 0, tzinfo=UTC)
+    target = SimpleNamespace(
+        project="samblog",
+        task_number=30,
+        task_id="samblog/30",
+        title="Execute SamBlog Phase 0 live MCP smoke test",
+        work_status=SimpleNamespace(value="blocked"),
+        blocked_by=[("samblog", 26)],
+        labels=[],
+        roles={},
+        priority=SimpleNamespace(value="high"),
+        flow_template_id="chat",
+        flow_template_version=1,
+        current_node_id=None,
+        updated_at=now,
+        created_at=now,
+        created_by="pm",
+    )
+    blocker = SimpleNamespace(
+        project="samblog",
+        task_number=26,
+        task_id="samblog/26",
+        title="Samblog Phase 0 needs your inputs",
+        work_status=SimpleNamespace(value="cancelled"),
+        labels=[],
+        roles={"requester": "user", "operator": "user"},
+        flow_template_id="chat",
+        flow_template_version=1,
+        current_node_id=None,
+    )
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.inbox_tasks_grouped",
+        lambda _config: {"samblog": [target]},
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.inbox_tasks_for_project",
+        lambda grouped, _config, project_key: grouped.get(project_key, []),
+    )
+
+    class _FakePgWorkService:
+        closed = False
+
+        def __init__(self, *, config) -> None:  # noqa: ARG002
+            pass
+
+        def get(self, task_id: str):
+            if task_id == "samblog/26":
+                return blocker
+            raise KeyError(task_id)
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(
+        "pollypm.work.pg_service.PgWorkService",
+        _FakePgWorkService,
+    )
+    project = SimpleNamespace(
+        tracked=True,
+        path=tmp_path / "samblog",
+        display_label=lambda: "Samblog",
+    )
+    config = SimpleNamespace(projects={"samblog": project})
+
+    previews = _recent_inbox_messages(config)
+
+    assert len(previews) == 1
+    assert previews[0].title == "Provide inputs to unblock Samblog Phase 0"
+    assert previews[0].allow_dormant_briefing is True
 
 
 def test_recovery_narration_filters_dormant_projects(monkeypatch) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Make the Home briefing greeting use the generated clock so afternoon/evening renders say where things stand instead of the overnight read.
- Reuse the work inbox cancelled-handoff helper for both the Inbox API and dashboard preview naming.
- Allow only explicitly marked real cancelled-handoff inbox previews to bypass recent-work liveness when choosing the briefing decision, preserving the dormant fixture filter.

Fixes #2544

## Tests
- `uv run --extra test python -m pytest -q tests/test_dashboard_data_alert_dedup.py` (pre-rebase full file: 47 passed)
- `uv run --extra test python -m pytest -q tests/test_dashboard_data_alert_dedup.py::test_briefing_greeting_tracks_generated_time tests/test_dashboard_data_alert_dedup.py::test_briefing_names_dormant_operator_blocked_handoff tests/test_dashboard_data_alert_dedup.py::test_recent_inbox_messages_reframes_cancelled_handoff_preview tests/test_dashboard_data_alert_dedup.py::test_briefing_uses_generic_inbox_line_when_only_dormant_items_exist`
- `uv run --extra test python -m pytest -q tests/test_inbox_writes_endpoint.py::test_list_inbox_reframes_blocked_cancelled_handoff tests/test_inbox_writes_endpoint.py::test_reply_to_blocked_cancelled_handoff_records_answer_and_unblocks`
- `uv run --extra dev ruff check src/pollypm/dashboard_data.py src/pollypm/work/inbox_view.py src/pollypm/web_api/service.py tests/test_dashboard_data_alert_dedup.py`