### PR TITLE
Fix project-scoped dashboard alert state

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -741,10 +741,10 @@ paths:
         - `?project=<key>` narrows the response to one project. The
           project list and per-project rows (sessions, commits,
           completed items, recent messages) are scoped to that key,
-          along with the three project-derived rollup counters
-          (`tracked_count`, `open_inbox_count`, `pending_plan_reviews`).
-          The four global activity counters (`alert_count`,
-          `sweep_count_24h`, `message_count_24h`, `recovery_count_24h`)
+          along with the project-derived rollup counters
+          (`tracked_count`, `open_inbox_count`, `pending_plan_reviews`,
+          `alert_count`). The three 24h activity counters
+          (`sweep_count_24h`, `message_count_24h`, `recovery_count_24h`)
           and `daemon_status` remain workspace-wide. See the
           `scoped_fields` array in the response for the authoritative
           enumeration of which fields were narrowed.
@@ -3820,8 +3820,8 @@ components:
       description: |
         Aggregate counters mirrored from the cockpit rail. Under
         `?project=<key>` only the project-derived counters
-        (`tracked_count`, `open_inbox_count`, `pending_plan_reviews`)
-        are narrowed; `alert_count` and the three `*_24h` activity
+        (`tracked_count`, `open_inbox_count`, `pending_plan_reviews`,
+        `alert_count`) are narrowed; the three `*_24h` activity
         counters remain whole-system. The response envelope's
         `scoped_fields` list enumerates which fields the filter
         actually narrowed.
@@ -3848,6 +3848,16 @@ components:
       properties:
         today: { type: integer }
         total: { type: integer }
+
+    DashboardAlertPreview:
+      type: object
+      required: [session_name, alert_type, severity, message, updated_at]
+      properties:
+        session_name: { type: string }
+        alert_type: { type: string }
+        severity: { type: string }
+        message: { type: string }
+        updated_at: { type: string }
 
     DashboardResponse:
       type: object
@@ -3886,7 +3896,7 @@ components:
             Names of response fields actually narrowed by `?project=`.
             Empty when no filter is in effect. Lets clients tell which
             counters reflect the requested project vs which remain
