### PR TITLE
Fix dashboard alert project attribution

### DIFF
--- a/src/pollypm/alert_actionability.py
+++ b/src/pollypm/alert_actionability.py
@@ -131,16 +131,23 @@ def _session_prefix_project(
     allow_numeric_tail: bool,
 ) -> str | None:
     for prefix in prefixes:
-        if not session_name.startswith(prefix):
-            continue
-        tail = session_name[len(prefix):].strip()
-        project = _known_project_match(tail, known_projects=known_projects)
-        if project is not None:
-            return project
-        if allow_numeric_tail and "-" in tail:
-            head, _sep, number = tail.rpartition("-")
-            if head and number.isdigit():
-                return head
+        candidate_prefixes = [prefix]
+        if prefix.endswith("-"):
+            candidate_prefixes.append(prefix[:-1] + "_")
+        for candidate_prefix in candidate_prefixes:
+            if not session_name.startswith(candidate_prefix):
+                continue
+            tail = session_name[len(candidate_prefix):].strip()
+            project = _known_project_match(tail, known_projects=known_projects)
+            if project is not None:
+                return project
+            if allow_numeric_tail:
+                for separator in ("-", "_"):
+                    if separator not in tail:
+                        continue
+                    head, _sep, number = tail.rpartition(separator)
+                    if head and number.isdigit():
+                        return head
     return None
 
 
@@ -216,10 +223,16 @@ def _queue_without_motion_project(
     known_projects: frozenset[str] | None,
 ) -> str | None:
     session_name = _text_value(alert, "session_name", "scope")
+    message = _text_value(alert, "message", "body")
+    alert_type = _text_value(alert, "alert_type", "type")
+    if alert_type == _WATCHDOG_ALERT_TYPE:
+        match = _QWM_PROJECT_RE.search(message)
+        if match is not None:
+            return match.group("project")
+
     if not session_name.startswith(_QUEUE_WITHOUT_MOTION_SESSION_PREFIX):
         return None
 
-    message = _text_value(alert, "message", "body")
     match = _QWM_PROJECT_RE.search(message)
     if match is not None:
         return match.group("project")

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -300,7 +300,7 @@ def test_worktree_state_demotes_tracked_project_without_recent_real_work() -> No
 def test_alert_project_key_resolves_project_scoped_alert_families() -> None:
     from pollypm.alert_actionability import alert_project_key
 
-    known = frozenset({"media", "sam-blog"})
+    known = frozenset({"media", "sam-blog", "savethenovel"})
     rows = [
         SimpleNamespace(
             session_name="plan_gate-media",
@@ -330,6 +330,19 @@ def test_alert_project_key_resolves_project_scoped_alert_families() -> None:
             session_name="worker-media-11",
             alert_type="worktree_state:media/11:dirty_stale",
         ),
+        SimpleNamespace(
+            session_name="architect_savethenovel",
+            alert_type="architect_worktree_stale",
+        ),
+        SimpleNamespace(
+            session_name="reviewer_sam-blog",
+            alert_type="review_pending",
+        ),
+        SimpleNamespace(
+            session_name="audit-plan_missing_queue_stalled-media-media",
+            alert_type="audit_watchdog",
+            message="Project media has 1 queued task(s) waiting on a plan.",
+        ),
     ]
 
     assert [
@@ -342,6 +355,9 @@ def test_alert_project_key_resolves_project_scoped_alert_families() -> None:
         "media",
         "sam-blog",
         "media",
+        "media",
+        "savethenovel",
+        "sam-blog",
         "media",
     ]
 


### PR DESCRIPTION
## Agent Identity
- Authoring agent: Codex
- Authoring persona: Codex Builder
- Creator label: codex-created
- Reviewer/merge agent: Claude
- Reviewer persona: Claude Reviewer
- Ownership label: needs-claude
- Self-merge prohibited: yes

## Summary
- Attribute `audit_watchdog` queue-stalled alerts from their message text even when the session name uses another watchdog family prefix.
- Resolve underscore-separated role sessions such as `architect_savethenovel` and `reviewer_sam-blog` through the same project-key helper used by dashboard drill-in filtering.
- Extend the dashboard alert project-key regression table with the #2559 cases.

Closes #2559

## Tests
- `uv run --extra test pytest tests/test_dashboard_data_alert_dedup.py -q` - 50 passed in 239.48s
- `uv run --extra dev ruff check src/pollypm/alert_actionability.py tests/test_dashboard_data_alert_dedup.py`
- `uv run --extra test python -m compileall -q src/pollypm/alert_actionability.py`
- `git diff --check`
