### PR TITLE
Filter fixture audit findings from activity feed

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2934,7 +2934,12 @@ paths:
         metadata into calm operator-facing prose. Low-signal plumbing
         events are hidden by default, but remain available through
         `include_low_signal=true` or explicit `event_type`/`pattern`
-        searches.
+        searches. Synthetic seed/test-project `audit.finding` rows are
+        also hidden by default, while repeated real-project findings
+        for the same project/subject/finding collapse into one row with
+        recurrence details in `metadata.activity_group`. Use
+        `include_fixtures=true` or an explicit `event_type`/`pattern`
+        search to inspect fixture findings.
       parameters:
         - in: query
           name: project
@@ -2965,6 +2970,12 @@ paths:
             type: boolean
             default: false
           description: Include low-signal plumbing rows such as `work_db.opened`.
+        - in: query
+          name: include_fixtures
+          schema:
+            type: boolean
+            default: false
+          description: Include audit findings from synthetic seed/test projects.
         - in: query
           name: limit
           schema:

--- a/src/pollypm/web_api/routes/activity.py
+++ b/src/pollypm/web_api/routes/activity.py
@@ -16,6 +16,7 @@ from pollypm.activity_low_signal import (
     is_low_signal_activity,
 )
 from pollypm.audit.query import iter_recent_matching_events, resolve_target_files
+from pollypm.project_liveness import project_key_looks_synthetic
 from pollypm.recovery.narration import is_recovery_event, summarize_audit_event
 from pollypm.web_api.models import Event
 from pollypm.web_api.routes._deps import ConfigDep
@@ -104,6 +105,15 @@ def activity_endpoint(
             )
         ),
     ] = False,
+    include_fixtures: Annotated[
+        bool,
+        Query(
+            description=(
+                "Include audit findings from synthetic seed/test projects. "
+                "Explicit event_type or pattern searches include them too."
+            )
+        ),
+    ] = False,
 ) -> ActivityResponse:
     """Return audit events shaped for the dashboard activity rail."""
 