-            whole-system (see `DashboardRollups` for why the four
+            whole-system (see `DashboardRollups` for why the 24h
             activity counters stay global).
           items:
             type: string
@@ -3912,6 +3922,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AccountQuotaUsage"
+        project_alerts:
+          type: array
+          description: |
+            Actionable alerts owned by the requested `?project=`.
+            Empty for unfiltered/all-project responses.
+          items:
+            $ref: "#/components/schemas/DashboardAlertPreview"
         daily_tokens:
           type: array
           description: |

--- a/src/pollypm/alert_actionability.py
+++ b/src/pollypm/alert_actionability.py
@@ -21,6 +21,7 @@ _QUEUE_WITHOUT_MOTION_SESSION_PREFIX = "audit-queue_without_motion-"
 _WORKTREE_STATE_PREFIX = "worktree_state:"
 _WATCHDOG_ALERT_TYPE = "audit_watchdog"
 _QWM_PROJECT_RE = re.compile(r"\bProject\s+(?P<project>[A-Za-z0-9_.-]+)\s+has\b")
+_TASK_PAYLOAD_RE = re.compile(r"^(?P<project>[A-Za-z0-9_.-]+)/\d+(?:\b|:)")
 
 # #2475/#2480 — system-internal recovery watchdog warns. Each of these
 # alert types is a mechanical recovery signal raised by the
@@ -75,6 +76,130 @@ def _text_value(row: object, *names: str) -> str:
     return str(value or "")
 
 
+def _known_project_match(
+    value: str,
+    *,
+    known_projects: frozenset[str] | None,
+) -> str | None:
+    if not value:
+        return None
+    if not known_projects:
+        return None
+    for project in sorted(known_projects, key=len, reverse=True):
+        if (
+            value == project
+            or value.startswith(project + "/")
+            or value.startswith(project + ":")
+        ):
+            return project
+    return None
+
+
+def _task_payload_project(value: str) -> str | None:
+    match = _TASK_PAYLOAD_RE.match(value.strip())
+    if match is None:
+        return None
+    return match.group("project") or None
+
+
+def _alert_type_payload_project(
+    alert_type: str,
+    *,
+    known_projects: frozenset[str] | None,
+) -> str | None:
+    if ":" not in alert_type:
+        return None
+    _family, _sep, payload = alert_type.partition(":")
+    payload = payload.strip()
+    if not payload:
+        return None
+    project = _task_payload_project(payload)
+    if project is None:
+        project = _known_project_match(payload, known_projects=known_projects)
+    if project is None:
+        return None
+    if known_projects is not None and project not in known_projects:
+        return None
+    return project
+
+
+def _session_prefix_project(
+    session_name: str,
+    *,
+    prefixes: tuple[str, ...],
+    known_projects: frozenset[str] | None,
+    allow_numeric_tail: bool,
+) -> str | None:
+    for prefix in prefixes:
+        if not session_name.startswith(prefix):
+            continue
+        tail = session_name[len(prefix):].strip()
+        project = _known_project_match(tail, known_projects=known_projects)
+        if project is not None:
+            return project
+        if allow_numeric_tail and "-" in tail:
+            head, _sep, number = tail.rpartition("-")
+            if head and number.isdigit():
+                return head
+    return None
+
+
+def alert_project_key(
+    alert: object,
+    *,
+    known_projects: frozenset[str] | None = None,
+) -> str | None:
+    """Return the project key encoded by a project-scoped alert, if known."""
+
+    alert_type = _text_value(alert, "alert_type", "type")
+    session_name = _text_value(alert, "session_name", "scope")
+
+    project = _queue_without_motion_project(
+        alert,
+        known_projects=known_projects,
+    )
+    if project:
+        return project
+
+    project = _recovery_watchdog_project(
+        alert,
+        alert_type,
+        known_projects=known_projects,
+    )
+    if project:
+        return project
+
+    project = _worktree_state_project(
+        alert_type,
+        known_projects=known_projects,
+    )
+    if project:
+        return project
+
+    project = _alert_type_payload_project(
+        alert_type,
+        known_projects=known_projects,
+    )
+    if project:
+        return project
+
+    project = _session_prefix_project(
+        session_name,
+        prefixes=("review-", "blocked-", "task-"),
+        known_projects=known_projects,
+        allow_numeric_tail=True,
+    )
+    if project:
+        return project
+
+    return _session_prefix_project(
+        session_name,
+        prefixes=("worker-", "architect-", "reviewer-", "pm-"),
+        known_projects=known_projects,
+        allow_numeric_tail=False,
+    )
+
+
 def _stuck_alert_already_user_waiting(
     alert_type: str,
     user_waiting_task_ids: frozenset[str],
@@ -102,7 +227,7 @@ def _queue_without_motion_project(
     tail = session_name[len(_QUEUE_WITHOUT_MOTION_SESSION_PREFIX):]
     if known_projects:
         for project in sorted(known_projects, key=len, reverse=True):
-            if tail == project or tail.startswith(project + "-"):
+            if tail == project:
                 return project
     return None
 
@@ -198,9 +323,9 @@ def _recovery_watchdog_project(
     name. ``plan_missing`` / ``worker_session_gap`` carry the project key
     directly (``plan_gate-<project>`` / ``worker_session_gap-<project>``).
     ``missing_task_worker`` is keyed per task (``missing_task_worker-<project>/<N>``)
-    so we strip the ``/<task-number>`` tail. Project keys can themselves
-    contain hyphens, so when a ``known_projects`` set is supplied we
-    prefer the longest matching key to disambiguate.
+    so we strip the ``/<task-number>`` tail. When a ``known_projects``
+    set is supplied, require an exact match so a ghost project such as
+    ``media-old`` cannot be counted against ``media``.
     """
 
     prefix = _RECOVERY_WATCHDOG_SESSION_PREFIXES.get(alert_type)
@@ -219,7 +344,7 @@ def _recovery_watchdog_project(
         return None
     if known_projects:
         for project in sorted(known_projects, key=len, reverse=True):
-            if tail == project or tail.startswith(project + "-"):
+            if tail == project:
                 return project
     return tail
 
@@ -327,6 +452,7 @@ def count_user_actionable_alerts(
 
 __all__ = [
     "AlertActionabilityContext",
+    "alert_project_key",
     "count_user_actionable_alerts",
     "is_user_actionable_alert",
     "user_actionable_alerts",

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -204,6 +204,7 @@ class DashboardData:
     recovery_count_24h: int
     inbox_count: int
     alert_count: int
+    alert_counts_by_project: dict[str, int] = field(default_factory=dict)
     account_usages: list[AccountQuotaUsage] = field(default_factory=list)
     briefing: str = ""  # morning briefing narrative (if user was away)
 
@@ -894,6 +895,49 @@ def dashboard_actionable_alerts(
     return user_actionable_alerts(open_alerts, context=context)
 
 
+def dashboard_actionable_alerts_for_project(
+    config: PollyPMConfig,
+    project: str,
+    open_alerts: list[object],
+    *,
+    user_waiting_task_ids: frozenset[str] | None = None,
+    project_task_facts: _AlertProjectTaskFacts | None = None,
+) -> list[object]:
+    """Return actionable alert rows owned by ``project``."""
+
+    from pollypm.alert_actionability import alert_project_key
+
+    known_projects = _known_project_keys(config)
+    return [
+        alert
+        for alert in dashboard_actionable_alerts(
+            config,
+            open_alerts,
+            user_waiting_task_ids=user_waiting_task_ids,
+            project_task_facts=project_task_facts,
+        )
+        if alert_project_key(alert, known_projects=known_projects) == project
+    ]
+
+
+def dashboard_alert_counts_by_project(
+    config: PollyPMConfig,
+    actionable_alerts: list[object],
+) -> dict[str, int]:
+    """Group an already-filtered actionable alert list by owning project."""
+
+    from pollypm.alert_actionability import alert_project_key
+
+    known_projects = _known_project_keys(config)
+    counts: dict[str, int] = {}
+    for alert in actionable_alerts:
+        project = alert_project_key(alert, known_projects=known_projects)
+        if not project:
+            continue
+        counts[project] = counts.get(project, 0) + 1
+    return counts
+
+
 def count_dashboard_alerts(
     config: PollyPMConfig,
     open_alerts: list[object] | None = None,
@@ -910,6 +954,31 @@ def count_dashboard_alerts(
     return len(
         dashboard_actionable_alerts(
             config,
+            open_alerts,
+            user_waiting_task_ids=user_waiting_task_ids,
+            project_task_facts=project_task_facts,
+        )
+    )
+
+
+def count_dashboard_alerts_for_project(
+    config: PollyPMConfig,
+    project: str,
+    open_alerts: list[object] | None = None,
+    *,
+    user_waiting_task_ids: frozenset[str] | None = None,
+    project_task_facts: _AlertProjectTaskFacts | None = None,
+) -> int:
+    """Count actionable alerts scoped to one project."""
+
+    if open_alerts is None:
+        from pollypm.storage.pg_alerts import open_alerts as pg_open_alerts
+
+        open_alerts = list(pg_open_alerts(config=config))
+    return len(
+        dashboard_actionable_alerts_for_project(
+            config,
+            project,
             open_alerts,
             user_waiting_task_ids=user_waiting_task_ids,
             project_task_facts=project_task_facts,
@@ -1855,11 +1924,16 @@ def gather(
         + len(recovery_events)
     )
     user_waiting = _user_waiting_task_ids_across_projects(config)
-    alert_count = count_dashboard_alerts(
+    actionable_alerts = dashboard_actionable_alerts(
         config,
         open_alerts,
         user_waiting_task_ids=user_waiting,
         project_task_facts=project_task_facts,
+    )
+    alert_count = len(actionable_alerts)
+    alert_counts_by_project = dashboard_alert_counts_by_project(
+        config,
+        actionable_alerts,
     )
     briefing_generated_at = now
     try:
@@ -1897,6 +1971,7 @@ def gather(
         recovery_count_24h=recoveries,
         inbox_count=inbox_count,
         alert_count=alert_count,
+        alert_counts_by_project=alert_counts_by_project,
         account_usages=account_usages,
         briefing=briefing,
     )

--- a/src/pollypm/web_api/routes/dashboard.py
+++ b/src/pollypm/web_api/routes/dashboard.py
@@ -108,13 +108,13 @@ class DashboardRollups(BaseModel):
     """Aggregate counters mirrored from the cockpit rail.
 
     Under ``?project=<key>``, only the project-derived counters
-    (``tracked_count``, ``open_inbox_count``, ``pending_plan_reviews``)
-    are narrowed to that project. ``alert_count`` and the three
-    ``*_24h`` activity counters remain whole-system because the
-    underlying ``gather`` pipeline aggregates them globally before
-    returning (see :func:`pollypm.dashboard_data.gather`). The set of
-    fields actually narrowed for a given response is enumerated on the
-    envelope's ``scoped_fields`` list so clients don't have to guess.
+    (``tracked_count``, ``open_inbox_count``, ``pending_plan_reviews``,
+    ``alert_count``) are narrowed to that project. The three ``*_24h``
+    activity counters remain whole-system because the underlying
+    ``gather`` pipeline aggregates them globally before returning (see
+    :func:`pollypm.dashboard_data.gather`). The set of fields actually
+    narrowed for a given response is enumerated on the envelope's
+    ``scoped_fields`` list so clients don't have to guess.
     """
 
     tracked_count: int
@@ -131,6 +131,16 @@ class DashboardTokens(BaseModel):
 
     today: int
     total: int
+
+
+class DashboardAlertPreviewModel(BaseModel):
+    """Project-scoped actionable alert preview for selected-project views."""
+
+    session_name: str
+    alert_type: str
+    severity: str
+    message: str
+    updated_at: str
 
 
 class DashboardResponse(BaseModel):
@@ -166,6 +176,13 @@ class DashboardResponse(BaseModel):
     recent_messages: list[InboxPreviewModel]
     tokens: DashboardTokens
     account_usages: list[AccountQuotaUsageModel]
+    project_alerts: list[DashboardAlertPreviewModel] = Field(
+        default_factory=list,
+        description=(
+            "Actionable alerts owned by the requested ``?project=``. "
+            "Empty for unfiltered/all-project responses."
+        ),
+    )
     daily_tokens: list[list[Any]] | None = Field(
         default=None,
         description=(
@@ -243,6 +260,16 @@ def _account_usage_to_wire(row: Any) -> AccountQuotaUsageModel:
     )
 
 
+def _alert_preview_to_wire(row: Any) -> DashboardAlertPreviewModel:
+    return DashboardAlertPreviewModel(
+        session_name=str(getattr(row, "session_name", "") or ""),
+        alert_type=str(getattr(row, "alert_type", "") or ""),
+        severity=str(getattr(row, "severity", "") or ""),
+        message=str(getattr(row, "message", "") or ""),
+        updated_at=str(getattr(row, "updated_at", "") or ""),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Gather wrapper (pg-only path; sqlite store-open lives in load_dashboard)
 # ---------------------------------------------------------------------------
@@ -317,10 +344,39 @@ def _call_dashboard_source_pair(
     return results["projects"], results["data"]
 
 
-def _fresh_dashboard_alert_count(config: Any) -> int | None:
+def _fresh_dashboard_project_alerts(
+    config: Any,
+    project: str,
+) -> list[object] | None:
+    """Return fresh project-scoped actionable alerts, or ``None`` on failure."""
+
+    try:
+        from pollypm.dashboard_data import dashboard_actionable_alerts_for_project
+        from pollypm.storage.pg_alerts import open_alerts
+
+        return dashboard_actionable_alerts_for_project(
+            config,
+            project,
+            list(open_alerts(config=config)),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "dashboard: fresh project alert refresh failed; using cached value",
+            exc_info=True,
+        )
+        return None
+
+
+def _fresh_dashboard_alert_count(
+    config: Any,
+    project: str | None = None,
+) -> int | None:
     """Return a fresh alert count so stale dashboard snapshots cannot alarm high."""
 
     try:
+        if project is not None:
+            alerts = _fresh_dashboard_project_alerts(config, project)
+            return None if alerts is None else len(alerts)
         from pollypm.dashboard_data import count_dashboard_alerts
 
         return count_dashboard_alerts(config)
@@ -404,10 +460,9 @@ async def get_dashboard_endpoint(
             description=(
                 "Narrow the per-project lists (projects, sessions, "
                 "commits, completed items, recent messages) and the "
-                "three project-derived rollup counters to one project "
-                "key. The response's ``scoped_fields`` enumerates the "
-                "exact fields narrowed; the four global activity "
-                "rollups (alert / sweep / message / recovery 24h) and "
+                "project-derived rollup counters to one project key. "
+                "The response's ``scoped_fields`` enumerates the exact "
+                "fields narrowed; the three 24h activity rollups and "
                 "``daemon_status`` remain whole-system."
             ),
         ),
@@ -501,12 +556,10 @@ async def get_dashboard_endpoint(
         recent_messages = [m for m in recent_messages if m.project == project]
         # Enumerate the fields that are actually project-scoped under
         # ``?project=`` so clients don't have to guess which rollups
-        # were narrowed. The four ``rollups.*`` activity counters
-        # (alert_count, sweep_count_24h, message_count_24h,
-        # recovery_count_24h) are intentionally NOT listed — they are
-        # aggregated globally inside ``gather`` and re-scoping them
-        # would require new pg queries we deferred for the v1 RC
-        # minimal-diff window.
+        # were narrowed. The three ``rollups.*`` 24h activity counters
+        # (sweep_count_24h, message_count_24h, recovery_count_24h)
+        # are intentionally NOT listed because they are aggregated
+        # globally inside ``gather``.
         scoped_fields = [
             "projects",
             "active_sessions",
@@ -516,10 +569,11 @@ async def get_dashboard_endpoint(
             "rollups.tracked_count",
             "rollups.open_inbox_count",
             "rollups.pending_plan_reviews",
+            "rollups.alert_count",
         ]
 
     # Rollups — project-derived counters narrow with ``?project=``;
-    # the four ``gather``-computed activity counters stay global and
+    # the three ``gather``-computed 24h activity counters stay global and
     # are documented as such on the response (see ``scoped_fields``
     # above and the ``DashboardRollups`` docstring).
     tracked_count = sum(1 for p in projects_view if p.tracked)
@@ -532,7 +586,19 @@ async def get_dashboard_endpoint(
     # older snapshots, refresh that one cheap counter and write it through so
     # the Home headline does not hold an old-high value (#2504).
     snapshot_age = time.monotonic() - snapshot.refreshed_at_monotonic
-    if snapshot_age > 2.0:
+    project_alerts: list[object] = []
+    if project is not None:
+        fresh_project_alerts = _fresh_dashboard_project_alerts(config, project)
+        if fresh_project_alerts is not None:
+            project_alerts = fresh_project_alerts
+            fresh_alert_count = len(project_alerts)
+        else:
+            raw_counts = getattr(data, "alert_counts_by_project", {}) or {}
+            try:
+                fresh_alert_count = int(raw_counts.get(project, 0) or 0)
+            except (AttributeError, TypeError, ValueError):
+                fresh_alert_count = 0
+    elif snapshot_age > 2.0:
         fresh_alert_count = _normalize_dashboard_alert_count(config, data)
     else:
         # Prefer the loader's explicit normalized value so the sync
@@ -588,6 +654,10 @@ async def get_dashboard_endpoint(
             _account_usage_to_wire(u)
             for u in (data.account_usages or [])
         ],
+        project_alerts=[
+            _alert_preview_to_wire(alert)
+            for alert in project_alerts[:5]
+        ],
         daily_tokens=daily_tokens,
         briefing=briefing,
     )
@@ -597,6 +667,7 @@ __all__ = [
     "AccountQuotaUsageModel",
     "CommitInfoModel",
     "CompletedItemModel",
+    "DashboardAlertPreviewModel",
     "DashboardResponse",
     "DashboardRollups",
     "DashboardSnapshotCache",

--- a/src/pollypm/web_api/ui/app.js
+++ b/src/pollypm/web_api/ui/app.js
@@ -1200,6 +1200,36 @@
     return count === 1 ? singular : (pluralText || singular + "s");
   }
 
+  function dashboardProjectLabel(data) {
+    const projects = data && Array.isArray(data.projects) ? data.projects : [];
+    const project = projects.length === 1 ? projects[0] : null;
+    if (!project) return state.selectedProject || "Project";
+    return project.name || project.key || state.selectedProject || "Project";
+  }
+
+  function firstProjectAlert(data) {
+    const alerts = data && Array.isArray(data.project_alerts)
+      ? data.project_alerts : [];
+    return alerts.length > 0 ? alerts[0] : null;
+  }
+
+  function projectAlertHeadline(data, alerts) {
+    const project = dashboardProjectLabel(data);
+    const firstAlert = firstProjectAlert(data);
+    const title = firstAlert && firstAlert.alert_type === "plan_missing"
+      ? project + " is waiting on a plan"
+      : project + " needs attention";
+    const detail = firstAlert && firstAlert.message
+      ? firstAlert.message
+      : alerts + " project " + plural(alerts, "alert") + " waiting.";
+    return {
+      title: title,
+      detail: detail,
+      actionLabel: "Open alerts",
+      target: "alerts",
+    };
+  }
+
   function dashboardStatus(data) {
     if (!data || typeof data !== "object") {
       return {
@@ -1215,11 +1245,16 @@
     const inbox = numeric(rollups.open_inbox_count);
     const alerts = numeric(rollups.alert_count);
     const total = planReviews + inbox;
+    const scopedAlerts = isScoped(data.scoped_fields, "rollups.alert_count");
+    const alertKind = scopedAlerts ? "project alert" : "background alert";
     const alertNote = alerts > 0
-      ? " " + alerts + " " + plural(alerts, "background alert")
+      ? " " + alerts + " " + plural(alerts, alertKind)
         + " being watched."
       : "";
     if (total === 0) {
+      if (scopedAlerts && alerts > 0) {
+        return projectAlertHeadline(data, alerts);
+      }
       const sweeps = numeric(rollups.sweep_count_24h);
       const recoveries = numeric(rollups.recovery_count_24h);
       const proof = sweeps || recoveries
@@ -3312,20 +3347,21 @@
       ));
     }
     if (typeof rollups.alert_count === "number") {
+      const scoped = isScoped(scopedFields, "rollups.alert_count");
       cards.push(buildCard(
         "watching",
         rollups.alert_count,
         rollups.alert_count > 0 ? "rollup-working" : "",
-        // alert_count is intentionally global per DashboardRollups
-        // docstring — never appears in scoped_fields, so no tag.
-        false,
+        scoped,
         dashboardCardAction({
           label: "watching",
           value: rollups.alert_count,
           target: "alerts",
-          detail: "Opens background alerts and recovery notes.",
+          detail: scoped
+            ? "Opens alerts for the selected project."
+            : "Opens background alerts and recovery notes.",
         }, data),
-        "Open background alerts",
+        scoped ? "Open project alerts" : "Open background alerts",
       ));
     }
 

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -297,6 +297,55 @@ def test_worktree_state_demotes_tracked_project_without_recent_real_work() -> No
     assert not is_user_actionable_alert(warn, context=context)
 
 
+def test_alert_project_key_resolves_project_scoped_alert_families() -> None:
+    from pollypm.alert_actionability import alert_project_key
+
+    known = frozenset({"media", "sam-blog"})
+    rows = [
+        SimpleNamespace(
+            session_name="plan_gate-media",
+            alert_type="plan_missing",
+        ),
+        SimpleNamespace(
+            session_name="task-sam-blog-7",
+            alert_type="tmux_window_probe_unavailable",
+        ),
+        SimpleNamespace(
+            session_name="blocked-media-12",
+            alert_type="blocked_dead_end",
+        ),
+        SimpleNamespace(
+            session_name="review-media-4",
+            alert_type="review_pending",
+        ),
+        SimpleNamespace(
+            session_name="task_assignment",
+            alert_type="no_session_for_assignment:sam-blog/9",
+        ),
+        SimpleNamespace(
+            session_name="worker-media",
+            alert_type="project_path_unspawnable",
+        ),
+        SimpleNamespace(
+            session_name="worker-media-11",
+            alert_type="worktree_state:media/11:dirty_stale",
+        ),
+    ]
+
+    assert [
+        alert_project_key(row, known_projects=known)
+        for row in rows
+    ] == [
+        "media",
+        "sam-blog",
+        "media",
+        "media",
+        "sam-blog",
+        "media",
+        "media",
+    ]
+
+
 def test_orphan_worktree_alert_is_not_user_actionable() -> None:
     from pollypm.alert_actionability import is_user_actionable_alert
 

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -16,6 +16,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -192,6 +193,11 @@ def patch_fresh_alert_count(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         dashboard_routes, "_fresh_dashboard_alert_count", lambda _config: None,
     )
+    monkeypatch.setattr(
+        dashboard_routes,
+        "_fresh_dashboard_project_alerts",
+        lambda _config, _project: None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +219,7 @@ def _make_data(
     recovery_count_24h: int = 0,
     inbox_count: int = 0,
     alert_count: int = 0,
+    alert_counts_by_project: dict[str, int] | None = None,
     account_usages: list[AccountQuotaUsage] | None = None,
     briefing: str = "",
 ) -> DashboardData:
@@ -229,6 +236,7 @@ def _make_data(
         recovery_count_24h=recovery_count_24h,
         inbox_count=inbox_count,
         alert_count=alert_count,
+        alert_counts_by_project=alert_counts_by_project or {},
         account_usages=account_usages or [],
         briefing=briefing,
     )
@@ -875,18 +883,15 @@ def test_dashboard_503_when_list_projects_raises(
 # ---------------------------------------------------------------------------
 
 
-def test_dashboard_project_filter_keeps_global_activity_rollups(
+def test_dashboard_project_filter_scopes_alert_rollup_and_keeps_global_activity_rollups(
     client, auth_headers, patch_gather, patch_list_projects,
 ):
-    """Regression for Codex PR #2057 P0 #1.
+    """Project filters scope project-owned alerts but keep 24h activity global.
 
     Under ``?project=myproj`` the response must NOT silently inherit
-    cross-project alert / sweep / message / recovery counts as if they
-    were narrowed to ``myproj``. The gather pipeline aggregates these
-    four counters globally (sessions for other projects contribute),
-    so for the v1 RC minimal-diff window we surface them unchanged and
-    enumerate the actually-narrowed fields in ``scoped_fields`` so
-    clients can tell the difference.
+    cross-project alert counts as if they were narrowed to ``myproj``.
+    ``alert_count`` now follows the selected project while the 24h
+    sweep / message / recovery counters remain whole-system.
     """
     patch_list_projects([
         _api_project("myproj", open_inbox_count=3, pending_plan_review=True),
@@ -894,8 +899,8 @@ def test_dashboard_project_filter_keeps_global_activity_rollups(
     ])
     # The dashboard data here represents the WHOLE system; sessions /
     # commits / inbox previews for "otherproj" are part of the global
-    # picture, and the four rollups below were computed across both
-    # projects.
+    # picture, and the 24h activity rollups below were computed across
+    # both projects.
     patch_gather(_make_data(
         active_sessions=[
             SessionActivity(
@@ -909,6 +914,7 @@ def test_dashboard_project_filter_keeps_global_activity_rollups(
                        age_seconds=1, project="otherproj"),
         ],
         alert_count=6,
+        alert_counts_by_project={"myproj": 2, "otherproj": 4},
         sweep_count_24h=12,
         message_count_24h=4,
         recovery_count_24h=2,
@@ -923,24 +929,71 @@ def test_dashboard_project_filter_keeps_global_activity_rollups(
     assert rollups["tracked_count"] == 1
     assert rollups["open_inbox_count"] == 3
     assert rollups["pending_plan_reviews"] == 1
-    # Global activity rollups are surfaced unchanged (documented as
-    # not-narrowed via the ``scoped_fields`` contract below).
-    assert rollups["alert_count"] == 6
+    assert rollups["alert_count"] == 2
+    # Global 24h activity rollups are surfaced unchanged (documented
+    # as not-narrowed via the ``scoped_fields`` contract below).
     assert rollups["sweep_count_24h"] == 12
     assert rollups["message_count_24h"] == 4
     assert rollups["recovery_count_24h"] == 2
 
     # Contract — the response enumerates exactly which fields the
-    # filter narrowed. The four global activity counters MUST NOT
+    # filter narrowed. The 24h global activity counters MUST NOT
     # appear here; the project-derived rollups MUST.
     scoped = set(body["scoped_fields"])
     assert "rollups.tracked_count" in scoped
     assert "rollups.open_inbox_count" in scoped
     assert "rollups.pending_plan_reviews" in scoped
-    assert "rollups.alert_count" not in scoped
+    assert "rollups.alert_count" in scoped
     assert "rollups.sweep_count_24h" not in scoped
     assert "rollups.message_count_24h" not in scoped
     assert "rollups.recovery_count_24h" not in scoped
+
+
+def test_dashboard_project_filter_uses_fresh_project_alerts(
+    client, auth_headers, patch_gather, patch_list_projects, monkeypatch,
+):
+    """A selected project with only plan_missing alerts must not look clean."""
+    patch_list_projects([
+        _api_project("myproj"),
+        _api_project("otherproj"),
+    ])
+    patch_gather(_make_data(
+        alert_count=6,
+        alert_counts_by_project={"myproj": 0},
+    ))
+    alert = SimpleNamespace(
+        session_name="plan_gate-myproj",
+        alert_type="plan_missing",
+        severity="warn",
+        message=(
+            "Project 'myproj' has no approved plan yet - queued task "
+            "myproj/1 is waiting. Run `pm project plan myproj`."
+        ),
+        updated_at="2026-06-03T15:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        dashboard_routes,
+        "_fresh_dashboard_project_alerts",
+        lambda _config, project: [alert] if project == "myproj" else [],
+    )
+
+    body = client.get(
+        "/api/v1/dashboard?project=myproj", headers=auth_headers,
+    ).json()
+
+    assert body["rollups"]["open_inbox_count"] == 0
+    assert body["rollups"]["pending_plan_reviews"] == 0
+    assert body["rollups"]["alert_count"] == 1
+    assert "rollups.alert_count" in body["scoped_fields"]
+    assert body["project_alerts"] == [
+        {
+            "session_name": "plan_gate-myproj",
+            "alert_type": "plan_missing",
+            "severity": "warn",
+            "message": alert.message,
+            "updated_at": "2026-06-03T15:00:00+00:00",
+        }
+    ]
 
 
 def test_dashboard_scoped_fields_empty_without_filter(

--- a/tests/web_api/test_web_ui.py
+++ b/tests/web_api/test_web_ui.py
@@ -2023,3 +2023,48 @@ def test_render_dashboard_scoped_fields_tag_filtered_cards() -> None:
     assert "inbox (filtered)" in rendered, (
         f"scoped inbox card should carry the (filtered) tag; got:\n{rendered}"
     )
+
+
+def test_render_dashboard_project_alert_headline_replaces_all_handled() -> None:
+    """A selected project with only scoped alerts must not render clean copy."""
+    payload = {
+        "rollups": {
+            "open_inbox_count": 0,
+            "pending_plan_reviews": 0,
+            "alert_count": 1,
+            "sweep_count_24h": 0,
+            "message_count_24h": 0,
+            "tracked_count": 1,
+        },
+        "daemon_status": "up",
+        "active_sessions": [],
+        "scoped_fields": [
+            "projects",
+            "rollups.alert_count",
+        ],
+        "projects": [
+            {
+                "key": "media",
+                "name": "media",
+                "tracked": True,
+            }
+        ],
+        "recent_messages": [],
+        "project_alerts": [
+            {
+                "session_name": "plan_gate-media",
+                "alert_type": "plan_missing",
+                "severity": "warn",
+                "message": (
+                    "Project 'media' has no approved plan yet - queued "
+                    "task media/1 is waiting. Run `pm project plan media`."
+                ),
+                "updated_at": "2026-06-03T15:00:00+00:00",
+            }
+        ],
+    }
+    rendered = _node_render_dashboard(payload)
+    assert "All handled - Polly's got it" not in rendered
+    assert "media is waiting on a plan" in rendered
+    assert "Run `pm project plan media`" in rendered
+    assert "watching (filtered)" in rendered


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Scope dashboard `alert_count` to the selected project under `?project=` and expose selected-project alert previews.
- Add a shared alert-to-project resolver so dashboard counts reuse the actionable alert policy instead of browser heuristics.
- Update the web dashboard headline/card so project drill-in surfaces `plan_missing` alerts instead of saying “All handled.”
- Update the OpenAPI dashboard contract and regression tests.

## Tests
- `uv run --extra test pytest --noconftest tests/test_dashboard_endpoint.py tests/test_dashboard_data_alert_dedup.py -q`
- `uv run --extra test pytest tests/web_api/test_web_ui.py -q -k "render_dashboard"`
- `uv run --extra dev ruff check src/pollypm/alert_actionability.py src/pollypm/dashboard_data.py src/pollypm/web_api/routes/dashboard.py tests/test_dashboard_data_alert_dedup.py tests/test_dashboard_endpoint.py tests/web_api/test_web_ui.py`

Fixes #2556