### PR TITLE
Surface real plan-stalled projects in alerts

### DIFF
--- a/src/pollypm/alert_actionability.py
+++ b/src/pollypm/alert_actionability.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from typing import Iterable, Mapping
 
 from pollypm.cockpit_alerts import is_operational_alert
+from pollypm.project_liveness import project_key_looks_synthetic
 
 
 _STUCK_ON_TASK_PREFIX = "stuck_on_task:"
@@ -31,9 +32,10 @@ _QWM_PROJECT_RE = re.compile(r"\bProject\s+(?P<project>[A-Za-z0-9_.-]+)\s+has\b"
 # ``ghost``, ``alpha``, ``queuestorm_*``, ...) — many of which were
 # still tracked, so trackedness alone was a false liveness signal. We
 # demote a recovery warn when it is scoped to a project that is not
-# tracked OR has no recent real completed work. The session-name →
-# project extraction mirrors the synthetic scope strings the sweep
-# writes (see ``plugins_builtin/task_assignment_notify/handlers/sweep.py``):
+# tracked, synthetic, or has neither recent real completed work nor real
+# stalled work. The session-name → project extraction mirrors the
+# synthetic scope strings the sweep writes (see
+# ``plugins_builtin/task_assignment_notify/handlers/sweep.py``):
 #   plan_missing        -> ``plan_gate-<project>``
 #   worker_session_gap  -> ``worker_session_gap-<project>``
 #   missing_task_worker -> ``missing_task_worker-<project>/<task-number>``
@@ -42,6 +44,13 @@ _RECOVERY_WATCHDOG_SESSION_PREFIXES: dict[str, str] = {
     "worker_session_gap": "worker_session_gap-",
     "missing_task_worker": "missing_task_worker-",
 }
+_REAL_WORK_STALL_STATUSES = frozenset({
+    "queued",
+    "blocked",
+    "in_progress",
+    "review",
+    "rework",
+})
 
 
 @dataclass(slots=True, frozen=True)
@@ -167,6 +176,22 @@ def _project_is_inactive_for_operator_count(
     return False
 
 
+def _project_has_real_stalled_work(
+    project: str,
+    *,
+    context: AlertActionabilityContext,
+) -> bool:
+    if project_key_looks_synthetic(project):
+        return False
+    counts = context.project_task_counts.get(project)
+    if not counts:
+        return False
+    for status in _REAL_WORK_STALL_STATUSES:
+        if int(counts.get(status, 0) or 0) > 0:
+            return True
+    return False
+
+
 def _worktree_state_is_stale(
     alert_type: str,
     *,
@@ -236,8 +261,10 @@ def _recovery_watchdog_warn_is_self_healing(
     Counting it in the operator's "N things need you" headline trains
     the operator to ignore the number (#2475/#2480). Trackedness is not
     enough: watchdog churn can keep a dead tracked project looking
-    freshly touched, so callers may also pass the set of projects with
-    recent real ``done`` work.
+    freshly touched, so callers may also pass recent real ``done`` work
+    and task-count facts. A real tracked project with queued / blocked /
+    in-progress work is still operator-relevant before its first done
+    task (#2545).
     """
 
     if alert_type not in _RECOVERY_WATCHDOG_SESSION_PREFIXES:
@@ -252,6 +279,8 @@ def _recovery_watchdog_warn_is_self_healing(
         known_projects=context.known_projects or context.tracked_projects,
     )
     if not project:
+        return False
+    if _project_has_real_stalled_work(project, context=context):
         return False
     return _project_is_inactive_for_operator_count(project, context=context)
 

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -191,7 +191,7 @@ def test_recovery_warn_demotes_tracked_but_dormant_project() -> None:
     A dead project can remain ``tracked=True`` while watchdog churn keeps
     touching its tasks. Recovery/hygiene warns on such projects should
     not inflate the operator "needs you" headline unless the project has
-    recent real completed work.
+    recent real completed work or real stalled work.
     """
     from pollypm.alert_actionability import (
         AlertActionabilityContext,
@@ -223,6 +223,36 @@ def test_recovery_warn_demotes_tracked_but_dormant_project() -> None:
     assert not is_user_actionable_alert(dormant_recovery_warn, context=context)
     assert is_user_actionable_alert(active_recovery_warn, context=context)
     assert is_user_actionable_alert(operator_decision, context=context)
+
+
+def test_recovery_warn_surfaces_tracked_project_with_stalled_work() -> None:
+    from pollypm.alert_actionability import (
+        AlertActionabilityContext,
+        is_user_actionable_alert,
+    )
+
+    context = AlertActionabilityContext(
+        known_projects=frozenset({"media", "pm_test_alpha"}),
+        tracked_projects=frozenset({"media", "pm_test_alpha"}),
+        recent_real_work_projects=frozenset(),
+        project_task_counts={
+            "media": {"queued": 2},
+            "pm_test_alpha": {"queued": 4},
+        },
+    )
+    media_plan_missing = SimpleNamespace(
+        session_name="plan_gate-media",
+        alert_type="plan_missing",
+        message="Project media has queued tasks but no plan.",
+    )
+    fixture_plan_missing = SimpleNamespace(
+        session_name="plan_gate-pm_test_alpha",
+        alert_type="plan_missing",
+        message="Project pm_test_alpha has queued tasks but no plan.",
+    )
+
+    assert is_user_actionable_alert(media_plan_missing, context=context)
+    assert not is_user_actionable_alert(fixture_plan_missing, context=context)
 
 
 def test_queue_without_motion_demotes_tracked_project_without_recent_real_work() -> None:
@@ -416,6 +446,81 @@ def test_alert_filter_task_facts_excludes_synthetic_done_projects(monkeypatch) -
     assert "pm_test" not in out
     assert "pm test" not in out
     assert "First up: Save the Novel has queued work without an active claim." in out
+
+
+def test_dashboard_alert_count_surfaces_real_plan_stall_not_fixture(
+    monkeypatch,
+) -> None:
+    from pollypm import dashboard_data
+
+    grouped = {
+        "media": [
+            SimpleNamespace(
+                work_status="queued",
+                updated_at=datetime.now(UTC),
+            ),
+            SimpleNamespace(
+                work_status="queued",
+                updated_at=datetime.now(UTC),
+            ),
+        ],
+        "pm_test_01wave_1779715196": [
+            SimpleNamespace(
+                work_status="queued",
+                updated_at=datetime.now(UTC),
+            )
+        ],
+    }
+    config = SimpleNamespace(
+        projects={
+            "media": SimpleNamespace(
+                tracked=True,
+                path="/Users/sam/dev/media",
+            ),
+            "pm_test_01wave_1779715196": SimpleNamespace(
+                tracked=True,
+                path="/private/tmp/pm_test_01wave_1779715196",
+            ),
+        }
+    )
+    alerts = [
+        SimpleNamespace(
+            session_name="plan_gate-media",
+            alert_type="plan_missing",
+            message="Project media has 2 queued tasks but no plan.",
+        ),
+        SimpleNamespace(
+            session_name="plan_gate-pm_test_01wave_1779715196",
+            alert_type="plan_missing",
+            message="Project pm_test_01wave_1779715196 has queued tasks but no plan.",
+        ),
+    ]
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.all_tasks_grouped",
+        lambda _config: grouped,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_pg_aggregates.all_tasks_for_project",
+        lambda data, _config, key: data[key],
+    )
+
+    facts = dashboard_data._project_task_facts_for_alert_filter(config, alerts)
+    actionable = dashboard_data.dashboard_actionable_alerts(
+        config,
+        alerts,
+        user_waiting_task_ids=frozenset(),
+        project_task_facts=facts,
+    )
+
+    assert facts.recent_real_work_projects == frozenset()
+    assert dashboard_data.count_dashboard_alerts(
+        config,
+        alerts,
+        user_waiting_task_ids=frozenset(),
+        project_task_facts=facts,
+    ) == 1
+    assert actionable == [alerts[0]]
 
 
 def test_session_description_skips_claude_tui_bottom_bar(tmp_path) -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Keep recovery watchdog alerts actionable for real tracked projects that have queued, blocked, in-progress, review, or rework tasks even when they have no recent done work yet.
- Continue demoting untracked/synthetic fixture projects such as `pm_test_*` even if they have queued task rows.
- Add dashboard alert-count coverage for a real plan-stalled `media` project alongside a synthetic fixture project.

Fixes #2545

## Tests
- `uv run --extra test python -m pytest -q tests/test_dashboard_data_alert_dedup.py` (46 passed)
- `uv run --extra test python -m pytest -q tests/test_dashboard_data_alert_dedup.py::test_recovery_warn_demotes_tracked_but_dormant_project tests/test_dashboard_data_alert_dedup.py::test_recovery_warn_surfaces_tracked_project_with_stalled_work tests/test_dashboard_data_alert_dedup.py::test_queue_without_motion_demotes_tracked_project_without_recent_real_work tests/test_dashboard_data_alert_dedup.py::test_dashboard_alert_count_surfaces_real_plan_stall_not_fixture` (4 passed)
- `uv run --extra dev ruff check src/pollypm/alert_actionability.py tests/test_dashboard_data_alert_dedup.py`