### PR TITLE
Clarify cockpit project rail status summary

### DIFF
--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -774,6 +774,20 @@
     return blocked + review + inbox + plan;
   }
 
+  function projectTriageText(attentionTotal, attentionProjects) {
+    if (attentionTotal <= 0) return "All projects clear";
+    const projectCount = attentionProjects.length;
+    const scope = projectCount === 1
+      ? " in 1 project"
+      : " across " + projectCount + " projects";
+    const names = attentionProjects.slice(0, 3).map((project) => (
+      project.name || project.key
+    )).join(", ");
+    return attentionTotal + " " + plural(attentionTotal, "project status flag")
+      + scope
+      + (names ? " - " + names : "");
+  }
+
   function formatShortTime(value) {
     const parsed = Date.parse(value);
     if (!Number.isFinite(parsed)) return String(value || "");
@@ -867,13 +881,7 @@
       (sum, project) => sum + projectAttentionCount(project),
       0,
     );
-    const triageText = attentionTotal > 0
-      ? attentionTotal + " " + plural(attentionTotal, "item")
-        + (attentionTotal === 1 ? " needs you - " : " need you - ")
-        + attentionProjects.slice(0, 3).map((project) => (
-          project.name || project.key
-        )).join(", ")
-      : "All handled - nothing needs you";
+    const triageText = projectTriageText(attentionTotal, attentionProjects);
     const triage = el("li", {
       class: "project-triage " + (attentionTotal > 0 ? "attention" : "clear"),
     }, [

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -1572,6 +1572,7 @@ function makeNode(tag) {
 const elements = {
   "dashboard-rollups": makeNode("div"),
   "surface-list": makeNode("ul"),
+  "project-list": makeNode("ul"),
   "message-list": makeNode("div"),
   "send-input": makeNode("input"),
   "send-button": makeNode("button"),
@@ -1606,12 +1607,15 @@ eval(source);
 
 global.window.PollyPM.state.surfaces = payload.surfaces || [];
 global.window.PollyPM.state.taskSurfaces = payload.tasks || [];
+global.window.PollyPM.state.projects = payload.projects || [];
 global.window.PollyPM.renderSurfaces();
+global.window.PollyPM.renderProjects();
 if (payload.selectTask) {
   global.window.PollyPM.selectTask(payload.selectTask);
 }
 process.stdout.write(JSON.stringify({
   rail: elements["surface-list"].innerHTML,
+  projectRail: elements["project-list"].innerHTML,
   title: elements["pane-title"].textContent,
   meta: elements["pane-meta"].textContent,
   messages: elements["message-list"].innerHTML,
@@ -1632,6 +1636,33 @@ process.stdout.write(JSON.stringify({
             f"STDOUT: {proc.stdout}\nSTDERR: {proc.stderr}"
         )
     return json.loads(proc.stdout)
+
+
+def test_project_rail_triage_is_status_not_needs_you_alarm() -> None:
+    rendered = _node_render_surface_rail({
+        "projects": [
+            {
+                "key": "polly-remote",
+                "name": "polly-remote",
+                "tracked": True,
+                "task_counts": {"blocked": 9},
+            },
+            {
+                "key": "SamBlog",
+                "name": "SamBlog",
+                "tracked": True,
+                "open_inbox_count": 1,
+                "pending_plan_review": True,
+                "task_counts": {"blocked": 6},
+            },
+        ],
+    })
+    rail = rendered["projectRail"]
+    assert "17 project status flags across 2 projects" in rail
+    assert "polly-remote" in rail
+    assert "SamBlog" in rail
+    assert "needs you" not in rail
+    assert "need you" not in rail
 
 
 def test_render_surface_rail_groups_chat_and_task_surfaces() -> None:


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Reword the cockpit project rail triage row from a competing “needs you” alarm into a project status summary.
- Preserve the underlying project status count and top project names for navigation.
- Add a Node-rendered web UI regression test for the rail wording.

## Tests
- `uv run --with pytest python -m pytest tests/web_api/test_web_ui.py -k "project_rail_triage or render_surface_rail" -q`
- `uv run --with pytest python -m pytest tests/web_api/test_web_ui.py -q`

Closes #2550