@@ -145,6 +155,9 @@ def activity_endpoint(
             include_low_signal=(
                 include_low_signal or bool(event_type) or bool(pattern)
             ),
+            include_fixtures=(
+                include_fixtures or bool(event_type) or bool(pattern)
+            ),
         ),
         next_cursor=None,
         _malformed_rows_skipped=(
@@ -162,9 +175,12 @@ class _ActivityGroup:
     representative: Event
     count: int = 0
     subjects: list[str] = field(default_factory=list)
+    last_seen: datetime | None = None
 
     def add(self, event: Event) -> None:
         self.count += 1
+        if self.last_seen is None or event.ts > self.last_seen:
+            self.last_seen = event.ts
         if event.subject:
             self.subjects.append(event.subject)
 
@@ -182,6 +198,7 @@ def _compose_activity_feed(
     limit: int,
     project_filter: str | None,
     include_low_signal: bool = False,
+    include_fixtures: bool = False,
 ) -> list[ActivityEvent]:
     deduped: list[Event] = []
     seen: set[tuple[str, str, str, str, str, str, str]] = set()
@@ -189,6 +206,7 @@ def _compose_activity_feed(
         if not _should_include_activity_event(
             event,
             include_low_signal=include_low_signal,
+            include_fixtures=include_fixtures,
         ):
             continue
         identity = _activity_event_identity(event)
@@ -200,7 +218,7 @@ def _compose_activity_feed(
     deduped.sort(key=_event_sort_key, reverse=True)
 
     entries: list[ActivityEvent] = []
-    groups: dict[tuple[str, str, str, str], _ActivityGroup] = {}
+    groups: dict[tuple[str, ...], _ActivityGroup] = {}
     for event in deduped:
         group_key = _activity_group_key(event)
         if group_key is None:
@@ -233,12 +251,20 @@ def _should_include_activity_event(
     event: Event,
     *,
     include_low_signal: bool,
+    include_fixtures: bool,
 ) -> bool:
-    if include_low_signal:
-        return True
     if is_recovery_event(event.event):
         return True
-    if event.event == "audit.finding" or event.event.startswith("watchdog."):
+    if event.event == "audit.finding":
+        if (
+            not include_fixtures
+            and project_key_looks_synthetic(event.project)
+        ):
+            return False
+        return True
+    if include_low_signal:
+        return True
+    if event.event.startswith("watchdog."):
         return True
     if event.event.strip().lower() in _LOW_SIGNAL_ACTIVITY_KINDS:
         return False
@@ -274,17 +300,30 @@ def _event_sort_key(event: Event) -> datetime:
     return event.ts
 
 
-def _activity_group_key(event: Event) -> tuple[str, str, str, str] | None:
+def _activity_group_key(event: Event) -> tuple[str, ...] | None:
+    if event.event == "audit.finding":
+        problem = _activity_problem_key(event)
+        return (
+            event.project,
+            event.event,
+            event.status,
+            event.subject,
+            problem,
+        )
     if event.event not in _ACTIVITY_GROUPED_EVENTS:
         return None
+    problem = _activity_problem_key(event)
+    return (event.project, event.event, event.status, problem)
+
+
+def _activity_problem_key(event: Event) -> str:
     metadata = event.metadata or {}
-    problem = str(
+    return str(
         metadata.get("rule")
         or metadata.get("finding_type")
         or metadata.get("reason")
         or ""
     )
-    return (event.project, event.event, event.status, problem)
 
 
 def _activity_event_from_group(group: _ActivityGroup) -> ActivityEvent:
@@ -294,6 +333,7 @@ def _activity_event_from_group(group: _ActivityGroup) -> ActivityEvent:
     metadata["activity_group"] = {
         "count": group.count,
         "event": event.event,
+        "last_seen": (group.last_seen or event.ts).isoformat(),
         "subjects": group.subjects[:10],
     }
     data["metadata"] = metadata
@@ -319,6 +359,16 @@ def _activity_group_summary(group: _ActivityGroup) -> str:
         problem = _plural_activity_problem(event, count)
         project = _activity_project_label(event.project)
         return f"I sent unstick briefs for {count} {problem} in {project}."
+    if event.event == "audit.finding":
+        summary = summarize_audit_event(
+            event_name=event.event,
+            subject=event.subject,
+            actor=event.actor,
+            status=event.status,
+            project=event.project,
+            metadata=event.metadata or {},
+        )
+        return f"{summary} (seen {count} times)."
     return summarize_audit_event(
         event_name=event.event,
         subject=event.subject,

--- a/tests/test_audit_endpoint.py
+++ b/tests/test_audit_endpoint.py
@@ -364,6 +364,140 @@ def test_activity_endpoint_groups_repeated_watchdog_escalations(
     assert event["metadata"]["activity_group"]["count"] == 3
 
 
+def test_activity_endpoint_hides_synthetic_audit_findings_and_groups_real_subjects(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+) -> None:
+    """Fixture-project findings stay out; recurring real findings collapse."""
+    now = datetime.now(timezone.utc)
+    latest_media_seen = now - timedelta(seconds=1)
+    _write_jsonl(
+        _central_log(audit_home, "media"),
+        [
+            _make_event(
+                project="media",
+                event="audit.finding",
+                subject="media",
+                status="warn",
+                actor="audit_watchdog",
+                ts=latest_media_seen.isoformat(),
+                metadata={"rule": "queue_without_motion"},
+            ),
+            _make_event(
+                project="media",
+                event="audit.finding",
+                subject="media",
+                status="warn",
+                actor="audit_watchdog",
+                ts=(now - timedelta(seconds=2)).isoformat(),
+                metadata={"rule": "queue_without_motion"},
+            ),
+            _make_event(
+                project="media",
+                event="audit.finding",
+                subject="media",
+                status="warn",
+                actor="audit_watchdog",
+                ts=(now - timedelta(seconds=3)).isoformat(),
+                metadata={"rule": "queue_without_motion"},
+            ),
+            _make_event(
+                project="booktalk",
+                event="audit.finding",
+                subject="booktalk/124",
+                status="warn",
+                actor="audit_watchdog",
+                ts=(now - timedelta(seconds=4)).isoformat(),
+                metadata={"rule": "stuck_draft"},
+            ),
+        ],
+    )
+    _write_jsonl(
+        _central_log(audit_home, "pm_test_01wave_1779715196"),
+        [
+            _make_event(
+                project="pm_test_01wave_1779715196",
+                event="audit.finding",
+                subject="pm_test_01wave_1779715196",
+                status="warn",
+                actor="audit_watchdog",
+                ts=(now - timedelta(seconds=5 + number)).isoformat(),
+                metadata={"rule": "queue_without_motion"},
+            )
+            for number in range(6)
+        ],
+    )
+    _write_jsonl(
+        _central_log(audit_home, "pr2316_drift_1779720195"),
+        [
+            _make_event(
+                project="pr2316_drift_1779720195",
+                event="audit.finding",
+                subject="pr2316_drift_1779720195",
+                status="warn",
+                actor="audit_watchdog",
+                ts=(now - timedelta(seconds=20 + number)).isoformat(),
+                metadata={"rule": "queue_without_motion"},
+            )
+            for number in range(7)
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={"since": "24h", "limit": 40},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    events = response.json()["events"]
+    subjects = [event["subject"] for event in events]
+    assert subjects.count("media") == 1
+    assert "booktalk/124" in subjects
+    assert not any(subject.startswith("pm_test_") for subject in subjects)
+    assert not any(subject.startswith("pr2316_drift_") for subject in subjects)
+    media = next(event for event in events if event["subject"] == "media")
+    assert media["metadata"]["activity_group"]["count"] == 3
+    assert media["metadata"]["activity_group"]["last_seen"] == (
+        latest_media_seen.isoformat()
+    )
+    assert "seen 3 times" in media["summary"]
+
+
+def test_activity_endpoint_include_fixtures_returns_synthetic_findings(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    audit_home: Path,
+) -> None:
+    """The explicit fixture override keeps the forensic stream inspectable."""
+    now = datetime.now(timezone.utc)
+    _write_jsonl(
+        _central_log(audit_home, "pm_test_01wave_1779715196"),
+        [
+            _make_event(
+                project="pm_test_01wave_1779715196",
+                event="audit.finding",
+                subject="pm_test_01wave_1779715196",
+                status="warn",
+                actor="audit_watchdog",
+                ts=now.isoformat(),
+                metadata={"rule": "queue_without_motion"},
+            )
+        ],
+    )
+
+    response = client.get(
+        "/api/v1/activity",
+        params={"since": "24h", "limit": 10, "include_fixtures": "1"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    subjects = [event["subject"] for event in response.json()["events"]]
+    assert "pm_test_01wave_1779715196" in subjects
+
+
 def test_activity_endpoint_keeps_cross_project_signal_when_one_project_is_noisy(
     client: TestClient,
     auth_headers: dict[str, str],
@@ -434,6 +568,8 @@ def test_activity_endpoint_hides_low_signal_plumbing_by_default(
             ),
             _make_event(
                 event="audit.finding",
+                project="media",
+                subject="media",
                 status="warn",
                 ts=(now - timedelta(seconds=4)).isoformat(),
             ),
@@ -554,6 +690,24 @@ def test_activity_low_signal_definition_is_shared_by_web_and_tui() -> None:
     assert activity._LOW_SIGNAL_ACTIVITY_KINDS is LOW_SIGNAL_ACTIVITY_KINDS
     assert "work_db.opened" in LOW_SIGNAL_ACTIVITY_KINDS
     assert "session.pause.skip" in LOW_SIGNAL_ACTIVITY_KINDS
+
+
+def test_activity_synthetic_project_definition_is_shared_with_alert_liveness() -> None:
+    """The feed imports the same synthetic predicate used by alert liveness."""
+    from pollypm import dashboard_data, project_liveness
+    from pollypm.web_api.routes import activity
+
+    assert (
+        activity.project_key_looks_synthetic
+        is project_liveness.project_key_looks_synthetic
+    )
+    assert (
+        dashboard_data.is_real_operator_project
+        is project_liveness.is_real_operator_project
+    )
+    assert project_liveness.project_key_looks_synthetic(
+        "pm_test_01wave_1779715196"
+    )
 
 
 def test_grep_regex_pattern_filters_lines(


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Hide synthetic seed/test-project audit.finding rows from the default /api/v1/activity feed using the shared project_liveness predicate.
- Collapse repeated real-project audit findings by project, subject, and finding type, preserving count and last_seen in metadata.activity_group.
- Add include_fixtures=true and document the OpenAPI contract for fixture inspection.

## Test Plan
- uv run --extra test pytest --noconftest tests/test_audit_endpoint.py tests/test_project_liveness.py
- uv run --extra dev ruff check src/pollypm/web_api/routes/activity.py tests/test_audit_endpoint.py
- git diff --check

Refs #2552