### PR TITLE
Emit plan-missing alerts for real dormant stalls

### DIFF
--- a/src/pollypm/alert_actionability.py
+++ b/src/pollypm/alert_actionability.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from typing import Iterable, Mapping
 
 from pollypm.cockpit_alerts import is_operational_alert
-from pollypm.project_liveness import project_key_looks_synthetic
+from pollypm.project_liveness import project_has_real_stalled_work
 
 
 _STUCK_ON_TASK_PREFIX = "stuck_on_task:"
@@ -44,14 +44,6 @@ _RECOVERY_WATCHDOG_SESSION_PREFIXES: dict[str, str] = {
     "worker_session_gap": "worker_session_gap-",
     "missing_task_worker": "missing_task_worker-",
 }
-_REAL_WORK_STALL_STATUSES = frozenset({
-    "queued",
-    "blocked",
-    "in_progress",
-    "review",
-    "rework",
-})
-
 
 @dataclass(slots=True, frozen=True)
 class AlertActionabilityContext:
@@ -176,22 +168,6 @@ def _project_is_inactive_for_operator_count(
     return False
 
 
-def _project_has_real_stalled_work(
-    project: str,
-    *,
-    context: AlertActionabilityContext,
-) -> bool:
-    if project_key_looks_synthetic(project):
-        return False
-    counts = context.project_task_counts.get(project)
-    if not counts:
-        return False
-    for status in _REAL_WORK_STALL_STATUSES:
-        if int(counts.get(status, 0) or 0) > 0:
-            return True
-    return False
-
-
 def _worktree_state_is_stale(
     alert_type: str,
     *,
@@ -280,7 +256,10 @@ def _recovery_watchdog_warn_is_self_healing(
     )
     if not project:
         return False
-    if _project_has_real_stalled_work(project, context=context):
+    if project_has_real_stalled_work(
+        project,
+        context.project_task_counts.get(project),
+    ):
         return False
     return _project_is_inactive_for_operator_count(project, context=context)
 

--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -52,7 +52,12 @@ from pollypm.plan_presence import (
     has_acceptable_plan,
     task_bypasses_plan_gate,
 )
-from pollypm.project_liveness import recent_real_work_project_keys
+from pollypm.project_liveness import (
+    is_real_operator_project,
+    project_has_real_stalled_work,
+    recent_real_work_project_keys,
+    task_status_key,
+)
 from pollypm.plugins_builtin.task_assignment_notify.resolver import (
     SWEEPER_COOLDOWN_SECONDS,
     _known_project_keys,
@@ -162,12 +167,20 @@ def _recent_real_work_project_keys_for_sweep(
     completed work.
     """
 
+    return _project_task_facts_for_sweep(services)[0]
+
+
+def _project_task_facts_for_sweep(
+    services: Any,
+) -> tuple[frozenset[str] | None, dict[str, dict[str, int]]]:
+    """Return recent-real-work and status-count facts for sweep liveness."""
+
     config = getattr(services, "config", None)
     if config is None:
-        return None
+        return None, {}
     projects = getattr(config, "projects", {}) or {}
     if not projects:
-        return None
+        return None, {}
     try:
         from pollypm.cockpit_pg_aggregates import (
             all_tasks_for_project,
@@ -176,17 +189,27 @@ def _recent_real_work_project_keys_for_sweep(
 
         grouped = all_tasks_grouped(config)
         if grouped is None:
-            return None
-        return recent_real_work_project_keys(
+            return None, {}
+        counts_by_project: dict[str, dict[str, int]] = {}
+        for project_key in projects:
+            counts: dict[str, int] = {}
+            for task in all_tasks_for_project(grouped, config, project_key):
+                status_key = task_status_key(task)
+                if not status_key:
+                    continue
+                counts[status_key] = counts.get(status_key, 0) + 1
+            counts_by_project[str(project_key)] = counts
+        recent = recent_real_work_project_keys(
             projects,
             lambda project_key: all_tasks_for_project(grouped, config, project_key),
         )
+        return recent, counts_by_project
     except Exception:  # noqa: BLE001
         logger.debug(
             "task_assignment sweep: recent real-work liveness lookup failed",
             exc_info=True,
         )
-        return None
+        return None, {}
 
 
 def _project_is_live_for_sweep(
@@ -214,6 +237,45 @@ def _known_projects_for_sweep(
         if _project_is_live_for_sweep(
             getattr(project, "key", None),
             recent_real_work_projects,
+        )
+    )
+
+
+def _project_can_emit_plan_missing_without_recent_work(
+    project: Any,
+    *,
+    project_task_counts: dict[str, dict[str, int]],
+) -> bool:
+    project_key = getattr(project, "key", None)
+    if not project_key:
+        return False
+    if not is_real_operator_project(project_key, project):
+        return False
+    return project_has_real_stalled_work(
+        project_key,
+        project_task_counts.get(str(project_key)),
+    )
+
+
+def _known_projects_for_plan_missing_precompute(
+    services: Any,
+    *,
+    recent_real_work_projects: frozenset[str] | None,
+    project_task_counts: dict[str, dict[str, int]],
+) -> tuple[Any, ...]:
+    projects = tuple(getattr(services, "known_projects", ()) or ())
+    if recent_real_work_projects is None:
+        return projects
+    return tuple(
+        project
+        for project in projects
+        if _project_is_live_for_sweep(
+            getattr(project, "key", None),
+            recent_real_work_projects,
+        )
+        or _project_can_emit_plan_missing_without_recent_work(
+            project,
+            project_task_counts=project_task_counts,
         )
     )
 
@@ -1312,12 +1374,17 @@ def _sweep_work_service(
     # ``auto_claim_skipped_plan_missing`` outcome on the same task.
     known_by_key: dict[str, Any] = {}
     if project is None and project_path is None:
-        for known in _known_projects_for_sweep(
-            services,
-            recent_real_work_projects=recent_real_work_projects,
-        ):
+        for known in tuple(getattr(services, "known_projects", ()) or ()):
             known_key = getattr(known, "key", None)
-            if known_key:
+            if not known_key:
+                continue
+            if (
+                _project_is_live_for_sweep(
+                    known_key,
+                    recent_real_work_projects,
+                )
+                or str(known_key) in plan_missing_projects
+            ):
                 known_by_key[known_key] = known
     for status in _SWEEPABLE_STATUSES:
         try:
@@ -1341,10 +1408,15 @@ def _sweep_work_service(
                 task_project_key,
                 recent_real_work_projects,
             ):
-                by_outcome["skipped_dormant_project"] = (
-                    by_outcome.get("skipped_dormant_project", 0) + 1
+                can_check_plan_missing = (
+                    status == WorkStatus.QUEUED.value
+                    and task_project_key in plan_missing_projects
                 )
-                continue
+                if not can_check_plan_missing:
+                    by_outcome["skipped_dormant_project"] = (
+                        by_outcome.get("skipped_dormant_project", 0) + 1
+                    )
+                    continue
             if (
                 review_pending_tasks is not None
                 and status == WorkStatus.REVIEW.value
@@ -2650,6 +2722,7 @@ def _precompute_plan_missing_projects(
     services: Any,
     *,
     recent_real_work_projects: frozenset[str] | None = None,
+    project_task_counts: dict[str, dict[str, int]] | None = None,
 ) -> dict[str, str | None]:
     """Return a mapping of plan-gated project keys → an example queued task_id.
 
@@ -2670,9 +2743,10 @@ def _precompute_plan_missing_projects(
         if not global_enforce:
             return {}
         known = list(
-            _known_projects_for_sweep(
+            _known_projects_for_plan_missing_precompute(
                 services,
                 recent_real_work_projects=recent_real_work_projects,
+                project_task_counts=project_task_counts or {},
             )
         )
         if not known:
@@ -3028,13 +3102,17 @@ def _task_assignment_sweep_body(
 
     totals: dict[str, Any] = {"considered": 0, "by_outcome": {}}
     alerted_pairs: set[tuple[str, str]] = set()
-    recent_real_work_projects = _recent_real_work_project_keys_for_sweep(services)
+    (
+        recent_real_work_projects,
+        project_task_counts,
+    ) = _project_task_facts_for_sweep(services)
     # #1524 — pre-compute the set of projects that are plan-gated this
     # tick so the emit/clear decision is deterministic across the
     # workspace pass + per-project pass.
     precomputed_missing = _precompute_plan_missing_projects(
         services,
         recent_real_work_projects=recent_real_work_projects,
+        project_task_counts=project_task_counts,
     )
     plan_missing_projects: set[str] = set(precomputed_missing.keys())
     plan_decisions: dict[str, bool] = {}

--- a/src/pollypm/project_liveness.py
+++ b/src/pollypm/project_liveness.py
@@ -104,6 +104,31 @@ def task_status_key(task: object) -> str:
     return str(status_value or "")
 
 
+REAL_WORK_STALL_STATUSES = frozenset({
+    "queued",
+    "blocked",
+    "in_progress",
+    "review",
+    "rework",
+})
+
+
+def project_has_real_stalled_work(
+    project_key: object,
+    status_counts: Mapping[str, int] | None,
+) -> bool:
+    """Return True when a real project has unfinished operator-relevant work."""
+
+    if project_key_looks_synthetic(project_key):
+        return False
+    if not status_counts:
+        return False
+    for status in REAL_WORK_STALL_STATUSES:
+        if int(status_counts.get(status, 0) or 0) > 0:
+            return True
+    return False
+
+
 def coerce_utc_datetime(value: object) -> datetime | None:
     """Coerce an ISO/datetime value to UTC, returning ``None`` on parse failure."""
 
@@ -222,9 +247,11 @@ def real_operator_project_items(
 
 __all__ = [
     "RECENT_REAL_WORK_WINDOW",
+    "REAL_WORK_STALL_STATUSES",
     "coerce_utc_datetime",
     "is_real_operator_project",
     "project_key_looks_synthetic",
+    "project_has_real_stalled_work",
     "project_path_looks_synthetic",
     "real_operator_project_items",
     "real_operator_project_keys",

--- a/tests/test_task_assignment_recovery_audit.py
+++ b/tests/test_task_assignment_recovery_audit.py
@@ -7,9 +7,12 @@ from pollypm.audit.log import EVENT_TASK_RECLAIMED, read_events
 from pollypm.plugins_builtin.task_assignment_notify.handlers import sweep as sweep_mod
 from pollypm.plugins_builtin.task_assignment_notify.handlers.sweep import (
     _auto_claim_next,
+    _precompute_plan_missing_projects,
     _recover_dead_claims,
+    _sweep_work_service,
     _sweep_workspace_per_project,
 )
+from pollypm.project_liveness import project_has_real_stalled_work
 from pollypm.work.models import WorkStatus
 
 
@@ -86,6 +89,24 @@ class _FakeAutoClaimWork:
         if self.claim_error is not None:
             raise self.claim_error
         self.claimed.append((task_id, actor))
+
+
+class _FakePlanWork:
+    def __init__(self, queued: list[SimpleNamespace]) -> None:
+        self.queued = queued
+        self.closed = False
+
+    def list_tasks(
+        self, *, project: str | None = None, work_status: str,
+    ) -> list[SimpleNamespace]:
+        if work_status != WorkStatus.QUEUED.value:
+            return []
+        if project is None:
+            return list(self.queued)
+        return [task for task in self.queued if task.project == project]
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class _FakeMsgStore:
@@ -178,6 +199,142 @@ def test_auto_claim_workspace_pass_skips_dormant_projects(monkeypatch) -> None:
     assert recovered == ["savethenovel"]
     assert claimed == ["savethenovel"]
     assert work_by_project["savethenovel"].closed
+
+
+def test_plan_missing_precompute_includes_real_dormant_stall_not_fixture(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """#2548: plan_missing emission gets the same stalled-work carve-out
+    that alert actionability uses, while synthetic fixtures stay quiet.
+    """
+    media_path = tmp_path / "media"
+    fixture_path = tmp_path / "pm_test_alpha"
+    media_path.mkdir()
+    fixture_path.mkdir()
+    media = SimpleNamespace(key="media", path=media_path, tracked=True)
+    fixture = SimpleNamespace(
+        key="pm_test_alpha",
+        path=fixture_path,
+        tracked=True,
+    )
+    media_task = SimpleNamespace(
+        project="media",
+        task_id="media/1",
+        labels=[],
+        flow_template_id="standard",
+    )
+    fixture_task = SimpleNamespace(
+        project="pm_test_alpha",
+        task_id="pm_test_alpha/1",
+        labels=[],
+        flow_template_id="standard",
+    )
+    works = {
+        "media": _FakePlanWork([media_task]),
+        "pm_test_alpha": _FakePlanWork([fixture_task]),
+    }
+    opened: list[str] = []
+
+    def _open(project, _services):
+        opened.append(project.key)
+        return works[project.key]
+
+    monkeypatch.setattr(
+        sweep_mod,
+        "_open_workspace_project_work_service",
+        _open,
+    )
+    monkeypatch.setattr(
+        "pollypm.plan_presence.has_acceptable_plan",
+        lambda *_args, **_kwargs: False,
+    )
+    services = SimpleNamespace(
+        enforce_plan=True,
+        known_projects=(media, fixture),
+        plan_dir="docs/plan",
+    )
+    project_task_counts = {
+        "media": {"queued": 1},
+        "pm_test_alpha": {"queued": 1},
+    }
+
+    assert project_has_real_stalled_work("media", project_task_counts["media"])
+    assert not project_has_real_stalled_work(
+        "pm_test_alpha",
+        project_task_counts["pm_test_alpha"],
+    )
+
+    missing = _precompute_plan_missing_projects(
+        services,
+        recent_real_work_projects=frozenset(),
+        project_task_counts=project_task_counts,
+    )
+
+    assert missing == {"media": "media/1"}
+    assert opened == ["media"]
+    assert works["media"].closed
+    assert not works["pm_test_alpha"].closed
+
+
+def test_sweep_checks_precomputed_plan_missing_before_dormant_skip(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A precomputed plan_missing project must not be lost at the
+    per-task dormant-project guard before the gate can record the skip.
+    """
+    project_path = tmp_path / "media"
+    project_path.mkdir()
+    task = SimpleNamespace(
+        project="media",
+        task_id="media/1",
+        labels=[],
+        flow_template_id="standard",
+    )
+    work = _FakePlanWork([task])
+    services = SimpleNamespace(
+        enforce_plan=True,
+        known_projects=(SimpleNamespace(key="media", path=project_path),),
+        plan_dir="docs/plan",
+        msg_store=_FakeMsgStore(),
+    )
+    totals = {"considered": 0, "by_outcome": {}}
+
+    monkeypatch.setattr(
+        sweep_mod,
+        "_build_event_for_task",
+        lambda _work, _task: SimpleNamespace(
+            project="media",
+            task_id="media/1",
+            actor_name="worker",
+            work_status=WorkStatus.QUEUED.value,
+        ),
+    )
+    monkeypatch.setattr(
+        sweep_mod,
+        "notify",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("plan-gated dormant task should not notify")
+        ),
+    )
+
+    _sweep_work_service(
+        work,
+        services,
+        throttle_override=30,
+        totals=totals,
+        alerted_pairs=set(),
+        plan_missing_projects={"media"},
+        plan_decisions={"media": False},
+        project_path=None,
+        project=None,
+        recent_real_work_projects=frozenset(),
+    )
+
+    assert totals["considered"] == 0
+    assert totals["by_outcome"]["skipped_plan_missing"] == 1
+    assert "skipped_dormant_project" not in totals["by_outcome"]
 
 
 def test_recover_dead_claims_emits_task_reclaimed_audit(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Move the real-stalled-work predicate into `project_liveness` so alert actionability and sweep emission share the same carve-out.
- Include real tracked projects with stalled work in deterministic `plan_missing` precompute even when they have no recent done task yet, while keeping synthetic fixtures out.
- Let precomputed queued plan-missing tasks pass the dormant guard only far enough to record the plan-gate skip instead of notifying workers.

Fixes #2548

## Tests
- `uv run --extra dev ruff check src/pollypm/project_liveness.py src/pollypm/alert_actionability.py src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py tests/test_task_assignment_recovery_audit.py`
- `uv run --extra test python -m pytest -q tests/test_task_assignment_recovery_audit.py::test_plan_missing_precompute_includes_real_dormant_stall_not_fixture tests/test_task_assignment_recovery_audit.py::test_sweep_checks_precomputed_plan_missing_before_dormant_skip tests/test_dashboard_data_alert_dedup.py::test_recovery_warn_surfaces_tracked_project_with_stalled_work`
- `uv run --extra test python -m pytest -q tests/test_task_assignment_recovery_audit.py tests/test_dashboard_data_alert_dedup.py` (61 passed)
